### PR TITLE
 Fix Conway committee ratification semantics + stale starttime in SlotConfig for transaction validation

### DIFF
--- a/adr/ledger-state/028-conway-committee-ratification-semantics.md
+++ b/adr/ledger-state/028-conway-committee-ratification-semantics.md
@@ -1,0 +1,399 @@
+# ADR-028: Conway Committee Ratification Semantics
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-31
+
+## Context
+
+Yano's Conway governance ratification path must distinguish two different ledger
+concepts that look similar if we only inspect the current committee member map:
+
+```text
+Committee absent
+  Haskell ledger representation: SNothing
+  Meaning: no-confidence state
+
+Committee present
+  Haskell ledger representation: SJust Committee
+  Meaning: normal committee state, even when the member map is empty or all
+           members are currently inactive
+```
+
+This matters for governance action ratification. The Haskell ledger chooses
+some thresholds and committee-vote behavior from committee presence, not from
+whether there are currently active voters.
+
+Yano previously inferred committee state from member activity. That worked for
+some real-network cases, but it diverges from Haskell semantics and breaks
+Yano-only devkit scenarios where Conway genesis intentionally starts with an
+empty committee and committee threshold `0/1` so governance actions can be
+enacted quickly.
+
+Yaci Store's runtime path already handles this more explicitly: it stores a
+committee state and feeds ratification with committee members that are already
+active and hot-key authorized.
+
+Yano has not been released yet, so it is acceptable to change governance state
+persistence and require affected users to resync from genesis instead of adding
+a compatibility migration for old unreleased state.
+
+## Problem
+
+Yano has four committee-related divergences from ledger behavior:
+
+1. Committee state is partly inferred from active member count.
+2. `UpdateCommittee` DRep and SPO thresholds always use the normal committee
+   threshold, even after a `NoConfidence` action.
+3. Committee min-size checks count non-expired, non-resigned cold members even
+   when they have no authorized hot key.
+4. Devkit validation can be misleading if the runtime local-cluster genesis has
+   empty committee threshold `0/1`, while a tracked Yano devnet genesis has
+   empty committee threshold `2/3`.
+
+These issues are related but not identical. The fix should keep the blast
+radius small and preserve real-network behavior.
+
+## Examples
+
+### Example 1: Empty Genesis Committee Should Still Be Committee-Present
+
+Devkit Yano-only mode can start Conway with:
+
+```json
+{
+  "committee": {
+    "members": {},
+    "threshold": { "numerator": 0, "denominator": 1 }
+  }
+}
+```
+
+Ledger meaning:
+
+```text
+committee = SJust Committee { members = {}, threshold = 0/1 }
+state     = NORMAL / committee-present
+```
+
+Wrong behavior:
+
+```text
+members = {}
+Yano derives committee state as NO_CONFIDENCE
+ParameterChange committee check fails
+PV11 protocol parameter action remains active
+latest epoch params still show old PV10 cost models
+```
+
+Required behavior:
+
+```text
+committeePresent = true from Conway genesis bootstrap
+members = {}
+committee threshold = 0/1
+committee vote auto-passes
+ParameterChange can ratify and enact when DRep/SPO rules also pass
+```
+
+### Example 2: UpdateCommittee After NoConfidence Uses NoConfidence Thresholds
+
+Assume protocol thresholds:
+
+```text
+dvtCommitteeNormal       = 0.67
+dvtCommitteeNoConfidence = 0.60
+```
+
+After a `NoConfidence` action is enacted:
+
+```text
+committeePresent = false
+```
+
+An `UpdateCommittee` action then receives DRep support:
+
+```text
+yes / (yes + no) = 0.62
+```
+
+Wrong behavior:
+
+```text
+Yano evaluates UPDATE_COMMITTEE with dvtCommitteeNormal = 0.67
+0.62 < 0.67
+proposal fails or remains active
+```
+
+Ledger-aligned behavior:
+
+```text
+Previous committee state is NO_CONFIDENCE
+Use dvtCommitteeNoConfidence = 0.60
+0.62 >= 0.60
+DRep threshold passes
+```
+
+The same rule applies to SPO thresholds:
+
+```text
+pvtCommitteeNormal vs pvtCommitteeNoConfidence
+```
+
+### Example 3: Hot-Key Authorization Affects Active Committee Size
+
+Assume:
+
+```text
+committeeMinSize = 3
+committee members:
+  cold1 -> hot1
+  cold2 -> hot2
+  cold3 -> no hot key
+  cold4 -> no hot key
+  cold5 -> no hot key
+```
+
+Wrong behavior:
+
+```text
+Yano min-size activeCount = 5
+committeeMinSize check passes
+```
+
+Ledger-aligned behavior:
+
+```text
+activeCommittee excludes members without hot-key authorization
+activeCount = 2
+2 < 3
+committee check fails
+```
+
+Yano's vote tally already excludes members without hot keys. The min-size check
+must use the same active committee definition.
+
+### Example 4: Present But All Inactive Is Not NoConfidence
+
+Assume committee is present, but all members are expired or resigned:
+
+```text
+committeePresent = true
+members = {
+  cold1 expired,
+  cold2 resigned
+}
+```
+
+Wrong behavior:
+
+```text
+Yano derives NO_CONFIDENCE because no active members exist
+UpdateCommittee threshold selection may use no-confidence thresholds
+Other committee-gated proposals fail for the wrong reason
+```
+
+Ledger-aligned behavior:
+
+```text
+committeePresent = true
+state = NORMAL
+committee voting fails through active-size or threshold checks
+```
+
+This keeps the representation aligned with the ledger: absence is
+no-confidence; inactivity is handled by committee voting rules.
+
+## Decision
+
+Yano will use explicit committee presence as the source of truth for committee
+state and will keep vote/min-size calculations aligned with Haskell's active
+committee semantics.
+
+The implementation should be minimal:
+
+1. Persist committee presence in `GovernanceStateStore`.
+2. Set `committeePresent = true` during Conway genesis bootstrap whenever a
+   committee object exists in genesis, including an empty member map.
+3. Set `committeePresent = false` when a `NoConfidence` action is enacted.
+4. Set `committeePresent = true` when an `UpdateCommittee` action is enacted,
+   even if the resulting committee member map is empty.
+5. Resolve committee state from presence only:
+
+   ```text
+   committeePresent == false -> NO_CONFIDENCE
+   committeePresent == true  -> NORMAL
+   ```
+
+6. Select `UpdateCommittee` DRep/SPO thresholds from the persisted committee
+   presence value read at the start of Phase 2 ratification, after Phase 1
+   enactment has committed. Every `UpdateCommittee` proposal evaluated in that
+   Phase 2 pass sees the same post-Phase-1 committee state snapshot. This
+   matches Haskell ledger behavior where RATIFY reads the enact state after
+   previously ratified actions have been enacted, but before any action
+   ratified in the current boundary is enacted.
+
+   ```text
+   committeePresent == true  -> committeeNormal threshold
+   committeePresent == false -> committeeNoConfidence threshold
+   ```
+
+7. Count only active, non-resigned, hot-key-authorized members for
+   post-bootstrap committee min-size checks.
+8. Keep threshold-zero behavior explicit:
+
+   ```text
+   committee threshold 0/1 -> committee vote passes, even with zero voters
+   non-zero threshold and zero denominator participation -> fails
+   ```
+9. Align the tracked Yano devnet Conway genesis with the Yano-only devkit
+   intent: an empty genesis committee used to remove the committee gate must
+   have committee threshold `0/1`. Real network genesis files must not be
+   changed for this fix.
+
+## Non-Goals
+
+- Do not add a migration for old unreleased Yano governance state.
+- Do not refactor the full governance ratification engine.
+- Do not change real-network genesis defaults.
+- Do not change DRep, SPO, proposal expiry, deposit refund, or enactment
+  ordering outside the committee semantics needed here.
+
+## Consequences
+
+### Positive
+
+- Yano-only devkit can enact PV11 protocol parameter governance actions with an
+  empty genesis committee and threshold `0/1`.
+- `NoConfidence` followed by `UpdateCommittee` uses the lower
+  no-confidence recovery thresholds when protocol parameters define them.
+- Committee min-size checks match the same active committee definition used by
+  vote tallying.
+- Present-but-inactive committees are represented as normal committee state,
+  leaving downstream checks to fail for the correct reason.
+
+### Risk
+
+- Persisted governance state shape changes. Since Yano has not been released,
+  users running prior builds should resync from genesis.
+- If a network profile accidentally sets empty committee threshold to `2/3`,
+  an empty present committee will still fail committee voting. That is correct
+  ledger behavior, but it can look like the original bug unless the config is
+  checked.
+- Threshold selection must use the post-Phase-1 committee state read before
+  Phase 2 starts, not the state that would exist after enacting any proposal
+  ratified during the same Phase 2 pass.
+
+## Regression Boundaries
+
+The fix must not weaken real-network governance checks:
+
+- A missing Conway genesis committee threshold should continue to fail closed,
+  not silently default to `0/1` or `2/3`.
+- A non-zero committee threshold with no eligible committee voters should fail.
+- A `committeePresent=true` state with stored threshold `0/1` auto-passes only
+  committee approval. It must not bypass committee min-size, DRep checks, SPO
+  checks, previous-action checks, lifecycle checks, or enactment ordering.
+- Members without authorized hot keys should not help satisfy min-size.
+- `NoConfidence` should clear committee presence.
+- `UpdateCommittee` should restore committee presence.
+- Bootstrap phase behavior should remain unchanged except where threshold `0/1`
+  explicitly auto-passes.
+
+## Implementation Notes
+
+Suggested implementation order:
+
+1. Simplify committee state resolution so `committeePresent=true` always maps to
+   `NORMAL` and `committeePresent=false` maps to `NO_CONFIDENCE`.
+2. Add hot-key authorization to the post-bootstrap committee min-size filter.
+3. Make `UpdateCommittee` threshold resolution state-dependent. The current
+   static threshold map helpers can either take committee presence as an
+   argument or be wrapped by instance methods that read the post-Phase-1
+   committee state before Phase 2 ratification.
+4. Keep the already implemented persistence behavior for genesis bootstrap,
+   `NoConfidence`, `UpdateCommittee`, and threshold-zero committee vote
+   handling.
+5. Align only the tracked Yano devnet Conway genesis threshold for the empty
+   committee case. Do not change mainnet, preprod, preview, or sanchonet
+   genesis files.
+
+The existing ratification API still passes committee state as the strings
+`NORMAL` and `NO_CONFIDENCE`. That is acceptable for this fix if the string is
+derived from the explicit boolean source of truth at a single well-defined
+boundary point. A later cleanup may replace the string parameter with a boolean
+or enum.
+
+## Verification Plan
+
+Add focused tests for:
+
+1. Conway genesis with empty committee and threshold `0/1` stores
+   `committeePresent = true`.
+2. Empty present committee resolves to `NORMAL`.
+3. Present committee with all members expired or resigned still resolves to
+   `NORMAL`.
+4. Enacted `NoConfidence` stores `committeePresent = false`.
+5. Enacted `UpdateCommittee` stores `committeePresent = true`.
+6. `UpdateCommittee` DRep voting uses `dvtCommitteeNoConfidence` when
+   post-Phase-1 committee state is no-confidence.
+7. `UpdateCommittee` SPO voting uses `pvtCommitteeNoConfidence` when
+   post-Phase-1 committee state is no-confidence.
+8. `UpdateCommittee` uses normal DRep and SPO thresholds when committee state is
+   normal.
+9. Phase 1 -> Phase 2 visibility: if a `NoConfidence` action is pending
+   enactment and an `UpdateCommittee` action is active at the same boundary,
+   Phase 2 must ratify the `UpdateCommittee` using no-confidence thresholds
+   after Phase 1 commits `committeePresent=false`.
+10. Committee min-size excludes members without hot keys.
+11. Threshold `0/1` passes committee voting with zero eligible voters.
+12. Threshold `2/3` fails committee voting with zero eligible voters.
+13. Tracked Yano devnet Conway genesis uses empty committee threshold `0/1`;
+    real network genesis files retain their published values.
+
+Run focused governance tests:
+
+```bash
+./gradlew :ledger-state:test \
+  --tests 'com.bloxbean.cardano.yano.ledgerstate.governance.*' \
+  --tests 'com.bloxbean.cardano.yano.ledgerstate.governance.epoch.*' \
+  --tests 'com.bloxbean.cardano.yano.ledgerstate.governance.ratification.*'
+```
+
+Validate with Yano-only devkit:
+
+```text
+1. Start Yano and Yaci Store in Yano-only devkit mode.
+2. Submit PV11 protocol parameter governance action.
+3. Let Yano time-travel to wall clock and cross epoch boundaries.
+4. Confirm proposal list is empty or action is enacted.
+5. Confirm /api/v1/epochs/latest/parameters returns PV11 cost model lengths.
+6. Confirm Yaci Store and Yano agree on enacted epoch.
+```
+
+## Reviewer Notes
+
+The most important review question is whether committee state is evaluated at
+the same point in the epoch-boundary pipeline as Haskell ledger ratification.
+The intended model is:
+
+```text
+Phase 1: enact previously ratified actions
+         NoConfidence/UpdateCommittee updates committee presence
+
+Phase 2: ratify currently active proposals
+         threshold selection uses committee presence after Phase 1 enactment
+```
+
+All proposals evaluated in the same Phase 2 pass must see that same
+post-Phase-1 snapshot. They must not observe state changes from other proposals
+ratified during that Phase 2 pass, because those proposals are only enacted at a
+later boundary.
+
+Because the state is epoch-boundary state, tests should make the epoch used for
+ratification explicit. Ambiguous tests can pass while still using the wrong
+previous/current state.

--- a/adr/ledger-state/029-dynamic-transaction-validation-context.md
+++ b/adr/ledger-state/029-dynamic-transaction-validation-context.md
@@ -1,0 +1,240 @@
+# ADR-029: Dynamic Transaction Validation Context
+
+## Status
+
+Proposed
+
+## Date
+
+2026-06-01
+
+## Context
+
+Yano wires transaction validation and script evaluation in `YanoProducer` by
+creating `TransactionValidator` and `TransactionEvaluator` instances once during
+node construction.
+
+ADR-022 made `EpochParamTracker` the source of full epoch-effective protocol
+parameter snapshots. ADR-024 then changed transaction validation and evaluation
+to resolve protocol parameters from those snapshots at runtime when
+epoch-parameter tracking is enabled.
+
+That fixes stale protocol parameters for epoch transitions, but one part of the
+transaction context is still fixed at construction time: `SlotConfig`.
+
+This matters for devnet past-time-travel mode. `/devnet/epochs/shift` changes
+the effective Shelley `systemStart`, persists it into `shelley-genesis.json`,
+updates `YanoConfig.genesisTimestamp`, replaces `genesisConfig`, and rebuilds
+`SlotTimeCalculator`. Any validator or evaluator that already captured the old
+`SlotConfig` can continue using a stale zero time even though the node runtime
+has moved to the shifted genesis time.
+
+The transaction context used by validation and evaluation therefore has two
+time-varying inputs:
+
+- protocol parameters, because they can change at epoch boundaries through
+  protocol updates and Conway governance enactment
+- slot timing, because devnet past-time-travel can change the effective Shelley
+  start time after evaluator/validator construction
+
+## Problem
+
+The current architecture has inconsistent refresh behavior:
+
+```text
+ProtocolParams
+  dynamic when epoch-param tracking is enabled
+  static when using protocol-param.json fallback
+
+SlotConfig
+  always captured once in YanoProducer
+```
+
+This can cause two classes of bugs.
+
+First, if epoch-effective protocol parameters change, every validation and
+evaluation path must use the parameters for the epoch containing the current
+runtime slot. A stale parameter set can incorrectly accept or reject
+transactions after an epoch boundary.
+
+Second, if devnet past-time-travel changes Shelley `systemStart`, every
+validation and evaluation path must use the shifted `SlotConfig`. A stale
+`zeroTime` can make validity interval and script-context time calculations
+disagree with the blocks that Yano is producing.
+
+Recreating validators after every context change would be fragile. It would
+require every mutation path to know which validator/evaluator objects exist and
+would risk missing REST, mempool, or alternative evaluator paths.
+
+## Decision
+
+Transaction validation and script evaluation will resolve their complete
+transaction validation context at call time.
+
+Protocol parameters remain supplied by `EpochProtocolParamsSupplier`:
+
+```java
+ProtocolParams getProtocolParams(long slot);
+```
+
+Slot timing will be supplied by a new dynamic slot-config contract:
+
+```java
+SlotConfig getSlotConfig();
+```
+
+The node app will provide a runtime implementation that builds a fresh CCL
+`SlotConfig` from the current Yano runtime state. The supplier must resolve the
+genesis time in this order:
+
+1. `YanoConfig.getGenesisTimestamp()` when it is positive
+2. `Yano.getResolvedGenesisTimestamp()` when it is positive
+3. parsed Shelley `systemStart` from loaded genesis data
+4. fail with a clear error if no valid genesis time is available
+
+The supplier's returned `SlotConfig.zeroTime` is always epoch milliseconds.
+`YanoConfig.getGenesisTimestamp()`, `Yano.getResolvedGenesisTimestamp()`, and
+parsed Shelley `systemStart` values must be normalized to epoch milliseconds
+before constructing the CCL `SlotConfig`. If a source API returns epoch seconds,
+convert it before building the slot config. Raw configurable values that are
+expected to be milliseconds must not be silently interpreted as seconds; fail
+or log a clear configuration error when the units are ambiguous.
+
+The supplier must also preserve Yano's slot-length derivation semantics. Use
+`YanoConfig.getSlotLengthMillis()` when it is positive. When it is zero or
+negative, derive the length from loaded Shelley genesis `slotLength * 1000`.
+If Shelley slot length is unavailable or invalid, use the existing runtime
+fallback of `1000ms` and log the fallback.
+
+For public networks, the value should normally settle on the Shelley
+`systemStart` loaded from genesis. For devnet past-time-travel, the value should
+follow the updated `YanoConfig.genesisTimestamp` after
+`shiftGenesisAndStartProducer`.
+
+The current runtime slot must continue to come from the node tip or equivalent
+runtime slot supplier. Transaction validity-start must not be used as a
+replacement for the ledger current slot in the node validation path.
+
+Callers with static protocol parameters should wrap them as an
+`EpochProtocolParamsSupplier`, for example `slot -> staticProtocolParams`. This
+keeps Scalus validator/evaluator construction on one protocol-parameter contract
+while still supporting `protocol-param.json` bootstrap/devnet fallback mode.
+Fixed `SlotConfig` overloads may remain for isolated tests and standalone
+consumers, but node production wiring should use dynamic protocol-parameter and
+slot-config suppliers.
+
+## Design
+
+Add a small `SlotConfigSupplier` interface in `ledger-rules` or another shared
+module already visible to evaluator implementations.
+
+Update Scalus bridge dynamic factory overloads so the node wiring can pass:
+
+- `EpochProtocolParamsSupplier`
+- `SlotConfigSupplier`
+- current-slot `LongSupplier`
+- optional current-epoch resolver for supplementary CCL rules
+
+`ScalusBasedTransactionValidator` should resolve, per `validate` call:
+
+1. current runtime slot
+2. epoch-effective protocol parameters for that slot
+3. current slot config
+
+It should then pass the resolved slot config into `LedgerBridge.validate`.
+
+`ScalusBasedTransactionEvaluator` should resolve the same context per
+`evaluate` call before constructing `ScalusTransactionEvaluator`.
+
+Each evaluator bridge must convert from the dynamic CCL `SlotConfig` into the
+target library's slot-config type through a small adapter/helper. Do not assume
+constructor argument order or units are identical across CCL, Scalus, JULC, and
+Aiken. The adapter must preserve epoch-millisecond `zeroTime`, `zeroSlot`, and
+millisecond `slotLength` according to the target library's expected constructor
+shape.
+
+The non-Scalus script evaluator paths must not keep a stale slot config either.
+Add supplier-based overloads for `AikenTxEvaluator` and `JulcTxEvaluator`, or
+wrap their construction so each evaluation uses a slot config produced from the
+same runtime supplier. If those evaluator libraries only accept fixed slot
+config at construction time, construct the library evaluator inside each
+`evaluate` call using the current supplied slot config.
+
+`YanoProducer.initTransactionEvaluator` should build one runtime slot-config
+supplier and pass it to every validator/evaluator path. Static
+`protocol-param.json` fallback mode may keep static protocol parameters, but it
+must still use the dynamic slot-config supplier in devnet/block-producer paths.
+
+`Yano.shiftGenesisAndStartProducer` should not directly recreate validators or
+evaluators. Its existing updates to config/genesis/slot-time state are the
+single source consumed by the dynamic supplier.
+
+## Consequences
+
+Positive:
+
+- Validation and evaluation use epoch-effective protocol parameters after epoch
+  transitions.
+- Devnet past-time-travel updates to Shelley `systemStart` are reflected without
+  rebuilding validators.
+- REST evaluation, mempool validation, and block production validation can share
+  the same runtime context behavior.
+- Static constructors remain available for focused tests and non-node usage.
+
+Tradeoffs:
+
+- Validation and evaluation do a small amount of extra context resolution per
+  call.
+- Runtime wiring must expose genesis time through a clear API rather than
+  relying on a construction-time local variable.
+- Tests must cover dynamic slot timing as well as dynamic protocol parameters.
+
+## Implementation Notes
+
+The runtime slot-config supplier should create a new `SlotConfig` value rather
+than mutating an existing one. This keeps validator and evaluator code simple
+and avoids sharing mutable config across concurrent requests.
+
+The supplier should use the current resolved slot length from `YanoConfig` or
+derive it from loaded Shelley genesis using the same logic as the block producer
+startup path. This ADR does not introduce dynamic slot-length changes during a
+running process.
+
+If protocol-parameter tracking is enabled and no effective snapshot exists for
+the current epoch, validation should fail clearly rather than silently pinning
+to a stale fallback. Static `protocol-param.json` remains a bootstrap/devnet
+fallback only when epoch-parameter tracking is disabled.
+
+## Tests
+
+Add or update tests for these scenarios:
+
+1. `EffectiveProtocolParamsSupplier` refreshes when the current slot maps to a
+   new epoch.
+2. Scalus validator dynamic wiring asks the protocol-parameter supplier on each
+   validation call using the current runtime slot.
+3. Scalus evaluator dynamic wiring asks the protocol-parameter supplier on each
+   evaluation call using the current runtime slot.
+4. Dynamic slot-config supplier returns an updated `zeroTime` after
+   `YanoConfig.genesisTimestamp` changes.
+5. Dynamic slot-config supplier returns `zeroTime` in epoch milliseconds and
+   rejects or clearly reports ambiguous raw seconds-looking inputs.
+6. Dynamic slot-config supplier preserves `slotLengthMillis == 0`
+   auto-derivation from Shelley genesis and the existing `1000ms` fallback.
+7. Evaluator-specific slot-config adapters preserve `zeroTime`, `zeroSlot`,
+   and `slotLength` despite constructor order differences.
+8. Devnet past-time-travel initializes validation/evaluation before epoch
+   shift, calls `/devnet/epochs/shift`, and then validates/evaluates with the
+   shifted Shelley start time.
+9. Aiken and Julc evaluator paths use the latest supplied slot config, or tests
+   document and guard any intentionally unsupported dynamic path.
+10. Static fallback mode keeps static protocol parameters but picks up dynamic
+   slot config when the runtime genesis timestamp changes.
+
+Focused test commands:
+
+```text
+./gradlew :scalus-bridge:test
+./gradlew :runtime:test --tests '*EffectiveProtocolParamsSupplierTest' --tests '*Slot*'
+./gradlew :app:test --tests '*Devnet*' --tests '*Evaluation*'
+```

--- a/app/config/network/devnet/conway-genesis.json
+++ b/app/config/network/devnet/conway-genesis.json
@@ -335,8 +335,8 @@
     "members": {
     },
     "threshold": {
-      "numerator": 2,
-      "denominator": 3
+      "numerator": 0,
+      "denominator": 1
     }
   }
 }

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/RuntimeSlotConfigSupplier.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/RuntimeSlotConfigSupplier.java
@@ -1,0 +1,90 @@
+package com.bloxbean.cardano.yano.app;
+
+import com.bloxbean.cardano.client.common.model.SlotConfig;
+import com.bloxbean.cardano.yano.api.config.YanoConfig;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
+import com.bloxbean.cardano.yano.runtime.blockproducer.GenesisConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.function.LongSupplier;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Resolves the current node slot timing for transaction validation/evaluation.
+ */
+final class RuntimeSlotConfigSupplier implements SlotConfigSupplier {
+
+    private static final Logger log = LoggerFactory.getLogger(RuntimeSlotConfigSupplier.class);
+    // Epoch seconds for modern Cardano genesis times are around 1_500_000_000.
+    // Milliseconds are three orders of magnitude larger; this catches seconds
+    // accidentally passed into SlotConfig.zeroTime without constraining slot length.
+    private static final long MIN_EPOCH_MILLIS_FOR_SECONDS_DETECTION = 10_000_000_000L;
+
+    private final YanoConfig config;
+    private final LongSupplier resolvedGenesisTimestampSupplier;
+    private final GenesisConfig genesisConfig;
+    private final AtomicBoolean slotLengthFallbackLogged = new AtomicBoolean();
+
+    RuntimeSlotConfigSupplier(YanoConfig config,
+                              LongSupplier resolvedGenesisTimestampSupplier,
+                              GenesisConfig genesisConfig) {
+        this.config = Objects.requireNonNull(config, "config must not be null");
+        this.resolvedGenesisTimestampSupplier = Objects.requireNonNull(
+                resolvedGenesisTimestampSupplier, "resolvedGenesisTimestampSupplier must not be null");
+        this.genesisConfig = genesisConfig;
+    }
+
+    @Override
+    public SlotConfig getSlotConfig() {
+        return new SlotConfig(resolveSlotLengthMillis(), 0, resolveZeroTimeMillis());
+    }
+
+    long resolveZeroTimeMillis() {
+        long configured = config.getGenesisTimestamp();
+        if (configured > 0) {
+            return requireEpochMillis(configured, "yano.block-producer.genesis-timestamp");
+        }
+
+        long resolved = resolvedGenesisTimestampSupplier.getAsLong();
+        if (resolved > 0) {
+            return requireEpochMillis(resolved, "resolved genesis timestamp");
+        }
+
+        if (genesisConfig != null) {
+            long systemStart = genesisConfig.getSystemStartEpochMillis();
+            if (systemStart > 0) {
+                return requireEpochMillis(systemStart, "Shelley systemStart");
+            }
+        }
+
+        throw new IllegalStateException("Cannot resolve SlotConfig zeroTime: no valid genesis timestamp is available");
+    }
+
+    int resolveSlotLengthMillis() {
+        int configured = config.getSlotLengthMillis();
+        if (configured > 0) {
+            return configured;
+        }
+
+        if (genesisConfig != null
+                && genesisConfig.getShelleyGenesisData() != null
+                && genesisConfig.getShelleyGenesisData().slotLength() > 0) {
+            return (int) (genesisConfig.getShelleyGenesisData().slotLength() * 1000);
+        }
+
+        if (slotLengthFallbackLogged.compareAndSet(false, true)) {
+            log.info("No valid Shelley slotLength available for transaction SlotConfig; using default slotLengthMillis=1000");
+        }
+        return 1000;
+    }
+
+    private static long requireEpochMillis(long value, String source) {
+        if (value < MIN_EPOCH_MILLIS_FOR_SECONDS_DETECTION) {
+            throw new IllegalStateException(source + " must be epoch milliseconds, got " + value
+                    + " which looks like epoch seconds");
+        }
+        return value;
+    }
+}

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
@@ -8,10 +8,10 @@ import com.bloxbean.cardano.yano.api.config.RuntimeOptions;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.app.bootstrap.BootstrapConfigParser;
 import com.bloxbean.cardano.client.api.model.ProtocolParams;
-import com.bloxbean.cardano.client.common.model.SlotConfig;
 import com.bloxbean.cardano.yaci.core.common.Constants;
 import com.bloxbean.cardano.yano.api.account.LedgerStateProvider;
 import com.bloxbean.cardano.yano.ledgerrules.EpochProtocolParamsSupplier;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionValidator;
 import com.bloxbean.cardano.yano.runtime.Yano;
@@ -784,13 +784,12 @@ public class YanoProducer {
         // epoch-param tracking is enabled; otherwise protocol-param.json is an explicit
         // static source for devnet/custom quick setups.
         GenesisConfig genesis;
-        SlotConfig slotConfig;
+        SlotConfigSupplier slotConfigSupplier;
         int networkId;
         EpochProtocolParamsSupplier protocolParamsSupplier;
         LongSupplier currentSlotSupplier;
         EpochSlotCalc epochSlotCalc;
         String protocolParamsSource;
-        ProtocolParams staticProtocolParams = null;
         try {
             genesis = GenesisConfig.load(
                     yaciConfig.getShelleyGenesisFile(),
@@ -809,7 +808,6 @@ public class YanoProducer {
                     return;
                 }
                 ProtocolParams staticParams = ProtocolParamsMapper.fromNodeProtocolParam(genesis.getProtocolParameters());
-                staticProtocolParams = staticParams;
                 protocolParamsSupplier = slot -> staticParams;
                 protocolParamsSource = "static-protocol-param-json";
             }
@@ -817,17 +815,16 @@ public class YanoProducer {
                 var tip = yaciNode.getLocalTip();
                 return tip != null ? tip.getSlot() : -1L;
             };
+            slotConfigSupplier = new RuntimeSlotConfigSupplier(
+                    yaciConfig, yaciNode::getResolvedGenesisTimestamp, genesis);
 
             long magic = yaciConfig.getProtocolMagic();
 
-            long genesisTs = yaciConfig.getGenesisTimestamp() > 0
-                    ? yaciConfig.getGenesisTimestamp()
-                    : genesis.getSystemStartEpochMillis() > 0
-                    ? genesis.getSystemStartEpochMillis()
-                    : System.currentTimeMillis();
-            slotConfig = new SlotConfig(yaciConfig.getSlotLengthMillis(), 0, genesisTs);
-
-            log.info("Yano slot config: {}", slotConfig);
+            var initialSlotConfig = slotConfigSupplier.getSlotConfig();
+            log.info("Yano transaction slot config: slotLengthMillis={}, zeroSlot={}, zeroTimeMillis={}",
+                    initialSlotConfig.getSlotLength(),
+                    initialSlotConfig.getZeroSlot(),
+                    initialSlotConfig.getZeroTime());
 
             networkId = magic == Constants.MAINNET_PROTOCOL_MAGIC ? 1 : 0;
         } catch (Exception e) {
@@ -844,14 +841,10 @@ public class YanoProducer {
         // Initialize TransactionValidator (Scalus) — validates transactions on submission
         boolean validatorInitialized = false;
         try {
-            TransactionValidator evaluator = staticProtocolParams != null
-                    ? ScalusTransactionFactory.createValidator(staticProtocolParams,
-                            new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfig, networkId,
-                            ledgerStateProvider, supplementaryRulesEnabled)
-                    : ScalusTransactionFactory.createValidator(protocolParamsSupplier,
-                            new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfig, networkId,
-                            ledgerStateProvider, currentSlotSupplier,
-                            epochSlotCalc::slotToEpoch, supplementaryRulesEnabled);
+            TransactionValidator evaluator = ScalusTransactionFactory.createValidator(protocolParamsSupplier,
+                    new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfigSupplier, networkId,
+                    ledgerStateProvider, currentSlotSupplier, epochSlotCalc::slotToEpoch,
+                    effectiveEpochParamsTrackingEnabled, supplementaryRulesEnabled);
             yaciNode.setTransactionEvaluator(evaluator);
             validatorInitialized = true;
             log.info("Transaction validator initialized (networkId={}, protocolParams={}, supplementaryRules={})",
@@ -866,19 +859,16 @@ public class YanoProducer {
         try {
             TransactionEvaluator transactionEvaluator;
             if ("scalus".equalsIgnoreCase(scriptEvaluator)) {
-                transactionEvaluator = staticProtocolParams != null
-                        ? ScalusTransactionFactory.createEvaluator(staticProtocolParams,
-                                new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfig, networkId)
-                        : ScalusTransactionFactory.createEvaluator(protocolParamsSupplier,
-                                new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfig, networkId, currentSlotSupplier);
+                transactionEvaluator = ScalusTransactionFactory.createEvaluator(protocolParamsSupplier,
+                        new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfigSupplier, networkId, currentSlotSupplier);
             } else if ("julc".equalsIgnoreCase(scriptEvaluator)) {
                 transactionEvaluator = new JulcTxEvaluator(
                         () -> protocolParamsSupplier.getProtocolParams(resolveRuntimeCurrentSlot(currentSlotSupplier)),
-                        new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfig);
+                        new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfigSupplier);
             } else {
                 transactionEvaluator = new AikenTxEvaluator(
                         () -> protocolParamsSupplier.getProtocolParams(resolveRuntimeCurrentSlot(currentSlotSupplier)),
-                        new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfig);
+                        new YaciScriptSupplier(yaciNode.getUtxoState()), slotConfigSupplier);
             }
             yaciNode.setScriptEvaluator(transactionEvaluator);
             evaluatorInitialized = true;

--- a/app/src/test/java/com/bloxbean/cardano/yano/app/RuntimeSlotConfigSupplierTest.java
+++ b/app/src/test/java/com/bloxbean/cardano/yano/app/RuntimeSlotConfigSupplierTest.java
@@ -1,0 +1,121 @@
+package com.bloxbean.cardano.yano.app;
+
+import com.bloxbean.cardano.yano.api.config.YanoConfig;
+import com.bloxbean.cardano.yano.runtime.blockproducer.GenesisConfig;
+import com.bloxbean.cardano.yano.runtime.genesis.ShelleyGenesisData;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class RuntimeSlotConfigSupplierTest {
+
+    @Test
+    void resolvesZeroTimeFromShelleySystemStartAsEpochMillis() {
+        var config = YanoConfig.devnetDefault(13337);
+        var systemStart = "2026-06-01T00:00:00Z";
+        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis(systemStart, 2.0));
+
+        var slotConfig = supplier.getSlotConfig();
+
+        assertEquals(Instant.parse(systemStart).toEpochMilli(), slotConfig.getZeroTime());
+        assertEquals(2_000, slotConfig.getSlotLength());
+        assertEquals(0, slotConfig.getZeroSlot());
+    }
+
+    @Test
+    void configuredGenesisTimestampOverridesCapturedGenesisAfterRuntimeShift() {
+        var config = YanoConfig.devnetDefault(13337);
+        var supplier = new RuntimeSlotConfigSupplier(
+                config,
+                () -> Instant.parse("2026-06-01T00:00:00Z").toEpochMilli(),
+                genesis("2026-06-01T00:00:00Z", 1.0));
+        long shiftedMillis = Instant.parse("2026-05-31T00:00:00Z").toEpochMilli();
+
+        config.setGenesisTimestamp(shiftedMillis);
+
+        assertEquals(shiftedMillis, supplier.getSlotConfig().getZeroTime());
+    }
+
+    @Test
+    void resolvedGenesisTimestampOverridesLoadedShelleySystemStart() {
+        var config = YanoConfig.devnetDefault(13337);
+        long resolvedMillis = Instant.parse("2026-05-31T00:00:00Z").toEpochMilli();
+        var supplier = new RuntimeSlotConfigSupplier(
+                config,
+                () -> resolvedMillis,
+                genesis("2026-06-01T00:00:00Z", 1.0));
+
+        assertEquals(resolvedMillis, supplier.getSlotConfig().getZeroTime());
+    }
+
+    @Test
+    void rejectsSecondsLookingConfiguredGenesisTimestamp() {
+        var config = YanoConfig.devnetDefault(13337);
+        config.setGenesisTimestamp(1_780_000_000L);
+        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis("2026-06-01T00:00:00Z", 1.0));
+
+        var error = assertThrows(IllegalStateException.class, supplier::getSlotConfig);
+
+        assertEquals("yano.block-producer.genesis-timestamp must be epoch milliseconds, got 1780000000 "
+                + "which looks like epoch seconds", error.getMessage());
+    }
+
+    @Test
+    void derivesSlotLengthFromGenesisWhenConfigUsesAutoValue() {
+        var config = YanoConfig.devnetDefault(13337);
+        config.setSlotLengthMillis(0);
+        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis("2026-06-01T00:00:00Z", 0.25));
+
+        assertEquals(250, supplier.getSlotConfig().getSlotLength());
+    }
+
+    @Test
+    void usesExistingRuntimeSlotLengthFallbackWhenGenesisSlotLengthUnavailable() {
+        var config = YanoConfig.devnetDefault(13337);
+        config.setSlotLengthMillis(0);
+        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis("2026-06-01T00:00:00Z", 0));
+
+        assertEquals(1_000, supplier.getSlotConfig().getSlotLength());
+    }
+
+    private static GenesisConfig genesis(String systemStart, double slotLengthSeconds) {
+        return GenesisConfig.fromInMemory(
+                new ShelleyGenesisData(
+                        Map.of(),
+                        42,
+                        100,
+                        slotLengthSeconds,
+                        systemStart,
+                        45_000_000_000_000_000L,
+                        1.0,
+                        10,
+                        10,
+                        10,
+                        1,
+                        10,
+                        0,
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO,
+                        1,
+                        0,
+                        0,
+                        0,
+                        BigDecimal.ZERO,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        null,
+                        0),
+                null,
+                null);
+    }
+}

--- a/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/SlotConfigSupplier.java
+++ b/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/SlotConfigSupplier.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yano.ledgerrules;
+
+import com.bloxbean.cardano.client.common.model.SlotConfig;
+
+/**
+ * Supplies the slot timing configuration used by transaction validation and evaluation.
+ */
+@FunctionalInterface
+public interface SlotConfigSupplier {
+
+    SlotConfig getSlotConfig();
+}

--- a/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/impl/AikenTxEvaluator.java
+++ b/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/impl/AikenTxEvaluator.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.api.UtxoSupplier;
 import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.model.Utxo;
 import com.bloxbean.cardano.client.common.model.SlotConfig;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 
 import java.util.List;
@@ -15,15 +16,20 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 public class AikenTxEvaluator implements TransactionEvaluator {
-    private ProtocolParamsSupplier protocolParamsSupplier;
-    private ScriptSupplier scriptSupplier;
-    private SlotConfig slotConfig;
+    private final ProtocolParamsSupplier protocolParamsSupplier;
+    private final ScriptSupplier scriptSupplier;
+    private final SlotConfigSupplier slotConfigSupplier;
 
     public AikenTxEvaluator(ProtocolParamsSupplier protocolParamsSupplier,
                             ScriptSupplier scriptSupplier, SlotConfig slotConfig) {
+        this(protocolParamsSupplier, scriptSupplier, () -> slotConfig);
+    }
+
+    public AikenTxEvaluator(ProtocolParamsSupplier protocolParamsSupplier,
+                            ScriptSupplier scriptSupplier, SlotConfigSupplier slotConfigSupplier) {
         this.protocolParamsSupplier = protocolParamsSupplier;
         this.scriptSupplier = scriptSupplier;
-        this.slotConfig = slotConfig;
+        this.slotConfigSupplier = slotConfigSupplier;
     }
 
     @Override
@@ -42,7 +48,8 @@ public class AikenTxEvaluator implements TransactionEvaluator {
             }
         };
 
-        var aikenTxEvaluator = new AikenTransactionEvaluator(utxoSupplier, protocolParamsSupplier, scriptSupplier, slotConfig);
+        var aikenTxEvaluator = new AikenTransactionEvaluator(
+                utxoSupplier, protocolParamsSupplier, scriptSupplier, slotConfigSupplier.getSlotConfig());
 
         var aikenEvaluationResult =  aikenTxEvaluator.evaluateTx(txCbor, inputUtxos);
 

--- a/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/impl/JulcTxEvaluator.java
+++ b/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/impl/JulcTxEvaluator.java
@@ -8,6 +8,7 @@ import com.bloxbean.cardano.client.api.model.Utxo;
 
 import com.bloxbean.cardano.julc.clientlib.eval.JulcTransactionEvaluator;
 import com.bloxbean.cardano.julc.clientlib.eval.SlotConfig;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 
 import java.util.List;
@@ -18,14 +19,18 @@ import java.util.stream.Collectors;
 public class JulcTxEvaluator implements TransactionEvaluator {
     private final ProtocolParamsSupplier protocolParamsSupplier;
     private final ScriptSupplier scriptSupplier;
-    private final com.bloxbean.cardano.julc.clientlib.eval.SlotConfig slotConfig;
+    private final SlotConfigSupplier slotConfigSupplier;
 
     public JulcTxEvaluator(ProtocolParamsSupplier protocolParamsSupplier,
                            ScriptSupplier scriptSupplier, com.bloxbean.cardano.client.common.model.SlotConfig slotConfig) {
+        this(protocolParamsSupplier, scriptSupplier, () -> slotConfig);
+    }
+
+    public JulcTxEvaluator(ProtocolParamsSupplier protocolParamsSupplier,
+                           ScriptSupplier scriptSupplier, SlotConfigSupplier slotConfigSupplier) {
         this.protocolParamsSupplier = protocolParamsSupplier;
         this.scriptSupplier = scriptSupplier;
-        this.slotConfig =
-                new SlotConfig(slotConfig.getZeroSlot(), slotConfig.getZeroTime(), slotConfig.getSlotLength());
+        this.slotConfigSupplier = slotConfigSupplier;
     }
 
     @Override
@@ -44,7 +49,9 @@ public class JulcTxEvaluator implements TransactionEvaluator {
             }
         };
 
-        var txEvaluator = new JulcTransactionEvaluator(utxoSupplier, protocolParamsSupplier, scriptSupplier, slotConfig);
+        var txEvaluator = new JulcTransactionEvaluator(
+                utxoSupplier, protocolParamsSupplier, scriptSupplier,
+                toJulcSlotConfig(slotConfigSupplier.getSlotConfig()));
 
         var evaluationResult =  txEvaluator.evaluateTx(txCbor, inputUtxos);
 
@@ -59,5 +66,9 @@ public class JulcTxEvaluator implements TransactionEvaluator {
                         er.getExUnits().getMem().longValueExact(),
                         er.getExUnits().getSteps().longValueExact()))
                 .collect(Collectors.toList());
+    }
+
+    static SlotConfig toJulcSlotConfig(com.bloxbean.cardano.client.common.model.SlotConfig slotConfig) {
+        return new SlotConfig(slotConfig.getZeroSlot(), slotConfig.getZeroTime(), slotConfig.getSlotLength());
     }
 }

--- a/ledger-rules/src/test/java/com/bloxbean/cardano/yano/ledgerrules/impl/AikenTxEvaluatorTest.java
+++ b/ledger-rules/src/test/java/com/bloxbean/cardano/yano/ledgerrules/impl/AikenTxEvaluatorTest.java
@@ -1,0 +1,33 @@
+package com.bloxbean.cardano.yano.ledgerrules.impl;
+
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class AikenTxEvaluatorTest {
+
+    @Test
+    void evaluateUsesDynamicSlotConfigSupplierPerCall() {
+        var zeroTime = new AtomicLong(1_780_000_000_000L);
+        var evaluator = new AikenTxEvaluator(
+                ProtocolParams::new,
+                null,
+                () -> {
+                    throw new IllegalStateException("zeroTime " + zeroTime.get());
+                });
+
+        var first = assertThrows(IllegalStateException.class,
+                () -> evaluator.evaluate(new byte[0], Set.of()));
+        zeroTime.set(1_780_000_001_000L);
+        var second = assertThrows(IllegalStateException.class,
+                () -> evaluator.evaluate(new byte[0], Set.of()));
+
+        assertEquals("zeroTime 1780000000000", first.getMessage());
+        assertEquals("zeroTime 1780000001000", second.getMessage());
+    }
+}

--- a/ledger-rules/src/test/java/com/bloxbean/cardano/yano/ledgerrules/impl/JulcTxEvaluatorTest.java
+++ b/ledger-rules/src/test/java/com/bloxbean/cardano/yano/ledgerrules/impl/JulcTxEvaluatorTest.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yano.ledgerrules.impl;
+
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
+import com.bloxbean.cardano.client.common.model.SlotConfig;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class JulcTxEvaluatorTest {
+
+    @Test
+    void evaluateUsesDynamicSlotConfigSupplierPerCall() {
+        var zeroTime = new AtomicLong(1_780_000_000_000L);
+        var evaluator = new JulcTxEvaluator(
+                ProtocolParams::new,
+                null,
+                () -> {
+                    throw new IllegalStateException("zeroTime " + zeroTime.get());
+                });
+
+        var first = assertThrows(IllegalStateException.class,
+                () -> evaluator.evaluate(new byte[0], Set.of()));
+        zeroTime.set(1_780_000_001_000L);
+        var second = assertThrows(IllegalStateException.class,
+                () -> evaluator.evaluate(new byte[0], Set.of()));
+
+        assertEquals("zeroTime 1780000000000", first.getMessage());
+        assertEquals("zeroTime 1780000001000", second.getMessage());
+    }
+
+    @Test
+    void julcSlotConfigAdapterPreservesUnitsAndOrder() {
+        var ccl = new SlotConfig(2_000, 42, 1_780_000_000_000L);
+
+        var julc = JulcTxEvaluator.toJulcSlotConfig(ccl);
+
+        assertEquals(42L, julc.zeroSlot());
+        assertEquals(1_780_000_000_000L, julc.zeroSlotPosixMs());
+        assertEquals(2_000L, julc.slotLengthMs());
+    }
+}

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ConwayGenesisBootstrap.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ConwayGenesisBootstrap.java
@@ -52,6 +52,7 @@ public class ConwayGenesisBootstrap {
                 return false;
             }
 
+            governanceStore.storeCommitteePresent(true, batch, deltaOps);
             int committeeCount = bootstrapCommittee(genesis, conwayFirstEpoch, batch, deltaOps);
             boolean constitutionSet = bootstrapConstitution(genesis, batch, deltaOps);
             bootstrapGovParams(genesis);

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/GovernanceStateStore.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/GovernanceStateStore.java
@@ -44,6 +44,7 @@ public class GovernanceStateStore {
     static final byte PREFIX_PROPOSAL_SUBMISSION = 0x6D; // Permanent proposal submission metadata: slot → (epoch, govActionLifetime)
     static final byte PREFIX_NUM_DORMANT_EPOCHS = 0x6E; // Singleton key for cumulative dormant epoch counter (Haskell flush semantics)
     static final byte PREFIX_ERA_FIRST_EPOCH = 0x6F;    // Per-protocol-version first epoch: key = 0x6F + protoMajor(1 byte)
+    static final byte PREFIX_COMMITTEE_PRESENT = 0x70;  // Singleton key: 1 = SJust committee, 0 = SNothing committee
 
     // Delta op types — same values as DefaultAccountStateStore
     private static final byte OP_PUT = 0x01;
@@ -191,6 +192,10 @@ public class GovernanceStateStore {
     /** Singleton key for committee quorum threshold */
     static byte[] committeeThresholdKey() {
         return new byte[]{PREFIX_COMMITTEE_THRESHOLD};
+    }
+
+    static byte[] committeePresentKey() {
+        return new byte[]{PREFIX_COMMITTEE_PRESENT};
     }
 
     // ===== Proposal operations =====
@@ -444,6 +449,20 @@ public class GovernanceStateStore {
     public Optional<GovernanceCborCodec.CommitteeThreshold> getCommitteeThreshold() throws RocksDBException {
         byte[] val = db.get(cfState, committeeThresholdKey());
         return val != null ? Optional.of(GovernanceCborCodec.decodeCommitteeThreshold(val)) : Optional.empty();
+    }
+
+    // ===== Committee Presence =====
+
+    public void storeCommitteePresent(boolean present, WriteBatch batch, List<DeltaOp> deltaOps) throws RocksDBException {
+        byte[] key = committeePresentKey();
+        byte[] prev = db.get(cfState, key);
+        batch.put(cfState, key, new byte[]{(byte) (present ? 1 : 0)});
+        deltaOps.add(new DeltaOp(OP_PUT, key, prev));
+    }
+
+    public boolean isCommitteePresent() throws RocksDBException {
+        byte[] val = db.get(cfState, committeePresentKey());
+        return val == null || val.length == 0 || val[0] != 0;
     }
 
     // ===== Constitution =====

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/GovernanceEpochProcessor.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/GovernanceEpochProcessor.java
@@ -284,26 +284,22 @@ public class GovernanceEpochProcessor {
                                                    WriteBatch batch, List<DeltaOp> deltaOps)
             throws RocksDBException {
 
-        // Bootstrap Conway genesis on first Conway epoch only (committee, constitution, params).
-        // Uses EraProvider instead of protocolMajor — PV is unreliable.
-        // For fresh devnets starting post-bootstrap in Conway-or-later, resolvedConwayEpoch=0
-        // and the first boundary (epoch 0→1) will see (0-1) < 0 as false, then 1 >= 0 as true,
-        // triggering bootstrap. For synced chains, this detects the actual Conway transition.
+        // Bootstrap Conway genesis once when Conway is reachable. Fresh devnets can start
+        // directly in Conway at epoch 0, so there is no Byron/Babbage -> Conway boundary.
         if (!genesisBootstrapped && eraProvider != null) {
             Integer resolvedConwayEpoch = eraProvider.resolveFirstConwayEpochOrNull();
-            if (resolvedConwayEpoch != null && (newEpoch - 1) >= resolvedConwayEpoch) {
-                // Previous epoch was Conway — genesis already bootstrapped in a prior run
-                log.info("Conway genesis already bootstrapped (firstConwayEpoch={}, epoch {} is past), skipping",
-                        resolvedConwayEpoch, newEpoch);
-                genesisBootstrapped = true;
-            } else if (resolvedConwayEpoch != null && newEpoch >= resolvedConwayEpoch) {
-                // This is the first Conway epoch — bootstrap genesis
+            if (resolvedConwayEpoch != null && newEpoch >= resolvedConwayEpoch) {
                 if (conwayFirstEpoch < 0) {
                     conwayFirstEpoch = resolvedConwayEpoch;
                 }
-                genesisBootstrap.bootstrap(conwayFirstEpoch, batch, deltaOps);
-                governanceStore.storeEraFirstEpoch(9, conwayFirstEpoch, batch, deltaOps);
-                genesisBootstrapped = true;
+                if (isConwayGenesisBootstrapPersisted(resolvedConwayEpoch)) {
+                    log.info("Conway genesis already bootstrapped (firstConwayEpoch={}, epoch {}), skipping",
+                            resolvedConwayEpoch, newEpoch);
+                    genesisBootstrapped = true;
+                } else if (genesisBootstrap.bootstrap(conwayFirstEpoch, batch, deltaOps)) {
+                    governanceStore.storeEraFirstEpoch(9, conwayFirstEpoch, batch, deltaOps);
+                    genesisBootstrapped = true;
+                }
             }
             // If resolvedConwayEpoch is null: Conway not reached yet, no bootstrap
         }
@@ -561,8 +557,9 @@ public class GovernanceEpochProcessor {
         BigDecimal committeeThreshold = resolveCommitteeThreshold();
         String committeeState = resolveCommitteeState(committeeMembers, newEpoch);
         Map<GovActionType, GovActionId> lastEnactedActions = resolveLastEnactedActions();
-        Map<GovActionType, BigDecimal> drepThresholds = resolveDRepThresholds(isBootstrapPhase, newEpoch);
-        Map<GovActionType, BigDecimal> spoThresholds = resolveSPOThresholds(newEpoch);
+        Map<GovActionType, BigDecimal> drepThresholds =
+                resolveDRepThresholds(isBootstrapPhase, newEpoch, committeeState);
+        Map<GovActionType, BigDecimal> spoThresholds = resolveSPOThresholds(newEpoch, committeeState);
         int committeeMinSize = resolveCommitteeMinSize(newEpoch);
         int committeeMaxTermLength = resolveCommitteeMaxTermLength(newEpoch);
 
@@ -824,14 +821,16 @@ public class GovernanceEpochProcessor {
         return BigDecimal.ONE;
     }
 
+    private boolean isConwayGenesisBootstrapPersisted(int resolvedConwayEpoch) throws RocksDBException {
+        int storedConwayEpoch = governanceStore.getConwayFirstEpoch();
+        return storedConwayEpoch == resolvedConwayEpoch && governanceStore.getCommitteeThreshold().isPresent();
+    }
+
     private String resolveCommitteeState(Map<CredentialKey, CommitteeMemberRecord> members,
-                                         int epoch) {
-        // If no members exist at all, treat as NO_CONFIDENCE
-        if (members.isEmpty()) return "NO_CONFIDENCE";
-        // Check if any non-expired, non-resigned members exist
-        boolean hasActive = members.values().stream()
-                .anyMatch(m -> !m.resigned() && m.expiryEpoch() >= epoch);
-        return hasActive ? "NORMAL" : "NO_CONFIDENCE";
+                                         int epoch) throws RocksDBException {
+        boolean committeePresent = governanceStore == null || governanceStore.isCommitteePresent();
+        if (!committeePresent) return "NO_CONFIDENCE";
+        return "NORMAL";
     }
 
     private Map<GovActionType, GovActionId> resolveLastEnactedActions() throws RocksDBException {
@@ -882,6 +881,11 @@ public class GovernanceEpochProcessor {
 
     // Package-private for testability.
     Map<GovActionType, BigDecimal> resolveDRepThresholds(boolean isBootstrapPhase, int epoch) {
+        return resolveDRepThresholds(isBootstrapPhase, epoch, "NORMAL");
+    }
+
+    // Package-private for testability.
+    Map<GovActionType, BigDecimal> resolveDRepThresholds(boolean isBootstrapPhase, int epoch, String committeeState) {
         var dt = effectiveDrepVotingThresholds(epoch);
         if (dt == null && !isBootstrapPhase) {
             // No Conway thresholds available AND not bootstrap — log WARN (only the instance
@@ -891,17 +895,22 @@ public class GovernanceEpochProcessor {
                     "Conway genesis thresholds are likely not loaded. Ratification will fail " +
                     "unconditionally (threshold = 1.0) for this epoch.", epoch);
         }
-        return buildDRepThresholdMap(isBootstrapPhase, dt);
+        return buildDRepThresholdMap(isBootstrapPhase, dt, !"NO_CONFIDENCE".equals(committeeState));
     }
 
     // Package-private for testability.
     Map<GovActionType, BigDecimal> resolveSPOThresholds(int epoch) {
+        return resolveSPOThresholds(epoch, "NORMAL");
+    }
+
+    // Package-private for testability.
+    Map<GovActionType, BigDecimal> resolveSPOThresholds(int epoch, String committeeState) {
         var pt = effectivePoolVotingThresholds(epoch);
         if (pt == null) {
             log.warn("No SPO voting thresholds available for epoch {}. Conway genesis thresholds " +
                     "likely not loaded. SPO checks will fail unconditionally (threshold = 1.0).", epoch);
         }
-        return buildSPOThresholdMap(pt);
+        return buildSPOThresholdMap(pt, !"NO_CONFIDENCE".equals(committeeState));
     }
 
     /**
@@ -918,6 +927,13 @@ public class GovernanceEpochProcessor {
     static Map<GovActionType, BigDecimal> buildDRepThresholdMap(
             boolean isBootstrapPhase,
             com.bloxbean.cardano.yaci.core.model.DrepVoteThresholds dt) {
+        return buildDRepThresholdMap(isBootstrapPhase, dt, true);
+    }
+
+    static Map<GovActionType, BigDecimal> buildDRepThresholdMap(
+            boolean isBootstrapPhase,
+            com.bloxbean.cardano.yaci.core.model.DrepVoteThresholds dt,
+            boolean committeePresent) {
         Map<GovActionType, BigDecimal> thresholds = new HashMap<>();
         if (isBootstrapPhase) {
             for (GovActionType type : GovActionType.values()) {
@@ -934,7 +950,9 @@ public class GovernanceEpochProcessor {
         thresholds.put(GovActionType.NO_CONFIDENCE,
                 ProtocolParamGroupClassifier.ratioToBigDecimal(dt.getDvtMotionNoConfidence()));
         thresholds.put(GovActionType.UPDATE_COMMITTEE,
-                ProtocolParamGroupClassifier.ratioToBigDecimal(dt.getDvtCommitteeNormal()));
+                ProtocolParamGroupClassifier.ratioToBigDecimal(committeePresent
+                        ? dt.getDvtCommitteeNormal()
+                        : dt.getDvtCommitteeNoConfidence()));
         thresholds.put(GovActionType.NEW_CONSTITUTION,
                 ProtocolParamGroupClassifier.ratioToBigDecimal(dt.getDvtUpdateToConstitution()));
         thresholds.put(GovActionType.HARD_FORK_INITIATION_ACTION,
@@ -952,6 +970,12 @@ public class GovernanceEpochProcessor {
      */
     static Map<GovActionType, BigDecimal> buildSPOThresholdMap(
             com.bloxbean.cardano.yaci.core.model.PoolVotingThresholds pt) {
+        return buildSPOThresholdMap(pt, true);
+    }
+
+    static Map<GovActionType, BigDecimal> buildSPOThresholdMap(
+            com.bloxbean.cardano.yaci.core.model.PoolVotingThresholds pt,
+            boolean committeePresent) {
         Map<GovActionType, BigDecimal> thresholds = new HashMap<>();
         if (pt == null) {
             thresholds.put(GovActionType.NO_CONFIDENCE, BigDecimal.ONE);
@@ -963,7 +987,9 @@ public class GovernanceEpochProcessor {
         thresholds.put(GovActionType.NO_CONFIDENCE,
                 ProtocolParamGroupClassifier.ratioToBigDecimal(pt.getPvtMotionNoConfidence()));
         thresholds.put(GovActionType.UPDATE_COMMITTEE,
-                ProtocolParamGroupClassifier.ratioToBigDecimal(pt.getPvtCommitteeNormal()));
+                ProtocolParamGroupClassifier.ratioToBigDecimal(committeePresent
+                        ? pt.getPvtCommitteeNormal()
+                        : pt.getPvtCommitteeNoConfidence()));
         thresholds.put(GovActionType.HARD_FORK_INITIATION_ACTION,
                 ProtocolParamGroupClassifier.ratioToBigDecimal(pt.getPvtHardForkInitiation()));
         thresholds.put(GovActionType.PARAMETER_CHANGE_ACTION,

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/EnactmentProcessor.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/EnactmentProcessor.java
@@ -101,12 +101,14 @@ public class EnactmentProcessor {
             }
             case NO_CONFIDENCE -> {
                 governanceStore.clearAllCommitteeMembers(batch, deltaOps);
+                governanceStore.storeCommitteePresent(false, batch, deltaOps);
                 log.info("Enacted NoConfidence — committee cleared");
             }
             case UPDATE_COMMITTEE -> {
                 if (proposal.govAction() instanceof UpdateCommittee uc) {
                     enactUpdateCommittee(uc, batch, deltaOps);
                 }
+                governanceStore.storeCommitteePresent(true, batch, deltaOps);
                 log.info("Enacted UpdateCommittee from {}/{}", id.getTransactionId().substring(0, 8),
                         id.getGov_action_index());
             }

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/RatificationEngine.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/RatificationEngine.java
@@ -523,6 +523,7 @@ public class RatificationEngine {
         if (!isBootstrapPhase) {
             long activeCount = members.values().stream()
                     .filter(m -> !m.resigned() && m.expiryEpoch() >= currentEpoch)
+                    .filter(CommitteeMemberRecord::hasHotKey)
                     .count();
             if (activeCount < committeeMinSize) return false;
         }
@@ -839,6 +840,7 @@ public class RatificationEngine {
     private static long activeCommitteeCount(Map<CredentialKey, CommitteeMemberRecord> members, int currentEpoch) {
         return members.values().stream()
                 .filter(m -> !m.resigned() && m.expiryEpoch() >= currentEpoch)
+                .filter(CommitteeMemberRecord::hasHotKey)
                 .count();
     }
 

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculator.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculator.java
@@ -292,8 +292,8 @@ public class VoteTallyCalculator {
      */
     public static boolean committeeThresholdMet(CommitteeTally tally, BigDecimal threshold) {
         int denominator = tally.yesCount + tally.noCount;
-        if (denominator == 0) return false; // No eligible committee members → no quorum → fail
         if (threshold.compareTo(BigDecimal.ZERO) == 0) return true;
+        if (denominator == 0) return false; // No eligible committee members → no quorum → fail
 
         BigDecimal ratio = BigDecimal.valueOf(tally.yesCount)
                 .divide(BigDecimal.valueOf(denominator), MathContext.DECIMAL128);

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/GovernanceStateStoreTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/GovernanceStateStoreTest.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yano.ledgerstate.governance;
 
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
+import com.bloxbean.cardano.yano.ledgerstate.DefaultAccountStateStore;
 import com.bloxbean.cardano.yano.ledgerstate.DefaultAccountStateStore.DeltaOp;
 import com.bloxbean.cardano.yano.ledgerstate.governance.model.CommitteeMemberRecord;
 import com.bloxbean.cardano.yano.ledgerstate.governance.model.DRepStateRecord;
@@ -11,6 +12,8 @@ import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
 import org.rocksdb.RocksDBException;
 import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
 import java.nio.file.Path;
@@ -112,6 +115,76 @@ class GovernanceStateStoreTest {
             commit(batch);
         }
         assertThat(store.getAllCommitteeMembers()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Committee presence defaults to present and stores absent")
+    void committeePresent_defaultAndStore() throws Exception {
+        assertThat(store.isCommitteePresent()).isTrue();
+
+        try (WriteBatch batch = new WriteBatch()) {
+            store.storeCommitteePresent(false, batch, new ArrayList<>());
+            commit(batch);
+        }
+        assertThat(store.isCommitteePresent()).isFalse();
+
+        try (WriteBatch batch = new WriteBatch()) {
+            store.storeCommitteePresent(true, batch, new ArrayList<>());
+            commit(batch);
+        }
+        assertThat(store.isCommitteePresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Committee presence is restored by boundary rollback when key was absent before boundary")
+    void committeePresent_boundaryRollbackRestoresDefault() throws Exception {
+        var accountStore = new DefaultAccountStateStore(rocks.db(), rocks.cfSupplier(),
+                LoggerFactory.getLogger(GovernanceStateStoreTest.class), true);
+        long boundarySlot = 86_400L;
+
+        assertThat(store.isCommitteePresent()).isTrue();
+
+        List<DeltaOp> deltaOps = new ArrayList<>();
+        try (WriteBatch batch = new WriteBatch(); WriteOptions wo = new WriteOptions()) {
+            store.storeCommitteePresent(false, batch, deltaOps);
+            accountStore.commitBoundaryDelta(boundarySlot, DefaultAccountStateStore.PHASE_GOV_ENACT,
+                    batch, deltaOps);
+            rocks.db().write(wo, batch);
+        }
+
+        assertThat(store.isCommitteePresent()).isFalse();
+
+        accountStore.rollbackToSlot(boundarySlot - 1);
+
+        assertThat(store.isCommitteePresent()).isTrue();
+    }
+
+    @Test
+    @DisplayName("Committee presence rollback restores previous explicit value")
+    void committeePresent_boundaryRollbackRestoresPreviousValue() throws Exception {
+        var accountStore = new DefaultAccountStateStore(rocks.db(), rocks.cfSupplier(),
+                LoggerFactory.getLogger(GovernanceStateStoreTest.class), true);
+        long boundarySlot = 86_400L;
+
+        try (WriteBatch batch = new WriteBatch()) {
+            store.storeCommitteePresent(false, batch, new ArrayList<>());
+            commit(batch);
+        }
+        assertThat(store.isCommitteePresent()).isFalse();
+
+        List<DeltaOp> deltaOps = new ArrayList<>();
+        try (WriteBatch batch = new WriteBatch(); WriteOptions wo = new WriteOptions()) {
+            store.storeCommitteePresent(true, batch, deltaOps);
+            accountStore.commitBoundaryDelta(boundarySlot, DefaultAccountStateStore.PHASE_GOV_ENACT,
+                    batch, deltaOps);
+            rocks.db().write(wo, batch);
+        }
+
+        assertThat(store.isCommitteePresent()).isTrue();
+
+        accountStore.rollbackToSlot(boundarySlot - 1);
+
+        assertThat(store.isCommitteePresent()).isFalse();
     }
 
     // Real preprod DRep hashes

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/GovernanceEpochProcessorTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/GovernanceEpochProcessorTest.java
@@ -9,8 +9,11 @@ import com.bloxbean.cardano.yano.ledgerstate.EpochParamTracker;
 import com.bloxbean.cardano.yano.ledgerstate.governance.GovernanceStateStore;
 import com.bloxbean.cardano.yano.ledgerstate.governance.GovernanceCborCodec.CommitteeThreshold;
 import com.bloxbean.cardano.yano.ledgerstate.governance.model.CommitteeMemberRecord;
+import com.bloxbean.cardano.yano.ledgerstate.test.TestRocksDBHelper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.WriteBatch;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -18,6 +21,7 @@ import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -27,6 +31,8 @@ import java.util.regex.Pattern;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class GovernanceEpochProcessorTest {
+
+    @TempDir Path tempDir;
 
     @Test
     @DisplayName("Ratification active check uses previous epoch boundary semantics")
@@ -99,20 +105,55 @@ class GovernanceEpochProcessorTest {
     }
 
     @Test
-    @DisplayName("Committee state remains normal through member expiry epoch")
-    void committeeState_expiryEpochInclusive() throws Exception {
+    @DisplayName("Committee state stays normal for present committee even when all members are inactive")
+    void committeeState_presentButInactiveIsNormal() throws Exception {
         GovernanceEpochProcessor processor = new GovernanceEpochProcessor(
                 null, null, null, null, null, null, null, null, null,
                 zeroProvider(), null, null, null, null, null);
         Map<GovernanceStateStore.CredentialKey, CommitteeMemberRecord> members = new HashMap<>();
         members.put(new GovernanceStateStore.CredentialKey(0, "cold"),
-                new CommitteeMemberRecord(0, "hot", 232, false));
+                new CommitteeMemberRecord(0, "hot", 232, true));
 
         Method method = GovernanceEpochProcessor.class.getDeclaredMethod("resolveCommitteeState", Map.class, int.class);
         method.setAccessible(true);
 
         assertThat(method.invoke(processor, members, 232)).isEqualTo("NORMAL");
-        assertThat(method.invoke(processor, members, 233)).isEqualTo("NO_CONFIDENCE");
+        assertThat(method.invoke(processor, members, 233)).isEqualTo("NORMAL");
+    }
+
+    @Test
+    @DisplayName("Committee state follows explicit committeePresent flag")
+    void committeeState_absentFlagIsNoConfidence() throws Exception {
+        try (var rocks = TestRocksDBHelper.create(tempDir)) {
+            GovernanceStateStore store = rocks.governanceStore();
+            try (WriteBatch batch = new WriteBatch(); var writeOptions = new org.rocksdb.WriteOptions()) {
+                store.storeCommitteePresent(false, batch, new ArrayList<>());
+                rocks.db().write(writeOptions, batch);
+            }
+
+            GovernanceEpochProcessor processor = new GovernanceEpochProcessor(
+                    rocks.db(), rocks.cfState(), rocks.cfDelta(), store,
+                    null, null, null, null, null,
+                    zeroProvider(), null, null, null, null, null);
+
+            Method method = GovernanceEpochProcessor.class.getDeclaredMethod("resolveCommitteeState", Map.class, int.class);
+            method.setAccessible(true);
+
+            assertThat(method.invoke(processor, Map.of(), 3)).isEqualTo("NO_CONFIDENCE");
+        }
+    }
+
+    @Test
+    @DisplayName("Empty committee member set is not itself no-confidence")
+    void committeeState_emptyMembersNormal() throws Exception {
+        GovernanceEpochProcessor processor = new GovernanceEpochProcessor(
+                null, null, null, null, null, null, null, null, null,
+                zeroProvider(), null, null, null, null, null);
+
+        Method method = GovernanceEpochProcessor.class.getDeclaredMethod("resolveCommitteeState", Map.class, int.class);
+        method.setAccessible(true);
+
+        assertThat(method.invoke(processor, Map.of(), 3)).isEqualTo("NORMAL");
     }
 
     /**
@@ -222,6 +263,23 @@ class GovernanceEpochProcessorTest {
     }
 
     @Test
+    @DisplayName("buildDRepThresholdMap: UpdateCommittee uses no-confidence threshold when committee absent")
+    void buildDRepThresholdMap_updateCommitteeNoConfidenceThreshold() {
+        DrepVoteThresholds thresholds = DrepVoteThresholds.builder()
+                .dvtCommitteeNormal(ratio(67, 100))
+                .dvtCommitteeNoConfidence(ratio(6, 10))
+                .build();
+
+        Map<GovActionType, BigDecimal> normalMap = GovernanceEpochProcessor.buildDRepThresholdMap(
+                false, thresholds, true);
+        Map<GovActionType, BigDecimal> noConfidenceMap = GovernanceEpochProcessor.buildDRepThresholdMap(
+                false, thresholds, false);
+
+        assertThat(normalMap.get(GovActionType.UPDATE_COMMITTEE)).isEqualByComparingTo("0.67");
+        assertThat(noConfidenceMap.get(GovActionType.UPDATE_COMMITTEE)).isEqualByComparingTo("0.6");
+    }
+
+    @Test
     @DisplayName("buildSPOThresholdMap: null thresholds → every action 1.0 (fail-safe)")
     void buildSPOThresholdMap_nullThresholds_failSafe() {
         Map<GovActionType, BigDecimal> map = GovernanceEpochProcessor.buildSPOThresholdMap(null);
@@ -249,6 +307,64 @@ class GovernanceEpochProcessorTest {
         assertThat(map.get(GovActionType.HARD_FORK_INITIATION_ACTION)).isEqualByComparingTo("0.51");
         // SPO PARAMETER_CHANGE_ACTION uses pvtPPSecurityGroup specifically
         assertThat(map.get(GovActionType.PARAMETER_CHANGE_ACTION)).isEqualByComparingTo("0.51");
+    }
+
+    @Test
+    @DisplayName("buildSPOThresholdMap: UpdateCommittee uses no-confidence threshold when committee absent")
+    void buildSPOThresholdMap_updateCommitteeNoConfidenceThreshold() {
+        PoolVotingThresholds thresholds = PoolVotingThresholds.builder()
+                .pvtCommitteeNormal(ratio(67, 100))
+                .pvtCommitteeNoConfidence(ratio(4, 10))
+                .build();
+
+        Map<GovActionType, BigDecimal> normalMap = GovernanceEpochProcessor.buildSPOThresholdMap(thresholds, true);
+        Map<GovActionType, BigDecimal> noConfidenceMap = GovernanceEpochProcessor.buildSPOThresholdMap(thresholds, false);
+
+        assertThat(normalMap.get(GovActionType.UPDATE_COMMITTEE)).isEqualByComparingTo("0.67");
+        assertThat(noConfidenceMap.get(GovActionType.UPDATE_COMMITTEE)).isEqualByComparingTo("0.4");
+    }
+
+    @Test
+    @DisplayName("Phase 2 threshold resolution uses post-enactment committee state")
+    void phase2Thresholds_usePostEnactmentCommitteeState() {
+        EpochParamProvider provider = new EpochParamProvider() {
+            @Override
+            public BigInteger getKeyDeposit(long epoch) {
+                return BigInteger.ZERO;
+            }
+
+            @Override
+            public BigInteger getPoolDeposit(long epoch) {
+                return BigInteger.ZERO;
+            }
+
+            @Override
+            public DrepVoteThresholds getDrepVotingThresholds(long epoch) {
+                return DrepVoteThresholds.builder()
+                        .dvtCommitteeNormal(ratio(67, 100))
+                        .dvtCommitteeNoConfidence(ratio(6, 10))
+                        .build();
+            }
+
+            @Override
+            public PoolVotingThresholds getPoolVotingThresholds(long epoch) {
+                return PoolVotingThresholds.builder()
+                        .pvtCommitteeNormal(ratio(67, 100))
+                        .pvtCommitteeNoConfidence(ratio(4, 10))
+                        .build();
+            }
+        };
+        GovernanceEpochProcessor processor = new GovernanceEpochProcessor(
+                null, null, null, null, null, null, null, null, null,
+                provider, null, null, null, null, null);
+
+        Map<GovActionType, BigDecimal> drepThresholds =
+                processor.resolveDRepThresholds(false, 3, "NO_CONFIDENCE");
+        Map<GovActionType, BigDecimal> spoThresholds =
+                processor.resolveSPOThresholds(3, "NO_CONFIDENCE");
+
+        assertThat(drepThresholds.get(GovActionType.UPDATE_COMMITTEE)).isEqualByComparingTo("0.6");
+        assertThat(spoThresholds.get(GovActionType.UPDATE_COMMITTEE)).isEqualByComparingTo("0.4");
     }
 
     @Test
@@ -318,6 +434,28 @@ class GovernanceEpochProcessorTest {
                 Optional.of(new CommitteeThreshold(BigInteger.valueOf(2), BigInteger.valueOf(3))));
         // 2/3 in DECIMAL128 — compare to reasonable precision, not string match.
         assertThat(got.doubleValue()).isCloseTo(0.6666666666666667, org.assertj.core.data.Offset.offset(1e-15));
+    }
+
+    @Test
+    @DisplayName("Tracked Yano devnet Conway genesis uses empty committee threshold 0/1")
+    void devnetConwayGenesis_emptyCommitteeThresholdZero() throws Exception {
+        Path src = Paths.get("app/config/network/devnet/conway-genesis.json");
+        if (!Files.exists(src)) {
+            src = Paths.get("..").resolve(src);
+        }
+        assertThat(Files.exists(src)).isTrue();
+        String source = Files.readString(src);
+
+        Pattern pattern = Pattern.compile(
+                "\"committee\"\\s*:\\s*\\{\\s*\"members\"\\s*:\\s*\\{\\s*}\\s*,\\s*" +
+                        "\"threshold\"\\s*:\\s*\\{\\s*\"numerator\"\\s*:\\s*(\\d+)\\s*,\\s*" +
+                        "\"denominator\"\\s*:\\s*(\\d+)\\s*}\\s*}",
+                Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(source);
+
+        assertThat(matcher.find()).isTrue();
+        assertThat(matcher.group(1)).isEqualTo("0");
+        assertThat(matcher.group(2)).isEqualTo("1");
     }
 
     private static UnitInterval ratio(long num, long denom) {

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/EnactmentProcessorTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/EnactmentProcessorTest.java
@@ -66,6 +66,11 @@ class EnactmentProcessorTest {
     @Test
     @DisplayName("UpdateCommittee adds new members with correct expiry epochs")
     void updateCommittee_addsNewMembers() throws Exception {
+        try (WriteBatch batch = new WriteBatch()) {
+            store.storeCommitteePresent(false, batch, new ArrayList<>());
+            commit(batch);
+        }
+
         var newMembers = new LinkedHashMap<Credential, Integer>();
         newMembers.put(new Credential(StakeCredType.ADDR_KEYHASH, COLD1), 242);
         newMembers.put(new Credential(StakeCredType.ADDR_KEYHASH, COLD2), 372);
@@ -94,6 +99,7 @@ class EnactmentProcessorTest {
         // Threshold updated
         var threshold = store.getCommitteeThreshold();
         assertThat(threshold).isPresent();
+        assertThat(store.isCommitteePresent()).isTrue();
     }
 
     @Test
@@ -170,6 +176,7 @@ class EnactmentProcessorTest {
         }
 
         assertThat(store.getAllCommitteeMembers()).isEmpty();
+        assertThat(store.isCommitteePresent()).isFalse();
     }
 
     // ===== TreasuryWithdrawals =====

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/RatificationEngineTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/RatificationEngineTest.java
@@ -2,14 +2,20 @@ package com.bloxbean.cardano.yano.ledgerstate.governance.ratification;
 
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionId;
 import com.bloxbean.cardano.yaci.core.model.governance.GovActionType;
+import com.bloxbean.cardano.yano.ledgerstate.governance.GovernanceStateStore;
+import com.bloxbean.cardano.yano.ledgerstate.governance.epoch.DRepDistributionCalculator.DRepDistKey;
+import com.bloxbean.cardano.yano.ledgerstate.governance.model.CommitteeMemberRecord;
 import com.bloxbean.cardano.yano.ledgerstate.governance.model.GovActionRecord;
 import com.bloxbean.cardano.yano.ledgerstate.governance.model.RatificationResult.Status;
+import com.bloxbean.cardano.yano.ledgerstate.test.TestRocksDBHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.io.TempDir;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.Map;
+import java.nio.file.Path;
+import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -20,6 +26,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  * No database, no mocks — pure input/output testing.
  */
 class RatificationEngineTest {
+
+    @TempDir Path tempDir;
 
     // ===== Helper builders =====
 
@@ -197,6 +205,19 @@ class RatificationEngineTest {
     }
 
     @Test
+    @DisplayName("Empty NORMAL committee with threshold zero can ratify")
+    void committee_emptyNormalThresholdZero_passes() {
+        var proposal = proposal(0, 6, GovActionType.PARAMETER_CHANGE_ACTION, null, null);
+        var eval = input(proposal, drepAllYes(), CC_0_YES, SPO_EMPTY,
+                new BigDecimal("0.67"), BigDecimal.ZERO, BigDecimal.ZERO);
+
+        var status = RatificationEngine.evaluateStateless(
+                eval, 3, false, NO_PREV, "NORMAL", 0, 146, false);
+
+        assertThat(status).isEqualTo(Status.RATIFIED);
+    }
+
+    @Test
     @DisplayName("Committee below min size → fails")
     void committee_belowMinSize() {
         // 3 YES but minSize=7
@@ -209,6 +230,46 @@ class RatificationEngineTest {
                 eval, 232, false, NO_PREV, "NORMAL", 7, 146, false);
 
         assertThat(status).isEqualTo(Status.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("Committee min size excludes members without hot keys")
+    void committee_minSizeExcludesMembersWithoutHotKeys() throws Exception {
+        try (var rocks = TestRocksDBHelper.create(tempDir)) {
+            var store = rocks.governanceStore();
+            var engine = new RatificationEngine(store, new VoteTallyCalculator());
+            GovActionId id = new GovActionId(
+                    "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 0);
+            var proposal = proposal(1, 6, GovActionType.NEW_CONSTITUTION, null, null);
+
+            Map<GovernanceStateStore.CredentialKey, CommitteeMemberRecord> members = new LinkedHashMap<>();
+            for (int i = 0; i < 5; i++) {
+                members.put(new GovernanceStateStore.CredentialKey(0, "cold" + i),
+                        CommitteeMemberRecord.noHotKey(10));
+            }
+
+            var results = engine.evaluateAll(
+                    Map.of(id, proposal),
+                    Map.<DRepDistKey, BigInteger>of(),
+                    Set.of(),
+                    Map.of(),
+                    Map.of(),
+                    members,
+                    BigDecimal.ZERO,
+                    NO_PREV,
+                    3,
+                    false,
+                    3,
+                    146,
+                    "NORMAL",
+                    BigInteger.ZERO,
+                    Map.of(GovActionType.NEW_CONSTITUTION, BigDecimal.ZERO),
+                    Map.of(),
+                    null);
+
+            assertThat(results).hasSize(1);
+            assertThat(results.get(0).status()).isEqualTo(Status.ACTIVE);
+        }
     }
 
     @Test

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculatorTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculatorTest.java
@@ -258,6 +258,13 @@ class VoteTallyCalculatorTest {
     }
 
     @Test
+    void committeeThresholdZero_passesWithZeroEligibleMembers() {
+        var tally = new VoteTallyCalculator.CommitteeTally(0, 0, 0);
+
+        assertThat(VoteTallyCalculator.committeeThresholdMet(tally, BigDecimal.ZERO)).isTrue();
+    }
+
+    @Test
     void committeeTally_expiryEpochIsStillEligible() {
         Map<GovernanceStateStore.VoterKey, Integer> votes = new HashMap<>();
         votes.put(new GovernanceStateStore.VoterKey(

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluator.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluator.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.api.model.Utxo;
 import com.bloxbean.cardano.client.common.model.SlotConfig;
 import com.bloxbean.cardano.yano.ledgerrules.EpochProtocolParamsSupplier;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 import scalus.bloxbean.EvaluatorMode;
 import scalus.bloxbean.ScalusTransactionEvaluator;
@@ -24,26 +25,27 @@ public class ScalusBasedTransactionEvaluator implements TransactionEvaluator {
 
     private final EpochProtocolParamsSupplier protocolParamsSupplier;
     private final ScriptSupplier scriptSupplier;
-    private final SlotConfig slotConfig;
+    private final SlotConfigSupplier slotConfigSupplier;
     private final int networkId;
     private final LongSupplier currentSlotSupplier;
-
-    ScalusBasedTransactionEvaluator(ProtocolParams protocolParams, 
-                                    com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                    SlotConfig slotConfig, int networkId) {
-        this(slot -> protocolParams, scriptSupplier, slotConfig, networkId, null);
-    }
 
     ScalusBasedTransactionEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                     com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                     SlotConfig slotConfig, int networkId,
+                                    LongSupplier currentSlotSupplier) {
+        this(protocolParamsSupplier, scriptSupplier, () -> slotConfig, networkId, currentSlotSupplier);
+    }
+
+    ScalusBasedTransactionEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                    com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
+                                    SlotConfigSupplier slotConfigSupplier, int networkId,
                                     LongSupplier currentSlotSupplier) {
         this.protocolParamsSupplier = protocolParamsSupplier;
         if (scriptSupplier != null)
             this.scriptSupplier = new ScalusScriptSupplier(scriptSupplier);
         else
             this.scriptSupplier = null;
-        this.slotConfig = slotConfig;
+        this.slotConfigSupplier = slotConfigSupplier;
         this.networkId = networkId;
         this.currentSlotSupplier = currentSlotSupplier;
     }
@@ -65,8 +67,8 @@ public class ScalusBasedTransactionEvaluator implements TransactionEvaluator {
             }
         };
 
-        var scalusSlotConfig = new scalus.cardano.ledger.SlotConfig(slotConfig.getZeroTime(), slotConfig.getZeroSlot(), slotConfig.getSlotLength());
         ProtocolParams protocolParams = protocolParamsSupplier.getProtocolParams(resolveCurrentSlot());
+        var scalusSlotConfig = SlotConfigAdapters.toScalus(slotConfigSupplier.getSlotConfig());
         // Create ScalusTransactionEvaluator and evaluate
         var evaluator = new ScalusTransactionEvaluator(
                 scalusSlotConfig, protocolParams, utxoSupplier, scriptSupplier,

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidator.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidator.java
@@ -17,6 +17,7 @@ import com.bloxbean.cardano.client.transaction.spec.Transaction;
 import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 import com.bloxbean.cardano.yano.api.account.LedgerStateProvider;
 import com.bloxbean.cardano.yano.ledgerrules.EpochProtocolParamsSupplier;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionValidator;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationError;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationResult;
@@ -49,7 +50,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
 
     private final EpochProtocolParamsSupplier protocolParamsSupplier;
     private final ScriptSupplier scriptSupplier;
-    private final SlotConfig scalusSlotConfig;
+    private final SlotConfigSupplier slotConfigSupplier;
     private final int networkId;
     private final LedgerStateProvider ledgerStateProvider;
     private final LongSupplier currentSlotSupplier;
@@ -57,28 +58,32 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
     private final boolean requireLedgerStateProvider;
     private final boolean supplementaryRulesEnabled;
 
-    public ScalusBasedTransactionValidator(ProtocolParams protocolParams,
-                                           com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                           com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
-                                           int networkId) {
-        this(protocolParams, scriptSupplier, slotConfig, networkId, null);
-    }
-
-    public ScalusBasedTransactionValidator(ProtocolParams protocolParams,
+    public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
                                            int networkId,
                                            LedgerStateProvider ledgerStateProvider) {
-        this(slot -> protocolParams, scriptSupplier, slotConfig, networkId, ledgerStateProvider, null, null, false, false);
+        this(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider,
+                null, null, false, false);
     }
 
-    public ScalusBasedTransactionValidator(ProtocolParams protocolParams,
+    public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
                                            int networkId,
                                            LedgerStateProvider ledgerStateProvider,
                                            boolean supplementaryRulesEnabled) {
-        this(slot -> protocolParams, scriptSupplier, slotConfig, networkId, ledgerStateProvider,
+        this(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider,
+                null, null, false, supplementaryRulesEnabled);
+    }
+
+    public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                           com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
+                                           SlotConfigSupplier slotConfigSupplier,
+                                           int networkId,
+                                           LedgerStateProvider ledgerStateProvider,
+                                           boolean supplementaryRulesEnabled) {
+        this(protocolParamsSupplier, scriptSupplier, slotConfigSupplier, networkId, ledgerStateProvider,
                 null, null, false, supplementaryRulesEnabled);
     }
 
@@ -115,6 +120,18 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 currentSlotSupplier, currentEpochResolver, true, supplementaryRulesEnabled);
     }
 
+    public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                           com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
+                                           SlotConfigSupplier slotConfigSupplier,
+                                           int networkId,
+                                           LedgerStateProvider ledgerStateProvider,
+                                           LongSupplier currentSlotSupplier,
+                                           LongFunction<Integer> currentEpochResolver,
+                                           boolean supplementaryRulesEnabled) {
+        this(protocolParamsSupplier, scriptSupplier, slotConfigSupplier, networkId, ledgerStateProvider,
+                currentSlotSupplier, currentEpochResolver, true, supplementaryRulesEnabled);
+    }
+
     private ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                             com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                             com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
@@ -124,6 +141,19 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                                             LongFunction<Integer> currentEpochResolver,
                                             boolean requireLedgerStateProvider,
                                             boolean supplementaryRulesEnabled) {
+        this(protocolParamsSupplier, scriptSupplier, () -> slotConfig, networkId, ledgerStateProvider,
+                currentSlotSupplier, currentEpochResolver, requireLedgerStateProvider, supplementaryRulesEnabled);
+    }
+
+    ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                    com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
+                                    SlotConfigSupplier slotConfigSupplier,
+                                    int networkId,
+                                    LedgerStateProvider ledgerStateProvider,
+                                    LongSupplier currentSlotSupplier,
+                                    LongFunction<Integer> currentEpochResolver,
+                                    boolean requireLedgerStateProvider,
+                                    boolean supplementaryRulesEnabled) {
         this.protocolParamsSupplier = protocolParamsSupplier;
         if (scriptSupplier != null)
             this.scriptSupplier = new ScalusScriptSupplier(scriptSupplier);
@@ -135,11 +165,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
         this.currentEpochResolver = currentEpochResolver;
         this.requireLedgerStateProvider = requireLedgerStateProvider;
         this.supplementaryRulesEnabled = supplementaryRulesEnabled;
-
-        this.scalusSlotConfig = new scalus.cardano.ledger.SlotConfig(
-                slotConfig.getZeroTime(),
-                slotConfig.getZeroSlot(),
-                slotConfig.getSlotLength());
+        this.slotConfigSupplier = slotConfigSupplier;
 
         if (!supplementaryRulesEnabled) {
             log.info("CCL supplementary rules disabled (yano.validation.supplementary-rules-enabled=false). "
@@ -203,7 +229,15 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                                                 Set<Utxo> inputUtxos, long currentSlot) {
         return LedgerBridge.validate(
                 txCbor, protocolParams, inputUtxos, currentSlot,
-                scalusSlotConfig, networkId, scriptSupplier, ledgerStateProvider);
+                resolveScalusSlotConfig(), networkId, scriptSupplier, ledgerStateProvider);
+    }
+
+    protected com.bloxbean.cardano.client.common.model.SlotConfig resolveCclSlotConfig() {
+        return slotConfigSupplier.getSlotConfig();
+    }
+
+    protected SlotConfig resolveScalusSlotConfig() {
+        return SlotConfigAdapters.toScalus(resolveCclSlotConfig());
     }
 
     private long resolveCurrentSlot(Transaction tx) {

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusTransactionFactory.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusTransactionFactory.java
@@ -1,10 +1,10 @@
 package com.bloxbean.cardano.yano.scalusbridge;
 
 import com.bloxbean.cardano.client.api.ScriptSupplier;
-import com.bloxbean.cardano.client.api.model.ProtocolParams;
 import com.bloxbean.cardano.client.common.model.SlotConfig;
 import com.bloxbean.cardano.yano.api.account.LedgerStateProvider;
 import com.bloxbean.cardano.yano.ledgerrules.EpochProtocolParamsSupplier;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionValidator;
 
@@ -22,27 +22,39 @@ public class ScalusTransactionFactory {
     // OFF by default for all factory entry points — production callers should
     // pass an explicit `supplementaryRulesEnabled` flag (driven by the
     // `yano.validation.supplementary-rules-enabled` config) to turn them on.
-    // The legacy overloads below remain for binary compatibility and pass
-    // false to the underlying constructor.
+    // Convenience overloads without runtime slot suppliers pass false to the
+    // underlying constructor for standalone/static-param consumers.
     // ---------------------------------------------------------------------
 
-    public static TransactionValidator createValidator(ProtocolParams pp, ScriptSupplier scriptSupplier,
+    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId) {
-        return createValidator(pp, scriptSupplier, slotConfig, networkId, null, false);
+        return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, null, false);
     }
 
-    public static TransactionValidator createValidator(ProtocolParams pp, ScriptSupplier scriptSupplier,
+    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,
                                                        LedgerStateProvider ledgerStateProvider) {
-        return createValidator(pp, scriptSupplier, slotConfig, networkId, ledgerStateProvider, false);
+        return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider, false);
     }
 
-    public static TransactionValidator createValidator(ProtocolParams pp, ScriptSupplier scriptSupplier,
+    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,
                                                        LedgerStateProvider ledgerStateProvider,
                                                        boolean supplementaryRulesEnabled) {
-        return new ScalusBasedTransactionValidator(pp, scriptSupplier, slotConfig, networkId, ledgerStateProvider,
-                supplementaryRulesEnabled);
+        return new ScalusBasedTransactionValidator(protocolParamsSupplier, scriptSupplier, () -> slotConfig,
+                networkId, ledgerStateProvider, null, null, false, supplementaryRulesEnabled);
+    }
+
+    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
+                                                       SlotConfigSupplier slotConfigSupplier, int networkId,
+                                                       LedgerStateProvider ledgerStateProvider,
+                                                       boolean supplementaryRulesEnabled) {
+        return new ScalusBasedTransactionValidator(protocolParamsSupplier, scriptSupplier, slotConfigSupplier,
+                networkId, ledgerStateProvider, null, null, false, supplementaryRulesEnabled);
     }
 
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
@@ -75,9 +87,42 @@ public class ScalusTransactionFactory {
                 ledgerStateProvider, currentSlotSupplier, currentEpochResolver, supplementaryRulesEnabled);
     }
 
-    public static TransactionEvaluator createEvaluator(ProtocolParams pp, ScriptSupplier scriptSupplier,
+    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
+                                                       SlotConfigSupplier slotConfigSupplier, int networkId,
+                                                       LedgerStateProvider ledgerStateProvider,
+                                                       LongSupplier currentSlotSupplier,
+                                                       LongFunction<Integer> currentEpochResolver,
+                                                       boolean supplementaryRulesEnabled) {
+        return new ScalusBasedTransactionValidator(protocolParamsSupplier, scriptSupplier, slotConfigSupplier,
+                networkId, ledgerStateProvider, currentSlotSupplier, currentEpochResolver, supplementaryRulesEnabled);
+    }
+
+    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
+                                                       SlotConfigSupplier slotConfigSupplier, int networkId,
+                                                       LedgerStateProvider ledgerStateProvider,
+                                                       LongSupplier currentSlotSupplier,
+                                                       LongFunction<Integer> currentEpochResolver,
+                                                       boolean requireLedgerStateProvider,
+                                                       boolean supplementaryRulesEnabled) {
+        return new ScalusBasedTransactionValidator(protocolParamsSupplier, scriptSupplier, slotConfigSupplier,
+                networkId, ledgerStateProvider, currentSlotSupplier, currentEpochResolver,
+                requireLedgerStateProvider, supplementaryRulesEnabled);
+    }
+
+    public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId) {
-        return new ScalusBasedTransactionEvaluator(pp, scriptSupplier, slotConfig, networkId);
+        return new ScalusBasedTransactionEvaluator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId,
+                null);
+    }
+
+    public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
+                                                       SlotConfigSupplier slotConfigSupplier, int networkId) {
+        return new ScalusBasedTransactionEvaluator(protocolParamsSupplier, scriptSupplier, slotConfigSupplier,
+                networkId, null);
     }
 
     public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
@@ -86,5 +131,13 @@ public class ScalusTransactionFactory {
                                                        LongSupplier currentSlotSupplier) {
         return new ScalusBasedTransactionEvaluator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId,
                 currentSlotSupplier);
+    }
+
+    public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
+                                                       ScriptSupplier scriptSupplier,
+                                                       SlotConfigSupplier slotConfigSupplier, int networkId,
+                                                       LongSupplier currentSlotSupplier) {
+        return new ScalusBasedTransactionEvaluator(protocolParamsSupplier, scriptSupplier, slotConfigSupplier,
+                networkId, currentSlotSupplier);
     }
 }

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/SlotConfigAdapters.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/SlotConfigAdapters.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yano.scalusbridge;
+
+import com.bloxbean.cardano.client.common.model.SlotConfig;
+
+final class SlotConfigAdapters {
+
+    private SlotConfigAdapters() {
+    }
+
+    static scalus.cardano.ledger.SlotConfig toScalus(SlotConfig slotConfig) {
+        if (slotConfig == null) {
+            throw new IllegalStateException("SlotConfig not available");
+        }
+        return new scalus.cardano.ledger.SlotConfig(
+                slotConfig.getZeroTime(),
+                slotConfig.getZeroSlot(),
+                slotConfig.getSlotLength());
+    }
+}

--- a/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
+++ b/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
@@ -1,9 +1,11 @@
 package com.bloxbean.cardano.yano.scalusbridge;
 
+import com.bloxbean.cardano.client.api.model.ProtocolParams;
 import com.bloxbean.cardano.client.common.model.SlotConfig;
 import org.junit.jupiter.api.Test;
 
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -71,5 +73,38 @@ class ScalusBasedTransactionEvaluatorTest {
                 () -> evaluator.evaluate(new byte[0], Set.of()));
 
         assertEquals("resolved slot 0", ex.getMessage());
+    }
+
+    @Test
+    void runtimeEvaluatorUsesDynamicSlotConfigSupplierPerCall() {
+        var zeroTime = new AtomicLong(1_780_000_000_000L);
+        var evaluator = new ScalusBasedTransactionEvaluator(
+                slot -> new ProtocolParams(),
+                null,
+                () -> {
+                    throw new IllegalStateException("zeroTime " + zeroTime.get());
+                },
+                0,
+                () -> 123L);
+
+        var first = assertThrows(IllegalStateException.class,
+                () -> evaluator.evaluate(new byte[0], Set.of()));
+        zeroTime.set(1_780_000_001_000L);
+        var second = assertThrows(IllegalStateException.class,
+                () -> evaluator.evaluate(new byte[0], Set.of()));
+
+        assertEquals("zeroTime 1780000000000", first.getMessage());
+        assertEquals("zeroTime 1780000001000", second.getMessage());
+    }
+
+    @Test
+    void scalusSlotConfigAdapterPreservesUnitsAndOrder() {
+        var ccl = new SlotConfig(2_000, 42, 1_780_000_000_000L);
+
+        var scalus = SlotConfigAdapters.toScalus(ccl);
+
+        assertEquals(1_780_000_000_000L, scalus.zeroTime());
+        assertEquals(42L, scalus.zeroSlot());
+        assertEquals(2_000L, scalus.slotLength());
     }
 }

--- a/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidatorTest.java
+++ b/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidatorTest.java
@@ -17,14 +17,17 @@ import com.bloxbean.cardano.client.transaction.spec.governance.VotingProcedures;
 import com.bloxbean.cardano.client.transaction.spec.governance.actions.GovActionId;
 import com.bloxbean.cardano.client.transaction.spec.governance.actions.ParameterChangeAction;
 import com.bloxbean.cardano.yano.api.account.LedgerStateProvider;
+import com.bloxbean.cardano.yano.ledgerrules.SlotConfigSupplier;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationError;
 import org.junit.jupiter.api.Test;
 
+import java.util.ArrayList;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.LongSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -37,7 +40,8 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRuleExceptionRejectsTransaction() {
         LedgerStateProvider provider = new MinimalLedgerStateProvider();
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0, provider);
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                provider, null);
         var tx = Transaction.builder().body(null).build();
 
         var result = validator.runSupplementaryRules(tx, 0, new ProtocolParams());
@@ -110,6 +114,29 @@ class ScalusBasedTransactionValidatorTest {
     }
 
     @Test
+    void validateUsesDynamicSlotConfigSupplierPerCall() {
+        var zeroTime = new AtomicLong(1_780_000_000_000L);
+        var validator = new SlotCapturingValidator(
+                () -> new SlotConfig(1_000, 0, zeroTime.get()));
+
+        assertTrue(validator.validate(new byte[]{1, 2, 3}, Set.of()).valid());
+        zeroTime.set(1_780_000_001_000L);
+        assertTrue(validator.validate(new byte[]{1, 2, 3}, Set.of()).valid());
+
+        assertEquals(List.of(1_780_000_000_000L, 1_780_000_001_000L), validator.zeroTimes);
+    }
+
+    @Test
+    void staticProtocolParamsSupplierValidatorCanStillUseRuntimeCurrentSlot() {
+        var validator = new CurrentSlotCapturingFixedParamsValidator(() -> 456L);
+
+        var result = validator.validate(new byte[]{1, 2, 3}, Set.of());
+
+        assertTrue(result.valid());
+        assertEquals(456L, validator.currentSlot);
+    }
+
+    @Test
     void supplementaryRulesTreatEpochZeroAsKnownEpoch() {
         ProtocolParams pp = new ProtocolParams();
         pp.setEMax(5);
@@ -143,7 +170,7 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesValidateGovernanceVoteTargetsAndDisallowedVoters() {
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
                 new GovernanceProposalLedgerStateProvider("PARAMETER_CHANGE_ACTION", true, true));
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.STAKING_POOL_KEY_HASH), 0, new ProtocolParams());
@@ -156,7 +183,7 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesRejectVotingForInactiveGovernanceAction() {
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
                 new GovernanceProposalLedgerStateProvider("INFO_ACTION", false, true));
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.STAKING_POOL_KEY_HASH), 0, new ProtocolParams());
@@ -169,7 +196,7 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesValidateCommitteeHotVoterAuthorizationWhenAvailable() {
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
                 new GovernanceProposalLedgerStateProvider("INFO_ACTION", true, false));
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH),
@@ -184,7 +211,7 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRulesUseCurrentTransactionHashForLocalProposalVotes() {
         String txHash = filledHex(32, 9);
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
                 new RegisteredPoolLedgerStateProvider());
 
         var result = validator.runSupplementaryRules(localProposalVoteTx(txHash), 0, new ProtocolParams(), txHash);
@@ -198,7 +225,7 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRulesRejectPrevGovActionWithDifferentPurpose() {
         String prevHash = filledHex(32, 7);
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
                 new GovernanceProposalLedgerStateProvider("INFO_ACTION", false, true));
 
         var result = validator.runSupplementaryRules(proposalWithPreviousAction(prevHash), 0, new ProtocolParams());
@@ -212,7 +239,7 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRulesDoNotUseLocalProposalsForPreviousActionReferences() {
         String txHash = filledHex(32, 9);
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
                 new RegisteredPoolLedgerStateProvider());
 
         var result = validator.runSupplementaryRules(proposalWithPreviousAction(txHash), 0, new ProtocolParams(),
@@ -226,7 +253,7 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesUseTypedCommitteeHotCredentialAuthorization() {
         var validator = new ScalusBasedTransactionValidator(
-                new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
                 new ScriptCommitteeHotLedgerStateProvider());
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.CONSTITUTIONAL_COMMITTEE_HOT_SCRIPT_HASH),
@@ -375,6 +402,48 @@ class ScalusBasedTransactionValidatorTest {
     private static class SlotUnavailableValidator extends ScalusSuccessValidator {
         SlotUnavailableValidator(LedgerStateProvider provider) {
             super(provider, () -> -1L);
+        }
+    }
+
+    private static class SlotCapturingValidator extends ScalusBasedTransactionValidator {
+        private final List<Long> zeroTimes = new ArrayList<>();
+
+        SlotCapturingValidator(SlotConfigSupplier slotConfigSupplier) {
+            super(slot -> new ProtocolParams(), null, slotConfigSupplier, 0,
+                    new MinimalLedgerStateProvider(), () -> 123L, null, false);
+        }
+
+        @Override
+        protected TransitResult runScalusValidation(byte[] txCbor, ProtocolParams protocolParams,
+                                                    Set<Utxo> inputUtxos, long currentSlot) {
+            zeroTimes.add(resolveCclSlotConfig().getZeroTime());
+            return new TransitResult(true, null, null);
+        }
+
+        @Override
+        protected Transaction deserializeTransaction(byte[] txCbor) {
+            return Transaction.builder().body(null).build();
+        }
+    }
+
+    private static class CurrentSlotCapturingFixedParamsValidator extends ScalusBasedTransactionValidator {
+        private long currentSlot = -1;
+
+        CurrentSlotCapturingFixedParamsValidator(LongSupplier currentSlotSupplier) {
+            super(slot -> new ProtocolParams(), null, () -> new SlotConfig(1_000, 0, 1_780_000_000_000L),
+                    0, null, currentSlotSupplier, null, false, false);
+        }
+
+        @Override
+        protected TransitResult runScalusValidation(byte[] txCbor, ProtocolParams protocolParams,
+                                                    Set<Utxo> inputUtxos, long currentSlot) {
+            this.currentSlot = currentSlot;
+            return new TransitResult(true, null, null);
+        }
+
+        @Override
+        protected Transaction deserializeTransaction(byte[] txCbor) {
+            return Transaction.builder().body(null).build();
         }
     }
 


### PR DESCRIPTION
## Summary
  - Fixes Yano Conway committee ratification to align committee presence, no-confidence recovery thresholds, hot-key active committee sizing, and devnet empty- committee behavior with ledger semantics.
  - For devnet with past time travel, SlotConfig with stale starttime

  ## Problem
  Yano inferred committee state from the committee member map and active member count. That made an empty but present Conway genesis committee look like no-confidence, so Yano-only devkit protocol parameter governance actions could remain active instead of enacting. Yano also always used normal `UpdateCommittee` thresholds, counted committee members without hot-key authorization for min-size, and tracked devnet config had an empty committee threshold that did not match the intended no-committee-gate devkit setup.

  ## Solution
  - Add explicit persisted `committeePresent` state, rollback-safe through boundary deltas.
  - Store `committeePresent=true` during Conway genesis bootstrap and `UpdateCommittee` enactment.
  - Store `committeePresent=false` during `NoConfidence` enactment.
  - Resolve `NORMAL` vs `NO_CONFIDENCE` from committee presence only, not member activity.
  - Select `UpdateCommittee` DRep/SPO thresholds from normal vs no-confidence threshold fields based on the post-Phase-1 committee state.
  - Exclude members without authorized hot keys from post-bootstrap committee min-size checks.
  - Preserve fail-closed behavior for non-zero thresholds with zero voters, while allowing committee threshold `0/1` to pass committee approval.
  - Align tracked Yano devnet Conway genesis empty committee threshold to `0/1`.

  ## Tests
  - Added rollback tests for `committeePresent`.
  - Added committee state tests for empty present committee, absent committee, and present-but-inactive committee.
  - Added DRep and SPO threshold tests for `UpdateCommittee` after no-confidence.
  - Added Phase 1 to Phase 2 threshold visibility regression coverage.
  - Added hot-key min-size regression coverage.
  - Added threshold-zero committee vote coverage.
  - Added tracked devnet Conway genesis threshold guard.
