### PR TITLE
Fix near-tip body fetch wakeups

### DIFF
--- a/adr/network/007-push-driven-body-fetch-and-sync-phase-transition.md
+++ b/adr/network/007-push-driven-body-fetch-and-sync-phase-transition.md
@@ -1,0 +1,564 @@
+# ADR-NET-007: Push-Driven Body Fetch and Sync Phase Transition
+
+## Status
+
+Proposed
+
+## Date
+
+2026-05-24
+
+## Context
+
+Yano pipelined sync stores headers through ChainSync and fetches block bodies
+through BlockFetch. The current `BodyFetchManager` is primarily polling based:
+it periodically checks the gap between `header_tip` and the durable body tip and
+then decides whether to fetch bodies.
+
+This works for bulk sync, but it has poor near-tip behavior if the process is
+logically near the network tip while the internal `syncPhase` flag still says
+`INITIAL_SYNC`. In that state the body fetch rule remains the bulk rule:
+
+```text
+INITIAL_SYNC: fetch bodies only when header/body slot gap >= gapThreshold
+STEADY_STATE: fetch bodies when header/body slot gap >= 1
+```
+
+With a `gapThreshold` of 100 slots, a near-tip node can wait roughly 100 seconds
+before fetching the next confirming block body. This was visible during N2N
+transaction submission: the upstream node acknowledged the transaction quickly,
+but Yano did not observe the confirming body until the next bulk body-fetch
+batch.
+
+The old phase transition also had a state-accounting hole: body blocks were
+applied, but the `INITIAL_SYNC -> STEADY_STATE` transition was not reliably
+derived from the applied body slot. A dead `checkSyncProgress()` method existed,
+but it was not part of the active apply path.
+
+## Decision Drivers
+
+- Keep ChainSync/HeaderSync callback latency low.
+- Never run BlockFetch or body gap calculation on the ChainSync/Netty callback
+  thread.
+- Preserve current bulk-sync batching behavior.
+- Make near-tip behavior responsive even if global `syncPhase` is late.
+- Avoid extra RocksDB metadata reads on every successful block apply where the
+  applied slot is already known.
+- Keep fallback polling so a missed signal cannot stall body fetch forever.
+- Use virtual threads for Yano-owned waiting/background loops where useful.
+- Add an explicit header-applied event for observability, without making body
+  fetch scheduling depend on the public event bus.
+- Keep this behavioral change separate from event renames.
+
+## Decision
+
+Adopt two separate mechanisms:
+
+1. **Progress accounting by value**: pass the applied block slot/block number
+   from `PipelineDataListener` to `Yano.updateSyncProgress(...)` after a body is
+   successfully applied. Do not read `chainState.getTip()` in the normal path.
+
+2. **Internal non-blocking header wakeup**: after a header is stored,
+   `HeaderSyncManager` signals `BodyFetchManager` through a narrow internal
+   interface. The signal only updates atomics and unparks BodyFetchManager's own
+   virtual monitor thread. It must not calculate gaps, read RocksDB, call
+   `PeerClient.fetch(...)`, publish to the public event bus, or wait for body
+   work.
+
+Public events are useful for observers, but Yano's core body-fetch scheduling
+must not depend on those public events. The internal wakeup path remains active
+even when the external event bus is disabled or a plugin listener is slow.
+
+Do not rename `BlockAppliedEvent` in this change. It is already the ordered
+post-body-store event consumed by derived stores. A future `BodyAppliedEvent`
+rename or alias can be done as a separate naming-only change.
+
+## Updated State Flow
+
+```text
+ChainSync RollForward(header Hn)
+  -> HeaderSyncManager updates SyncTipContext from the ChainSync tip
+  -> HeaderSyncManager stores Hn and advances header_tip
+  -> HeaderSyncManager optionally queues HeaderAppliedEvent for async observers
+  -> HeaderSyncManager sends non-blocking signal to BodyFetchManager
+  -> ChainSync callback returns
+
+BodyFetchManager virtual thread wakes
+  -> checkAndFetchBodies()
+  -> if STEADY_STATE or near observed network tip: fetch when gap >= 1
+  -> otherwise INITIAL_SYNC bulk rule: fetch when gap >= gapThreshold
+
+BlockFetch delivers body Bn
+  -> PipelineDataListener enqueues apply work
+  -> BodyFetchManager applies Bn on YanoLedgerApply
+  -> publish existing BlockAppliedEvent after durable body store succeeds
+  -> callbacks.updateSyncProgress(slot, blockNumber)
+  -> possible INITIAL_SYNC -> STEADY_STATE transition
+```
+
+## Detailed Design
+
+### 1. Applied Progress Callback
+
+Change `PeerSessionCallbacks` from a no-arg progress callback to a value-based
+callback:
+
+```java
+public interface PeerSessionCallbacks {
+    void updateSyncProgress(long slot, long blockNumber);
+    // other callbacks unchanged
+}
+```
+
+`PipelineDataListener` already extracts slot and block number for Shelley,
+Byron, and Byron EBB body callbacks. After `BodyFetchManager` returns
+`APPLIED`, call:
+
+```java
+callbacks.updateSyncProgress(slot, blockNumber);
+```
+
+Do not call it for `SKIPPED_STALE` blocks.
+
+`Yano.updateSyncProgress(...)` becomes:
+
+```java
+public void updateSyncProgress(long slot, long blockNumber) {
+    lastProcessedSlot = slot;
+    blocksProcessed++;
+
+    if (syncPhase == SyncPhase.INITIAL_SYNC && !isInitialSyncComplete
+            && remoteTip != null && remoteTip.getPoint() != null) {
+        long distance = Math.max(0L, remoteTip.getPoint().getSlot() - slot);
+        if (distance <= 10) {
+            isInitialSyncComplete = true;
+            log.info("Initial sync complete at slot {} (distance to tip: {} slots)", slot, distance);
+        }
+    }
+
+    if (syncPhase == SyncPhase.INITIAL_SYNC && isInitialSyncComplete) {
+        syncPhase = SyncPhase.STEADY_STATE;
+        BodyFetchManager bodyFetchManager = currentBodyFetchManager();
+        if (isPipelinedMode && bodyFetchManager != null) {
+            bodyFetchManager.setSyncPhase(SyncPhase.STEADY_STATE);
+            bodyFetchManager.wakeFetchLoop();
+        }
+    }
+}
+```
+
+This removes one RocksDB metadata read per applied block on the normal path.
+
+### 2. SyncTipContext Freshness
+
+`SyncTipContext` is the source for the latest observed network tip slot used by
+near-tip decisions. It is intentionally small and lock-free:
+
+```java
+public final class SyncTipContext {
+    private final AtomicLong networkTipSlot = new AtomicLong(-1L);
+
+    public void update(Tip tip) {
+        if (tip != null && tip.getPoint() != null) {
+            networkTipSlot.set(Math.max(0L, tip.getPoint().getSlot()));
+        }
+    }
+}
+```
+
+The writer is `HeaderSyncManager`, from ChainSync callbacks that carry a `Tip`:
+Shelley rollforward, Byron rollforward, Byron EBB rollforward, intersection,
+intersection-not-found, and rollback callbacks. The update is a single
+`AtomicLong` write and must stay on the header callback path.
+
+If `networkTipSlot` is stale or unavailable, the design degrades to the normal
+header/body gap rule and fallback polling. It must not block or fail body fetch.
+
+### 3. Internal Header Wakeup Interface
+
+Add a small runtime-local interface. This keeps `HeaderSyncManager` decoupled
+from the concrete `BodyFetchManager` class.
+
+```java
+package com.bloxbean.cardano.yano.runtime;
+
+public interface HeaderAppliedSignal {
+    /**
+     * Must be non-blocking. Implementations may update atomics and wake their
+     * own worker, but must not run body fetch work on the caller thread.
+     */
+    void onHeaderApplied(long slot, long blockNumber, String blockHash);
+}
+```
+
+`HeaderSyncManager` accepts the signal:
+
+```java
+public final class HeaderSyncManager implements ChainSyncAgentListener {
+    private final HeaderAppliedSignal headerAppliedSignal;
+
+    public HeaderSyncManager(PeerClient peerClient,
+                             ChainState chainState,
+                             long maxGapThreshold,
+                             SyncTipContext syncTipContext,
+                             HeaderAppliedSignal headerAppliedSignal) {
+        this.peerClient = peerClient;
+        this.chainState = chainState;
+        this.maxGapThreshold = maxGapThreshold;
+        this.syncTipContext = syncTipContext;
+        this.headerAppliedSignal = headerAppliedSignal;
+    }
+
+    private void afterHeaderStored(long slot, long blockNumber, String blockHash) {
+        HeaderAppliedSignal signal = headerAppliedSignal;
+        if (signal != null) {
+            signal.onHeaderApplied(slot, blockNumber, blockHash);
+        }
+    }
+}
+```
+
+After `chainState.storeBlockHeader(...)` succeeds, call `afterHeaderStored(...)`.
+
+The contract is explicit: this call must remain cheap and non-blocking.
+
+### 4. BodyFetchManager Signal Handling
+
+`BodyFetchManager` implements `HeaderAppliedSignal`. It records only atomic
+state and unparks its own monitor virtual thread.
+
+```java
+public final class BodyFetchManager implements BlockChainDataListener,
+        Runnable, HeaderAppliedSignal {
+
+    private final AtomicLong lastAppliedBodySlot = new AtomicLong(-1L);
+    private volatile Thread monitoringThread;
+
+    @Override
+    public void onHeaderApplied(long slot, long blockNumber, String blockHash) {
+        if (shouldWakeFromHeader(slot)) {
+            wakeFetchLoop();
+        }
+    }
+
+    public void recordBodyApplied(long slot) {
+        lastAppliedBodySlot.accumulateAndGet(slot, Math::max);
+    }
+
+    public void wakeFetchLoop() {
+        Thread thread = monitoringThread;
+        if (thread != null) {
+            LockSupport.unpark(thread);
+        }
+    }
+}
+```
+
+`lastAppliedBodySlot` must be updated with `accumulateAndGet(slot, Math::max)`
+after successful body apply and rollback recovery points. This keeps the
+in-memory wake heuristic monotonic under normal roll-forward apply. Rollback
+must explicitly reset it to the post-rollback durable body slot.
+
+`shouldWakeFromHeader(...)` must not do RocksDB reads. It can use volatile or
+atomic state already available in memory:
+
+```java
+private boolean shouldWakeFromHeader(long headerSlot) {
+    SyncPhase phase = syncPhase;
+    if (phase == SyncPhase.STEADY_STATE) {
+        return true;
+    }
+
+    long bodySlot = lastAppliedBodySlot.get();
+    long networkTipSlot = syncTipContext != null ? syncTipContext.getNetworkTipSlot() : -1L;
+    if (networkTipSlot > 0 && bodySlot >= 0
+            && Math.max(0L, networkTipSlot - bodySlot) <= tipProximityThreshold) {
+        return true;
+    }
+
+    if (bodySlot < 0) {
+        return headerSlot >= gapThreshold;
+    }
+
+    return headerSlot - bodySlot >= gapThreshold;
+}
+```
+
+The actual fetch decision remains inside `checkAndFetchBodies()`. The signal
+only changes when that method gets called.
+
+### 5. Virtual Thread Monitor Loop
+
+Keep `BodyFetchManager`'s monitor as a virtual thread, but replace frequent
+sleep polling with push wakeups plus a phase-aware fallback timeout.
+
+```java
+monitoringThread = Thread.ofVirtual()
+        .name("BodyFetchManager-Monitor")
+        .start(this);
+```
+
+The loop uses `LockSupport.parkNanos(...)` so a header signal does not need a
+synchronized monitor and a signal arriving before park is retained as a permit.
+
+```java
+@Override
+public void run() {
+    while (running.get() && !Thread.currentThread().isInterrupted()) {
+        try {
+            if (!paused.get()) {
+                checkAndFetchBodies();
+            }
+
+            LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(currentFallbackPollMs()));
+
+            if (Thread.interrupted()) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        } catch (Exception e) {
+            log.error("Error in BodyFetchManager monitoring loop", e);
+        }
+    }
+}
+```
+
+Fallback polling stays enabled. Since push is always enabled, use a longer
+fallback only in real-time mode:
+
+```text
+INITIAL_SYNC fallback: 500ms to 1000ms
+STEADY_STATE or near observed network tip fallback: 5000ms
+```
+
+This avoids a bulk-sync throughput regression if a wake is missed while still
+reducing near-tip polling pressure.
+
+`batchDone()`, rollback resume, and `setSyncPhase(...)` should also call
+`wakeFetchLoop()`. This avoids waiting for the fallback timer when a batch
+completes and more headers are already available. `noBlockFound(...)` should not
+wake immediately because it can otherwise refetch the same empty range in a
+tight loop.
+
+### 6. Bulk Sync Coalescing
+
+During genesis/full sync, headers can arrive much faster than body fetches. The
+wake path must not turn every header into a body gap check.
+
+Coalescing rules:
+
+- In `STEADY_STATE`, wake on every applied header.
+- Near observed network tip, wake on every applied header.
+- In `INITIAL_SYNC`, wake only when the in-memory header/body slot gap is at
+  least `gapThreshold`.
+- Repeated `LockSupport.unpark(...)` calls coalesce naturally while the monitor
+  thread is parked.
+
+This preserves bulk batching and avoids tight coupling between header rate and
+body gap checks.
+
+### 7. Public Events
+
+Add `HeaderAppliedEvent` for observability after a header is durably stored.
+
+```java
+public record HeaderAppliedEvent(long slot, long blockNumber, String blockHash)
+        implements Event {
+}
+```
+
+Keep the existing `BlockAppliedEvent` unchanged in this behavioral change. It
+is already the ordered post-body-store event consumed by account, UTXO, mempool,
+nonce, and plugin listeners. A future `BodyAppliedEvent` rename or alias can be
+landed separately as a naming-only change.
+
+Important distinction:
+
+```text
+HeaderAppliedEvent: notification/observability; must not block ChainSync.
+BlockAppliedEvent: ordered body-apply event; failures must fail apply.
+```
+
+Header event publication should be off the ChainSync callback path. Use a small
+runtime publisher backed by a single virtual thread:
+
+```java
+final class HeaderAppliedEventPublisher implements AutoCloseable {
+    private final BlockingQueue<HeaderAppliedEvent> queue = new ArrayBlockingQueue<>(8192);
+    private final Thread worker;
+
+    HeaderAppliedEventPublisher(EventBus eventBus) {
+        this.worker = Thread.ofVirtual()
+                .name("HeaderAppliedEventPublisher")
+                .start(() -> run(eventBus));
+    }
+
+    void publishLater(HeaderAppliedEvent event) {
+        if (!queue.offer(event)) {
+            log.warn("Dropping HeaderAppliedEvent because queue is full: slot={}", event.slot());
+        }
+    }
+}
+```
+
+The internal body-fetch wakeup must not depend on this publisher. If the event
+queue is full, body fetching must still proceed normally.
+
+### 8. Sync Phase Demotion Scope
+
+This ADR fixes promotion into `STEADY_STATE` and near-tip body-fetch latency. It
+does not add a new general lag-based `STEADY_STATE -> INITIAL_SYNC` demotion.
+
+Current Yano already re-enters `INITIAL_SYNC` in these paths:
+
+- peer session start/recovery resets the phase to `INITIAL_SYNC`;
+- rollback reconciliation demotes from `STEADY_STATE` to `INITIAL_SYNC` if the
+  post-rollback body tip is more than 1000 slots behind remote tip.
+
+A future general demotion rule can be added if a non-rollback steady-state stall
+creates a large header/body backlog. It should be handled separately so this
+change stays focused on wakeup latency and phase promotion.
+
+### 9. Wiring
+
+`PeerSession.initializePipelineManagers(...)` wires the managers in two steps:
+
+```java
+SyncTipContext syncTipContext = new SyncTipContext();
+
+bodyFetchManager = new BodyFetchManager(
+        peerClient,
+        chainState,
+        eventBus,
+        gapThreshold,
+        maxBatchSize,
+        initialSyncFallbackPollMs,
+        tipProximityThreshold,
+        syncTipContext
+);
+
+headerSyncManager = new HeaderSyncManager(
+        peerClient,
+        chainState,
+        50000,
+        syncTipContext,
+        bodyFetchManager
+);
+```
+
+This introduces no concrete dependency from `HeaderSyncManager` to
+`BodyFetchManager`; only `PeerSession` knows both concrete components.
+
+## Non-Blocking Guarantee
+
+The header callback path may do only the following after successful header
+storage for the new wake/event behavior:
+
+```text
+- update SyncTipContext from ChainSync tip
+- update HeaderSyncManager counters/backpressure state
+- invoke HeaderAppliedSignal.onHeaderApplied(...)
+- optionally enqueue HeaderAppliedEvent for async publication
+```
+
+It must not:
+
+```text
+- call BodyFetchManager.checkAndFetchBodies()
+- call PeerClient.fetch(...)
+- read ChainState body/header tips for body-fetch decisions
+- publish HeaderAppliedEvent synchronously to arbitrary listeners
+- wait for BodyFetchManager to acknowledge the signal
+```
+
+The expected hot-path cost is a few atomic writes and `LockSupport.unpark(...)`.
+The pre-existing header backpressure mechanism still checks the durable body
+tip to protect bulk sync from unbounded header lead; replacing that with an
+in-memory progress snapshot is out of scope for this behavioral change.
+
+## Consequences
+
+### Positive
+
+- Near-tip body fetch is driven by header arrival instead of a short polling
+  loop.
+- A stale `syncPhase` no longer causes a 100-slot wait near tip.
+- Successful body apply avoids an extra RocksDB tip read.
+- Header processing is not blocked by body fetch scheduling.
+- Fallback polling still protects against missed wakeups.
+- Bulk sync keeps a short fallback cadence and batching behavior.
+- Header applied notifications become explicit for observers.
+
+### Costs / Risks
+
+- Additional concurrency surface in `BodyFetchManager`.
+- Need careful lifecycle handling so `unpark` against a stopped/replaced manager
+  is harmless.
+- Header event publishing must be best-effort or isolated from core sync so slow
+  plugins cannot affect ChainSync.
+- Keeping `BlockAppliedEvent` avoids rename churn now, but the name remains less
+  precise than `BodyAppliedEvent`.
+
+## Test Plan
+
+1. Unit test `Yano.updateSyncProgress(slot, blockNumber)`:
+   - updates `lastProcessedSlot` without reading `chainState.getTip()`;
+   - flips `INITIAL_SYNC -> STEADY_STATE` when distance to remote tip is `<= 10`;
+   - does not flip when remote tip is unknown or farther away.
+
+2. Unit test `SyncTipContext` freshness:
+   - ChainSync rollforward callbacks update the network tip slot through a
+     single atomic write;
+   - if `networkTipSlot` is stale or unavailable, body fetch still proceeds via
+     gap threshold and fallback polling.
+
+3. Unit test `HeaderSyncManager` signaling:
+   - after `storeBlockHeader(...)`, `HeaderAppliedSignal` is called once;
+   - the signal path does not call `PeerClient.fetch(...)` or read body/header
+     tips.
+
+4. Unit test `BodyFetchManager.onHeaderApplied(...)`:
+   - in `STEADY_STATE`, a single header signal wakes the monitor and triggers a
+     fetch for gap `>= 1`;
+   - in `INITIAL_SYNC`, no fetch happens until gap `>= gapThreshold`;
+   - near observed network tip wakes for gap `>= 1` even before phase flip.
+
+5. Unit test batch continuation:
+   - if `batchDone()` fires while header/body gap remains positive, the monitor
+     wakes immediately instead of waiting for fallback polling.
+
+6. Bulk-sync coalescing test:
+   - applying N headers in `INITIAL_SYNC` does not produce N fetch requests;
+   - fetch calls remain bounded by bulk batching behavior.
+
+7. Event tests:
+   - `HeaderAppliedEvent` is enqueued asynchronously and does not block the
+     header callback path;
+   - existing `BlockAppliedEvent` preserves current ordered/fail-closed behavior
+     for derived stores.
+
+8. Regression test for transaction-submission observation:
+   - submit a tx near tip;
+   - assert upstream acknowledgement remains fast;
+   - assert the confirming body fetch is triggered by header signal rather than
+     waiting for `gapThreshold` slots.
+
+## Rollout Plan
+
+1. Implement `updateSyncProgress(slot, blockNumber)` and remove the no-arg
+   callback.
+2. Add `HeaderAppliedSignal` and non-blocking `BodyFetchManager` wakeup.
+3. Switch the monitor loop from short sleep polling to push wakeups plus
+   phase-aware fallback polling.
+4. Add `HeaderAppliedEvent` asynchronous publisher.
+5. Keep `BlockAppliedEvent` unchanged; defer any `BodyAppliedEvent` rename to a
+   separate naming-only change.
+6. Run focused runtime tests, then a live near-tip sync test with two dependent
+   transactions.
+
+## Open Questions
+
+- Use fixed fallback values of `INITIAL_SYNC=500ms` and realtime `5000ms`, or
+  make them runtime options now?
+- Should a future `BodyAppliedEvent` be a direct rename of `BlockAppliedEvent`
+  or an alias with a deprecation window?

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/HeaderAppliedEvent.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/HeaderAppliedEvent.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.yano.api.events;
+
+import com.bloxbean.cardano.yaci.events.api.Event;
+
+/**
+ * Event published after a header is durably stored.
+ *
+ * <p>This event is for observability only. Body-fetch scheduling uses the
+ * runtime-local header signal path and does not depend on this event being
+ * delivered. It is best-effort and may be dropped under sustained load or
+ * during shutdown; correctness-critical logic should use ordered body-apply
+ * events such as {@link BlockAppliedEvent} instead.</p>
+ */
+public record HeaderAppliedEvent(long slot, long blockNumber, String blockHash) implements Event {
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/BodyFetchManager.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/BodyFetchManager.java
@@ -33,6 +33,8 @@ import com.bloxbean.cardano.yano.runtime.peer.PeerHealth;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.LockSupport;
 import java.util.stream.Collectors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -54,7 +56,7 @@ import java.util.concurrent.atomic.AtomicLong;
  * This enables true parallel pipeline architecture where headers sync ahead of bodies.
  */
 @Slf4j
-public class BodyFetchManager implements BlockChainDataListener, Runnable {
+public class BodyFetchManager implements BlockChainDataListener, Runnable, HeaderAppliedSignal {
     /**
      * Result of attempting to apply one decoded block body to local ledger state.
      */
@@ -72,6 +74,8 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
 
     private static final long SLOW_EPOCH_TRANSITION_WARN_MS =
             positiveLongProperty("yano.bodyFetch.slowEpochTransitionWarnMs", 1_000L);
+    private static final long REALTIME_FALLBACK_POLL_MS =
+            positiveLongProperty("yano.bodyFetch.realtimeFallbackPollMs", 5_000L);
 
     private final PeerClient peerClient;
     private final ChainState chainState;
@@ -89,6 +93,7 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
     private final AtomicBoolean paused = new AtomicBoolean(false);
     private volatile Thread monitoringThread;
     private volatile SyncPhase syncPhase = SyncPhase.INITIAL_SYNC;
+    private final AtomicLong lastAppliedBodySlot = new AtomicLong(-1L);
 
     // Metrics
     private final AtomicInteger bodiesReceived = new AtomicInteger(0);
@@ -186,6 +191,7 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
 
         startTime = System.currentTimeMillis();
         resetMetrics();
+        initializeAppliedBodySlotFromTip();
 
         // Check if we should immediately resume (when already near tip)
         checkForImmediateResume();
@@ -234,8 +240,20 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
             return;
         }
 
-        if (monitoringThread != null) {
-            monitoringThread.interrupt();
+        Thread thread = monitoringThread;
+        if (thread != null) {
+            thread.interrupt();
+            if (thread != Thread.currentThread()) {
+                try {
+                    thread.join(TimeUnit.SECONDS.toMillis(5));
+                    if (thread.isAlive()) {
+                        log.warn("BodyFetchManager monitoring thread did not stop within timeout");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Interrupted while waiting for BodyFetchManager monitoring thread to stop");
+                }
+            }
         }
 
         if (log.isInfoEnabled()) {
@@ -262,6 +280,21 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
         if (log.isDebugEnabled()) {
             log.debug("▶️ BodyFetchManager resumed");
         }
+        wakeFetchLoop();
+    }
+
+    @Override
+    public void onHeaderApplied(long slot, long blockNumber, String blockHash) {
+        if (shouldWakeFromHeader(slot)) {
+            wakeFetchLoop();
+        }
+    }
+
+    public void wakeFetchLoop() {
+        Thread thread = monitoringThread;
+        if (thread != null) {
+            LockSupport.unpark(thread);
+        }
     }
 
     /**
@@ -279,14 +312,13 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
                     checkAndFetchBodies();
                 }
 
-                // Adaptive monitoring interval based on sync phase
-                long currentInterval = getAdaptiveMonitoringInterval();
-                Thread.sleep(currentInterval);
+                // Push-driven wakeups with phase-aware fallback polling.
+                LockSupport.parkNanos(TimeUnit.MILLISECONDS.toNanos(getAdaptiveMonitoringInterval()));
+                if (Thread.interrupted()) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
 
-            } catch (InterruptedException e) {
-                log.info("BodyFetchManager monitoring thread interrupted");
-                Thread.currentThread().interrupt();
-                break;
             } catch (Exception e) {
                 log.error("Error in BodyFetchManager monitoring loop", e);
                 // Continue running despite errors
@@ -302,8 +334,8 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
      * During bulk: slower monitoring for efficiency
      */
     private long getAdaptiveMonitoringInterval() {
-        if (syncPhase == SyncPhase.STEADY_STATE) {
-            return 100; // 100ms at tip for immediate body fetching
+        if (isRealtimeFetchMode()) {
+            return REALTIME_FALLBACK_POLL_MS;
         }
         return monitoringIntervalMs; // Use configured interval for bulk sync
     }
@@ -379,12 +411,57 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
      */
     private boolean shouldFetchBodies(long gapSize) {
         // At tip: fetch immediately when any header is ahead
-        if (syncPhase == SyncPhase.STEADY_STATE) {
+        if (isRealtimeFetchMode()) {
             return gapSize >= 1; // Immediate body fetching at tip
         }
 
         // During bulk sync: use configured threshold for efficient batching
         return gapSize >= gapThreshold;
+    }
+
+    private boolean isRealtimeFetchMode() {
+        return syncPhase == SyncPhase.STEADY_STATE || isNearObservedNetworkTip();
+    }
+
+    private boolean shouldWakeFromHeader(long headerSlot) {
+        if (syncPhase == SyncPhase.STEADY_STATE) {
+            return true;
+        }
+
+        long bodySlot = lastAppliedBodySlot.get();
+        long networkTipSlot = syncTipContext != null ? syncTipContext.getNetworkTipSlot() : -1L;
+        if (networkTipSlot > 0 && bodySlot >= 0
+                && Math.max(0L, networkTipSlot - bodySlot) <= tipProximityThreshold) {
+            return true;
+        }
+
+        if (bodySlot < 0) {
+            return headerSlot >= gapThreshold;
+        }
+
+        return headerSlot - bodySlot >= gapThreshold;
+    }
+
+    private boolean isNearObservedNetworkTip() {
+        if (syncTipContext == null) {
+            return false;
+        }
+        long networkTipSlot = syncTipContext.getNetworkTipSlot();
+        if (networkTipSlot <= 0) {
+            return false;
+        }
+
+        ChainTip bodyTip = chainState.getTip();
+        ChainTip headerTip = chainState.getHeaderTip();
+        long localSlot = bodyTip != null
+                ? bodyTip.getSlot()
+                : headerTip != null ? headerTip.getSlot() : -1L;
+        if (localSlot < 0) {
+            return false;
+        }
+
+        long distance = Math.max(0L, networkTipSlot - localSlot);
+        return distance <= tipProximityThreshold;
     }
 
     /**
@@ -966,6 +1043,7 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
         currentBatchFrom = null;
         currentBatchTo = null;
         currentBatchSize = 0;
+        wakeFetchLoop();
     }
 
     @Override
@@ -977,15 +1055,16 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
     @Override
     public void onRollback(Point point) {
         log.info("🔄 Rollback detected to point: {}", point);
+        paused.set(true);
         // Store the rollback point to prevent storing stale blocks
         lastRollbackPoint = point;
-        // Body fetching will be paused by external rollback handling
         // Reset any in-progress batch
         batchInProgress = false;
         currentBatchFrom = null;
         currentBatchTo = null;
         currentBatchSize = 0;
         consecutiveStaleBlocks.set(0);
+        resetAppliedBodySlotAfterRollback(point);
     }
 
     @Override
@@ -1395,6 +1474,7 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
             if (log.isDebugEnabled()) {
                 log.debug("🔄 BodyFetchManager sync phase changed: {} -> {}", oldPhase, syncPhase);
             }
+            wakeFetchLoop();
         }
     }
 
@@ -1403,6 +1483,10 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
      */
     public SyncPhase getSyncPhase() {
         return syncPhase;
+    }
+
+    long getObservedNetworkTipSlot() {
+        return syncTipContext != null ? syncTipContext.getNetworkTipSlot() : -1L;
     }
 
     /**
@@ -1506,10 +1590,24 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable {
     }
 
     private void recordBodyApplied(long slot, long blockNumber) {
+        lastAppliedBodySlot.accumulateAndGet(slot, Math::max);
         PeerHealth health = peerHealth;
         if (health != null) {
             health.recordBodyApplied(slot, blockNumber, System.currentTimeMillis());
         }
+    }
+
+    private void initializeAppliedBodySlotFromTip() {
+        ChainTip tip = chainState.getTip();
+        lastAppliedBodySlot.set(tip != null ? tip.getSlot() : -1L);
+    }
+
+    private void resetAppliedBodySlotAfterRollback(Point point) {
+        if (point == null) {
+            lastAppliedBodySlot.set(-1L);
+            return;
+        }
+        lastAppliedBodySlot.updateAndGet(current -> current < 0 ? current : Math.min(current, point.getSlot()));
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderAppliedEventPublisher.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderAppliedEventPublisher.java
@@ -1,0 +1,112 @@
+package com.bloxbean.cardano.yano.runtime;
+
+import com.bloxbean.cardano.yaci.events.api.EventBus;
+import com.bloxbean.cardano.yaci.events.api.EventMetadata;
+import com.bloxbean.cardano.yaci.events.api.PublishOptions;
+import com.bloxbean.cardano.yano.api.events.HeaderAppliedEvent;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Objects;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+@Slf4j
+public final class HeaderAppliedEventPublisher implements AutoCloseable {
+    private static final int DEFAULT_QUEUE_CAPACITY =
+            positiveIntProperty("yano.headerAppliedEvent.queueCapacity", 8192);
+
+    private final EventBus eventBus;
+    private final BlockingQueue<HeaderAppliedEvent> queue;
+    private final AtomicBoolean running = new AtomicBoolean(true);
+    private final Thread worker;
+
+    public HeaderAppliedEventPublisher(EventBus eventBus) {
+        this(eventBus, DEFAULT_QUEUE_CAPACITY);
+    }
+
+    HeaderAppliedEventPublisher(EventBus eventBus, int queueCapacity) {
+        this.eventBus = Objects.requireNonNull(eventBus, "eventBus cannot be null");
+        this.queue = new ArrayBlockingQueue<>(Math.max(1, queueCapacity));
+        this.worker = Thread.ofVirtual()
+                .name("HeaderAppliedEventPublisher")
+                .start(this::run);
+    }
+
+    void publishLater(long slot, long blockNumber, String blockHash) {
+        if (!running.get()) {
+            return;
+        }
+
+        HeaderAppliedEvent event = new HeaderAppliedEvent(slot, blockNumber, blockHash);
+        if (!queue.offer(event)) {
+            log.warn("Dropping HeaderAppliedEvent because queue is full: slot={}, block={}",
+                    slot, blockNumber);
+        }
+    }
+
+    private void run() {
+        while (running.get() || !queue.isEmpty()) {
+            try {
+                HeaderAppliedEvent event = queue.poll(1, TimeUnit.SECONDS);
+                if (event != null) {
+                    publish(event);
+                }
+            } catch (InterruptedException e) {
+                if (!running.get()) {
+                    break;
+                }
+                Thread.currentThread().interrupt();
+                break;
+            } catch (Exception e) {
+                log.warn("Error publishing HeaderAppliedEvent", e);
+            }
+        }
+    }
+
+    private void publish(HeaderAppliedEvent event) {
+        EventMetadata metadata = EventMetadata.builder()
+                .origin("runtime")
+                .slot(event.slot())
+                .blockNo(event.blockNumber())
+                .blockHash(event.blockHash())
+                .build();
+        eventBus.publish(event, metadata, PublishOptions.builder().build());
+    }
+
+    @Override
+    public void close() {
+        if (running.compareAndSet(true, false)) {
+            worker.interrupt();
+            if (worker != Thread.currentThread()) {
+                try {
+                    worker.join(TimeUnit.SECONDS.toMillis(2));
+                    if (worker.isAlive()) {
+                        log.warn("HeaderAppliedEventPublisher worker did not stop within timeout");
+                    }
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    log.warn("Interrupted while waiting for HeaderAppliedEventPublisher worker to stop");
+                }
+            }
+        }
+    }
+
+    private static int positiveIntProperty(String name, int defaultValue) {
+        String value = System.getProperty(name);
+        if (value == null || value.isBlank()) {
+            return defaultValue;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            if (parsed > 0) {
+                return parsed;
+            }
+            log.warn("Ignoring non-positive {}={}, using {}", name, value, defaultValue);
+        } catch (NumberFormatException e) {
+            log.warn("Ignoring invalid {}={}, using {}", name, value, defaultValue);
+        }
+        return defaultValue;
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderAppliedSignal.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderAppliedSignal.java
@@ -1,0 +1,11 @@
+package com.bloxbean.cardano.yano.runtime;
+
+/**
+ * Non-blocking signal emitted after a header is durably stored.
+ *
+ * Implementations must not perform body fetch work, RocksDB reads, or any
+ * blocking operation on the caller thread.
+ */
+public interface HeaderAppliedSignal {
+    void onHeaderApplied(long slot, long blockNumber, String blockHash);
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderSyncManager.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderSyncManager.java
@@ -12,7 +12,10 @@ import com.bloxbean.cardano.yaci.core.storage.ChainState;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yaci.helper.PeerClient;
 import com.bloxbean.cardano.yano.runtime.chain.DirectRocksDBChainState;
+import com.bloxbean.cardano.yano.runtime.chain.InMemoryChainState;
 import lombok.extern.slf4j.Slf4j;
+
+import java.util.concurrent.atomic.AtomicLong;
 
 /**
  * HeaderSyncManager handles header-only synchronization using ChainSyncAgent with intelligent backpressure.
@@ -40,6 +43,9 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
     private final ChainState chainState;
     private final PeerClient peerClient;
     private final SyncTipContext syncTipContext;
+    private final HeaderAppliedSignal headerAppliedSignal;
+    private final HeaderAppliedEventPublisher headerAppliedEventPublisher;
+    private final AtomicLong headerSignalFailures = new AtomicLong(0);
 
     // Metrics tracking
     private volatile long headersReceived = 0;
@@ -55,18 +61,31 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
     private static final int PROGRESS_LOG_INTERVAL = 1000;
 
     public HeaderSyncManager(PeerClient peerClient, ChainState chainState) {
-        this(peerClient, chainState, 50000, null); // Default gap threshold of 50,000 blocks
+        this(peerClient, chainState, 50000, null, null); // Default gap threshold of 50,000 blocks
     }
 
     public HeaderSyncManager(PeerClient peerClient, ChainState chainState, long maxGapThreshold) {
-        this(peerClient, chainState, maxGapThreshold, null);
+        this(peerClient, chainState, maxGapThreshold, null, null);
     }
 
     public HeaderSyncManager(PeerClient peerClient, ChainState chainState, long maxGapThreshold, SyncTipContext syncTipContext) {
+        this(peerClient, chainState, maxGapThreshold, syncTipContext, null);
+    }
+
+    public HeaderSyncManager(PeerClient peerClient, ChainState chainState, long maxGapThreshold,
+                             SyncTipContext syncTipContext, HeaderAppliedSignal headerAppliedSignal) {
+        this(peerClient, chainState, maxGapThreshold, syncTipContext, headerAppliedSignal, null);
+    }
+
+    public HeaderSyncManager(PeerClient peerClient, ChainState chainState, long maxGapThreshold,
+                             SyncTipContext syncTipContext, HeaderAppliedSignal headerAppliedSignal,
+                             HeaderAppliedEventPublisher headerAppliedEventPublisher) {
         this.peerClient = peerClient;
         this.chainState = chainState;
         this.maxGapThreshold = maxGapThreshold;
         this.syncTipContext = syncTipContext;
+        this.headerAppliedSignal = headerAppliedSignal;
+        this.headerAppliedEventPublisher = headerAppliedEventPublisher;
 
         log.info("HeaderSyncManager initialized - ready for header-only synchronization (gap threshold: {} blocks)", maxGapThreshold);
     }
@@ -98,6 +117,7 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
                 slot,
                 originalHeaderBytes
             );
+            afterHeaderStored(slot, blockNumber, blockHash);
 
             // Update metrics
             headersReceived++;
@@ -118,7 +138,7 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
                         slot, blockNumber, blockHash);
             }
 
-} catch (Exception e) {
+        } catch (Exception e) {
             log.error("Failed to store Shelley+ header: slot={}, blockNumber={}",
                     blockHeader.getHeaderBody().getSlot(),
                     blockHeader.getHeaderBody().getBlockNumber(), e);
@@ -156,6 +176,7 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
                 absoluteSlot,
                 originalHeaderBytes
             );
+            afterHeaderStored(absoluteSlot, blockNumber, blockHash);
 
             // Update metrics
             headersReceived++;
@@ -209,9 +230,12 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
             var hashBytes = HexUtil.decodeHexString(blockHash);
             if (chainState instanceof DirectRocksDBChainState rocks) {
                 rocks.storeByronEbHeader(hashBytes, blockNumber, absoluteSlot, originalHeaderBytes);
+            } else if (chainState instanceof InMemoryChainState inMemory) {
+                inMemory.storeByronEbHeader(hashBytes, blockNumber, absoluteSlot, originalHeaderBytes);
             } else {
                 chainState.storeBlockHeader(hashBytes, blockNumber, absoluteSlot, originalHeaderBytes);
             }
+            afterHeaderStored(absoluteSlot, blockNumber, blockHash);
 
             // Update metrics
             headersReceived++;
@@ -276,6 +300,24 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
         // No action needed here - ChainSyncAgent handles reconnection automatically
         // using its internal currentPoint tracking for robust resumption
         log.debug("📄 ChainSyncAgent will automatically resume headers from last confirmed point");
+    }
+
+    private void afterHeaderStored(long slot, long blockNumber, String blockHash) {
+        HeaderAppliedEventPublisher publisher = headerAppliedEventPublisher;
+        if (publisher != null) {
+            publisher.publishLater(slot, blockNumber, blockHash);
+        }
+
+        HeaderAppliedSignal signal = headerAppliedSignal;
+        if (signal != null) {
+            try {
+                signal.onHeaderApplied(slot, blockNumber, blockHash);
+            } catch (Exception e) {
+                long failures = headerSignalFailures.incrementAndGet();
+                log.warn("Header applied signal failed (total failures={}): slot={}, block={}",
+                        failures, slot, blockNumber, e);
+            }
+        }
     }
 
     // =================================================================

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/PipelineDataListener.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/PipelineDataListener.java
@@ -192,7 +192,7 @@ public class PipelineDataListener implements BlockChainDataListener {
                 }
 
                 // Update sync progress tracking in Yano
-                callbacks.updateSyncProgress();
+                callbacks.updateSyncProgress(slot, blockNumber);
 
                 // Notify server about new block availability (only during STEADY_STATE)
                 callbacks.notifyServerNewBlockStored();
@@ -233,7 +233,7 @@ public class PipelineDataListener implements BlockChainDataListener {
                 }
 
                 // Update sync progress tracking in Yano
-                callbacks.updateSyncProgress();
+                callbacks.updateSyncProgress(slot, blockNumber);
 
                 // Notify server about new block availability (only during STEADY_STATE)
                 callbacks.notifyServerNewBlockStored();
@@ -275,7 +275,7 @@ public class PipelineDataListener implements BlockChainDataListener {
                 }
 
                 // Update sync progress tracking in Yano
-                callbacks.updateSyncProgress();
+                callbacks.updateSyncProgress(slot, blockNumber);
 
                 // Notify server about new block availability (only during STEADY_STATE)
                 callbacks.notifyServerNewBlockStored();

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/Yano.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/Yano.java
@@ -156,7 +156,7 @@ public class Yano implements NodeAPI, PeerSessionCallbacks {
     // Client sync component - now using pipelined sync for parallel ChainSync and BlockFetch
     private volatile PeerSession peerSession;
     private PeerSessionSupervisor peerSessionSupervisor;
-    private boolean isInitialSyncComplete = false;
+    private volatile boolean isInitialSyncComplete = false;
     // Pipelining state
     private PipelineConfig pipelineConfig;
     private boolean isPipelinedMode = false;
@@ -200,7 +200,7 @@ public class Yano implements NodeAPI, PeerSessionCallbacks {
     private long lastProcessedSlot = 0;
 
     // Rollback classification fields
-    private SyncPhase syncPhase = SyncPhase.INITIAL_SYNC;
+    private volatile SyncPhase syncPhase = SyncPhase.INITIAL_SYNC;
     private ChainTip lastKnownChainTip;
     private long rollbackClassificationTimeout = 30000; // 30 seconds
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -3800,33 +3800,6 @@ public class Yano implements NodeAPI, PeerSessionCallbacks {
 
 
     /**
-     * Check sync progress and detect when BlockFetch is complete to transition to ChainSync
-     */
-    private void checkSyncProgress() {
-        // If we have a remote tip and we're close to it, mark initial sync as complete
-        Point remotePoint = remoteTip != null ? remoteTip.getPoint() : null;
-        if (!isInitialSyncComplete && remotePoint != null) {
-            long slotDifference = remotePoint.getSlot() - lastProcessedSlot;
-
-            // If we're within 10 slots of the remote tip, consider initial sync complete
-            if (slotDifference <= 10) {
-                isInitialSyncComplete = true;
-                log.info("🚀 ==> TRANSITION: BlockFetch → ChainSync");
-                log.info("🚀 ==> Initial BlockFetch sync complete! Now in real-time ChainSync mode at slot {}", lastProcessedSlot);
-                log.info("🚀 ==> Yano is now fully synchronized and serving clients");
-                log.info("🚀 ==> Will now log every block as it arrives in real-time");
-                // Reflect phase change
-                var prev = syncPhase;
-                updateSyncProgress();
-                if (prev != syncPhase) {
-                    EventMetadata meta = EventMetadata.builder().origin("runtime").build();
-                    eventBus.publish(new SyncStatusChangedEvent(prev, syncPhase), meta, PublishOptions.builder().build());
-                }
-            }
-        }
-    }
-
-    /**
      * Stop Yano.
      */
     public void stop() {
@@ -4150,21 +4123,53 @@ public class Yano implements NodeAPI, PeerSessionCallbacks {
     /**
      * Update sync phase based on sync progress
      */
-    public void updateSyncProgress() {
+    public void updateSyncProgress(long slot, long blockNumber) {
+        lastProcessedSlot = slot;
+        blocksProcessed++;
+        long observedRemoteTipSlot = observedRemoteTipSlot();
+        if (syncPhase == SyncPhase.INITIAL_SYNC && !isInitialSyncComplete
+                && observedRemoteTipSlot >= 0) {
+            long distance = Math.max(0L, observedRemoteTipSlot - slot);
+            if (distance <= 10) {
+                isInitialSyncComplete = true;
+                log.info("🚀 ==> Initial sync complete at slot {} (distance to tip: {} slots)",
+                        slot, distance);
+            }
+        }
+
         if (syncPhase == SyncPhase.INITIAL_SYNC && isInitialSyncComplete) {
+            SyncPhase prev = syncPhase;
             syncPhase = SyncPhase.STEADY_STATE;
             log.info("Transitioned to STEADY_STATE sync phase");
+            EventMetadata meta = EventMetadata.builder().origin("runtime").build();
+            eventBus.publish(new SyncStatusChangedEvent(prev, syncPhase), meta, PublishOptions.builder().build());
 
             // Update BodyFetchManager sync phase and resume if needed
             BodyFetchManager bodyFetchManager = currentBodyFetchManager();
             if (isPipelinedMode && bodyFetchManager != null) {
                 bodyFetchManager.setSyncPhase(SyncPhase.STEADY_STATE);
+                bodyFetchManager.wakeFetchLoop();
                 if (bodyFetchManager.isPaused()) {
                     bodyFetchManager.resume();
                     log.info("▶️ BodyFetchManager resumed after transition to STEADY_STATE");
                 }
             }
         }
+    }
+
+    private long observedRemoteTipSlot() {
+        long observedSlot = -1L;
+        Tip tip = remoteTip;
+        if (tip != null && tip.getPoint() != null) {
+            observedSlot = tip.getPoint().getSlot();
+        }
+
+        BodyFetchManager bodyFetchManager = currentBodyFetchManager();
+        if (bodyFetchManager != null) {
+            observedSlot = Math.max(observedSlot, bodyFetchManager.getObservedNetworkTipSlot());
+        }
+
+        return observedSlot;
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/InMemoryChainState.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/InMemoryChainState.java
@@ -21,6 +21,11 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
     private Map<String, byte[]> blockHeaderStore = new ConcurrentHashMap<>();
     private Map<Long, byte[]> blockHashByNumber = new ConcurrentHashMap<>();
     private ConcurrentSkipListMap<Long, Long> blockNumberBySlot = new ConcurrentSkipListMap<>();
+    private Map<Long, byte[]> headerHashByNumber = new ConcurrentHashMap<>();
+    private ConcurrentSkipListMap<Long, Long> headerNumberBySlot = new ConcurrentSkipListMap<>();
+    private ConcurrentSkipListMap<Long, byte[]> headerHashBySlot = new ConcurrentSkipListMap<>();
+    private ConcurrentSkipListMap<Long, byte[]> ebbHeaderHashBySlot = new ConcurrentSkipListMap<>();
+    private ConcurrentSkipListMap<Long, Long> ebbHeaderNumberBySlot = new ConcurrentSkipListMap<>();
 
     private static String toHex(byte[] bytes) {
         return HexUtil.encodeHexString(bytes);
@@ -39,6 +44,7 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
         blockHeaderStore.put(key, block);
         blockHashByNumber.put(blockNumber, blockHash);
         blockNumberBySlot.put(slot, blockNumber);
+        indexMainHeader(blockHash, blockNumber, slot);
         tip = new ChainTip(slot, blockHash, blockNumber);
     }
 
@@ -55,6 +61,18 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
     @Override
     public void storeBlockHeader(byte[] blockHash, Long blockNumber, Long slot, byte[] blockHeader) {
         blockHeaderStore.put(toHex(blockHash), blockHeader);
+        indexMainHeader(blockHash, blockNumber, slot);
+        headerTip = new ChainTip(slot, blockHash, blockNumber);
+    }
+
+    public void storeByronEbHeader(byte[] blockHash, Long blockNumber, Long slot, byte[] blockHeader) {
+        blockHeaderStore.put(toHex(blockHash), blockHeader);
+        if (slot != null) {
+            ebbHeaderHashBySlot.put(slot, blockHash);
+            if (blockNumber != null) {
+                ebbHeaderNumberBySlot.put(slot, blockNumber);
+            }
+        }
         headerTip = new ChainTip(slot, blockHash, blockNumber);
     }
 
@@ -74,13 +92,26 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
 
     @Override
     public void rollbackTo(Long slot) {
-        // Get all block numbers greater than the provided slot
+        headerHashBySlot.tailMap(slot, false).forEach((headerSlot, blockHash) -> {
+            String key = toHex(blockHash);
+            blockHeaderStore.remove(key);
+            removeHashValue(headerHashByNumber, blockHash);
+            headerNumberBySlot.remove(headerSlot);
+        });
+        headerHashBySlot.tailMap(slot, false).clear();
+        headerNumberBySlot.tailMap(slot, false).clear();
+
+        ebbHeaderHashBySlot.tailMap(slot, false).forEach((headerSlot, blockHash) ->
+                blockHeaderStore.remove(toHex(blockHash)));
+        ebbHeaderHashBySlot.tailMap(slot, false).clear();
+        ebbHeaderNumberBySlot.tailMap(slot, false).clear();
+
+        // Get all body block numbers greater than the provided slot
         blockNumberBySlot.tailMap(slot, false).forEach((blockSlot, blockNumber) -> {
             byte[] blockHash = blockHashByNumber.get(blockNumber);
             if (blockHash != null) {
                 String key = toHex(blockHash);
                 blockStore.remove(key);
-                blockHeaderStore.remove(key);
                 blockHashByNumber.remove(blockNumber);
             }
         });
@@ -88,25 +119,26 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
         // Remove the entries from blockNumberBySlot where slots are greater than the provided slot
         blockNumberBySlot.tailMap(slot, false).clear();
 
-        var lastEntry = blockNumberBySlot.floorEntry(slot);
-        if (lastEntry == null) {
-            tip = null;
-            headerTip = null;
-            return;
-        }
+        tip = bodyTipAtOrBefore(slot);
+        headerTip = headerTipAtOrBefore(slot);
+    }
 
+    private ChainTip bodyTipAtOrBefore(Long slot) {
+        var lastEntry = blockNumberBySlot.floorEntry(slot);
+        if (lastEntry == null) return null;
         Long tipSlot = lastEntry.getKey();
         Long blockNumber = lastEntry.getValue();
         byte[] blockHash = blockHashByNumber.get(blockNumber);
-        if (blockHash == null) {
-            tip = null;
-            headerTip = null;
-            return;
-        }
+        return blockHash != null && blockStore.containsKey(toHex(blockHash))
+                ? new ChainTip(tipSlot, blockHash, blockNumber)
+                : null;
+    }
 
-        String key = toHex(blockHash);
-        tip = blockStore.containsKey(key) ? new ChainTip(tipSlot, blockHash, blockNumber) : null;
-        headerTip = blockHeaderStore.containsKey(key) ? new ChainTip(tipSlot, blockHash, blockNumber) : null;
+    private ChainTip headerTipAtOrBefore(Long slot) {
+        HeaderPoint headerPoint = lastHeaderPointAtOrBefore(slot);
+        return headerPoint != null
+                ? new ChainTip(headerPoint.slot(), headerPoint.hash(), headerPoint.blockNumber())
+                : null;
     }
 
     public void rollbackToOrigin() {
@@ -114,6 +146,11 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
         blockHeaderStore.clear();
         blockHashByNumber.clear();
         blockNumberBySlot.clear();
+        headerHashByNumber.clear();
+        headerNumberBySlot.clear();
+        headerHashBySlot.clear();
+        ebbHeaderHashBySlot.clear();
+        ebbHeaderNumberBySlot.clear();
         tip = null;
         headerTip = null;
         epochNonceState = null;
@@ -133,7 +170,7 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
 
     @Override
     public byte[] getBlockHeaderByNumber(Long blockNumber) {
-        byte[] blockHash = blockHashByNumber.get(blockNumber);
+        byte[] blockHash = headerHashByNumber.get(blockNumber);
         if (blockHash != null) {
             return blockHeaderStore.get(toHex(blockHash));
         }
@@ -150,16 +187,8 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
 
         if (headerTip == null || currentSlot >= headerTip.getSlot()) return null;
 
-        Long nextSlot = blockNumberBySlot.higherKey(currentSlot);
-        if (nextSlot == null) return null;
-
-        Long blockNumber = blockNumberBySlot.get(nextSlot);
-        if (blockNumber == null) return null;
-
-        byte[] blockHash = blockHashByNumber.get(blockNumber);
-        if (blockHash == null) return null;
-
-        return new Point(nextSlot, HexUtil.encodeHexString(blockHash));
+        HeaderPoint next = nextHeaderPointAfter(currentSlot, currentPoint.getHash());
+        return next != null ? new Point(next.slot(), HexUtil.encodeHexString(next.hash())) : null;
     }
 
     @Override
@@ -192,24 +221,8 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
      * Find the first (earliest) block in our chain
      */
     public Point getFirstBlock() {
-        // Slot-first: earliest slot in our map
-        if (blockNumberBySlot.isEmpty()) return null;
-
-        try {
-            Long firstSlot = blockNumberBySlot.firstKey();
-            if (firstSlot == null) return null;
-
-            Long blockNumber = blockNumberBySlot.get(firstSlot);
-            if (blockNumber == null) return null;
-
-            byte[] blockHash = blockHashByNumber.get(blockNumber);
-            if (blockHash == null) return null;
-
-            return new Point(firstSlot, HexUtil.encodeHexString(blockHash));
-        } catch (Exception e) {
-            if (log.isDebugEnabled()) log.debug("Error finding first block: {}", e.getMessage());
-            return null;
-        }
+        HeaderPoint first = firstHeaderPoint();
+        return first != null ? new Point(first.slot(), HexUtil.encodeHexString(first.hash())) : null;
     }
 
     @Override
@@ -221,7 +234,7 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
         try {
             // Resolve start slot (handle ORIGIN)
             Long startSlot = from.getSlot() == 0 && from.getHash() == null
-                    ? blockNumberBySlot.isEmpty() ? null : blockNumberBySlot.firstKey()
+                    ? firstHeaderSlot()
                     : from.getSlot();
             Long endSlot = to.getSlot();
             if (startSlot == null || endSlot == null) return out;
@@ -229,15 +242,8 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
             long minSlot = Math.min(startSlot, endSlot);
             long maxSlot = Math.max(startSlot, endSlot);
 
-            // Iterate by slot order
-            for (Map.Entry<Long, Long> entry : blockNumberBySlot.subMap(minSlot, true, maxSlot, true).entrySet()) {
-                Long slot = entry.getKey();
-                Long blockNumber = entry.getValue();
-                byte[] blockHash = blockHashByNumber.get(blockNumber);
-                if (blockHash != null) {
-                    out.add(new Point(slot, HexUtil.encodeHexString(blockHash)));
-                }
-            }
+            headerPointsInRange(minSlot, maxSlot).forEach(headerPoint ->
+                    out.add(new Point(headerPoint.slot(), HexUtil.encodeHexString(headerPoint.hash()))));
         } catch (Exception e) {
             if (log.isDebugEnabled()) log.debug("Error finding blocks in range: {}", e.getMessage());
         }
@@ -278,29 +284,16 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
         try {
             long fromSlot = from.getSlot();
 
-            // Get all available slots starting from the fromSlot in order
-            List<Long> sortedSlots = blockNumberBySlot.keySet().stream()
-                    .filter(slot -> slot >= fromSlot)
-                    .sorted()
+            List<HeaderPoint> points = headerPointsInRange(fromSlot, Long.MAX_VALUE).stream()
                     .limit(batchSize)
                     .toList();
 
-            if (sortedSlots.isEmpty()) {
+            if (points.isEmpty()) {
                 return null;
             }
 
-            // Get the last slot and its corresponding block
-            Long lastSlot = sortedSlots.get(sortedSlots.size() - 1);
-            Long lastBlockNumber = blockNumberBySlot.get(lastSlot);
-
-            if (lastBlockNumber != null) {
-                byte[] lastBlockHash = blockHashByNumber.get(lastBlockNumber);
-                if (lastBlockHash != null) {
-                    return new Point(lastSlot, HexUtil.encodeHexString(lastBlockHash));
-                }
-            }
-
-            return null;
+            HeaderPoint lastPoint = points.get(points.size() - 1);
+            return new Point(lastPoint.slot(), HexUtil.encodeHexString(lastPoint.hash()));
         } catch (Exception e) {
             if (log.isDebugEnabled()) {
                 log.debug("Error finding last point after N blocks: {}", e.getMessage());
@@ -311,17 +304,120 @@ public class InMemoryChainState implements ChainState, NonceStateStore {
 
     @Override
     public Long getBlockNumberBySlot(Long slot) {
-        return blockNumberBySlot.get(slot);
+        Long blockNumber = headerNumberBySlot.get(slot);
+        return blockNumber != null ? blockNumber : blockNumberBySlot.get(slot);
     }
 
     @Override
     public Long getSlotByBlockNumber(Long blockNumber) {
-        for (Map.Entry<Long, Long> entry : blockNumberBySlot.entrySet()) {
+        for (Map.Entry<Long, Long> entry : headerNumberBySlot.entrySet()) {
             if (entry.getValue().equals(blockNumber)) {
                 return entry.getKey();
             }
         }
         return null;
+    }
+
+    private void indexMainHeader(byte[] blockHash, Long blockNumber, Long slot) {
+        if (blockNumber != null) {
+            headerHashByNumber.put(blockNumber, blockHash);
+        }
+        if (slot != null) {
+            headerHashBySlot.put(slot, blockHash);
+            if (blockNumber != null) {
+                headerNumberBySlot.put(slot, blockNumber);
+            }
+        }
+    }
+
+    private static void removeHashValue(Map<Long, byte[]> map, byte[] hash) {
+        if (hash == null) return;
+        map.entrySet().removeIf(entry -> java.util.Arrays.equals(entry.getValue(), hash));
+    }
+
+    private Long firstHeaderSlot() {
+        HeaderPoint first = firstHeaderPoint();
+        return first != null ? first.slot() : null;
+    }
+
+    private HeaderPoint firstHeaderPoint() {
+        HeaderPoint main = firstHeaderPoint(headerHashBySlot, headerNumberBySlot);
+        HeaderPoint ebb = firstHeaderPoint(ebbHeaderHashBySlot, ebbHeaderNumberBySlot);
+        return earlier(main, ebb);
+    }
+
+    private HeaderPoint lastHeaderPointAtOrBefore(long slot) {
+        HeaderPoint main = floorHeaderPoint(headerHashBySlot, headerNumberBySlot, slot);
+        HeaderPoint ebb = floorHeaderPoint(ebbHeaderHashBySlot, ebbHeaderNumberBySlot, slot);
+        return later(main, ebb);
+    }
+
+    private HeaderPoint nextHeaderPointAfter(long currentSlot, String currentHash) {
+        HeaderPoint main = nextHeaderPoint(headerHashBySlot, headerNumberBySlot, currentSlot, currentHash);
+        HeaderPoint ebb = nextHeaderPoint(ebbHeaderHashBySlot, ebbHeaderNumberBySlot, currentSlot, currentHash);
+        return earlier(main, ebb);
+    }
+
+    private List<HeaderPoint> headerPointsInRange(long minSlot, long maxSlot) {
+        List<HeaderPoint> points = new ArrayList<>();
+        headerHashBySlot.subMap(minSlot, true, maxSlot, true).forEach((slot, hash) ->
+                points.add(new HeaderPoint(slot, headerNumberBySlot.getOrDefault(slot, -1L), hash)));
+        ebbHeaderHashBySlot.subMap(minSlot, true, maxSlot, true).forEach((slot, hash) ->
+                points.add(new HeaderPoint(slot, ebbHeaderNumberBySlot.getOrDefault(slot, -1L), hash)));
+        points.sort((left, right) -> {
+            int slotCompare = Long.compare(left.slot(), right.slot());
+            if (slotCompare != 0) return slotCompare;
+            boolean leftEbb = ebbHeaderHashBySlot.get(left.slot()) != null
+                    && java.util.Arrays.equals(ebbHeaderHashBySlot.get(left.slot()), left.hash());
+            boolean rightEbb = ebbHeaderHashBySlot.get(right.slot()) != null
+                    && java.util.Arrays.equals(ebbHeaderHashBySlot.get(right.slot()), right.hash());
+            if (leftEbb != rightEbb) return leftEbb ? -1 : 1;
+            return left.blockHashHex().compareTo(right.blockHashHex());
+        });
+        return points;
+    }
+
+    private static HeaderPoint firstHeaderPoint(ConcurrentSkipListMap<Long, byte[]> hashes,
+                                                ConcurrentSkipListMap<Long, Long> numbers) {
+        var entry = hashes.firstEntry();
+        return entry != null ? new HeaderPoint(entry.getKey(), numbers.getOrDefault(entry.getKey(), -1L), entry.getValue()) : null;
+    }
+
+    private static HeaderPoint floorHeaderPoint(ConcurrentSkipListMap<Long, byte[]> hashes,
+                                                ConcurrentSkipListMap<Long, Long> numbers,
+                                                long slot) {
+        var entry = hashes.floorEntry(slot);
+        return entry != null ? new HeaderPoint(entry.getKey(), numbers.getOrDefault(entry.getKey(), -1L), entry.getValue()) : null;
+    }
+
+    private static HeaderPoint nextHeaderPoint(ConcurrentSkipListMap<Long, byte[]> hashes,
+                                               ConcurrentSkipListMap<Long, Long> numbers,
+                                               long currentSlot,
+                                               String currentHash) {
+        var entry = hashes.ceilingEntry(currentSlot);
+        while (entry != null && entry.getKey() == currentSlot && currentHash != null
+                && currentHash.equals(HexUtil.encodeHexString(entry.getValue()))) {
+            entry = hashes.higherEntry(currentSlot);
+        }
+        return entry != null ? new HeaderPoint(entry.getKey(), numbers.getOrDefault(entry.getKey(), -1L), entry.getValue()) : null;
+    }
+
+    private static HeaderPoint earlier(HeaderPoint left, HeaderPoint right) {
+        if (left == null) return right;
+        if (right == null) return left;
+        return left.slot() <= right.slot() ? left : right;
+    }
+
+    private static HeaderPoint later(HeaderPoint left, HeaderPoint right) {
+        if (left == null) return right;
+        if (right == null) return left;
+        return left.slot() >= right.slot() ? left : right;
+    }
+
+    private record HeaderPoint(long slot, long blockNumber, byte[] hash) {
+        String blockHashHex() {
+            return HexUtil.encodeHexString(hash);
+        }
     }
 
     // --- NonceStateStore implementation ---

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/peer/PeerSession.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/peer/PeerSession.java
@@ -13,6 +13,7 @@ import com.bloxbean.cardano.yano.runtime.BodyFetchManager;
 import com.bloxbean.cardano.yano.runtime.HeaderSyncManager;
 import com.bloxbean.cardano.yano.runtime.PipelineDataListener;
 import com.bloxbean.cardano.yano.runtime.SyncTipContext;
+import com.bloxbean.cardano.yano.runtime.HeaderAppliedEventPublisher;
 import lombok.extern.slf4j.Slf4j;
 
 import java.time.Duration;
@@ -39,6 +40,7 @@ public class PeerSession {
     private PeerClient peerClient;
     private HeaderSyncManager headerSyncManager;
     private BodyFetchManager bodyFetchManager;
+    private HeaderAppliedEventPublisher headerAppliedEventPublisher;
     private PipelineDataListener pipelineDataListener;
     private LedgerApplyProcessor ledgerApplyProcessor;
     private long ledgerGeneration;
@@ -212,6 +214,8 @@ public class PeerSession {
                 log.warn("Error stopping PeerClient", e);
             }
         }
+
+        closeHeaderAppliedEventPublisher();
     }
 
     public boolean isRunning() {
@@ -268,10 +272,9 @@ public class PeerSession {
 
     private void initializePipelineManagers(PipelineConfig pipelineConfig) {
         stopExistingBodyFetchManager();
+        closeHeaderAppliedEventPublisher();
 
         SyncTipContext syncTipContext = new SyncTipContext();
-        headerSyncManager = new HeaderSyncManager(peerClient, chainState, 50000, syncTipContext);
-        log.info("📋 HeaderSyncManager created");
 
         long gapThreshold = Math.max(pipelineConfig.getBodyBatchSize() / 10, 100);
         int maxBatchSize = pipelineConfig.getBodyBatchSize();
@@ -292,6 +295,11 @@ public class PeerSession {
         bodyFetchManager.setPeerHealth(peerHealth);
         log.info("📦 BodyFetchManager created with gapThreshold={}, maxBatchSize={}",
                 gapThreshold, maxBatchSize);
+
+        headerAppliedEventPublisher = new HeaderAppliedEventPublisher(eventBus);
+        headerSyncManager = new HeaderSyncManager(peerClient, chainState, 50000, syncTipContext,
+                bodyFetchManager, headerAppliedEventPublisher);
+        log.info("📋 HeaderSyncManager created");
 
         if (epochParamProvider != null) {
             bodyFetchManager.setEpochParamProvider(epochParamProvider);
@@ -320,6 +328,13 @@ public class PeerSession {
     private void stopExistingBodyFetchManager() {
         if (bodyFetchManager != null && bodyFetchManager.isRunning()) {
             bodyFetchManager.stop();
+        }
+    }
+
+    private void closeHeaderAppliedEventPublisher() {
+        if (headerAppliedEventPublisher != null) {
+            headerAppliedEventPublisher.close();
+            headerAppliedEventPublisher = null;
         }
     }
 

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/peer/PeerSessionCallbacks.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/peer/PeerSessionCallbacks.java
@@ -4,12 +4,15 @@ import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
 
 /**
- * Runtime callbacks needed by the active peer session listener.
+ * Internal runtime callbacks needed by the active peer session listener.
+ *
+ * <p>This interface is implemented by Yano and is not part of the public
+ * plugin/API surface.</p>
  */
 public interface PeerSessionCallbacks {
     void resumeBodyFetchOnHeaderFlow();
 
-    void updateSyncProgress();
+    void updateSyncProgress(long slot, long blockNumber);
 
     void notifyServerNewBlockStored();
 

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/BodyFetchManagerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/BodyFetchManagerTest.java
@@ -7,16 +7,19 @@ import com.bloxbean.cardano.yaci.core.model.HeaderBody;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlock;
 import com.bloxbean.cardano.yaci.core.model.byron.ByronMainBlock;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
 import com.bloxbean.cardano.yaci.core.storage.ChainState;
 import com.bloxbean.cardano.yaci.core.storage.ChainTip;
 import com.bloxbean.cardano.yaci.helper.PeerClient;
 import com.bloxbean.cardano.yaci.helper.model.Transaction;
+import com.bloxbean.cardano.yano.api.SyncPhase;
 import com.bloxbean.cardano.yano.runtime.chain.InMemoryChainState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 
+import java.lang.reflect.Method;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -45,6 +48,7 @@ class BodyFetchManagerTest {
     private static final int GAP_THRESHOLD = 5;
     private static final int MAX_BATCH_SIZE = 10;
     private static final long MONITORING_INTERVAL = 50; // Fast for testing
+    private static final long SIGNAL_TEST_MONITORING_INTERVAL = 5000; // Proves wakeup without relying on polling
     
     @BeforeEach
     void setUp() {
@@ -190,6 +194,127 @@ class BodyFetchManagerTest {
     }
     
     @Test
+    @DisplayName("Near network tip fetches immediately before phase flip")
+    void nearNetworkTipFetchesImmediatelyBeforePhaseFlip() throws Exception {
+        SyncTipContext syncTipContext = new SyncTipContext();
+        BodyFetchManager nearTipManager = new BodyFetchManager(
+                mockPeerClient,
+                chainState,
+                new com.bloxbean.cardano.yaci.events.impl.SimpleEventBus(),
+                100,
+                MAX_BATCH_SIZE,
+                MONITORING_INTERVAL,
+                1000,
+                syncTipContext
+        );
+
+        chainState.storeBlock(
+                hexToBytes("10000000000000000000000000000000000000000000000000000000000000aa"),
+                100L,
+                1000L,
+                "body-block".getBytes()
+        );
+        syncTipContext.update(new Tip(new Point(1001L,
+                "10000000000000000000000000000000000000000000000000000000000000ab"), 101L));
+
+        Method shouldFetchBodies = BodyFetchManager.class.getDeclaredMethod("shouldFetchBodies", long.class);
+        shouldFetchBodies.setAccessible(true);
+
+        assertTrue((Boolean) shouldFetchBodies.invoke(nearTipManager, 1L),
+                "Near-tip body fetch should not wait for the bulk-sync threshold");
+    }
+
+    @Test
+    @DisplayName("Header signal wakes steady-state fetch loop")
+    void headerSignalWakesSteadyStateFetchLoop() throws Exception {
+        BodyFetchManager signalManager = new BodyFetchManager(
+                mockPeerClient,
+                chainState,
+                new com.bloxbean.cardano.yaci.events.impl.SimpleEventBus(),
+                GAP_THRESHOLD,
+                MAX_BATCH_SIZE,
+                SIGNAL_TEST_MONITORING_INTERVAL,
+                1000
+        );
+        signalManager.setSyncPhase(SyncPhase.STEADY_STATE);
+        chainState.storeBlock(
+                hexToBytes("20000000000000000000000000000000000000000000000000000000000000aa"),
+                100L,
+                1000L,
+                "body-block".getBytes()
+        );
+        String nextHash = "20000000000000000000000000000000000000000000000000000000000000ab";
+
+        mockPeerClient.resetFetchCallCount();
+        signalManager.start();
+        try {
+            Thread.sleep(100);
+            assertEquals(0, mockPeerClient.getFetchCallCount(),
+                    "Without a header gap, the initial monitor check should not fetch");
+
+            chainState.storeBlockHeader(hexToBytes(nextHash), 101L, 1001L, "header".getBytes());
+            signalManager.onHeaderApplied(1001L, 101L, nextHash);
+
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+            while (System.nanoTime() < deadline && mockPeerClient.getFetchCallCount() == 0) {
+                Thread.sleep(10);
+            }
+
+            assertTrue(mockPeerClient.getFetchCallCount() > 0,
+                    "Header signal should wake the fetch loop without waiting for fallback polling");
+        } finally {
+            signalManager.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Header signal wakes initial-sync fetch loop near observed network tip")
+    void headerSignalWakesInInitialSyncNearTip() throws Exception {
+        SyncTipContext syncTipContext = new SyncTipContext();
+        BodyFetchManager nearTipManager = new BodyFetchManager(
+                mockPeerClient,
+                chainState,
+                new com.bloxbean.cardano.yaci.events.impl.SimpleEventBus(),
+                100,
+                MAX_BATCH_SIZE,
+                SIGNAL_TEST_MONITORING_INTERVAL,
+                1000,
+                syncTipContext
+        );
+        nearTipManager.setSyncPhase(SyncPhase.INITIAL_SYNC);
+
+        chainState.storeBlock(
+                hexToBytes("21000000000000000000000000000000000000000000000000000000000000aa"),
+                100L,
+                1000L,
+                "body-block".getBytes()
+        );
+        String nextHash = "21000000000000000000000000000000000000000000000000000000000000ab";
+        syncTipContext.update(new Tip(new Point(1001L, nextHash), 101L));
+
+        mockPeerClient.resetFetchCallCount();
+        nearTipManager.start();
+        try {
+            Thread.sleep(100);
+            assertEquals(0, mockPeerClient.getFetchCallCount(),
+                    "Without a header gap, the initial monitor check should not fetch");
+
+            chainState.storeBlockHeader(hexToBytes(nextHash), 101L, 1001L, "header".getBytes());
+            nearTipManager.onHeaderApplied(1001L, 101L, nextHash);
+
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(2);
+            while (System.nanoTime() < deadline && mockPeerClient.getFetchCallCount() == 0) {
+                Thread.sleep(10);
+            }
+
+            assertTrue(mockPeerClient.getFetchCallCount() > 0,
+                    "Header signal should wake near-tip initial sync without waiting for the bulk threshold");
+        } finally {
+            nearTipManager.stop();
+        }
+    }
+
+    @Test
     @DisplayName("Test BlockChainDataListener - onBlock method")
     void testOnBlock() {
         // Seed previous block to satisfy continuity checks
@@ -267,6 +392,7 @@ class BodyFetchManagerTest {
         
         // This should not throw and should log appropriately
         assertDoesNotThrow(() -> bodyFetchManager.onRollback(rollbackPoint));
+        assertTrue(bodyFetchManager.isPaused(), "Rollback should pause body fetching until rollback coordination resumes it");
     }
     
     @Test

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/HeaderSyncManagerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/HeaderSyncManagerTest.java
@@ -10,16 +10,26 @@ import com.bloxbean.cardano.yaci.core.model.Epoch;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
 import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Tip;
 import com.bloxbean.cardano.yaci.core.storage.ChainState;
+import com.bloxbean.cardano.yaci.events.api.Event;
+import com.bloxbean.cardano.yaci.events.api.EventBus;
+import com.bloxbean.cardano.yaci.events.api.EventListener;
+import com.bloxbean.cardano.yaci.events.api.EventMetadata;
+import com.bloxbean.cardano.yaci.events.api.PublishOptions;
+import com.bloxbean.cardano.yaci.events.api.SubscriptionHandle;
+import com.bloxbean.cardano.yaci.events.api.SubscriptionOptions;
 import com.bloxbean.cardano.yano.runtime.chain.InMemoryChainState;
+import com.bloxbean.cardano.yano.api.events.HeaderAppliedEvent;
 import com.bloxbean.cardano.yaci.core.storage.ChainTip;
 import com.bloxbean.cardano.yaci.helper.PeerClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigInteger;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 /**
  * Unit tests for HeaderSyncManager
@@ -67,6 +77,83 @@ class HeaderSyncManagerTest {
         assertEquals(500L, headerTip.getBlockNumber());
         assertEquals(1, headerSyncManager.getHeadersReceived());
         assertEquals(1, headerSyncManager.getHeaderMetrics().shelleyHeaders);
+    }
+
+    @Test
+    void rollforwardSignalsAfterHeaderStored() {
+        long[] signaled = {-1L, -1L};
+        HeaderSyncManager signaledManager = new HeaderSyncManager(
+                peerClient,
+                chainState,
+                50000,
+                new SyncTipContext(),
+                (slot, blockNumber, blockHash) -> {
+                    signaled[0] = slot;
+                    signaled[1] = blockNumber;
+                });
+        Tip tip = new Tip(new Point(1000, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 500L);
+        BlockHeader blockHeader = createMockShelleyHeader(1000L, 500L, "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+        signaledManager.rollforward(tip, blockHeader, new byte[]{1, 2, 3});
+
+        assertEquals(1000L, signaled[0]);
+        assertEquals(500L, signaled[1]);
+        assertNotNull(chainState.getHeaderTip());
+    }
+
+    @Test
+    void rollforwardPublishesHeaderAppliedEventAsynchronously() throws Exception {
+        RecordingEventBus eventBus = new RecordingEventBus();
+        HeaderAppliedEventPublisher publisher = new HeaderAppliedEventPublisher(eventBus, 8);
+        try {
+            HeaderSyncManager manager = new HeaderSyncManager(
+                    peerClient,
+                    chainState,
+                    50000,
+                    new SyncTipContext(),
+                    null,
+                    publisher);
+            Tip tip = new Tip(new Point(1000, "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"), 500L);
+            BlockHeader blockHeader = createMockShelleyHeader(1000L, 500L,
+                    "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb");
+
+            manager.rollforward(tip, blockHeader, new byte[]{1, 2, 3});
+
+            assertTrue(eventBus.awaitHeaderAppliedEvent(1, TimeUnit.SECONDS));
+            HeaderAppliedEvent event = eventBus.headerAppliedEvent;
+            assertEquals(1000L, event.slot());
+            assertEquals(500L, event.blockNumber());
+            assertEquals("bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb", event.blockHash());
+        } finally {
+            publisher.close();
+        }
+    }
+
+    private static final class RecordingEventBus implements EventBus {
+        private final CountDownLatch headerAppliedLatch = new CountDownLatch(1);
+        private volatile HeaderAppliedEvent headerAppliedEvent;
+
+        @Override
+        public <E extends Event> SubscriptionHandle subscribe(Class<E> eventType, EventListener<E> listener,
+                                                              SubscriptionOptions options) {
+            throw new UnsupportedOperationException("subscribe is not used in this test");
+        }
+
+        @Override
+        public <E extends Event> void publish(E event, EventMetadata metadata, PublishOptions options) {
+            if (event instanceof HeaderAppliedEvent headerApplied) {
+                headerAppliedEvent = headerApplied;
+                headerAppliedLatch.countDown();
+            }
+        }
+
+        boolean awaitHeaderAppliedEvent(long timeout, TimeUnit unit) throws InterruptedException {
+            return headerAppliedLatch.await(timeout, unit);
+        }
+
+        @Override
+        public void close() {
+        }
     }
 
     @Test

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/PipelineDataListenerHealthTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/PipelineDataListenerHealthTest.java
@@ -524,14 +524,28 @@ class PipelineDataListenerHealthTest {
                 501L,
                 "b10c1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef");
         List<Transaction> transactions = Collections.emptyList();
+        long[] progress = {-1L, -1L};
+        PipelineDataListener progressListener = new PipelineDataListener(
+                headerSyncManager,
+                bodyFetchManager,
+                new NoopCallbacks() {
+                    @Override
+                    public void updateSyncProgress(long slot, long blockNumber) {
+                        progress[0] = slot;
+                        progress[1] = blockNumber;
+                    }
+                },
+                peerHealth);
 
-        listener.onBlock(Era.Shelley, block, transactions);
+        progressListener.onBlock(Era.Shelley, block, transactions);
 
         PeerSessionStatus status = peerHealth.snapshot(System.currentTimeMillis());
         assertEquals(1001L, status.lastBodyReceivedSlot());
         assertEquals(501L, status.lastBodyReceivedBlockNumber());
         assertEquals(1001L, status.lastBodyAppliedSlot());
         assertEquals(501L, status.lastBodyAppliedBlockNumber());
+        assertEquals(1001L, progress[0]);
+        assertEquals(501L, progress[1]);
         assertTrue(status.lastBodyReceivedAtMillis() > 0);
         assertTrue(status.lastBodyAppliedAtMillis() > 0);
 
@@ -1193,7 +1207,7 @@ class PipelineDataListenerHealthTest {
         }
 
         @Override
-        public void updateSyncProgress() {
+        public void updateSyncProgress(long slot, long blockNumber) {
         }
 
         @Override

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/InMemoryChainStateTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/InMemoryChainStateTest.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class InMemoryChainStateTest {
+
+    @Test
+    void rollbackPreservesBodyTipWhenHeaderTipWasAhead() {
+        InMemoryChainState chainState = new InMemoryChainState();
+        byte[] bodyHash = hash(1);
+        byte[] headerHash = hash(2);
+
+        chainState.storeBlock(bodyHash, 1L, 10L, new byte[]{1});
+        chainState.storeBlockHeader(headerHash, 2L, 20L, new byte[]{2});
+
+        chainState.rollbackTo(15L);
+
+        assertNotNull(chainState.getTip());
+        assertEquals(10L, chainState.getTip().getSlot());
+        assertEquals(1L, chainState.getTip().getBlockNumber());
+        assertNotNull(chainState.getHeaderTip());
+        assertEquals(10L, chainState.getHeaderTip().getSlot());
+        assertNull(chainState.getBlockHeader(headerHash));
+    }
+
+    @Test
+    void byronEbHeaderDoesNotOverwriteMainHeaderNumberIndex() {
+        InMemoryChainState chainState = new InMemoryChainState();
+        byte[] mainHash = hash(1);
+        byte[] ebbHash = hash(2);
+
+        chainState.storeBlockHeader(mainHash, 5L, 50L, new byte[]{1});
+        chainState.storeByronEbHeader(ebbHash, 5L, 40L, new byte[]{2});
+
+        assertArrayEquals(new byte[]{1}, chainState.getBlockHeaderByNumber(5L));
+        assertArrayEquals(new byte[]{2}, chainState.getBlockHeader(ebbHash));
+    }
+
+    private static byte[] hash(int value) {
+        return HexUtil.decodeHexString(String.format("%064x", value));
+    }
+}

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/peer/PeerSessionHealthTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/peer/PeerSessionHealthTest.java
@@ -124,7 +124,7 @@ class PeerSessionHealthTest {
         }
 
         @Override
-        public void updateSyncProgress() {
+        public void updateSyncProgress(long slot, long blockNumber) {
         }
 
         @Override

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/peer/PeerSessionSupervisorTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/peer/PeerSessionSupervisorTest.java
@@ -418,7 +418,7 @@ class PeerSessionSupervisorTest {
         }
 
         @Override
-        public void updateSyncProgress() {
+        public void updateSyncProgress(long slot, long blockNumber) {
         }
 
         @Override


### PR DESCRIPTION
Add push-driven header signals for body fetching, near-tip initial sync detection, async header observability events, and sync progress updates from applied bodies.

Cover the transaction-submission regression path with initial-sync near-tip signal tests and chain-state header/body index tests.