### PR TITLE
 Add advanced JS testkit helpers and fix release publishing metadata

### DIFF
--- a/.github/workflows/npm-testkit.yml
+++ b/.github/workflows/npm-testkit.yml
@@ -4,12 +4,14 @@ on:
   pull_request:
     paths:
       - 'npm/**'
+      - 'gradle.properties'
       - '.github/workflows/npm-testkit.yml'
   push:
     branches:
       - main
     paths:
       - 'npm/**'
+      - 'gradle.properties'
       - '.github/workflows/npm-testkit.yml'
   workflow_dispatch:
 
@@ -29,6 +31,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '24'
+
+      - name: Sync npm package versions
+        working-directory: npm
+        run: npm run sync:versions
 
       - name: Install npm testkit dependencies
         working-directory: npm

--- a/.github/workflows/release-dist.yml
+++ b/.github/workflows/release-dist.yml
@@ -190,11 +190,11 @@ jobs:
 
           VERSION="${{ needs.validate.outputs.version }}"
           NPM_TAG=latest
-          if [[ "$VERSION" == *"-preview"* ]]; then
+          if [[ "$VERSION" == *"-preview"* || "$VERSION" == *"-pre"* || "$VERSION" == *"-alpha"* ]]; then
             NPM_TAG=preview
           elif [[ "$VERSION" == *"-beta"* ]]; then
             NPM_TAG=beta
-          elif [[ "$VERSION" == *"-pre"* || "$VERSION" == *"-rc"* || "$VERSION" == *"-alpha"* ]]; then
+          elif [[ "$VERSION" == *"-rc"* ]]; then
             NPM_TAG=next
           fi
 
@@ -204,7 +204,7 @@ jobs:
             yano-testkit-macos-arm64 \
             yano-testkit-windows-x64 \
             yano-testkit; do
-            npm publish "npm/${package_dir}" --access public --provenance --tag "$NPM_TAG"
+            npm publish "./npm/${package_dir}" --access public --provenance --tag "$NPM_TAG"
           done
 
   release:

--- a/adr/in-progress/031-yano-native-testkit-npm-non-jvm-testing.md
+++ b/adr/in-progress/031-yano-native-testkit-npm-non-jvm-testing.md
@@ -125,6 +125,8 @@ The package should:
 - spawn the native fixture;
 - poll the real HTTP endpoints until the fixture is ready;
 - expose a small typed API for lifecycle and connection details;
+- expose small HTTP-backed devnet conveniences such as `fundAddress(address,
+  ada)` where they avoid boilerplate without hiding runtime behavior;
 - stream or retain logs for failed tests;
 - avoid depending on a specific JavaScript test runner.
 
@@ -139,6 +141,8 @@ const yano = await startYanoDevnet({
 });
 
 try {
+  await yano.fundAddress("addr_test1...", 1000);
+
   const response = await fetch(new URL("node/tip", yano.apiBaseUrl));
   const tip = await response.json();
   // application test assertions
@@ -163,6 +167,17 @@ usable from plain Node.js.
 The non-JVM fixture should use Yano's real HTTP endpoints. JavaScript
 applications should call those endpoints directly or through their chosen
 Blockfrost-compatible client.
+
+The npm wrapper may provide thin helpers over devnet-only HTTP endpoints. The
+initial helper is `fundAddress(address, ada)`, which calls
+`POST /api/v1/devnet/fund` and returns the HTTP response shape
+`{ tx_hash, index, lovelace }`. The amount is in ADA, matching the endpoint.
+This helper does not create keys, sign transactions, or expose runtime internals.
+
+The npm testkit does not publish a default JavaScript wallet, mnemonic, or
+pre-funded account. JS applications should create or load their own test wallet
+with their normal Cardano library, fund that address through `fundAddress()`,
+and then build/sign transactions through application code.
 
 This is intentionally separate from the embedded Java CCL adapter:
 
@@ -213,6 +228,7 @@ The base npm package should not require Docker.
      testing.
 
 5. Completed in documentation: keep transaction workflows HTTP-only.
+   - `fundAddress(address, ada)` wraps Yano's devnet-only HTTP faucet endpoint.
    - Applications submit through `POST /api/v1/tx/submit`.
    - Applications query UTXOs through Blockfrost-compatible endpoints.
    - Wallet/key generation stays in the application or a JS Cardano library.
@@ -242,6 +258,8 @@ The implementation is complete when these checks pass:
 - temp directories are removed after `stop()`;
 - persistent-storage mode keeps its configured path;
 - the npm wrapper can start and stop the fixture from a plain Node.js test;
+- `fundAddress(address, ada)` calls the devnet HTTP faucet and returns
+  `{ tx_hash, index, lovelace }`;
 - failed startup includes enough process output to diagnose the issue;
 - the fixture remains independent of JVM-only testkit types.
 

--- a/adr/in-progress/032-yano-js-testkit-advanced-http-helpers.md
+++ b/adr/in-progress/032-yano-js-testkit-advanced-http-helpers.md
@@ -1,0 +1,503 @@
+# ADR-032: Advanced JavaScript Testkit Helpers Over Yano HTTP
+
+**Status:** Accepted / Partially Implemented
+**Date:** 2026-06-26
+**Related:** ADR-030 (Yano Testkit For JVM Integration Testing), ADR-031 (Native Yano Testkit For Non-JVM And npm Testing)
+
+## Context
+
+ADR-030 gives Java/JVM tests a rich embedded testkit. Because those tests run in
+the same process as Yano, they can call helper facades backed directly by public
+runtime roles:
+
+- wallet fixtures through Cardano Client Lib;
+- faucet funding;
+- deterministic time and epoch advance;
+- snapshot/restore;
+- rollback;
+- chain, ledger, UTXO, protocol-parameter, and epoch queries;
+- transaction submit/evaluate;
+- await and assertion helpers.
+
+ADR-031 created the JavaScript/npm fixture around the native Yano binary. That
+is the right process boundary for JS applications, but it means JS tests can
+only interact with Yano through HTTP. The npm package currently starts/stops the
+native process and exposes a small helper for `POST /api/v1/devnet/fund`.
+
+The goal of this ADR is to make JS tests productive in the same way as the Java
+testkit while preserving the ADR-031 boundary:
+
+- no JVM objects in JS;
+- no runtime internals exposed through npm;
+- real native Yano process and real RocksDB storage by default;
+- production HTTP endpoints for normal chain/ledger workflows;
+- devnet-only HTTP endpoints for mutation helpers such as funding, rollback,
+  snapshots, and time travel.
+
+## Existing HTTP Surface
+
+The following endpoint inventory is relative to `yano.apiBaseUrl`
+(`http://127.0.0.1:<port>/api/v1/`) unless noted otherwise.
+
+### Readiness
+
+- `GET /q/health/ready` from `baseUrl`, not `apiBaseUrl`.
+- `GET node/tip` from `apiBaseUrl`.
+
+ADR-031 readiness already waits for both.
+
+### Node And Chain Basics
+
+- `GET node/status`
+- `POST node/start`
+- `POST node/stop`
+- `GET node/tip`
+- `GET node/config`
+- `GET node/protocol-params`
+- `GET node/epoch-calc-status`
+- `GET node/epoch-nonce`
+- `POST node/recover`
+- `GET status`
+- `GET genesis`
+- `GET network`
+- `GET blocks/latest`
+- `GET blocks/{hashOrNumber}`
+
+These support query, await, and assertion helpers without new server work.
+
+### UTXO, Transactions, And Evaluation
+
+- `GET addresses/{address}/utxos`
+- `GET addresses/{address}/utxos/{asset}`
+- `GET credentials/{paymentCredential}/utxos`
+- `GET utxos/{txHash}/{index}`
+- `POST node/tx/submit` with `application/octet-stream`
+- `POST tx/submit` with `application/cbor` or `text/plain`
+- `GET txs/{txHash}`
+- `GET txs/{txHash}/utxos`
+- `POST utils/txs/evaluate` with `application/cbor` or `text/plain`
+- `GET scripts/{script_hash}/cbor`
+
+These map to transaction, UTXO, balance, and script-evaluation helpers. The JS
+testkit should still let applications use their own Blockfrost-compatible client
+directly against `apiBaseUrl`.
+
+### Devnet Mutation And Time Control
+
+These endpoints require Yano dev mode and are not production controls:
+
+- `POST devnet/fund` with `{ "address": string, "ada": number }`
+- `POST devnet/rollback` with one of `slot`, `block_number`, or `count`
+- `POST devnet/snapshot` with `{ "name": string }`
+- `POST devnet/restore/{name}`
+- `GET devnet/snapshots`
+- `DELETE devnet/snapshot/{name}`
+- `POST devnet/time/advance` with exactly one of `slots`, `seconds`, `epochs`
+- `POST devnet/epochs/shift` with `{ "epochs": number }`
+- `POST devnet/epochs/catch-up`
+- `GET devnet/genesis/download`
+
+This is enough to expose most of Java `YanoFaucet`, `YanoSnapshots`, and
+`YanoTime` in JS.
+
+### Epoch, Account, Governance, And Debug Queries
+
+Additional public query endpoints already exist:
+
+- `GET epochs/latest`
+- `GET epochs/latest/parameters`
+- `GET epochs/{number}/parameters`
+- `GET epochs/latest/adapot`
+- `GET epochs/{number}/adapot`
+- `GET epochs/adapots`
+- `GET epochs/latest/stake/total`
+- `GET epochs/{number}/stake/total`
+- `GET epochs/{number}/stakes/{poolId}`
+- `GET epochs/{number}/stake/pool/{poolId}`
+- `GET accounts/{stakeAddress}`
+- `GET accounts/{stakeAddress}/stake`
+- `GET accounts/{stakeAddress}/stake/{epoch}`
+- `GET accounts/{stakeAddress}/withdrawals`
+- `GET accounts/{stakeAddress}/delegations`
+- `GET accounts/{stakeAddress}/registrations`
+- `GET accounts/{stakeAddress}/mirs`
+- `GET accounts/registrations`
+- `GET accounts/delegations`
+- `GET accounts/drep-delegations`
+- `GET accounts/pools`
+- `GET accounts/pool-retirements`
+- `GET governance/proposals`
+- `GET governance/proposals/{txHash}/{certIndex}`
+- `GET governance/proposals/{txHash}/{certIndex}/votes`
+- `GET governance/dreps`
+- `GET governance/dreps/{drepId}`
+- `GET governance/dreps/{drepId}/distribution`
+- `GET governance/dreps/{drepId}/distribution/{epoch}`
+
+The npm testkit should not wrap every query in the first pass. Prefer focused
+helpers for common tests and keep raw `apiBaseUrl` available for advanced
+application-specific queries.
+
+`/api/debug/...` endpoints also exist for internal diagnostics. They should not
+be promoted into the public JS testkit unless a later ADR explicitly makes them
+part of the test contract.
+
+## Decision
+
+Extend `@bloxbean/yano-testkit` with typed, HTTP-backed helper facades on the
+object returned by `startYanoDevnet()`.
+
+The helper facades should be small wrappers over existing HTTP endpoints. They
+must not hide the fact that JS tests are using a native process through HTTP, and
+they must not introduce a second execution path that behaves differently from
+the app's production endpoints.
+
+The root object remains the lifecycle/process handle:
+
+```ts
+const yano = await startYanoDevnet();
+const address = appWallet.address();
+
+try {
+  await yano.faucet.fundAddress(address, 1000);
+  await yano.time.advanceSlots(5);
+  await yano.await.untilSlotAtLeast(5);
+} finally {
+  await yano.stop();
+}
+```
+
+Existing direct helpers such as `yano.fundAddress(address, ada)` may remain as
+short aliases, but grouped helpers should be the primary documented API:
+
+- `yano.client` - low-level typed HTTP helper for testkit internals and escape
+  hatch use;
+- `yano.queries` - status, tip, config, genesis, protocol params, UTXO, block,
+  transaction, epoch, and selected account queries;
+- `yano.faucet` - fund one or many addresses;
+- `yano.time` - advance by slots/seconds/epochs, advance to slot/epoch, cross
+  epoch boundary, shift genesis, catch up to wall clock;
+- `yano.snapshots` - create, restore, list, delete, exists, withSnapshot;
+- `yano.rollback` or `yano.devnet.rollback` - rollback by slot, block number, or
+  count;
+- `yano.transactions` - submit CBOR/hex, evaluate CBOR/hex, submitAndAwait;
+- `yano.await` - polling helpers for node readiness, slot, block, epoch, and tx
+  visibility;
+- `yano.assertions` - runner-neutral assertion helpers that throw plain
+  `AssertionError`/`Error`, not Jest/Vitest-specific assertion types.
+
+The base npm package should keep direct access to:
+
+```ts
+yano.baseUrl;
+yano.apiBaseUrl;
+yano.url("node/tip");
+yano.stop();
+yano.logs();
+```
+
+This keeps existing low-level usage viable.
+
+## Response Casing And Normalization
+
+The npm wrapper should not normalize every HTTP response at the client boundary.
+`yano.client` and query helpers preserve the server response shape so JS tests
+see the same JSON contract as production HTTP clients. This means Blockfrost
+compatible endpoints may expose snake_case fields such as `tx_hash`,
+`block_number`, or `output_index`.
+
+Wrapper-only request options may use idiomatic JavaScript camelCase and map to
+the server request shape internally. This keeps convenience method calls natural
+without hiding the actual HTTP response contract from tests.
+
+Follow-up: pin response DTO contracts for devnet-only endpoints and consider
+adding explicitly named normalized convenience DTOs if JS users need them. Do
+not silently change `yano.client` or existing query helpers to return a
+different casing model.
+
+## HTTP Address Boundary And JS Wallet Convenience
+
+Java `YanoWallets` is backed by Cardano Client Lib and can create signing
+accounts in-process. The JS native fixture cannot create usable signing keys
+through Yano HTTP today, and it should not make the Yano native process own test
+private keys.
+
+The Yano HTTP boundary must stay address-only:
+
+- Yano HTTP accepts addresses and serialized transactions, not wallets,
+  mnemonics, private keys, accounts, or signing callbacks.
+- The npm base package helpers accept address strings where funding, UTXO, and
+  balance helpers need a target.
+- Wallet/key generation and transaction signing must happen in the JS test
+  process, owned by the application or an explicit JS-side test helper.
+- The HTTP wrapper must not pass wallet objects, mnemonics, private keys, or
+  signing callbacks to Yano.
+
+The npm wrapper may still provide a JS-side test wallet convenience for default
+test addresses. That helper is not a Yano HTTP feature; it runs locally in Node
+and only passes derived addresses to `yano.faucet`, `yano.queries`, and
+`yano.assertions`.
+
+Preferred shape:
+
+```ts
+import { testWallets } from "@bloxbean/yano-testkit/wallets";
+
+const wallets = testWallets({
+  networkMagic: yano.networkMagic,
+  networkId: 0
+});
+
+const alice = await wallets.defaultWallet();
+await yano.faucet.fundAddress(alice.address, 1000);
+
+const signedTx = await appBuildsAndSignsTx(alice);
+await yano.transactions.submitAndAwait(signedTx);
+```
+
+The wallet helper may expose the same deterministic mnemonic/default-address
+scheme as the Java testkit so examples are repeatable across languages. If it
+needs a Cardano JS library, keep that dependency isolated in the `wallets`
+subpath or a separate package so the base native-process fixture remains small.
+
+This keeps Yano's HTTP contract aligned with production usage while still
+letting JS tests get default deterministic addresses when they want them.
+
+## Proposed API Shape
+
+### Low-Level HTTP Client
+
+```ts
+await yano.client.getJson("node/tip");
+await yano.client.postJson("devnet/time/advance", { slots: 5 });
+await yano.client.deleteJson("devnet/snapshot/before-test");
+await yano.client.postCbor("tx/submit", txCbor);
+await yano.client.postText("utils/txs/evaluate", txHex);
+```
+
+The client should:
+
+- resolve paths relative to `apiBaseUrl`;
+- parse JSON responses;
+- preserve response status and body in thrown errors;
+- support `AbortSignal` or timeout options where useful;
+- never retry mutating requests automatically.
+
+### Faucet
+
+```ts
+await yano.faucet.fundAddress(address, 1000);      // ADA
+await yano.faucet.fundAddressLovelace(address, 1_000_000n);
+await yano.faucet.fundAll([
+  { address: aliceAddress, ada: 1000 },
+  { address: bobAddress, lovelace: 2_000_000n }
+]);
+```
+
+`fundAll` is sequential and non-atomic, matching the Java testkit behavior and
+runtime semantics.
+
+### Time
+
+```ts
+await yano.time.advanceSlots(5);
+await yano.time.advanceSeconds(10);
+await yano.time.advanceEpochs(1);
+await yano.time.advanceToSlot(50);
+await yano.time.advanceToEpoch(2);
+await yano.time.crossEpochBoundary();
+await yano.time.shiftGenesisAndStartProducer(3);
+await yano.time.catchUpToWallClock();
+```
+
+`advanceToSlot()` can be implemented initially with `GET node/tip` followed by
+`POST devnet/time/advance` with the computed slot delta. If we need exact
+server-side "advance until absolute slot" semantics, extend
+`TimeAdvanceRequest` later with `target_slot` and add tests around race-free
+behavior. Until that endpoint exists, `advanceToSlot()`, `advanceToEpoch()`,
+and `crossEpochBoundary()` are best-effort helpers under live block production;
+tests that need a precise final state should follow them with an await helper or
+assertion.
+
+`advanceToEpoch()` and `crossEpochBoundary()` can use `GET node/config` and the
+same epoch-slot calculation rules as Java's `EpochSlotCalc`. The JS helper must
+handle `epochLength`, `byronSlotsPerEpoch`, and `firstNonByronSlot`; do not
+hardcode devnet-only epoch math if config exposes the full values.
+
+### Snapshots And Rollback
+
+```ts
+await yano.snapshots.create("before");
+await yano.snapshots.restore("before");
+const snapshots = await yano.snapshots.list();
+await yano.snapshots.delete("before");
+await yano.snapshots.withSnapshot("case-1", async () => {
+  // test setup
+});
+
+await yano.devnet.rollback({ count: 1 });
+await yano.devnet.rollback({ slot: 10 });
+await yano.devnet.rollback({ blockNumber: 4 });
+```
+
+`withSnapshot()` should restore in `finally` and preserve/suppress errors in a
+way that keeps the original failure visible.
+
+### Queries
+
+Minimum first-pass query helpers:
+
+```ts
+await yano.queries.status();
+await yano.queries.tip();
+await yano.queries.config();
+await yano.queries.currentSlot();
+await yano.queries.currentBlockNumber();
+await yano.queries.currentEpoch();
+await yano.queries.genesis();
+await yano.queries.protocolParameters();   // GET epochs/latest/parameters
+await yano.queries.protocolParameters(0);
+await yano.queries.utxosByAddress(address, { page: 1, count: 100 });
+await yano.queries.utxo(txHash, index);
+await yano.queries.tx(txHash);
+await yano.queries.txUtxos(txHash);
+await yano.queries.latestBlock();
+await yano.queries.block(hashOrNumber);
+```
+
+Additional account, governance, and epoch queries can be added in follow-up
+slices based on real JS application needs. The raw `apiBaseUrl` remains the
+escape hatch.
+
+### Transactions
+
+```ts
+await yano.transactions.submitCbor(txCbor);
+await yano.transactions.submitHex(txHex);
+await yano.transactions.submitAndAwait(txCbor);
+await yano.transactions.evaluateCbor(txCbor);
+await yano.transactions.evaluateHex(txHex);
+```
+
+The helpers do not build or sign transactions. They only submit/evaluate
+serialized transactions produced by the application or its Cardano JS library.
+
+### Await And Assertions
+
+```ts
+await yano.await.untilReady();
+await yano.await.untilSlotAtLeast(10);
+await yano.await.untilBlockAtLeast(5);
+await yano.await.untilEpochAtLeast(1);
+await yano.await.untilTxVisible(txHash);
+
+await yano.assertions.slotAtLeast(10);
+await yano.assertions.blockAtLeast(5);
+await yano.assertions.address(address).hasAtLeastAda(1000);
+```
+
+Await helpers should default to short test-friendly polling intervals and
+configurable timeouts. Assertions should be runner-neutral and throw normal
+errors so they work in Node test runner, Vitest, Jest, Mocha, and custom tests.
+
+ADA-denominated assertion helpers are convenience helpers for typical test
+amounts; lovelace helpers using `bigint` or string values are the exact path for
+large or fractional amounts.
+
+## Known Follow-Ups
+
+- Pin response DTO contracts for devnet-only endpoints and decide whether to add
+  explicitly named normalized DTO helpers while preserving raw HTTP query
+  helpers.
+- Add a server-side absolute `target_slot` time-advance request if JS tests need
+  race-free target-slot movement equivalent to the JVM embedded testkit SPI.
+- Consider string-based ADA amount inputs if JS applications need exact
+  fractional ADA convenience helpers. Lovelace helpers remain exact today.
+
+## Implementation Plan
+
+1. Completed: add an internal HTTP client layer.
+   - Centralize path resolution, JSON parsing, content-type handling, and error
+     messages.
+   - Move the existing `fundAddress()` implementation onto this layer.
+   - Add fake-server tests for success, HTTP error body propagation, and
+     mutating-request no-retry behavior.
+
+2. Completed: add devnet control facades.
+   - `faucet`, `time`, `snapshots`, and `devnet.rollback`.
+   - Keep `yano.fundAddress(address, ada)` as an alias for
+     `yano.faucet.fundAddress(address, ada)`.
+   - Unit-test every request path/body against the fake server.
+
+3. Completed: add query, transaction, await, and assertion facades.
+   - Start with the minimum query set listed above.
+   - `submitAndAwait()` should use `txs/{txHash}/utxos` or another public UTXO
+     query, not a runtime-internal status.
+   - Tests should cover timeout messages and polling success/failure.
+
+4. Completed: document the HTTP address boundary.
+   - Accept address strings in faucet, UTXO, and balance helpers.
+   - Do not pass wallet objects, mnemonics, private keys, or signing callbacks
+     to Yano HTTP.
+   - Document that Yano helpers still fund/query by address and submit
+     serialized transactions.
+
+5. Deferred: JS-side wallet convenience.
+   - Allow a JS-side `wallets` helper or package to provide default
+     deterministic test wallets/addresses.
+   - Isolate any Cardano JS wallet/signing dependency from the base package.
+
+6. Deferred: add server endpoints only for proven gaps.
+   - Candidate: `POST devnet/time/advance` with `target_slot` for race-free
+     `advanceToSlot()`.
+   - Candidate: batch funding if sequential client-side funding proves too slow.
+   - Candidate: `GET devnet/capabilities` if JS needs to detect optional devnet
+     controls before calling them.
+
+No new server endpoints were needed for the implemented helper set.
+
+## Compatibility And Production Safety
+
+- These helpers are npm-side wrappers. They should not change normal Yano
+  production startup or existing production HTTP endpoint behavior.
+- Devnet mutation helpers must call only endpoints that already require
+  `yano.dev-mode=true`.
+- The base package remains plain Node.js and test-runner agnostic.
+- New helper methods must be additive. Existing `startYanoDevnet()` lifecycle
+  behavior and returned connection fields must continue to work.
+- No helper should expose `RuntimeNode`, RocksDB handles, Java objects, or debug
+  endpoints as public JS API.
+
+## Validation
+
+The HTTP helper implementation is complete when:
+
+- npm unit tests verify every helper's HTTP method, path, body, response
+  parsing, and error behavior using a fake Yano server;
+- TypeScript definitions cover all helper facades and response DTOs;
+- a real native devnet smoke test demonstrates funding, slot advance, snapshot
+  restore, transaction visibility polling, and cleanup;
+- docs show plain Node.js usage and at least one test-runner usage;
+- docs clearly state that Yano HTTP is address-only and any test wallet helper
+  is local to the JS process;
+- production app tests still pass, proving no regression to normal Yano HTTP
+  usage.
+
+Current validation:
+
+- `npm test` covers lifecycle plus HTTP-backed faucet, time, snapshot, rollback,
+  query, transaction, await, assertion, and HTTP-error helpers against a fake
+  Yano process.
+- `npm run typecheck` validates the JavaScript source and TypeScript
+  definitions.
+
+## Consequences
+
+JS users get most of the Java testkit ergonomics while keeping the native-process
+boundary honest. The wrapper becomes a small HTTP test client plus lifecycle
+owner, not a second Yano runtime.
+
+The main tradeoff is that JS tests do not get wallet fixtures from Yano HTTP.
+That is intentional. A JS-side helper may provide default deterministic
+addresses or wallets, but `@bloxbean/yano-testkit` exercises Yano by address and
+serialized transaction.

--- a/devnet-toolkit/build.gradle
+++ b/devnet-toolkit/build.gradle
@@ -2,3 +2,14 @@ dependencies {
     api project(':core-api')
     api project(':runtime')
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Yano Devnet Toolkit'
+                description = 'Devnet control adapter and assembly helpers for Yano tests and local devnet workflows'
+            }
+        }
+    }
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = com.bloxbean.cardano
 artifactId = yano
-version = 0.1.0-pre7
+version = 0.1.0-pre7-ci1
 quarkusPluginVersion = 3.25.0
 quarkusPlatformGroupId = io.quarkus.platform
 quarkusPlatformArtifactId = quarkus-bom

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = com.bloxbean.cardano
 artifactId = yano
-version = 0.1.0-pre7-ci2
+version = 0.1.0-pre8
 quarkusPluginVersion = 3.25.0
 quarkusPlatformGroupId = io.quarkus.platform
 quarkusPlatformArtifactId = quarkus-bom

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 group = com.bloxbean.cardano
 artifactId = yano
-version = 0.1.0-pre7-ci1
+version = 0.1.0-pre7-ci2
 quarkusPluginVersion = 3.25.0
 quarkusPlatformGroupId = io.quarkus.platform
 quarkusPlatformArtifactId = quarkus-bom

--- a/npm/README.md
+++ b/npm/README.md
@@ -45,22 +45,20 @@ testing portable across macOS, Linux, and Windows.
 ## 2. Keep Versions In Sync
 
 The npm packages should normally use the same version as `gradle.properties`.
-Release CI does this automatically before publishing, so no manual version edit
-is needed for a normal release.
+Release CI and npm testkit CI sync this automatically before publishing or
+validating packages, so no manual package JSON edit is needed for a normal
+release or PR build.
 
-For local testing after the Gradle version changes, sync the npm package
-manifests and lockfile once:
+For local testing after the Gradle version changes, run the same sync command:
 
 ```bash
-cd /path/to/yano
-node npm/scripts/set-package-version.mjs 0.1.0-pre7
-npm install --prefix npm/yano-testkit --package-lock-only --omit=optional
+cd /path/to/yano/npm
+npm run sync:versions
 ```
 
-Replace `0.1.0-pre7` with the version from `gradle.properties`. Then verify:
+Then verify:
 
 ```bash
-cd npm
 npm run check:versions
 ```
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -184,8 +184,10 @@ const yano = await startYanoDevnet({
 });
 
 try {
-  const response = await fetch(new URL("node/tip", yano.apiBaseUrl));
-  console.log(await response.json());
+  await yano.faucet.fundAddress("addr_test1...", 1000);
+  await yano.time.advanceSlots(3);
+
+  console.log(await yano.queries.tip());
 } finally {
   await yano.stop();
 }
@@ -243,5 +245,11 @@ platform package tarball is installed too.
 
 - The default storage mode is real RocksDB in a test-owned temporary directory.
 - The wrapper uses Yano's production HTTP API under `/api/v1`.
+- Use `yano.faucet`, `yano.time`, `yano.snapshots`, `yano.devnet`,
+  `yano.queries`, `yano.transactions`, `yano.await`, and `yano.assertions` for
+  HTTP-backed integration-test helpers.
+- Use `yano.faucet.fundAddress(address, ada)` to fund addresses from the devnet
+  faucet; the package does not expose a default JavaScript wallet or pre-funded
+  account.
 - The wrapper does not expose JVM testkit classes or runtime internals.
 - Platform packages are populated from native distribution zips in release CI.

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "scripts": {
+    "sync:versions": "node scripts/set-package-version.mjs",
     "install:testkit": "npm install --prefix yano-testkit --omit=optional",
     "test": "npm test --prefix yano-testkit",
     "typecheck": "npm run typecheck --prefix yano-testkit",

--- a/npm/scripts/check-package-versions.mjs
+++ b/npm/scripts/check-package-versions.mjs
@@ -34,4 +34,18 @@ for (const dir of packageDirs) {
   }
 }
 
+const lockFile = resolve(npmRoot, "yano-testkit", "package-lock.json");
+const lock = JSON.parse(await readFile(lockFile, "utf8"));
+if (lock.version !== version) {
+  throw new Error(`yano-testkit/package-lock.json version ${lock.version} does not match Gradle version ${version}`);
+}
+if (lock.packages?.[""]?.version !== version) {
+  throw new Error(`yano-testkit/package-lock.json root package version ${lock.packages?.[""]?.version} does not match Gradle version ${version}`);
+}
+for (const [name, dependencyVersion] of Object.entries(lock.packages?.[""]?.optionalDependencies ?? {})) {
+  if (dependencyVersion !== version) {
+    throw new Error(`yano-testkit/package-lock.json optional dependency ${name} version ${dependencyVersion} does not match ${version}`);
+  }
+}
+
 console.log(`All npm package versions match Gradle version ${version}`);

--- a/npm/scripts/set-package-version.mjs
+++ b/npm/scripts/set-package-version.mjs
@@ -4,12 +4,6 @@ import { readFile, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
-const version = process.argv[2];
-if (!version) {
-  console.error("Usage: node scripts/set-package-version.mjs <version>");
-  process.exit(1);
-}
-
 const packageDirs = [
   "yano-testkit",
   "yano-testkit-linux-x64",
@@ -19,6 +13,8 @@ const packageDirs = [
 ];
 
 const npmRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = resolve(npmRoot, "..");
+const version = process.argv[2] ?? await readGradleVersion();
 
 for (const dir of packageDirs) {
   const file = resolve(npmRoot, dir, "package.json");
@@ -27,6 +23,30 @@ for (const dir of packageDirs) {
   if (json.optionalDependencies) {
     for (const key of Object.keys(json.optionalDependencies)) {
       json.optionalDependencies[key] = version;
+    }
+  }
+  await writeFile(file, `${JSON.stringify(json, null, 2)}\n`);
+}
+
+await updateMainPackageLock(version);
+
+async function readGradleVersion() {
+  const gradleProperties = await readFile(resolve(repoRoot, "gradle.properties"), "utf8");
+  const detected = gradleProperties.match(/^version\s*=\s*(.+)$/m)?.[1]?.trim();
+  if (!detected) {
+    throw new Error("Could not read version from gradle.properties");
+  }
+  return detected;
+}
+
+async function updateMainPackageLock(version) {
+  const file = resolve(npmRoot, "yano-testkit", "package-lock.json");
+  const json = JSON.parse(await readFile(file, "utf8"));
+  json.version = version;
+  if (json.packages?.[""]) {
+    json.packages[""].version = version;
+    for (const key of Object.keys(json.packages[""].optionalDependencies ?? {})) {
+      json.packages[""].optionalDependencies[key] = version;
     }
   }
   await writeFile(file, `${JSON.stringify(json, null, 2)}\n`);

--- a/npm/yano-testkit-linux-arm64/package.json
+++ b/npm/yano-testkit-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloxbean/yano-testkit-linux-arm64",
-  "version": "0.1.0-pre6",
+  "version": "0.1.0-pre7-ci2",
   "description": "Linux arm64 native Yano binary for @bloxbean/yano-testkit.",
   "main": "./bin/yano",
   "files": [

--- a/npm/yano-testkit-linux-x64/package.json
+++ b/npm/yano-testkit-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloxbean/yano-testkit-linux-x64",
-  "version": "0.1.0-pre6",
+  "version": "0.1.0-pre7-ci2",
   "description": "Linux x64 native Yano binary for @bloxbean/yano-testkit.",
   "main": "./bin/yano",
   "files": [

--- a/npm/yano-testkit-macos-arm64/package.json
+++ b/npm/yano-testkit-macos-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloxbean/yano-testkit-macos-arm64",
-  "version": "0.1.0-pre6",
+  "version": "0.1.0-pre7-ci2",
   "description": "macOS arm64 native Yano binary for @bloxbean/yano-testkit.",
   "main": "./bin/yano",
   "files": [

--- a/npm/yano-testkit-windows-x64/package.json
+++ b/npm/yano-testkit-windows-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloxbean/yano-testkit-windows-x64",
-  "version": "0.1.0-pre6",
+  "version": "0.1.0-pre7-ci2",
   "description": "Windows x64 native Yano binary for @bloxbean/yano-testkit.",
   "main": "./bin/yano.exe",
   "files": [

--- a/npm/yano-testkit/JS_USER_GUIDE.md
+++ b/npm/yano-testkit/JS_USER_GUIDE.md
@@ -1,0 +1,565 @@
+# Yano JavaScript Testkit User Guide
+
+This guide is for JavaScript and TypeScript developers who want to run tests
+against a local Cardano devnet without starting Docker or a JVM test fixture.
+
+`@bloxbean/yano-testkit` starts the native Yano binary in devnet mode, waits for
+the HTTP API to be ready, and gives your test code a small helper object for
+funding addresses, querying chain state, moving devnet time, snapshots, rollback,
+transaction submission, and assertions.
+
+## What You Get
+
+- A real Yano native process started from your JS test.
+- RocksDB-backed devnet storage by default, isolated in a temporary directory.
+- Random free HTTP and node-to-node ports by default.
+- Yano's production Blockfrost-compatible HTTP API under `/api/v1/`.
+- Devnet-only helpers for faucet funding, time travel, snapshots, and rollback.
+- No wallet custody inside Yano. Your JS app or Cardano SDK owns keys and signs
+  transactions.
+
+## Install
+
+```bash
+npm install --save-dev @bloxbean/yano-testkit
+```
+
+For preview releases:
+
+```bash
+npm install --save-dev @bloxbean/yano-testkit@preview
+```
+
+The package depends on optional platform packages that contain the native Yano
+binary for the local OS and CPU. You normally do not need to set any binary
+environment variable after installing from npm.
+
+Supported native packages:
+
+- Linux x64
+- Linux arm64
+- macOS arm64
+- Windows x64
+
+Node.js 20.8 or newer is required.
+
+## Minimal Node Test
+
+```js
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { startYanoDevnet } from "@bloxbean/yano-testkit";
+
+test("starts a Yano devnet", async () => {
+  const yano = await startYanoDevnet({ blockTimeMillis: 200 });
+
+  try {
+    const tip = await yano.queries.tip();
+    assert.ok(tip);
+
+    await yano.time.advanceSlots(3);
+    await yano.assertions.slotAtLeast(3);
+  } finally {
+    await yano.stop();
+  }
+});
+```
+
+Plain Node.js tests must call `await yano.stop()`. Put it in a `finally` block
+so the native process is stopped even when an assertion fails.
+
+## Vitest
+
+Use the Vitest adapter when one devnet should be shared by a suite:
+
+```js
+import { describe, expect, test } from "vitest";
+import { yanoDevnet } from "@bloxbean/yano-testkit/vitest";
+
+const yano = yanoDevnet({ blockTimeMillis: 200 });
+
+describe("my Cardano app", () => {
+  test("reads the chain tip", async () => {
+    const tip = await yano.queries.tip();
+    expect(tip).toBeTruthy();
+  });
+});
+```
+
+The adapter starts Yano in `beforeAll()` and stops it in `afterAll()`.
+
+## Devnet Object
+
+`startYanoDevnet()` returns:
+
+```js
+const yano = await startYanoDevnet();
+
+console.log(yano.baseUrl);     // http://127.0.0.1:<port>/
+console.log(yano.apiBaseUrl);  // http://127.0.0.1:<port>/api/v1/
+console.log(yano.n2nPort);
+console.log(yano.storage.path);
+console.log(yano.workDir);
+```
+
+Important fields and helpers:
+
+- `baseUrl` - root Quarkus URL, useful for health endpoints such as
+  `/q/health/ready`.
+- `apiBaseUrl` - Yano's Blockfrost-compatible API root.
+- `url(path)` - creates a URL under `apiBaseUrl`.
+- `logs()` - returns the recent Yano stdout/stderr log tail.
+- `stop()` - stops the native process and cleans temporary storage.
+- `process` - the underlying Node `ChildProcess`, mainly for diagnostics.
+
+## Start Options
+
+```js
+const yano = await startYanoDevnet({
+  blockTimeMillis: 200,
+  timeoutMs: 60_000,
+  networkMagic: 42,
+  httpPort: 0,
+  n2nPort: 0,
+  storage: "temp-rocksdb",
+  onStdout: line => console.log(`[yano] ${line}`),
+  onStderr: line => console.error(`[yano] ${line}`)
+});
+```
+
+Common options:
+
+- `blockTimeMillis` - devnet block production interval.
+- `timeoutMs` - startup readiness timeout.
+- `httpPort` and `n2nPort` - set fixed ports, or omit them for random free
+  ports.
+- `networkMagic` - protocol magic for the devnet.
+- `storage` - `"temp-rocksdb"` or `"persistent-rocksdb"`.
+- `workDir` / `storagePath` - explicit directories for persistent tests.
+- `preserveWorkDir` - keep temporary work directory after `stop()`.
+- `binaryPath` - path to a local Yano binary.
+- `cwd` - working directory for the Yano process. It should contain `config/`
+  when using a local app build.
+- `env` - extra environment variables for the Yano process.
+- `extraArgs` - extra `-D...` JVM/native image system properties.
+- `onStdout` / `onStderr` - stream Yano logs into your test output.
+
+## Storage Modes
+
+The default is `temp-rocksdb`:
+
+```js
+const yano = await startYanoDevnet({
+  storage: "temp-rocksdb"
+});
+```
+
+This uses real RocksDB storage in a test-owned temporary directory. The wrapper
+deletes that directory when `stop()` succeeds.
+
+Use persistent storage when you need to inspect chain state after shutdown:
+
+```js
+const yano = await startYanoDevnet({
+  storage: "persistent-rocksdb",
+  workDir: "./tmp/yano-case-1"
+});
+```
+
+`persistent-rocksdb` requires `workDir` or `storagePath`.
+
+## Wallets And Funding
+
+Yano HTTP does not own wallets, mnemonics, private keys, or signing callbacks.
+That boundary is intentional. Create test wallets with your normal Cardano JS
+library, then fund their addresses through the devnet faucet.
+
+```js
+const address = "addr_test1...";
+
+const result = await yano.faucet.fundAddress(address, 1000);
+console.log(result.tx_hash, result.index, result.lovelace);
+```
+
+Funding helpers:
+
+```js
+await yano.faucet.fundAddress(address, 1000);          // ADA
+await yano.faucet.fundAddressLovelace(address, 1_000_000n);
+
+await yano.faucet.fundAll([
+  { address: alice, ada: 1000 },
+  { address: bob, lovelace: 2_000_000n }
+]);
+```
+
+`fundAll()` is sequential and non-atomic. If one funding request fails, previous
+funding transactions are not rolled back.
+
+There is also a compatibility alias:
+
+```js
+await yano.fundAddress(address, 1000);
+```
+
+## Use With Cardano JavaScript SDKs
+
+Yano exposes a Blockfrost-compatible API at `yano.apiBaseUrl`. Cardano JS
+libraries that can use a Blockfrost-style provider should point at that URL.
+
+MeshJS example:
+
+```js
+import { BlockfrostProvider, MeshWallet } from "@meshsdk/core";
+
+const provider = new BlockfrostProvider(yano.apiBaseUrl);
+const wallet = new MeshWallet({
+  networkId: 0,
+  fetcher: provider,
+  submitter: provider,
+  key: {
+    type: "mnemonic",
+    words: testMnemonicWords
+  }
+});
+
+await wallet.init();
+
+const address = await wallet.getChangeAddress();
+const funding = await yano.faucet.fundAddress(address, 20);
+await yano.await.untilTxVisible(funding.tx_hash);
+```
+
+After funding, build and sign transactions with the SDK, then submit through the
+SDK provider or through `yano.transactions`.
+
+## Query Chain State
+
+Use `yano.queries` for common Blockfrost-compatible and Yano query endpoints:
+
+```js
+const status = await yano.queries.status();
+const tip = await yano.queries.tip();
+const config = await yano.queries.config();
+const latestBlock = await yano.queries.latestBlock();
+const protocolParams = await yano.queries.protocolParameters();
+
+const utxos = await yano.queries.utxosByAddress(address);
+const tx = await yano.queries.tx(txHash);
+const txUtxos = await yano.queries.txUtxos(txHash);
+```
+
+Useful derived queries:
+
+```js
+const slot = await yano.queries.currentSlot();
+const block = await yano.queries.currentBlockNumber();
+const epoch = await yano.queries.currentEpoch();
+const epochStart = await yano.queries.epochStartSlot(2);
+```
+
+Response objects preserve Yano's HTTP JSON shape. For Blockfrost-compatible
+endpoints this usually means snake_case fields such as `tx_hash`,
+`output_index`, and `block_number`.
+
+## Devnet Time
+
+Use time helpers to move the devnet quickly:
+
+```js
+await yano.time.advanceSlots(5);
+await yano.time.advanceSeconds(10);
+await yano.time.advanceEpochs(1);
+
+await yano.time.advanceToSlot(50);
+await yano.time.advanceToEpoch(2);
+await yano.time.crossEpochBoundary();
+```
+
+`advanceToSlot()`, `advanceToEpoch()`, and `crossEpochBoundary()` are
+best-effort helpers. They read current chain state and then request a relative
+advance. When a producer is running, the chain can move during that calculation.
+Follow them with an await helper or assertion when the exact final state matters:
+
+```js
+await yano.time.advanceToEpoch(2);
+await yano.await.untilEpochAtLeast(2);
+```
+
+Epoch maintenance helpers:
+
+```js
+await yano.time.shiftGenesisAndStartProducer(3);
+await yano.time.catchUpToWallClock();
+```
+
+## Snapshots And Rollback
+
+Create snapshots around destructive test cases:
+
+```js
+await yano.snapshots.create("before-case");
+
+try {
+  await runCase();
+} finally {
+  await yano.snapshots.restore("before-case");
+}
+```
+
+Or use `withSnapshot()`:
+
+```js
+await yano.snapshots.withSnapshot("case", async () => {
+  await yano.time.advanceSlots(10);
+  await yano.devnet.rollback({ count: 1 });
+});
+```
+
+Other snapshot helpers:
+
+```js
+const snapshots = await yano.snapshots.list();
+const exists = await yano.snapshots.exists("case");
+await yano.snapshots.delete("case");
+```
+
+Rollback can target exactly one of `slot`, `blockNumber`, or `count`:
+
+```js
+await yano.devnet.rollback({ count: 1 });
+await yano.devnet.rollback({ slot: 20 });
+await yano.devnet.rollback({ blockNumber: 5 });
+```
+
+## Submit And Evaluate Transactions
+
+Build and sign transactions in your app or Cardano JS SDK. Submit the serialized
+transaction through Yano:
+
+```js
+const txHash = await yano.transactions.submitHex(signedTxHex);
+await yano.await.untilTxVisible(txHash);
+```
+
+For CBOR bytes:
+
+```js
+const txHash = await yano.transactions.submitCbor(signedTxCborBytes);
+```
+
+Submit and wait in one call:
+
+```js
+const txHash = await yano.transactions.submitAndAwait(signedTxHex, {
+  timeoutMs: 20_000,
+  pollIntervalMs: 200
+});
+```
+
+Evaluate transactions:
+
+```js
+const result = await yano.transactions.evaluateHex(unsignedOrSignedTxHex);
+```
+
+The MeshJS example in `test-examples/yano-testkit-meshjs` shows the complete
+flow: create a Mesh wallet, fund it, build a self-transfer, sign, submit, wait,
+and verify.
+
+## Await Helpers
+
+Await helpers poll until the condition is true or a timeout is reached:
+
+```js
+await yano.await.untilReady();
+await yano.await.untilSlotAtLeast(10);
+await yano.await.untilBlockAtLeast(5);
+await yano.await.untilEpochAtLeast(1);
+await yano.await.untilTxVisible(txHash);
+```
+
+Override polling per call:
+
+```js
+await yano.await.untilTxVisible(txHash, {
+  timeoutMs: 30_000,
+  pollIntervalMs: 200
+});
+```
+
+Custom condition:
+
+```js
+await yano.await.until(
+  async () => (await yano.queries.utxosByAddress(address)).length > 0,
+  "address to have at least one UTXO"
+);
+```
+
+## Assertions
+
+Assertions are runner-neutral. They throw normal errors, so they work with
+Node's test runner, Vitest, Jest, Mocha, and custom runners.
+
+```js
+await yano.assertions.nodeIsRunning();
+await yano.assertions.runtimeNotDegraded();
+await yano.assertions.slotAtLeast(10);
+await yano.assertions.blockAtLeast(5);
+await yano.assertions.epochAtLeast(1);
+await yano.assertions.snapshotExists("case");
+await yano.assertions.snapshotMissing("case");
+```
+
+Address assertions:
+
+```js
+await yano.assertions.address(address).hasAtLeastAda(1000);
+await yano.assertions.address(address).hasAtLeast(1_000_000n);
+await yano.assertions.address(address).hasExactly(2_000_000n);
+
+const balance = await yano.assertions.address(address).balanceLovelace();
+```
+
+ADA helpers accept JavaScript numbers for convenience. Use lovelace helpers with
+`bigint` or string values when exact arithmetic matters.
+
+## Low-Level HTTP Client
+
+Use `yano.client` when a named helper does not exist:
+
+```js
+const params = await yano.client.getJson("epochs/latest/parameters");
+const bytes = await yano.client.getBytes("devnet/genesis/download");
+```
+
+Available methods:
+
+- `getJson(path, options)`
+- `postJson(path, body, options)`
+- `deleteJson(path, options)`
+- `postCbor(path, body, options)`
+- `postText(path, body, options)`
+- `getBytes(path, options)`
+
+The path is relative to `yano.apiBaseUrl`.
+
+## Error Handling
+
+HTTP failures throw `YanoHttpError`:
+
+```js
+import { YanoHttpError } from "@bloxbean/yano-testkit";
+
+try {
+  await yano.queries.tx("missing");
+} catch (error) {
+  if (error instanceof YanoHttpError) {
+    console.error(error.method, error.url, error.status);
+    console.error(error.bodyText);
+  }
+}
+```
+
+Startup failures include the recent Yano log tail in the error message. You can
+also print logs after a failed test:
+
+```js
+try {
+  await runTest();
+} catch (error) {
+  console.error(yano?.logs());
+  throw error;
+}
+```
+
+## Local Yano Binary
+
+Use `YANO_TESTKIT_BINARY` only when testing a local build or an unsupported
+platform. Published npm packages include the platform binary automatically.
+
+Build a native binary from this repository:
+
+```bash
+./gradlew :app:quarkusBuild \
+  -Dquarkus.native.enabled=true \
+  -Dquarkus.package.jar.enabled=false \
+  -PskipSigning=true
+```
+
+Run a JS test with the local binary:
+
+```bash
+YANO_TESTKIT_BINARY=/path/to/yano/app/build/yano node my-test.mjs
+```
+
+When the binary is from `app/build`, set `cwd` to the app directory so Yano can
+find `config/`:
+
+```js
+const yano = await startYanoDevnet({
+  binaryPath: "/path/to/yano/app/build/yano",
+  cwd: "/path/to/yano/app"
+});
+```
+
+Windows PowerShell:
+
+```powershell
+$env:YANO_TESTKIT_BINARY="C:\path\to\yano\app\build\yano.exe"
+node my-test.mjs
+```
+
+## TypeScript
+
+The package ships TypeScript declarations:
+
+```ts
+import { startYanoDevnet, type YanoDevnet } from "@bloxbean/yano-testkit";
+
+let yano: YanoDevnet | undefined;
+
+yano = await startYanoDevnet();
+```
+
+No separate `@types` package is needed.
+
+## Troubleshooting
+
+### The process does not start
+
+- Increase `timeoutMs` or set `YANO_TESTKIT_TIMEOUT_MS`.
+- Pass `onStdout` and `onStderr` to see Yano logs while the test runs.
+- Print `yano.logs()` in failure handlers when a process started but the test
+  later failed.
+- For local binaries, verify `cwd` points to a directory containing `config/`.
+
+### The package cannot find a binary
+
+- Verify the local platform is supported by the optional native packages.
+- Reinstall dependencies so npm installs optional dependencies for your OS/CPU.
+- For unsupported platforms or local development, set `YANO_TESTKIT_BINARY`.
+
+### Tests hang after completion
+
+- Plain Node.js tests must call `await yano.stop()`.
+- Use `try/finally`.
+- In Vitest, prefer `yanoDevnet()` so `afterAll()` stops the process.
+
+### A funded address has no visible UTXO yet
+
+- Wait for the faucet transaction:
+
+```js
+const result = await yano.faucet.fundAddress(address, 1000);
+await yano.await.untilTxVisible(result.tx_hash);
+```
+
+- Then query UTXOs or use address assertions.
+
+## Examples
+
+- `test-examples/yano-testkit-js` - minimal published-package smoke test.
+- `test-examples/yano-testkit-meshjs` - MeshJS wallet, funding, signed transfer,
+  submit, await, and verification.

--- a/npm/yano-testkit/README.md
+++ b/npm/yano-testkit/README.md
@@ -5,6 +5,9 @@ Programmatic Yano devnet fixture for JavaScript and TypeScript tests.
 The package starts a local Yano native binary in devnet mode, waits until the
 HTTP API is ready, and returns connection details for your test code.
 
+For a detailed JavaScript developer guide, see
+[JS_USER_GUIDE.md](./JS_USER_GUIDE.md).
+
 ## Install
 
 ```bash
@@ -25,8 +28,10 @@ const yano = await startYanoDevnet({
 });
 
 try {
-  const response = await fetch(new URL("node/tip", yano.apiBaseUrl));
-  const tip = await response.json();
+  await yano.faucet.fundAddress("addr_test1...", 1000);
+  await yano.time.advanceSlots(3);
+
+  const tip = await yano.queries.tip();
   console.log(tip);
 } finally {
   await yano.stop();
@@ -42,6 +47,90 @@ The default fixture uses:
 - a random available HTTP port;
 - a random available node-to-node port;
 - the production Blockfrost-compatible API under `/api/v1/`.
+
+## Funding Test Addresses
+
+Yano devnet exposes a devnet-only faucet endpoint. The wrapper provides a small
+helper so tests do not need to hand-roll the HTTP request:
+
+```js
+const result = await yano.fundAddress("addr_test1...", 1000);
+console.log(result.tx_hash, result.index, result.lovelace);
+```
+
+`yano.fundAddress(address, ada)` is a compatibility alias for
+`yano.faucet.fundAddress(address, ada)`.
+
+The amount is in ADA, matching the HTTP API:
+
+```http
+POST /api/v1/devnet/fund
+{ "address": "addr_test1...", "ada": 1000 }
+```
+
+The response shape is `{ tx_hash, index, lovelace }`.
+
+The npm testkit does not expose a default JavaScript wallet or pre-funded
+account. JS tests should create or load their own test wallet/address using the
+application's normal Cardano library, then call `fundAddress()` before building
+transactions. The devnet's initial funds are owned by the runtime faucet, not by
+an npm-exported mnemonic.
+
+## Advanced Helpers
+
+The returned devnet object includes typed, HTTP-backed helper groups:
+
+```js
+await yano.faucet.fundAddress(address, 1000);
+await yano.faucet.fundAddressLovelace(address, 1_000_000n);
+
+await yano.time.advanceSlots(5);
+await yano.time.advanceToEpoch(1);
+await yano.time.crossEpochBoundary();
+
+await yano.snapshots.create("before-case");
+await yano.snapshots.withSnapshot("case", async () => {
+  await yano.time.advanceSlots(1);
+});
+
+await yano.devnet.rollback({ count: 1 });
+
+const utxos = await yano.queries.utxosByAddress(address);
+const txHash = await yano.transactions.submitAndAwait(signedTxCbor);
+
+await yano.await.untilTxVisible(txHash);
+await yano.assertions.address(address).hasAtLeastAda(1000);
+```
+
+Query helpers and `yano.client` preserve Yano's HTTP response shape, including
+Blockfrost-style snake_case fields such as `tx_hash`, `block_number`, and
+`output_index`. Wrapper request options use normal JavaScript camelCase where a
+convenience method needs an option object.
+
+`advanceToSlot()`, `advanceToEpoch()`, and `crossEpochBoundary()` are
+best-effort helpers. They read current chain state and then ask Yano to advance
+by the computed delta, so a live producer can move the chain while the helper is
+running. Use `await.untilSlotAtLeast()`, `await.untilEpochAtLeast()`, or an
+assertion after advancing when the test needs to verify the final chain state.
+
+ADA assertion helpers such as `hasAtLeastAda(1000)` accept JavaScript numbers
+for convenience. Use the lovelace helpers, for example `hasAtLeast(1_000_000n)`
+or `hasExactly(1_000_000n)`, when exact arithmetic matters.
+
+The low-level `yano.client` helper is available for endpoints that do not need a
+named convenience method:
+
+```js
+const status = await yano.client.getJson("node/status");
+const params = await yano.client.getJson("epochs/latest/parameters");
+```
+
+All mutation helpers call Yano's existing devnet-only HTTP endpoints. They do
+not expose runtime internals or RocksDB handles.
+
+Wallet/key generation and transaction signing stay in your JavaScript
+application or its chosen Cardano library. Yano helpers fund and query addresses
+and submit serialized transactions.
 
 ## Vitest
 
@@ -76,8 +165,10 @@ await fetch(new URL("tx/submit", yano.apiBaseUrl), {
 });
 ```
 
-Query UTXOs through the Blockfrost-compatible endpoints under `yano.apiBaseUrl`.
-Wallet and key generation are intentionally outside this package.
+Use `yano.faucet.fundAddress(address, ada)` to create test UTXOs, then query
+UTXOs through `yano.queries` or the Blockfrost-compatible endpoints under
+`yano.apiBaseUrl`. Wallet and key generation are intentionally outside this
+package.
 
 ## Local Wrapper Testing
 

--- a/npm/yano-testkit/package-lock.json
+++ b/npm/yano-testkit/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@bloxbean/yano-testkit",
-  "version": "0.1.0-pre6",
+  "version": "0.1.0-pre7-ci2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@bloxbean/yano-testkit",
-      "version": "0.1.0-pre6",
+      "version": "0.1.0-pre7-ci2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^24.0.0",
@@ -17,10 +17,10 @@
         "node": ">=20.8.0"
       },
       "optionalDependencies": {
-        "@bloxbean/yano-testkit-linux-arm64": "0.1.0-pre6",
-        "@bloxbean/yano-testkit-linux-x64": "0.1.0-pre6",
-        "@bloxbean/yano-testkit-macos-arm64": "0.1.0-pre6",
-        "@bloxbean/yano-testkit-windows-x64": "0.1.0-pre6"
+        "@bloxbean/yano-testkit-linux-arm64": "0.1.0-pre7-ci2",
+        "@bloxbean/yano-testkit-linux-x64": "0.1.0-pre7-ci2",
+        "@bloxbean/yano-testkit-macos-arm64": "0.1.0-pre7-ci2",
+        "@bloxbean/yano-testkit-windows-x64": "0.1.0-pre7-ci2"
       },
       "peerDependencies": {
         "vitest": ">=1.0.0"

--- a/npm/yano-testkit/package.json
+++ b/npm/yano-testkit/package.json
@@ -25,6 +25,7 @@
   },
   "files": [
     "README.md",
+    "JS_USER_GUIDE.md",
     "src"
   ],
   "license": "MIT",

--- a/npm/yano-testkit/package.json
+++ b/npm/yano-testkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bloxbean/yano-testkit",
-  "version": "0.1.0-pre6",
+  "version": "0.1.0-pre7-ci2",
   "description": "Programmatic Yano devnet test fixture for JavaScript and TypeScript tests.",
   "keywords": [
     "yano",
@@ -44,10 +44,10 @@
     "pack:dry": "npm pack --dry-run"
   },
   "optionalDependencies": {
-    "@bloxbean/yano-testkit-linux-x64": "0.1.0-pre6",
-    "@bloxbean/yano-testkit-linux-arm64": "0.1.0-pre6",
-    "@bloxbean/yano-testkit-macos-arm64": "0.1.0-pre6",
-    "@bloxbean/yano-testkit-windows-x64": "0.1.0-pre6"
+    "@bloxbean/yano-testkit-linux-x64": "0.1.0-pre7-ci2",
+    "@bloxbean/yano-testkit-linux-arm64": "0.1.0-pre7-ci2",
+    "@bloxbean/yano-testkit-macos-arm64": "0.1.0-pre7-ci2",
+    "@bloxbean/yano-testkit-windows-x64": "0.1.0-pre7-ci2"
   },
   "peerDependencies": {
     "vitest": ">=1.0.0"

--- a/npm/yano-testkit/src/facades.js
+++ b/npm/yano-testkit/src/facades.js
@@ -1,0 +1,986 @@
+// @ts-check
+
+import { YanoHttpError } from "./http.js";
+
+const DEFAULT_AWAIT_TIMEOUT_MS = 30_000;
+const DEFAULT_POLL_INTERVAL_MS = 100;
+const LOVELACE_PER_ADA = 1_000_000n;
+
+/**
+ * @typedef {import("./http.js").YanoHttpClient} YanoHttpClient
+ *
+ * @typedef YanoFundingRequest
+ * @property {string} address
+ * @property {number=} ada
+ * @property {number | string | bigint=} lovelace
+ *
+ * @typedef YanoAwaitOptions
+ * @property {number=} timeoutMs
+ * @property {number=} pollIntervalMs
+ *
+ * @typedef YanoFacades
+ * @property {YanoHttpClient} client
+ * @property {ReturnType<typeof createQueries>} queries
+ * @property {ReturnType<typeof createFaucet>} faucet
+ * @property {ReturnType<typeof createTime>} time
+ * @property {ReturnType<typeof createSnapshots>} snapshots
+ * @property {ReturnType<typeof createDevnetControls>} devnet
+ * @property {ReturnType<typeof createTransactions>} transactions
+ * @property {ReturnType<typeof createAwait>} await
+ * @property {ReturnType<typeof createAssertions>} assertions
+ */
+
+/**
+ * @param {YanoHttpClient} client
+ * @returns {YanoFacades}
+ */
+export function createYanoFacades(client) {
+  const queries = createQueries(client);
+  const awaiter = createAwait(queries);
+  const snapshots = createSnapshots(client);
+  return {
+    client,
+    queries,
+    faucet: createFaucet(client),
+    time: createTime(client, queries),
+    snapshots,
+    devnet: createDevnetControls(client),
+    transactions: createTransactions(client, awaiter),
+    await: awaiter,
+    assertions: createAssertions(queries, snapshots)
+  };
+}
+
+/**
+ * @param {YanoHttpClient} client
+ */
+function createFaucet(client) {
+  return {
+    /**
+     * @param {string} address
+     * @param {number} ada
+     */
+    async fundAddress(address, ada) {
+      requireAddress(address);
+      requirePositiveNumber(ada, "ada");
+      return client.postJson("devnet/fund", { address, ada });
+    },
+
+    /**
+     * @param {string} address
+     * @param {number | string | bigint} lovelace
+     */
+    async fundAddressLovelace(address, lovelace) {
+      requireAddress(address);
+      return client.postJson("devnet/fund", {
+        address,
+        ada: lovelaceToAdaDecimal(lovelace)
+      });
+    },
+
+    /**
+     * Funds addresses sequentially. Runtime funding is not atomic.
+     *
+     * @param {YanoFundingRequest[]} requests
+     */
+    async fundAll(requests) {
+      if (!Array.isArray(requests)) {
+        throw new Error("fundAll requires an array of funding requests");
+      }
+      const results = [];
+      for (const request of requests) {
+        if (!request || typeof request !== "object") {
+          throw new Error("fundAll request must be an object");
+        }
+        if (request.lovelace !== undefined) {
+          results.push(await this.fundAddressLovelace(request.address, request.lovelace));
+        } else {
+          results.push(await this.fundAddress(request.address, request.ada ?? 0));
+        }
+      }
+      return results;
+    }
+  };
+}
+
+/**
+ * @param {YanoHttpClient} client
+ * @param {ReturnType<typeof createQueries>} queries
+ */
+function createTime(client, queries) {
+  return {
+    /** @param {number} slots */
+    async advanceSlots(slots) {
+      requirePositiveInteger(slots, "slots");
+      return client.postJson("devnet/time/advance", { slots });
+    },
+
+    /** @param {number} seconds */
+    async advanceSeconds(seconds) {
+      requirePositiveInteger(seconds, "seconds");
+      return client.postJson("devnet/time/advance", { seconds });
+    },
+
+    /** @param {number} epochs */
+    async advanceEpochs(epochs) {
+      requirePositiveInteger(epochs, "epochs");
+      return client.postJson("devnet/time/advance", { epochs });
+    },
+
+    /** @param {number} targetSlot */
+    async advanceToSlot(targetSlot) {
+      requireNonNegativeInteger(targetSlot, "targetSlot");
+      const currentSlot = await queries.currentSlot();
+      if (targetSlot <= currentSlot) {
+        return {
+          message: "Already at or past target slot",
+          new_slot: currentSlot,
+          new_block_number: await queries.currentBlockNumber(),
+          blocks_produced: 0
+        };
+      }
+      return this.advanceSlots(targetSlot - currentSlot);
+    },
+
+    /** @param {number} targetEpoch */
+    async advanceToEpoch(targetEpoch) {
+      requireNonNegativeInteger(targetEpoch, "targetEpoch");
+      const currentEpoch = await queries.currentEpoch();
+      if (targetEpoch <= currentEpoch) {
+        return {
+          message: "Already at or past target epoch",
+          new_slot: await queries.currentSlot(),
+          new_block_number: await queries.currentBlockNumber(),
+          blocks_produced: 0
+        };
+      }
+      return this.advanceToSlot(await queries.epochStartSlot(targetEpoch));
+    },
+
+    async crossEpochBoundary() {
+      const currentEpoch = await queries.currentEpoch();
+      return this.advanceToEpoch(currentEpoch + 1);
+    },
+
+    /** @param {number} epochs */
+    async shiftGenesisAndStartProducer(epochs) {
+      requirePositiveInteger(epochs, "epochs");
+      return client.postJson("devnet/epochs/shift", { epochs });
+    },
+
+    async catchUpToWallClock() {
+      return client.postJson("devnet/epochs/catch-up");
+    }
+  };
+}
+
+/**
+ * @param {YanoHttpClient} client
+ */
+function createSnapshots(client) {
+  return {
+    /** @param {string} name */
+    async create(name) {
+      requireName(name, "snapshot name");
+      return client.postJson("devnet/snapshot", { name });
+    },
+
+    /** @param {string} name */
+    async restore(name) {
+      requireName(name, "snapshot name");
+      return client.postJson(`devnet/restore/${encodeURIComponent(name)}`);
+    },
+
+    async list() {
+      return client.getJson("devnet/snapshots");
+    },
+
+    /** @param {string} name */
+    async delete(name) {
+      requireName(name, "snapshot name");
+      return client.deleteJson(`devnet/snapshot/${encodeURIComponent(name)}`);
+    },
+
+    /** @param {string} name */
+    async exists(name) {
+      requireName(name, "snapshot name");
+      const snapshots = await this.list();
+      return Array.isArray(snapshots)
+        && snapshots.some((snapshot) => snapshot && typeof snapshot === "object"
+          && "name" in snapshot && snapshot.name === name);
+    },
+
+    /**
+     * @template T
+     * @param {string} name
+     * @param {() => Promise<T> | T} action
+     * @returns {Promise<T>}
+     */
+    async withSnapshot(name, action) {
+      requireName(name, "snapshot name");
+      if (typeof action !== "function") {
+        throw new Error("withSnapshot requires an action function");
+      }
+      await this.create(name);
+      /** @type {unknown} */
+      let failure;
+      /** @type {T | undefined} */
+      let result;
+      try {
+        result = await action();
+      } catch (error) {
+        failure = error;
+      }
+
+      try {
+        await this.restore(name);
+      } catch (restoreError) {
+        if (failure instanceof Error) {
+          attachSuppressed(failure, restoreError);
+          throw failure;
+        }
+        throw restoreError;
+      }
+
+      if (failure) {
+        throw failure;
+      }
+      return /** @type {T} */ (result);
+    }
+  };
+}
+
+/**
+ * @param {YanoHttpClient} client
+ */
+function createDevnetControls(client) {
+  return {
+    /**
+     * @param {{ slot?: number, blockNumber?: number, count?: number }} target
+     */
+    async rollback(target) {
+      if (!target || typeof target !== "object") {
+        throw new Error("rollback requires a target");
+      }
+      const supplied = [
+        target.slot !== undefined,
+        target.blockNumber !== undefined,
+        target.count !== undefined
+      ].filter(Boolean).length;
+      if (supplied !== 1) {
+        throw new Error("rollback requires exactly one of slot, blockNumber, or count");
+      }
+      const body = {
+        slot: target.slot,
+        block_number: target.blockNumber,
+        count: target.count
+      };
+      return client.postJson("devnet/rollback", body);
+    },
+
+    async downloadGenesisZip() {
+      return client.getBytes("devnet/genesis/download");
+    }
+  };
+}
+
+/**
+ * @param {YanoHttpClient} client
+ */
+function createQueries(client) {
+  /** @type {Promise<unknown> | undefined} */
+  let configPromise;
+  return {
+    status: () => client.getJson("node/status"),
+    tip: () => client.getJson("node/tip"),
+    /** node/config is immutable for the fixture lifetime, so fetch it once and reuse it. */
+    config() {
+      if (!configPromise) {
+        configPromise = client.getJson("node/config").catch((error) => {
+          configPromise = undefined;
+          throw error;
+        });
+      }
+      return configPromise;
+    },
+    genesis: () => client.getJson("genesis"),
+    latestBlock: () => client.getJson("blocks/latest"),
+
+    /** @param {string | number} hashOrNumber */
+    async block(hashOrNumber) {
+      return client.getJson(`blocks/${encodeURIComponent(String(hashOrNumber))}`);
+    },
+
+    /** @param {number=} epoch */
+    async protocolParameters(epoch) {
+      if (epoch === undefined) {
+        return client.getJson("epochs/latest/parameters");
+      }
+      requireNonNegativeInteger(epoch, "epoch");
+      return client.getJson(`epochs/${epoch}/parameters`);
+    },
+
+    async currentSlot() {
+      const tip = await this.tip();
+      return numberField(tip, ["slot", "slotNo", "slot_no"], 0);
+    },
+
+    async currentBlockNumber() {
+      const tip = await this.tip();
+      return numberField(tip, ["blockNumber", "block_number", "block"], 0);
+    },
+
+    async currentEpoch() {
+      const config = await this.config();
+      const calc = epochSlotCalc(config);
+      return calc.slotToEpoch(await this.currentSlot());
+    },
+
+    /** @param {number} epoch */
+    async epochStartSlot(epoch) {
+      requireNonNegativeInteger(epoch, "epoch");
+      const config = await this.config();
+      return epochSlotCalc(config).epochToStartSlot(epoch);
+    },
+
+    /**
+     * @param {string} address
+     * @param {{ page?: number, count?: number, order?: "asc" | "desc", usePaymentCredential?: boolean }=} options
+     */
+    async utxosByAddress(address, options = {}) {
+      requireAddress(address);
+      const params = queryParams({
+        page: options.page,
+        count: options.count,
+        order: options.order,
+        use_payment_credential: options.usePaymentCredential
+      });
+      return client.getJson(`addresses/${encodeURIComponent(address)}/utxos${params}`);
+    },
+
+    /**
+     * @param {string} address
+     * @param {string} asset
+     * @param {{ page?: number, count?: number, order?: "asc" | "desc" }=} options
+     */
+    async utxosByAddressAndAsset(address, asset, options = {}) {
+      requireAddress(address);
+      requireName(asset, "asset");
+      const params = queryParams({
+        page: options.page,
+        count: options.count,
+        order: options.order
+      });
+      return client.getJson(`addresses/${encodeURIComponent(address)}/utxos/${encodeURIComponent(asset)}${params}`);
+    },
+
+    /**
+     * @param {string} txHash
+     * @param {number} index
+     */
+    async utxo(txHash, index) {
+      requireName(txHash, "txHash");
+      requireNonNegativeInteger(index, "index");
+      return client.getJson(`utxos/${encodeURIComponent(txHash)}/${index}`);
+    },
+
+    /** @param {string} txHash */
+    async tx(txHash) {
+      requireName(txHash, "txHash");
+      return client.getJson(`txs/${encodeURIComponent(txHash)}`);
+    },
+
+    /** @param {string} txHash */
+    async txUtxos(txHash) {
+      requireName(txHash, "txHash");
+      return client.getJson(`txs/${encodeURIComponent(txHash)}/utxos`);
+    },
+
+    /** @param {string} paymentCredential */
+    async utxosByPaymentCredential(paymentCredential) {
+      requireName(paymentCredential, "paymentCredential");
+      return client.getJson(`credentials/${encodeURIComponent(paymentCredential)}/utxos`);
+    }
+  };
+}
+
+/**
+ * @param {YanoHttpClient} client
+ * @param {ReturnType<typeof createAwait>} awaiter
+ */
+function createTransactions(client, awaiter) {
+  return {
+    /** @param {BodyInit} txCbor */
+    async submitCbor(txCbor) {
+      requireBinaryBody(txCbor, "txCbor");
+      return extractTxHash(await client.postCbor("tx/submit", txCbor));
+    },
+
+    /** @param {string} txHex */
+    async submitHex(txHex) {
+      requireName(txHex, "txHex");
+      return extractTxHash(await client.postText("tx/submit", txHex));
+    },
+
+    /**
+     * @param {BodyInit | string} tx
+     * @param {YanoAwaitOptions=} options
+     */
+    async submitAndAwait(tx, options = {}) {
+      const txHash = typeof tx === "string"
+        ? await this.submitHex(tx)
+        : await this.submitCbor(tx);
+      await awaiter.untilTxVisible(txHash, options);
+      return txHash;
+    },
+
+    /** @param {BodyInit} txCbor */
+    async evaluateCbor(txCbor) {
+      requireBinaryBody(txCbor, "txCbor");
+      return client.postCbor("utils/txs/evaluate", txCbor);
+    },
+
+    /** @param {string} txHex */
+    async evaluateHex(txHex) {
+      requireName(txHex, "txHex");
+      return client.postText("utils/txs/evaluate", txHex);
+    }
+  };
+}
+
+/**
+ * @param {ReturnType<typeof createQueries>} queries
+ */
+function createAwait(queries) {
+  return {
+    /**
+     * @param {() => Promise<boolean> | boolean} condition
+     * @param {string} description
+     * @param {YanoAwaitOptions=} options
+     */
+    async until(condition, description, options = {}) {
+      if (typeof condition !== "function") {
+        throw new Error("until requires a condition function");
+      }
+      requireName(description, "description");
+      const timeoutMs = options.timeoutMs ?? DEFAULT_AWAIT_TIMEOUT_MS;
+      const pollIntervalMs = options.pollIntervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+      const deadline = Date.now() + timeoutMs;
+      /** @type {unknown} */
+      let lastFailure;
+      while (Date.now() <= deadline) {
+        try {
+          if (await condition()) {
+            return;
+          }
+          lastFailure = undefined;
+        } catch (error) {
+          lastFailure = error;
+        }
+        await delay(Math.max(1, pollIntervalMs));
+      }
+
+      const error = assertionError(`Timed out after ${timeoutMs}ms waiting for ${description}`);
+      if (lastFailure) {
+        attachSuppressed(error, lastFailure);
+      }
+      throw error;
+    },
+
+    /** @param {YanoAwaitOptions=} options */
+    untilReady(options = {}) {
+      return this.until(async () => {
+        const status = await queries.status();
+        return booleanField(status, "running", true)
+          && !booleanField(status, "runtimeDegraded", false);
+      }, "Yano devnet to be ready", options);
+    },
+
+    /** @param {number} slot @param {YanoAwaitOptions=} options */
+    untilSlotAtLeast(slot, options = {}) {
+      requireNonNegativeInteger(slot, "slot");
+      return this.until(async () => await queries.currentSlot() >= slot, `slot >= ${slot}`, options);
+    },
+
+    /** @param {number} blockNumber @param {YanoAwaitOptions=} options */
+    untilBlockAtLeast(blockNumber, options = {}) {
+      requireNonNegativeInteger(blockNumber, "blockNumber");
+      return this.until(async () => await queries.currentBlockNumber() >= blockNumber, `block >= ${blockNumber}`, options);
+    },
+
+    /** @param {number} epoch @param {YanoAwaitOptions=} options */
+    untilEpochAtLeast(epoch, options = {}) {
+      requireNonNegativeInteger(epoch, "epoch");
+      return this.until(async () => await queries.currentEpoch() >= epoch, `epoch >= ${epoch}`, options);
+    },
+
+    /** @param {string} txHash @param {YanoAwaitOptions=} options */
+    untilTxVisible(txHash, options = {}) {
+      requireName(txHash, "txHash");
+      return this.until(async () => {
+        try {
+          const txUtxos = await queries.txUtxos(txHash);
+          return hasVisibleTxOutput(txUtxos);
+        } catch (error) {
+          if (error instanceof YanoHttpError && error.status === 404) {
+            return false;
+          }
+          throw error;
+        }
+      }, `tx ${txHash} to be visible`, options);
+    }
+  };
+}
+
+/**
+ * @param {ReturnType<typeof createQueries>} queries
+ * @param {ReturnType<typeof createSnapshots>} snapshots
+ */
+function createAssertions(queries, snapshots) {
+  return {
+    async nodeIsRunning() {
+      const status = await queries.status();
+      if (!booleanField(status, "running", false)) {
+        throw assertionError("Expected Yano devnet node to be running");
+      }
+    },
+
+    async runtimeNotDegraded() {
+      const status = await queries.status();
+      if (booleanField(status, "runtimeDegraded", false)) {
+        throw assertionError(`Expected runtime to be healthy, got degraded: ${stringField(status, "runtimeDegradedReason", "")}`);
+      }
+    },
+
+    /** @param {number} slot */
+    async slotAtLeast(slot) {
+      const actual = await queries.currentSlot();
+      if (actual < slot) {
+        throw assertionError(`Expected slot >= ${slot}, got ${actual}`);
+      }
+    },
+
+    /** @param {number} blockNumber */
+    async blockAtLeast(blockNumber) {
+      const actual = await queries.currentBlockNumber();
+      if (actual < blockNumber) {
+        throw assertionError(`Expected block >= ${blockNumber}, got ${actual}`);
+      }
+    },
+
+    /** @param {number} epoch */
+    async epochAtLeast(epoch) {
+      const actual = await queries.currentEpoch();
+      if (actual < epoch) {
+        throw assertionError(`Expected epoch >= ${epoch}, got ${actual}`);
+      }
+    },
+
+    /** @param {string} name */
+    async snapshotExists(name) {
+      if (!await snapshots.exists(name)) {
+        throw assertionError(`Expected snapshot to exist: ${name}`);
+      }
+    },
+
+    /** @param {string} name */
+    async snapshotMissing(name) {
+      if (await snapshots.exists(name)) {
+        throw assertionError(`Expected snapshot to be missing: ${name}`);
+      }
+    },
+
+    /** @param {string} address */
+    address(address) {
+      requireAddress(address);
+      return createAddressAssertions(queries, address);
+    }
+  };
+}
+
+/**
+ * @param {ReturnType<typeof createQueries>} queries
+ * @param {string} address
+ */
+function createAddressAssertions(queries, address) {
+  return {
+    async balanceLovelace() {
+      return addressBalanceLovelace(queries, address);
+    },
+
+    /** @param {number | string | bigint} lovelace */
+    async hasAtLeast(lovelace) {
+      const expected = toPositiveOrZeroBigInt(lovelace, "lovelace");
+      const actual = await this.balanceLovelace();
+      if (actual < expected) {
+        throw assertionError(`Expected address ${address} to have at least ${expected} lovelace, got ${actual}`);
+      }
+    },
+
+    /** @param {number} ada */
+    async hasAtLeastAda(ada) {
+      requireNonNegativeNumber(ada, "ada");
+      await this.hasAtLeast(adaToLovelaceBigInt(ada));
+    },
+
+    /** @param {number | string | bigint} lovelace */
+    async hasExactly(lovelace) {
+      const expected = toPositiveOrZeroBigInt(lovelace, "lovelace");
+      const actual = await this.balanceLovelace();
+      if (actual !== expected) {
+        throw assertionError(`Expected address ${address} to have exactly ${expected} lovelace, got ${actual}`);
+      }
+    },
+
+    /** @param {number} ada */
+    async hasExactlyAda(ada) {
+      requireNonNegativeNumber(ada, "ada");
+      await this.hasExactly(adaToLovelaceBigInt(ada));
+    }
+  };
+}
+
+/**
+ * @param {ReturnType<typeof createQueries>} queries
+ * @param {string} address
+ */
+async function addressBalanceLovelace(queries, address) {
+  let total = 0n;
+  let page = 1;
+  while (true) {
+    const utxos = await queries.utxosByAddress(address, { page, count: 100 });
+    if (!Array.isArray(utxos) || utxos.length === 0) {
+      return total;
+    }
+    for (const utxo of utxos) {
+      total += lovelaceFromAmounts(objectField(utxo, "amount"));
+    }
+    if (utxos.length < 100) {
+      return total;
+    }
+    page++;
+  }
+}
+
+/**
+ * @param {unknown} amounts
+ */
+function lovelaceFromAmounts(amounts) {
+  if (!Array.isArray(amounts)) {
+    return 0n;
+  }
+  for (const amount of amounts) {
+    if (amount && typeof amount === "object" && "unit" in amount && amount.unit === "lovelace") {
+      return BigInt(String("quantity" in amount ? amount.quantity : 0));
+    }
+  }
+  return 0n;
+}
+
+/**
+ * @param {unknown} value
+ */
+function hasVisibleTxOutput(value) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  if ("outputs" in value && Array.isArray(value.outputs)) {
+    return value.outputs.length > 0;
+  }
+  return true;
+}
+
+/**
+ * @param {unknown} response
+ */
+function extractTxHash(response) {
+  if (typeof response === "string" && response.trim()) {
+    return response;
+  }
+  if (response && typeof response === "object") {
+    const record = /** @type {Record<string, unknown>} */ (response);
+    for (const field of ["txHash", "tx_hash", "hash"]) {
+      const value = record[field];
+      if (typeof value === "string" && value) {
+        return value;
+      }
+    }
+  }
+  throw new Error(`Transaction submission response did not include a transaction hash: ${JSON.stringify(response)}`);
+}
+
+/**
+ * @param {unknown} config
+ */
+function epochSlotCalc(config) {
+  const epochLength = numberField(config, ["epochLength", "epoch_length"], NaN);
+  const byronSlotsPerEpoch = numberField(config, ["byronSlotsPerEpoch", "byron_slots_per_epoch"], epochLength);
+  const firstNonByronSlot = numberField(config, ["firstNonByronSlot", "first_non_byron_slot"], 0);
+  if (!Number.isFinite(epochLength) || epochLength <= 0) {
+    throw new Error("node/config does not include a positive epochLength");
+  }
+  if (!Number.isFinite(byronSlotsPerEpoch) || byronSlotsPerEpoch <= 0) {
+    throw new Error("node/config does not include a positive byronSlotsPerEpoch");
+  }
+  if (firstNonByronSlot > 0 && firstNonByronSlot % byronSlotsPerEpoch !== 0) {
+    throw new Error("node/config firstNonByronSlot must be aligned to byronSlotsPerEpoch");
+  }
+  const firstNonByronEpoch = firstNonByronSlot > 0
+    ? Math.trunc(firstNonByronSlot / byronSlotsPerEpoch)
+    : 0;
+  return {
+    /** @param {number} slot */
+    slotToEpoch(slot) {
+      if (firstNonByronSlot === 0) {
+        return Math.trunc(slot / epochLength);
+      }
+      if (slot < firstNonByronSlot) {
+        return Math.trunc(slot / byronSlotsPerEpoch);
+      }
+      return firstNonByronEpoch + Math.trunc((slot - firstNonByronSlot) / epochLength);
+    },
+    /** @param {number} epoch */
+    epochToStartSlot(epoch) {
+      if (firstNonByronSlot === 0) {
+        return epoch * epochLength;
+      }
+      if (epoch <= firstNonByronEpoch) {
+        return epoch * byronSlotsPerEpoch;
+      }
+      return firstNonByronSlot + (epoch - firstNonByronEpoch) * epochLength;
+    }
+  };
+}
+
+/**
+ * @param {Record<string, unknown>} values
+ */
+function queryParams(values) {
+  const params = new URLSearchParams();
+  for (const [key, value] of Object.entries(values)) {
+    if (value !== undefined && value !== null) {
+      params.set(key, String(value));
+    }
+  }
+  const text = params.toString();
+  return text ? `?${text}` : "";
+}
+
+/**
+ * @param {number | string | bigint} lovelace
+ */
+function lovelaceToAdaDecimal(lovelace) {
+  const value = toPositiveBigInt(lovelace, "lovelace");
+  const whole = value / LOVELACE_PER_ADA;
+  const fraction = value % LOVELACE_PER_ADA;
+  if (fraction === 0n) {
+    return whole.toString();
+  }
+  return `${whole}.${fraction.toString().padStart(6, "0").replace(/0+$/, "")}`;
+}
+
+/**
+ * @param {number} ada
+ */
+function adaToLovelaceBigInt(ada) {
+  return BigInt(Math.trunc(ada * Number(LOVELACE_PER_ADA)));
+}
+
+/**
+ * @param {unknown} value
+ * @returns {Record<string, unknown> | undefined}
+ */
+function asRecord(value) {
+  return value && typeof value === "object"
+    ? /** @type {Record<string, unknown>} */ (value)
+    : undefined;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string[]} names
+ * @param {number} fallback
+ */
+function numberField(value, names, fallback) {
+  const record = asRecord(value);
+  if (!record) {
+    return fallback;
+  }
+  for (const name of names) {
+    if (typeof record[name] === "number") {
+      return record[name];
+    }
+  }
+  return fallback;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} name
+ * @param {boolean} fallback
+ */
+function booleanField(value, name, fallback) {
+  const record = asRecord(value);
+  return record && typeof record[name] === "boolean" ? record[name] : fallback;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} name
+ * @param {string} fallback
+ */
+function stringField(value, name, fallback) {
+  const record = asRecord(value);
+  return record && typeof record[name] === "string" ? record[name] : fallback;
+}
+
+/**
+ * @param {unknown} value
+ * @param {string} name
+ */
+function objectField(value, name) {
+  const record = asRecord(value);
+  return record ? record[name] : undefined;
+}
+
+/**
+ * @param {string} address
+ */
+function requireAddress(address) {
+  requireName(address, "address");
+}
+
+/**
+ * @param {string} value
+ * @param {string} name
+ */
+function requireName(value, name) {
+  if (typeof value !== "string" || !value.trim()) {
+    throw new Error(`${name} must not be blank`);
+  }
+}
+
+/**
+ * @param {number} value
+ * @param {string} name
+ */
+function requirePositiveNumber(value, name) {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`${name} must be positive`);
+  }
+}
+
+/**
+ * @param {number} value
+ * @param {string} name
+ */
+function requireNonNegativeNumber(value, name) {
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`${name} must be non-negative`);
+  }
+}
+
+/**
+ * @param {number} value
+ * @param {string} name
+ */
+function requirePositiveInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive safe integer`);
+  }
+}
+
+/**
+ * @param {number} value
+ * @param {string} name
+ */
+function requireNonNegativeInteger(value, name) {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative safe integer`);
+  }
+}
+
+/**
+ * @param {number | string | bigint} value
+ * @param {string} name
+ */
+function toPositiveBigInt(value, name) {
+  const parsed = toBigInt(value, name);
+  if (parsed <= 0n) {
+    throw new Error(`${name} must be positive`);
+  }
+  return parsed;
+}
+
+/**
+ * @param {number | string | bigint} value
+ * @param {string} name
+ */
+function toPositiveOrZeroBigInt(value, name) {
+  const parsed = toBigInt(value, name);
+  if (parsed < 0n) {
+    throw new Error(`${name} must be non-negative`);
+  }
+  return parsed;
+}
+
+/**
+ * @param {number | string | bigint} value
+ * @param {string} name
+ */
+function toBigInt(value, name) {
+  if (typeof value === "bigint") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`${name} must be a safe integer`);
+    }
+    return BigInt(value);
+  }
+  if (/^\d+$/.test(value)) {
+    return BigInt(value);
+  }
+  throw new Error(`${name} must be an integer`);
+}
+
+/**
+ * @param {BodyInit} body
+ * @param {string} name
+ */
+function requireBinaryBody(body, name) {
+  if (body == null) {
+    throw new Error(`${name} must not be empty`);
+  }
+  if (body instanceof ArrayBuffer && body.byteLength === 0) {
+    throw new Error(`${name} must not be empty`);
+  }
+  if (ArrayBuffer.isView(body) && body.byteLength === 0) {
+    throw new Error(`${name} must not be empty`);
+  }
+}
+
+/**
+ * @param {string} message
+ */
+function assertionError(message) {
+  const error = new Error(message);
+  error.name = "AssertionError";
+  return error;
+}
+
+/**
+ * @param {Error} error
+ * @param {unknown} suppressed
+ */
+function attachSuppressed(error, suppressed) {
+  const target = /** @type {Error & { suppressed?: unknown[] }} */ (error);
+  target.suppressed = [...(target.suppressed ?? []), suppressed];
+}
+
+/**
+ * @param {number} ms
+ */
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/npm/yano-testkit/src/http.js
+++ b/npm/yano-testkit/src/http.js
@@ -1,0 +1,154 @@
+// @ts-check
+
+/**
+ * @typedef YanoHttpRequestOptions
+ * @property {AbortSignal=} signal
+ * @property {number=} timeoutMs
+ * @property {Record<string, string>=} headers
+ *
+ * @typedef YanoHttpClient
+ * @property {string} apiBaseUrl
+ * @property {(path: string) => URL} url
+ * @property {<T = unknown>(path: string, options?: YanoHttpRequestOptions) => Promise<T>} getJson
+ * @property {<T = unknown>(path: string, body?: unknown, options?: YanoHttpRequestOptions) => Promise<T>} postJson
+ * @property {<T = unknown>(path: string, options?: YanoHttpRequestOptions) => Promise<T>} deleteJson
+ * @property {<T = unknown>(path: string, body: BodyInit, options?: YanoHttpRequestOptions) => Promise<T>} postCbor
+ * @property {<T = unknown>(path: string, body: string, options?: YanoHttpRequestOptions) => Promise<T>} postText
+ * @property {(path: string, options?: YanoHttpRequestOptions) => Promise<Uint8Array>} getBytes
+ */
+
+export class YanoHttpError extends Error {
+  /**
+   * @param {string} message
+   * @param {{ method: string, url: string, status: number, statusText: string, bodyText: string }} details
+   */
+  constructor(message, details) {
+    super(message);
+    this.name = "YanoHttpError";
+    /** @type {string} */
+    this.method = details.method;
+    /** @type {string} */
+    this.url = details.url;
+    /** @type {number} */
+    this.status = details.status;
+    /** @type {string} */
+    this.statusText = details.statusText;
+    /** @type {string} */
+    this.bodyText = details.bodyText;
+  }
+}
+
+/**
+ * @param {string} apiBaseUrl
+ * @returns {YanoHttpClient}
+ */
+export function createYanoHttpClient(apiBaseUrl) {
+  const base = apiBaseUrl.endsWith("/") ? apiBaseUrl : `${apiBaseUrl}/`;
+
+  /**
+   * @param {string} path
+   * @param {string} contentType
+   * @param {BodyInit | undefined} body
+   * @param {YanoHttpRequestOptions} options
+   */
+  const postBody = (path, contentType, body, options) =>
+    requestJson(base, "POST", path, body, {
+      ...options,
+      headers: { "content-type": contentType, ...(options.headers ?? {}) }
+    });
+
+  return {
+    apiBaseUrl: base,
+    url: (path) => new URL(trimLeadingSlash(path), base),
+    getJson: (path, options = {}) => requestJson(base, "GET", path, undefined, options),
+    postJson: (path, body, options = {}) =>
+      postBody(path, "application/json", body === undefined ? undefined : JSON.stringify(body), options),
+    deleteJson: (path, options = {}) => requestJson(base, "DELETE", path, undefined, options),
+    postCbor: (path, body, options = {}) => postBody(path, "application/cbor", body, options),
+    postText: (path, body, options = {}) => postBody(path, "text/plain", body, options),
+    getBytes: (path, options = {}) => requestBytes(base, "GET", path, options)
+  };
+}
+
+/**
+ * @param {string} base
+ * @param {string} method
+ * @param {string} path
+ * @param {BodyInit | undefined} body
+ * @param {YanoHttpRequestOptions} options
+ */
+async function requestJson(base, method, path, body, options) {
+  const response = await request(base, method, path, body, options);
+  return parseResponseBody(response);
+}
+
+/**
+ * @param {string} base
+ * @param {string} method
+ * @param {string} path
+ * @param {YanoHttpRequestOptions} options
+ */
+async function requestBytes(base, method, path, options) {
+  const response = await request(base, method, path, undefined, options);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+/**
+ * @param {string} base
+ * @param {string} method
+ * @param {string} path
+ * @param {BodyInit | undefined} body
+ * @param {YanoHttpRequestOptions} options
+ */
+async function request(base, method, path, body, options) {
+  const url = new URL(trimLeadingSlash(path), base);
+  const response = await fetch(url, {
+    method,
+    headers: options.headers,
+    body,
+    signal: options.signal ?? timeoutSignal(options.timeoutMs)
+  });
+  if (!response.ok) {
+    const bodyText = await response.text();
+    throw new YanoHttpError(
+      `${method} ${url} failed with ${response.status}: ${bodyText}`,
+      {
+        method,
+        url: url.toString(),
+        status: response.status,
+        statusText: response.statusText,
+        bodyText
+      }
+    );
+  }
+  return response;
+}
+
+/**
+ * @param {Response} response
+ */
+async function parseResponseBody(response) {
+  const bodyText = await response.text();
+  if (!bodyText) {
+    return null;
+  }
+  try {
+    return JSON.parse(bodyText);
+  } catch {
+    return bodyText;
+  }
+}
+
+/**
+ * @param {number | undefined} timeoutMs
+ */
+function timeoutSignal(timeoutMs) {
+  return timeoutMs && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined;
+}
+
+/**
+ * @param {string} path
+ */
+function trimLeadingSlash(path) {
+  return path.replace(/^\/+/, "");
+}

--- a/npm/yano-testkit/src/index.d.ts
+++ b/npm/yano-testkit/src/index.d.ts
@@ -1,6 +1,8 @@
 import type { ChildProcess } from "node:child_process";
 
 export type YanoStorageMode = "temp-rocksdb" | "persistent-rocksdb";
+export type YanoLovelaceAmount = number | string | bigint;
+export type YanoCborBody = BodyInit;
 
 export interface StartYanoDevnetOptions {
   binaryPath?: string;
@@ -34,10 +36,204 @@ export interface YanoReadyInfo {
   workDir: string;
 }
 
-export interface YanoDevnet extends YanoReadyInfo {
+export interface YanoFundResult {
+  tx_hash: string;
+  index: number;
+  lovelace: number;
+}
+
+export interface YanoHttpRequestOptions {
+  signal?: AbortSignal;
+  timeoutMs?: number;
+  headers?: Record<string, string>;
+}
+
+export class YanoHttpError extends Error {
+  method: string;
+  url: string;
+  status: number;
+  statusText: string;
+  bodyText: string;
+}
+
+export interface YanoHttpClient {
+  apiBaseUrl: string;
+  url(path: string): URL;
+  getJson<T = unknown>(path: string, options?: YanoHttpRequestOptions): Promise<T>;
+  postJson<T = unknown>(path: string, body?: unknown, options?: YanoHttpRequestOptions): Promise<T>;
+  deleteJson<T = unknown>(path: string, options?: YanoHttpRequestOptions): Promise<T>;
+  postCbor<T = unknown>(path: string, body: YanoCborBody, options?: YanoHttpRequestOptions): Promise<T>;
+  postText<T = unknown>(path: string, body: string, options?: YanoHttpRequestOptions): Promise<T>;
+  getBytes(path: string, options?: YanoHttpRequestOptions): Promise<Uint8Array>;
+}
+
+export interface YanoFundingRequest {
+  address: string;
+  ada?: number;
+  lovelace?: YanoLovelaceAmount;
+}
+
+export interface YanoTimeAdvanceResult {
+  message: string;
+  new_slot: number;
+  new_block_number: number;
+  blocks_produced: number;
+}
+
+export interface YanoSnapshotInfo {
+  name: string;
+  slot: number;
+  block_number: number;
+  created_at: number;
+}
+
+export interface YanoRollbackResult {
+  message: string;
+  slot: number;
+  block_number: number;
+}
+
+export interface YanoAwaitOptions {
+  timeoutMs?: number;
+  pollIntervalMs?: number;
+}
+
+export interface YanoFaucet {
+  fundAddress(address: string, ada: number): Promise<YanoFundResult>;
+  fundAddressLovelace(address: string, lovelace: YanoLovelaceAmount): Promise<YanoFundResult>;
+  fundAll(requests: YanoFundingRequest[]): Promise<YanoFundResult[]>;
+}
+
+export interface YanoTime {
+  advanceSlots(slots: number): Promise<YanoTimeAdvanceResult>;
+  advanceSeconds(seconds: number): Promise<YanoTimeAdvanceResult>;
+  advanceEpochs(epochs: number): Promise<YanoTimeAdvanceResult>;
+  advanceToSlot(targetSlot: number): Promise<YanoTimeAdvanceResult>;
+  advanceToEpoch(targetEpoch: number): Promise<YanoTimeAdvanceResult>;
+  crossEpochBoundary(): Promise<YanoTimeAdvanceResult>;
+  shiftGenesisAndStartProducer(epochs: number): Promise<Record<string, unknown>>;
+  catchUpToWallClock(): Promise<YanoTimeAdvanceResult>;
+}
+
+export interface YanoSnapshots {
+  create(name: string): Promise<YanoSnapshotInfo>;
+  restore(name: string): Promise<Record<string, unknown>>;
+  list(): Promise<YanoSnapshotInfo[]>;
+  delete(name: string): Promise<Record<string, unknown>>;
+  exists(name: string): Promise<boolean>;
+  withSnapshot<T>(name: string, action: () => Promise<T> | T): Promise<T>;
+}
+
+export interface YanoDevnetControls {
+  rollback(target: { slot?: number; blockNumber?: number; count?: number }): Promise<YanoRollbackResult>;
+  downloadGenesisZip(): Promise<Uint8Array>;
+}
+
+export interface YanoUtxoAmount {
+  unit: string;
+  quantity: string | number;
+}
+
+export interface YanoUtxo {
+  tx_hash: string;
+  output_index: number;
+  address: string;
+  amount: YanoUtxoAmount[];
+  data_hash?: string | null;
+  inline_datum?: string | null;
+  script_ref?: string | null;
+  reference_script_hash?: string | null;
+  block?: string | null;
+}
+
+export interface YanoTxUtxos {
+  hash: string;
+  inputs: YanoUtxo[];
+  outputs: YanoUtxo[];
+}
+
+export interface YanoQueries {
+  status<T = Record<string, unknown>>(): Promise<T>;
+  tip<T = Record<string, unknown>>(): Promise<T>;
+  config<T = Record<string, unknown>>(): Promise<T>;
+  genesis<T = Record<string, unknown>>(): Promise<T>;
+  latestBlock<T = Record<string, unknown>>(): Promise<T>;
+  block<T = Record<string, unknown>>(hashOrNumber: string | number): Promise<T>;
+  protocolParameters<T = unknown>(epoch?: number): Promise<T>;
+  currentSlot(): Promise<number>;
+  currentBlockNumber(): Promise<number>;
+  currentEpoch(): Promise<number>;
+  epochStartSlot(epoch: number): Promise<number>;
+  utxosByAddress(address: string, options?: {
+    page?: number;
+    count?: number;
+    order?: "asc" | "desc";
+    usePaymentCredential?: boolean;
+  }): Promise<YanoUtxo[]>;
+  utxosByAddressAndAsset(address: string, asset: string, options?: {
+    page?: number;
+    count?: number;
+    order?: "asc" | "desc";
+  }): Promise<YanoUtxo[]>;
+  utxo(txHash: string, index: number): Promise<YanoUtxo>;
+  tx<T = Record<string, unknown>>(txHash: string): Promise<T>;
+  txUtxos(txHash: string): Promise<YanoTxUtxos>;
+  utxosByPaymentCredential(paymentCredential: string): Promise<YanoUtxo[]>;
+}
+
+export interface YanoTransactions {
+  submitCbor(txCbor: YanoCborBody): Promise<string>;
+  submitHex(txHex: string): Promise<string>;
+  submitAndAwait(tx: YanoCborBody | string, options?: YanoAwaitOptions): Promise<string>;
+  evaluateCbor<T = Record<string, unknown>>(txCbor: YanoCborBody): Promise<T>;
+  evaluateHex<T = Record<string, unknown>>(txHex: string): Promise<T>;
+}
+
+export interface YanoAwait {
+  until(condition: () => Promise<boolean> | boolean, description: string, options?: YanoAwaitOptions): Promise<void>;
+  untilReady(options?: YanoAwaitOptions): Promise<void>;
+  untilSlotAtLeast(slot: number, options?: YanoAwaitOptions): Promise<void>;
+  untilBlockAtLeast(blockNumber: number, options?: YanoAwaitOptions): Promise<void>;
+  untilEpochAtLeast(epoch: number, options?: YanoAwaitOptions): Promise<void>;
+  untilTxVisible(txHash: string, options?: YanoAwaitOptions): Promise<void>;
+}
+
+export interface YanoAddressAssertions {
+  balanceLovelace(): Promise<bigint>;
+  hasAtLeast(lovelace: YanoLovelaceAmount): Promise<void>;
+  hasAtLeastAda(ada: number): Promise<void>;
+  hasExactly(lovelace: YanoLovelaceAmount): Promise<void>;
+  hasExactlyAda(ada: number): Promise<void>;
+}
+
+export interface YanoAssertions {
+  nodeIsRunning(): Promise<void>;
+  runtimeNotDegraded(): Promise<void>;
+  slotAtLeast(slot: number): Promise<void>;
+  blockAtLeast(blockNumber: number): Promise<void>;
+  epochAtLeast(epoch: number): Promise<void>;
+  snapshotExists(name: string): Promise<void>;
+  snapshotMissing(name: string): Promise<void>;
+  address(address: string): YanoAddressAssertions;
+}
+
+export interface YanoHelperFacades {
+  client: YanoHttpClient;
+  queries: YanoQueries;
+  faucet: YanoFaucet;
+  time: YanoTime;
+  snapshots: YanoSnapshots;
+  devnet: YanoDevnetControls;
+  transactions: YanoTransactions;
+  await: YanoAwait;
+  assertions: YanoAssertions;
+}
+
+export interface YanoDevnet extends YanoReadyInfo, YanoHelperFacades {
   process: ChildProcess;
   logs(): string;
   url(path: string): URL;
+  fundAddress(address: string, ada: number): Promise<YanoFundResult>;
   stop(): Promise<void>;
 }
 

--- a/npm/yano-testkit/src/index.js
+++ b/npm/yano-testkit/src/index.js
@@ -6,6 +6,10 @@ import { mkdtemp, rm } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import { tmpdir } from "node:os";
 import { resolveYanoBinary, assertBinaryExists } from "./binary.js";
+import { createYanoHttpClient } from "./http.js";
+import { createYanoFacades } from "./facades.js";
+
+export { YanoHttpError } from "./http.js";
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_BLOCK_TIME_MS = 200;
@@ -42,10 +46,16 @@ const MAX_LOG_LINES = 500;
  * @property {{ mode: YanoStorageMode, path: string }} storage
  * @property {string} workDir
  *
- * @typedef {YanoReadyInfo & {
+ * @typedef YanoFundResult
+ * @property {string} tx_hash
+ * @property {number} index
+ * @property {number} lovelace
+ *
+ * @typedef {YanoReadyInfo & import("./facades.js").YanoFacades & {
  *   process: import("node:child_process").ChildProcess,
  *   logs: () => string,
  *   url: (path: string) => URL,
+ *   fundAddress: (address: string, ada: number) => Promise<YanoFundResult>,
  *   stop: () => Promise<void>
  * }} YanoDevnet
  */
@@ -134,12 +144,16 @@ export async function startYanoDevnet(options = {}) {
     },
     workDir
   };
+  const client = createYanoHttpClient(apiBaseUrl);
+  const facades = createYanoFacades(client);
 
   return {
     ...ready,
+    ...facades,
     process: child,
     logs: logs.text,
     url: (path) => new URL(path, apiBaseUrl),
+    fundAddress: (address, ada) => /** @type {Promise<YanoFundResult>} */ (facades.faucet.fundAddress(address, ada)),
     stop: async () => {
       await stopProcess(child);
       await cleanup();

--- a/npm/yano-testkit/src/vitest.d.ts
+++ b/npm/yano-testkit/src/vitest.d.ts
@@ -1,9 +1,30 @@
-import type { StartYanoDevnetOptions, YanoDevnet } from "./index.js";
+import type {
+  StartYanoDevnetOptions,
+  YanoAssertions,
+  YanoAwait,
+  YanoDevnet,
+  YanoDevnetControls,
+  YanoFaucet,
+  YanoHttpClient,
+  YanoQueries,
+  YanoSnapshots,
+  YanoTime,
+  YanoTransactions
+} from "./index.js";
 
 export interface VitestYanoDevnet {
   readonly current: YanoDevnet;
   readonly baseUrl: string;
   readonly apiBaseUrl: string;
+  readonly client: YanoHttpClient;
+  readonly queries: YanoQueries;
+  readonly faucet: YanoFaucet;
+  readonly time: YanoTime;
+  readonly snapshots: YanoSnapshots;
+  readonly devnet: YanoDevnetControls;
+  readonly transactions: YanoTransactions;
+  readonly await: YanoAwait;
+  readonly assertions: YanoAssertions;
   url(path: string): URL;
 }
 

--- a/npm/yano-testkit/src/vitest.js
+++ b/npm/yano-testkit/src/vitest.js
@@ -34,6 +34,33 @@ export function yanoDevnet(options = {}) {
     get apiBaseUrl() {
       return this.current.apiBaseUrl;
     },
+    get client() {
+      return this.current.client;
+    },
+    get queries() {
+      return this.current.queries;
+    },
+    get faucet() {
+      return this.current.faucet;
+    },
+    get time() {
+      return this.current.time;
+    },
+    get snapshots() {
+      return this.current.snapshots;
+    },
+    get devnet() {
+      return this.current.devnet;
+    },
+    get transactions() {
+      return this.current.transactions;
+    },
+    get await() {
+      return this.current.await;
+    },
+    get assertions() {
+      return this.current.assertions;
+    },
     /** @param {string} path */
     url(path) {
       return this.current.url(path);

--- a/npm/yano-testkit/test/fake-yano.mjs
+++ b/npm/yano-testkit/test/fake-yano.mjs
@@ -6,6 +6,13 @@ import { writeFile } from "node:fs/promises";
 const args = process.argv.slice(2);
 const portArg = args.find((arg) => arg.startsWith("-Dquarkus.http.port="));
 const port = Number.parseInt(portArg?.split("=")[1] ?? "0", 10);
+const state = {
+  slot: 1,
+  blockNumber: 1,
+  snapshots: new Map(),
+  funded: new Map(),
+  submittedTxs: new Set()
+};
 
 if (process.env.FAKE_YANO_ARGS_FILE) {
   await writeFile(process.env.FAKE_YANO_ARGS_FILE, JSON.stringify(args, null, 2));
@@ -17,20 +24,299 @@ if (process.env.FAKE_YANO_EXIT_BEFORE_READY === "true") {
 }
 
 const server = createServer((request, response) => {
-  if (request.url === "/q/health/ready") {
+  const url = new URL(request.url ?? "/", `http://${request.headers.host ?? "127.0.0.1"}`);
+  const path = url.pathname;
+
+  if (path === "/q/health/ready") {
     response.writeHead(200, { "content-type": "application/json" });
     response.end(JSON.stringify({ status: "UP" }));
     return;
   }
 
-  if (request.url === "/api/v1/node/tip") {
-    response.writeHead(200, { "content-type": "application/json" });
-    response.end(JSON.stringify({ slot: 1, blockNumber: 1 }));
+  if (path === "/api/v1/node/status") {
+    json(response, {
+      running: true,
+      runtimeDegraded: false,
+      localTipSlot: state.slot,
+      localTipBlockNumber: state.blockNumber
+    });
     return;
   }
 
-  response.writeHead(404, { "content-type": "application/json" });
-  response.end(JSON.stringify({ error: "not found" }));
+  if (path === "/api/v1/node/tip") {
+    json(response, tip());
+    return;
+  }
+
+  if (path === "/api/v1/node/config") {
+    json(response, {
+      protocolMagic: 42,
+      devMode: true,
+      useRocksDB: true,
+      epochLength: 10,
+      byronSlotsPerEpoch: 5,
+      firstNonByronSlot: 0
+    });
+    return;
+  }
+
+  if (path === "/api/v1/epochs/latest/parameters") {
+    json(response, { epoch: 0, min_fee_a: 44, min_fee_b: 155381 });
+    return;
+  }
+
+  if (path === "/api/v1/genesis") {
+    json(response, { network_magic: 42, epoch_length: 10 });
+    return;
+  }
+
+  if (path === "/api/v1/epochs/0/parameters") {
+    json(response, { epoch: 0, min_fee_a: 44 });
+    return;
+  }
+
+  if (path === "/api/v1/blocks/latest") {
+    json(response, {
+      number: state.blockNumber,
+      slot: state.slot,
+      hash: `fake-block-${state.blockNumber}`
+    });
+    return;
+  }
+
+  if (path.startsWith("/api/v1/blocks/")) {
+    const hashOrNumber = path.split("/").pop();
+    json(response, {
+      number: Number.parseInt(hashOrNumber ?? "0", 10) || state.blockNumber,
+      slot: state.slot,
+      hash: hashOrNumber
+    });
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/devnet/fund") {
+    readBody(request).then((body) => {
+      const requestBody = JSON.parse(body);
+      const address = String(requestBody.address);
+      const lovelace = adaToLovelace(requestBody.ada);
+      const txHash = `fake-fund-tx-${state.funded.size + 1}`;
+      const utxo = {
+        tx_hash: txHash,
+        output_index: 0,
+        address,
+        amount: [{ unit: "lovelace", quantity: String(lovelace) }],
+        block: String(state.blockNumber)
+      };
+      state.funded.set(address, [...(state.funded.get(address) ?? []), utxo]);
+      json(response, {
+        tx_hash: txHash,
+        index: 0,
+        lovelace: Number(lovelace)
+      });
+    }).catch((error) => {
+      json(response, { error: error.message }, 400);
+    });
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/devnet/time/advance") {
+    readBody(request).then((body) => {
+      const requestBody = JSON.parse(body || "{}");
+      const produced = Number(requestBody.slots ?? requestBody.seconds ?? ((requestBody.epochs ?? 0) * 10));
+      state.slot += produced;
+      state.blockNumber += produced;
+      json(response, {
+        message: `Advanced ${produced} blocks`,
+        new_slot: state.slot,
+        new_block_number: state.blockNumber,
+        blocks_produced: produced
+      });
+    }).catch((error) => {
+      json(response, { error: error.message }, 400);
+    });
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/devnet/epochs/shift") {
+    readBody(request).then((body) => {
+      const requestBody = JSON.parse(body || "{}");
+      json(response, {
+        message: `Shifted genesis back by ${requestBody.epochs} epochs and started block producer`,
+        shift_millis: Number(requestBody.epochs) * 10_000,
+        new_system_start: "2026-01-01T00:00:00Z",
+        genesis_slot: 0
+      });
+    });
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/devnet/epochs/catch-up") {
+    state.slot += 3;
+    state.blockNumber += 3;
+    json(response, {
+      message: "Caught up to wall-clock: 3 blocks produced",
+      new_slot: state.slot,
+      new_block_number: state.blockNumber,
+      blocks_produced: 3
+    });
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/devnet/snapshot") {
+    readBody(request).then((body) => {
+      const requestBody = JSON.parse(body);
+      const snapshot = {
+        name: requestBody.name,
+        slot: state.slot,
+        block_number: state.blockNumber,
+        created_at: Date.now()
+      };
+      state.snapshots.set(requestBody.name, snapshot);
+      json(response, snapshot);
+    });
+    return;
+  }
+
+  if (request.method === "POST" && path.startsWith("/api/v1/devnet/restore/")) {
+    const name = decodeURIComponent(path.slice("/api/v1/devnet/restore/".length));
+    const snapshot = state.snapshots.get(name);
+    if (!snapshot) {
+      json(response, { error: "snapshot not found" }, 404);
+      return;
+    }
+    state.slot = snapshot.slot;
+    state.blockNumber = snapshot.block_number;
+    json(response, {
+      message: `Restored snapshot '${name}'`,
+      slot: state.slot,
+      block_number: state.blockNumber
+    });
+    return;
+  }
+
+  if (request.method === "GET" && path === "/api/v1/devnet/snapshots") {
+    json(response, Array.from(state.snapshots.values()));
+    return;
+  }
+
+  if (request.method === "DELETE" && path.startsWith("/api/v1/devnet/snapshot/")) {
+    const name = decodeURIComponent(path.slice("/api/v1/devnet/snapshot/".length));
+    state.snapshots.delete(name);
+    json(response, { message: `Snapshot '${name}' deleted` });
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/devnet/rollback") {
+    readBody(request).then((body) => {
+      const requestBody = JSON.parse(body || "{}");
+      if (requestBody.count !== undefined) {
+        const count = Number(requestBody.count);
+        state.slot = Math.max(0, state.slot - count);
+        state.blockNumber = Math.max(0, state.blockNumber - count);
+      } else if (requestBody.slot !== undefined) {
+        state.slot = Number(requestBody.slot);
+        state.blockNumber = Math.min(state.blockNumber, state.slot);
+      } else if (requestBody.block_number !== undefined) {
+        state.blockNumber = Number(requestBody.block_number);
+        state.slot = Math.min(state.slot, state.blockNumber);
+      }
+      json(response, {
+        message: `Rolled back to slot ${state.slot}, block ${state.blockNumber}`,
+        slot: state.slot,
+        block_number: state.blockNumber
+      });
+    });
+    return;
+  }
+
+  if (request.method === "GET" && path === "/api/v1/devnet/genesis/download") {
+    response.writeHead(200, { "content-type": "application/zip" });
+    response.end(Buffer.from("fake-zip"));
+    return;
+  }
+
+  if (request.method === "GET" && path.startsWith("/api/v1/addresses/") && path.includes("/utxos/")) {
+    const start = "/api/v1/addresses/".length;
+    const separator = path.indexOf("/utxos/", start);
+    const address = decodeURIComponent(path.slice(start, separator));
+    const asset = decodeURIComponent(path.slice(separator + "/utxos/".length));
+    const utxos = state.funded.get(address) ?? [];
+    json(response, asset === "lovelace"
+      ? utxos
+      : utxos.filter((utxo) => utxo.amount.some((amount) => amount.unit === asset)));
+    return;
+  }
+
+  if (request.method === "GET" && path.startsWith("/api/v1/addresses/") && path.endsWith("/utxos")) {
+    const address = decodeURIComponent(path.slice("/api/v1/addresses/".length, -"/utxos".length));
+    json(response, state.funded.get(address) ?? []);
+    return;
+  }
+
+  if (request.method === "GET" && path.startsWith("/api/v1/credentials/") && path.endsWith("/utxos")) {
+    json(response, []);
+    return;
+  }
+
+  if (request.method === "GET" && path.startsWith("/api/v1/utxos/")) {
+    const parts = path.split("/");
+    const txHash = parts[4];
+    const index = parts[5];
+    const utxo = Array.from(state.funded.values()).flat()
+      .find((candidate) => candidate.tx_hash === txHash && candidate.output_index === Number(index));
+    if (!utxo) {
+      json(response, { error: "not found" }, 404);
+      return;
+    }
+    json(response, utxo);
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/tx/submit") {
+    readBody(request).then(() => {
+      state.submittedTxs.add("submitted-tx");
+      json(response, "submitted-tx");
+    });
+    return;
+  }
+
+  if (request.method === "GET" && path === "/api/v1/txs/submitted-tx") {
+    json(response, { hash: "submitted-tx", block: String(state.blockNumber) });
+    return;
+  }
+
+  if (request.method === "GET" && path === "/api/v1/txs/submitted-tx/utxos") {
+    if (!state.submittedTxs.has("submitted-tx")) {
+      json(response, { error: "not found" }, 404);
+      return;
+    }
+    json(response, {
+      hash: "submitted-tx",
+      inputs: [],
+      outputs: [{
+        tx_hash: "submitted-tx",
+        output_index: 0,
+        address: "addr_test1submitted",
+        amount: [{ unit: "lovelace", quantity: "1" }]
+      }]
+    });
+    return;
+  }
+
+  if (request.method === "POST" && path === "/api/v1/utils/txs/evaluate") {
+    response.writeHead(200, { "content-type": "application/json" });
+    response.end(JSON.stringify({
+      type: "jsonwsp/response",
+      result: {
+        EvaluationResult: {
+          "spend:0": { memory: 1, steps: 2 }
+        }
+      }
+    }));
+    return;
+  }
+
+  json(response, { error: "not found" }, 404);
 });
 
 server.listen(port, "127.0.0.1", () => {
@@ -43,3 +329,34 @@ const stop = () => {
 
 process.on("SIGTERM", stop);
 process.on("SIGINT", stop);
+
+function readBody(request) {
+  return new Promise((resolve, reject) => {
+    let body = "";
+    request.setEncoding("utf8");
+    request.on("data", (chunk) => {
+      body += chunk;
+    });
+    request.on("end", () => resolve(body));
+    request.on("error", reject);
+  });
+}
+
+function tip() {
+  return {
+    slot: state.slot,
+    blockNumber: state.blockNumber,
+    blockHash: `fake-block-${state.blockNumber}`
+  };
+}
+
+function json(response, body, status = 200) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+function adaToLovelace(ada) {
+  const text = String(ada);
+  const [whole, fraction = ""] = text.split(".");
+  return BigInt(whole) * 1_000_000n + BigInt(fraction.padEnd(6, "0").slice(0, 6) || "0");
+}

--- a/npm/yano-testkit/test/start.test.js
+++ b/npm/yano-testkit/test/start.test.js
@@ -6,7 +6,7 @@ import { fileURLToPath } from "node:url";
 import { tmpdir } from "node:os";
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { startYanoDevnet } from "../src/index.js";
+import { startYanoDevnet, YanoHttpError } from "../src/index.js";
 import { platformPackage, supportedPlatformKeys } from "../src/platform.js";
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -63,6 +63,179 @@ test("starts devnet, returns readiness details, and cleans temp storage", async 
   await rm(dirname(argsFile), { recursive: true, force: true });
 
   await assert.rejects(() => stat(workDir));
+});
+
+test("funds an address through the devnet faucet endpoint", async () => {
+  const binaryPath = await fakeBinaryPath();
+  const yano = await startYanoDevnet({
+    binaryPath,
+    cwd: here,
+    timeoutMs: 10_000
+  });
+
+  try {
+    const result = await yano.fundAddress("addr_test1qfakeaddress", 12.5);
+
+    assert.deepEqual(result, {
+      tx_hash: "fake-fund-tx-1",
+      index: 0,
+      lovelace: 12_500_000
+    });
+  } finally {
+    await yano.stop();
+  }
+});
+
+test("validates fundAddress inputs before calling the devnet faucet", async () => {
+  const binaryPath = await fakeBinaryPath();
+  const yano = await startYanoDevnet({
+    binaryPath,
+    cwd: here,
+    timeoutMs: 10_000
+  });
+
+  try {
+    await assert.rejects(
+      () => yano.fundAddress("", 10),
+      /address must not be blank/
+    );
+    await assert.rejects(
+      () => yano.fundAddress("addr_test1qfakeaddress", 0),
+      /ada must be positive/
+    );
+  } finally {
+    await yano.stop();
+  }
+});
+
+test("exposes advanced HTTP-backed devnet helpers", async () => {
+  const binaryPath = await fakeBinaryPath();
+  const yano = await startYanoDevnet({
+    binaryPath,
+    cwd: here,
+    timeoutMs: 10_000
+  });
+
+  try {
+    await yano.await.untilReady({ timeoutMs: 1_000 });
+    assert.equal(await yano.queries.currentSlot(), 1);
+    assert.equal(await yano.queries.currentBlockNumber(), 1);
+
+    const firstFund = await yano.faucet.fundAddress("addr_test1qalice", 2);
+    assert.equal(firstFund.lovelace, 2_000_000);
+    const secondFund = await yano.faucet.fundAddressLovelace("addr_test1qalice", 1_500_000n);
+    assert.equal(secondFund.lovelace, 1_500_000);
+    const batchFunds = await yano.faucet.fundAll([
+      { address: "addr_test1qbob", ada: 1 },
+      { address: "addr_test1qbob", lovelace: "2500000" }
+    ]);
+    assert.equal(batchFunds.length, 2);
+
+    assert.equal(await yano.assertions.address("addr_test1qalice").balanceLovelace(), 3_500_000n);
+    await yano.assertions.address("addr_test1qalice").hasAtLeastAda(3.5);
+    assert.equal((await yano.queries.utxo(firstFund.tx_hash, 0)).address, "addr_test1qalice");
+    assert.equal((await yano.queries.utxosByAddressAndAsset("addr_test1qalice", "lovelace")).length, 2);
+    assert.deepEqual(await yano.queries.utxosByPaymentCredential("credential"), []);
+    const currentParams = /** @type {{ min_fee_a: number }} */ (await yano.queries.protocolParameters());
+    const epochParams = /** @type {{ epoch: number }} */ (await yano.queries.protocolParameters(0));
+    assert.equal(currentParams.min_fee_a, 44);
+    assert.equal(epochParams.epoch, 0);
+    assert.equal((await yano.queries.latestBlock()).number, 1);
+    assert.equal((await yano.queries.block("fake-block")).hash, "fake-block");
+
+    const advanced = await yano.time.advanceSlots(4);
+    assert.equal(advanced.new_slot, 5);
+    assert.equal(await yano.queries.currentEpoch(), 0);
+    assert.equal((await yano.time.advanceSeconds(1)).blocks_produced, 1);
+    assert.equal((await yano.time.advanceEpochs(1)).blocks_produced, 10);
+    assert.equal((await yano.time.shiftGenesisAndStartProducer(2)).shift_millis, 20_000);
+    assert.equal((await yano.time.catchUpToWallClock()).blocks_produced, 3);
+
+    await yano.time.advanceToEpoch(1);
+    await yano.await.untilEpochAtLeast(1, { timeoutMs: 1_000 });
+    assert.equal(await yano.queries.epochStartSlot(2), 20);
+
+    await yano.time.crossEpochBoundary();
+    await yano.assertions.epochAtLeast(2);
+
+    const snapshot = await yano.snapshots.create("before");
+    assert.equal(snapshot.name, "before");
+    await yano.assertions.snapshotExists("before");
+    await yano.time.advanceSlots(2);
+    await yano.snapshots.restore("before");
+    const withSnapshotResult = await yano.snapshots.withSnapshot("temp", async () => {
+      await yano.time.advanceSlots(1);
+      return "ok";
+    });
+    assert.equal(withSnapshotResult, "ok");
+    await yano.snapshots.delete("before");
+    await yano.assertions.snapshotMissing("before");
+
+    const rollback = await yano.devnet.rollback({ count: 1 });
+    assert.equal(typeof rollback.slot, "number");
+    assert.equal((await yano.devnet.rollback({ slot: 2 })).slot, 2);
+    assert.equal((await yano.devnet.rollback({ blockNumber: 1 })).block_number, 1);
+    const genesisZip = await yano.devnet.downloadGenesisZip();
+    assert.equal(Buffer.from(genesisZip).toString("utf8"), "fake-zip");
+
+    const txHash = await yano.transactions.submitAndAwait(new Uint8Array([1, 2]), { timeoutMs: 1_000 });
+    assert.equal(txHash, "submitted-tx");
+    assert.equal(await yano.transactions.submitHex("00"), "submitted-tx");
+    assert.equal((await yano.queries.tx(txHash)).hash, "submitted-tx");
+    const evaluation = /** @type {any} */ (await yano.transactions.evaluateHex("00"));
+    assert.equal(evaluation.result.EvaluationResult["spend:0"].memory, 1);
+    const cborEvaluation = /** @type {any} */ (await yano.transactions.evaluateCbor(new Uint8Array([0])));
+    assert.equal(cborEvaluation.result.EvaluationResult["spend:0"].steps, 2);
+
+    await yano.assertions.nodeIsRunning();
+    await yano.assertions.runtimeNotDegraded();
+  } finally {
+    await yano.stop();
+  }
+});
+
+test("HTTP client exposes status and response body on failures", async () => {
+  const binaryPath = await fakeBinaryPath();
+  const yano = await startYanoDevnet({
+    binaryPath,
+    cwd: here,
+    timeoutMs: 10_000
+  });
+
+  try {
+    let failure;
+    try {
+      await yano.client.getJson("missing-route");
+    } catch (error) {
+      failure = error;
+    }
+
+    assert.ok(failure instanceof YanoHttpError);
+    assert.equal(failure.status, 404);
+    assert.match(failure.bodyText, /not found/);
+  } finally {
+    await yano.stop();
+  }
+});
+
+test("await helper times out with an assertion error", async () => {
+  const binaryPath = await fakeBinaryPath();
+  const yano = await startYanoDevnet({
+    binaryPath,
+    cwd: here,
+    timeoutMs: 10_000
+  });
+
+  try {
+    await assert.rejects(
+      () => yano.await.untilSlotAtLeast(999, { timeoutMs: 20, pollIntervalMs: 5 }),
+      (error) => error instanceof Error
+        && error.name === "AssertionError"
+        && /slot >= 999/.test(error.message)
+    );
+  } finally {
+    await yano.stop();
+  }
 });
 
 test("keeps persistent storage work directory", async () => {

--- a/test-examples/yano-testkit-js/README.md
+++ b/test-examples/yano-testkit-js/README.md
@@ -1,0 +1,85 @@
+# Yano Testkit JavaScript Smoke Test
+
+Minimal JavaScript example for testing the published
+`@bloxbean/yano-testkit` npm package. The example starts a native Yano devnet,
+queries the production HTTP API, and then stops the native process.
+
+## Requirements
+
+- Node.js 20.8 or newer.
+- A supported platform package published to npm:
+  - Linux x64
+  - Linux arm64
+  - macOS arm64
+  - Windows x64
+
+Unsupported platforms can still run the example by setting
+`YANO_TESTKIT_BINARY` to a locally built Yano native binary.
+
+## Run
+
+```bash
+cd test-examples/yano-testkit-js
+npm install
+npm test
+```
+
+The example depends on `@bloxbean/yano-testkit@preview`, so it installs the
+current preview/pre-release package and the matching optional native binary
+package for the local OS/CPU.
+
+## Use An Exact Version
+
+To test a specific release:
+
+```bash
+npm install --save-dev @bloxbean/yano-testkit@0.1.0-pre7
+npm test
+```
+
+## Use A Local Binary
+
+```bash
+YANO_TESTKIT_BINARY=/path/to/yano/app/build/yano npm test
+```
+
+On Windows:
+
+```powershell
+$env:YANO_TESTKIT_BINARY="C:\path\to\yano\app\build\yano.exe"
+npm test
+```
+
+## Fund A Test Address
+
+The npm wrapper exposes Yano devnet's faucet endpoint as `fundAddress(address,
+ada)`. Provide an address through the environment to exercise it in this smoke
+test:
+
+```bash
+YANO_TEST_ADDRESS=addr_test1... YANO_TEST_ADA=1000 npm test
+```
+
+On Windows:
+
+```powershell
+$env:YANO_TEST_ADDRESS="addr_test1..."
+$env:YANO_TEST_ADA="1000"
+npm test
+```
+
+The amount is in ADA. The response contains `tx_hash`, `index`, and `lovelace`.
+
+The testkit does not publish a default JavaScript wallet or pre-funded account.
+Create or load a normal test wallet in your application, pass its address to
+`fundAddress()`, and then build/sign transactions with your app's Cardano
+library.
+
+## What It Checks
+
+- Starts Yano native devnet with temporary RocksDB storage.
+- Reads `/q/health/ready`.
+- Reads `/api/v1/node/tip`.
+- Optionally funds `YANO_TEST_ADDRESS` through `yano.fundAddress()`.
+- Waits briefly and reads the tip again.
+- Stops Yano in a `finally` block.

--- a/test-examples/yano-testkit-js/package-lock.json
+++ b/test-examples/yano-testkit-js/package-lock.json
@@ -1,0 +1,105 @@
+{
+  "name": "yano-testkit-js-smoke-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yano-testkit-js-smoke-test",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@bloxbean/yano-testkit": "preview"
+      }
+    },
+    "node_modules/@bloxbean/yano-testkit": {
+      "version": "0.1.0-pre7-ci1",
+      "resolved": "https://registry.npmjs.org/@bloxbean/yano-testkit/-/yano-testkit-0.1.0-pre7-ci1.tgz",
+      "integrity": "sha512-eq4YVRejXu7rB3KBhAhO8k9TZS6ynH29sVGsb8Ix+RCU6mO39YaH4mZee3+Nw/fVFVSO4BqQlNQHMOUAaudfWA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.8.0"
+      },
+      "optionalDependencies": {
+        "@bloxbean/yano-testkit-linux-arm64": "0.1.0-pre7-ci1",
+        "@bloxbean/yano-testkit-linux-x64": "0.1.0-pre7-ci1",
+        "@bloxbean/yano-testkit-macos-arm64": "0.1.0-pre7-ci1",
+        "@bloxbean/yano-testkit-windows-x64": "0.1.0-pre7-ci1"
+      },
+      "peerDependencies": {
+        "vitest": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@bloxbean/yano-testkit-linux-arm64": {
+      "version": "0.1.0-pre7-ci1",
+      "resolved": "https://registry.npmjs.org/@bloxbean/yano-testkit-linux-arm64/-/yano-testkit-linux-arm64-0.1.0-pre7-ci1.tgz",
+      "integrity": "sha512-NLYFUg6jz6rxr/pvYOWkkXpfJXELfZlF6CcQ7W4RVB4t5+7LBz8Q2kvTUkcqUl1uEr/RFh+EspH86l34Z3LvlQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.8.0"
+      }
+    },
+    "node_modules/@bloxbean/yano-testkit-linux-x64": {
+      "version": "0.1.0-pre7-ci1",
+      "resolved": "https://registry.npmjs.org/@bloxbean/yano-testkit-linux-x64/-/yano-testkit-linux-x64-0.1.0-pre7-ci1.tgz",
+      "integrity": "sha512-aclVQQb3KinaMzhyGyvlqwrjbR/vmAV5vnXor/sOKVz3ehktCK1gw9NqPltVrhxHlECu3jSOTQ5v/yabto7Xuw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20.8.0"
+      }
+    },
+    "node_modules/@bloxbean/yano-testkit-macos-arm64": {
+      "version": "0.1.0-pre7-ci1",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20.8.0"
+      }
+    },
+    "node_modules/@bloxbean/yano-testkit-windows-x64": {
+      "version": "0.1.0-pre7-ci1",
+      "resolved": "https://registry.npmjs.org/@bloxbean/yano-testkit-windows-x64/-/yano-testkit-windows-x64-0.1.0-pre7-ci1.tgz",
+      "integrity": "sha512-cLQbpKjX5wusmQA0W9wUsVjjv2HhPCVOD/hlP6gbEKL1A9OX5FqVPjc72RrnbPLGjxd1eVHGS/5LpOMCE83zGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=20.8.0"
+      }
+    }
+  }
+}

--- a/test-examples/yano-testkit-js/package.json
+++ b/test-examples/yano-testkit-js/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "yano-testkit-js-smoke-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "Minimal JavaScript smoke test for @bloxbean/yano-testkit.",
+  "type": "module",
+  "scripts": {
+    "test": "node src/smoke-test.mjs"
+  },
+  "devDependencies": {
+    "@bloxbean/yano-testkit": "preview"
+  }
+}

--- a/test-examples/yano-testkit-js/src/smoke-test.mjs
+++ b/test-examples/yano-testkit-js/src/smoke-test.mjs
@@ -1,0 +1,108 @@
+import { startYanoDevnet } from "@bloxbean/yano-testkit";
+
+const blockTimeMillis = numberFromEnv("YANO_BLOCK_TIME_MILLIS", 200);
+const timeoutMs = numberFromEnv("YANO_TESTKIT_TIMEOUT_MS", 90_000);
+const verboseLogs = process.env.YANO_TESTKIT_VERBOSE === "true";
+const testAddress = process.env.YANO_TEST_ADDRESS;
+const testAda = numberFromEnv("YANO_TEST_ADA", 1000);
+
+let yano;
+
+try {
+  yano = await startYanoDevnet({
+    blockTimeMillis,
+    timeoutMs,
+    onStdout: verboseLogs ? line => console.log(`[yano] ${line}`) : undefined,
+    onStderr: verboseLogs ? line => console.error(`[yano] ${line}`) : undefined
+  });
+
+  console.log("Yano devnet started");
+  console.log(`  pid: ${yano.pid}`);
+  console.log(`  baseUrl: ${yano.baseUrl}`);
+  console.log(`  apiBaseUrl: ${yano.apiBaseUrl}`);
+  console.log(`  n2nPort: ${yano.n2nPort}`);
+  console.log(`  storage: ${yano.storage.path}`);
+
+  const health = await getJson(new URL("q/health/ready", yano.baseUrl));
+  assert(health.status === "UP", `Expected health status UP, got ${JSON.stringify(health)}`);
+  console.log(`Ready health: ${health.status}`);
+
+  const firstTip = await getJson(yano.url("node/tip"));
+  console.log(`Initial tip: ${formatTip(firstTip)}`);
+
+  if (testAddress) {
+    assert(typeof yano.fundAddress === "function", "Installed @bloxbean/yano-testkit does not expose fundAddress()");
+    const fundResult = await yano.fundAddress(testAddress, testAda);
+    console.log(`Funded ${testAda} ADA: tx=${fundResult.tx_hash}#${fundResult.index}, lovelace=${fundResult.lovelace}`);
+  } else {
+    console.log("Set YANO_TEST_ADDRESS to also exercise the devnet fundAddress helper");
+  }
+
+  await sleep(Math.max(blockTimeMillis * 3, 1_000));
+
+  const secondTip = await getJson(yano.url("node/tip"));
+  console.log(`Later tip:   ${formatTip(secondTip)}`);
+
+  assertTipShape(secondTip);
+  console.log("Smoke test passed");
+} catch (error) {
+  console.error("Smoke test failed");
+  console.error(error instanceof Error ? error.stack : error);
+  if (yano) {
+    console.error("\nYano log tail:");
+    console.error(yano.logs());
+  }
+  process.exitCode = 1;
+} finally {
+  if (yano) {
+    await yano.stop();
+    console.log("Yano devnet stopped");
+  }
+}
+
+async function getJson(url) {
+  const response = await fetch(url);
+  const body = await response.text();
+  if (!response.ok) {
+    throw new Error(`GET ${url} failed with ${response.status}: ${body}`);
+  }
+  return body ? JSON.parse(body) : null;
+}
+
+function assertTipShape(tip) {
+  assert(tip && typeof tip === "object", "Tip response should be an object");
+  const hasSlot = Object.prototype.hasOwnProperty.call(tip, "slot");
+  const hasBlock = Object.prototype.hasOwnProperty.call(tip, "block")
+    || Object.prototype.hasOwnProperty.call(tip, "blockNumber")
+    || Object.prototype.hasOwnProperty.call(tip, "block_number");
+  assert(hasSlot || hasBlock, `Tip response should include slot or block information: ${JSON.stringify(tip)}`);
+}
+
+function formatTip(tip) {
+  if (!tip || typeof tip !== "object") {
+    return JSON.stringify(tip);
+  }
+  const slot = tip.slot ?? tip.slotNo ?? tip.slot_no ?? "unknown";
+  const block = tip.block ?? tip.blockNumber ?? tip.block_number ?? "unknown";
+  const hash = tip.hash ?? tip.blockHash ?? tip.block_hash ?? "";
+  return `slot=${slot}, block=${block}${hash ? `, hash=${String(hash).slice(0, 16)}...` : ""}`;
+}
+
+function numberFromEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/test-examples/yano-testkit-meshjs/README.md
+++ b/test-examples/yano-testkit-meshjs/README.md
@@ -1,0 +1,74 @@
+# Yano Testkit MeshJS Transfer Test
+
+MeshJS example for JavaScript integration tests. It starts a native Yano devnet
+through `@bloxbean/yano-testkit`, creates a deterministic MeshJS wallet, funds
+that wallet through the Yano faucet, builds and submits a signed self-transfer,
+and verifies the result through both Yano testkit helpers and MeshJS.
+
+## Requirements
+
+- Node.js 20.8 or newer.
+- A Yano native binary.
+
+From this repository, build the native binary first:
+
+```bash
+export JAVA_HOME=/path/to/graalvm
+./gradlew :app:quarkusBuild \
+  -Dquarkus.native.enabled=true \
+  -Dquarkus.package.jar.enabled=false \
+  -PskipSigning=true
+```
+
+The local build creates `app/build/yano`. The example auto-detects that path
+when run from this checkout and uses `app` as the working directory. If
+`YANO_TESTKIT_BINARY` points at an `app/build/yano` binary, the example also
+infers `app` as the working directory. For release ZIP layouts, the testkit
+wrapper's normal working-directory inference is used.
+
+## Run
+
+```bash
+cd test-examples/yano-testkit-meshjs
+npm install
+npm test
+```
+
+The example depends on the workspace copy of `@bloxbean/yano-testkit`:
+
+```json
+"@bloxbean/yano-testkit": "file:../../npm/yano-testkit"
+```
+
+To test a published package instead:
+
+```bash
+npm install --save-dev @bloxbean/yano-testkit@preview
+npm test
+```
+
+## Configuration
+
+```bash
+YANO_TESTKIT_BINARY=/path/to/yano npm test
+YANO_TESTKIT_CWD=/path/to/yano-distribution-root npm test
+YANO_TESTKIT_VERBOSE=true npm test
+YANO_FUNDING_ADA=20 npm test
+YANO_TRANSFER_ADA=2 npm test
+```
+
+Use `TEST_MNEMONIC` to override the deterministic MeshJS wallet mnemonic. The
+default mnemonic is not expected to rely on genesis funds; the example funds it
+through the Yano faucet before building a transaction.
+
+## What It Checks
+
+- Starts Yano native devnet with temporary RocksDB storage.
+- Creates a MeshJS wallet and derives a testnet address.
+- Funds the MeshJS address through `yano.faucet.fundAddress`.
+- Asserts funded balance through `yano.assertions.address(...)`.
+- Reads protocol parameters through MeshJS `BlockfrostProvider`.
+- Builds, signs, and submits a MeshJS self-transfer.
+- Waits for the submitted transaction through `yano.await.untilTxVisible`.
+- Verifies the submitted transaction through Yano query helpers and MeshJS.
+- Stops Yano in a `finally` block.

--- a/test-examples/yano-testkit-meshjs/package-lock.json
+++ b/test-examples/yano-testkit-meshjs/package-lock.json
@@ -1,0 +1,2482 @@
+{
+  "name": "yano-testkit-meshjs-transfer-test",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "yano-testkit-meshjs-transfer-test",
+      "version": "1.0.0",
+      "dependencies": {
+        "@meshsdk/core": "latest",
+        "xhr2": "^0.2.1"
+      },
+      "devDependencies": {
+        "@bloxbean/yano-testkit": "file:../../npm/yano-testkit"
+      }
+    },
+    "../../npm/yano-testkit": {
+      "name": "@bloxbean/yano-testkit",
+      "version": "0.1.0-pre6",
+      "dev": true,
+      "license": "MIT",
+      "devDependencies": {
+        "@types/node": "^24.0.0",
+        "typescript": "^5.8.0",
+        "vitest": "^4.1.9"
+      },
+      "engines": {
+        "node": ">=20.8.0"
+      },
+      "optionalDependencies": {
+        "@bloxbean/yano-testkit-linux-arm64": "0.1.0-pre6",
+        "@bloxbean/yano-testkit-linux-x64": "0.1.0-pre6",
+        "@bloxbean/yano-testkit-macos-arm64": "0.1.0-pre6",
+        "@bloxbean/yano-testkit-windows-x64": "0.1.0-pre6"
+      },
+      "peerDependencies": {
+        "vitest": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "vitest": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@biglup/is-cid": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@biglup/is-cid/-/is-cid-1.0.3.tgz",
+      "integrity": "sha512-R0XPZ/IQhU2TtetSFI9vI+7kJOJYNiCncn5ixEBW+/LNaZCo2HK37Mq3pRNzrM4FryuAkyeqY7Ujmj3I3e3t9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@multiformats/mafmt": "^12.1.6",
+        "@multiformats/multiaddr": "^12.1.14",
+        "iso-url": "^1.1.3",
+        "multiformats": "^13.0.1",
+        "uint8arrays": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=16.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@bloxbean/yano-testkit": {
+      "resolved": "../../npm/yano-testkit",
+      "link": true
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.10.1.tgz",
+      "integrity": "sha512-wJ8ReQbHxsAfXhrf9ixl0aYbZorRuOWpBNzm8pL8ftmSxQx/wnJD5Eg861NwJU/czy2VXFIebCeZnZrI9rktIQ==",
+      "license": "(Apache-2.0 AND BSD-3-Clause)"
+    },
+    "node_modules/@cardano-ogmios/client": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/client/-/client-6.9.0.tgz",
+      "integrity": "sha512-IsoUVsaMXiYyhWrdVKYOA5PDlX0EZ2gaq4lfk4JelRw6mcWVxemUrMaU2ndvugO9LQ3SCM1nESPgMIU0xe5FWw==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "@cardano-ogmios/schema": "6.9.0",
+        "@cardanosolutions/json-bigint": "^1.0.1",
+        "@types/json-bigint": "^1.0.1",
+        "bech32": "^2.0.0",
+        "cross-fetch": "^3.1.4",
+        "fastq": "^1.11.0",
+        "isomorphic-ws": "^4.0.1",
+        "nanoid": "^3.1.31",
+        "ts-custom-error": "^3.2.0",
+        "ws": "^7.5.10"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cardano-ogmios/schema": {
+      "version": "6.9.0",
+      "resolved": "https://registry.npmjs.org/@cardano-ogmios/schema/-/schema-6.9.0.tgz",
+      "integrity": "sha512-e7QVLF+dQMIv9p+p5CWQjMfBmkERYRa2wK2AjyehQZCJnecZ0gvTbRqewdX5VW4mVXf6KUfFyphsxWK46Pg6LA==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@cardano-sdk/core": {
+      "version": "0.46.12",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.46.12.tgz",
+      "integrity": "sha512-yUA/xBUQMiMqIWiZPvIhM911pL3jNKg4PkZQ8qP9R7yU3NQ5x4RQkZ+zFDlVLxUt+gJiwIW2es0iPd8ObIKCxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@biglup/is-cid": "^1.0.3",
+        "@cardano-ogmios/client": "6.9.0",
+        "@cardano-ogmios/schema": "6.9.0",
+        "@cardano-sdk/crypto": "~0.4.5",
+        "@cardano-sdk/util": "~0.17.1",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "rxjs": "^7.4.0"
+      },
+      "peerDependenciesMeta": {
+        "rxjs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/crypto": {
+      "version": "0.4.5",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.5.tgz",
+      "integrity": "sha512-ymliqxdmen5dGVaiMVQ0VnhrwaYUjbPD3sHoMj8NI6MTuxrREp3pLJASREtWhwmv9k+QzDT6CoyuIXnlEQiWZQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/util": "~0.17.1",
+        "blake2b": "^2.1.4",
+        "i": "^0.3.7",
+        "libsodium-wrappers-sumo": "0.7.10",
+        "lodash": "^4.17.21",
+        "pbkdf2": "^3.1.3",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-browser": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-browser": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-nodejs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/dapp-connector": {
+      "version": "0.13.28",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/dapp-connector/-/dapp-connector-0.13.28.tgz",
+      "integrity": "sha512-lSHtxKhh1iUviFIeBXFn7XoZy2Y0XNRLXvTIdbt+ENVC8bG+D7llCUofKgYPQHwvmQhM+q4+b0eIWVEQC2QKjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.46.14",
+        "@cardano-sdk/crypto": "~0.4.6",
+        "@cardano-sdk/util": "~0.17.1",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "webextension-polyfill": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/dapp-connector/node_modules/@cardano-sdk/core": {
+      "version": "0.46.14",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.46.14.tgz",
+      "integrity": "sha512-mP3k26RKgc4Txi621QRdGtjlma6kRejhKsqT7mop3uWrnipKyLSrB+QDPxL/PHfmv2wZFaWapyq9VKJprmROIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@biglup/is-cid": "^1.0.3",
+        "@cardano-sdk/crypto": "~0.4.6",
+        "@cardano-sdk/util": "~0.17.1",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/dapp-connector/node_modules/@cardano-sdk/crypto": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.6.tgz",
+      "integrity": "sha512-dyUyj/HG8MAotVz7FzlsrFnoqKJb2YUbu89jYLSjX+V1nIdzEwauY7RjOhPvrV+P9mS/iPWtzfQoJpJvW0GpFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/util": "~0.17.1",
+        "blake2b": "^2.1.4",
+        "i": "^0.3.7",
+        "libsodium-wrappers-sumo": "0.8.4",
+        "lodash": "^4.17.21",
+        "pbkdf2": "^3.1.3",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-browser": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-browser": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-nodejs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/dapp-connector/node_modules/libsodium-sumo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.8.4.tgz",
+      "integrity": "sha512-TMtHShQfVVsaxDygyapvUC3o7YsPgXa/hRWeIgzyFz6w5k/1hirGptCxp1U7XwW3rCskaTTYKgV10v86UiGgNw==",
+      "license": "ISC"
+    },
+    "node_modules/@cardano-sdk/dapp-connector/node_modules/libsodium-wrappers-sumo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.8.4.tgz",
+      "integrity": "sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium-sumo": "^0.8.0"
+      }
+    },
+    "node_modules/@cardano-sdk/input-selection": {
+      "version": "0.14.28",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/input-selection/-/input-selection-0.14.28.tgz",
+      "integrity": "sha512-pbysJUaIbbpesbv/f0XfFPKBb+bLjCmPcMfNJzpePSZBvr8bUcFpnfKtq28KthVdpe2mgL3k9ebTTcBSk7aERw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.46.12",
+        "@cardano-sdk/key-management": "~0.29.12",
+        "@cardano-sdk/util": "~0.17.1",
+        "bignumber.js": "^9.1.1",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/key-management": {
+      "version": "0.29.15",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/key-management/-/key-management-0.29.15.tgz",
+      "integrity": "sha512-KIuukC9Simbmene3cS3WcseYX9xIwa5DK7hz3ARSKvdD8YWqVlWbY2717wu7b1+bynNp6FCU3tywRYSQzdxNSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/core": "~0.46.14",
+        "@cardano-sdk/crypto": "~0.4.6",
+        "@cardano-sdk/dapp-connector": "~0.13.28",
+        "@cardano-sdk/util": "~0.17.1",
+        "@emurgo/cardano-message-signing-nodejs": "^1.0.1",
+        "bip39": "^3.0.4",
+        "chacha": "^2.1.0",
+        "get-random-values": "^2.0.0",
+        "lodash": "^4.17.21",
+        "pbkdf2": "^3.1.3",
+        "rxjs": "^7.4.0",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/core": {
+      "version": "0.46.14",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/core/-/core-0.46.14.tgz",
+      "integrity": "sha512-mP3k26RKgc4Txi621QRdGtjlma6kRejhKsqT7mop3uWrnipKyLSrB+QDPxL/PHfmv2wZFaWapyq9VKJprmROIg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@biglup/is-cid": "^1.0.3",
+        "@cardano-sdk/crypto": "~0.4.6",
+        "@cardano-sdk/util": "~0.17.1",
+        "@foxglove/crc": "^0.0.3",
+        "@scure/base": "^1.1.1",
+        "fraction.js": "4.0.1",
+        "ip-address": "^9.0.5",
+        "lodash": "^4.17.21",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4",
+        "web-encoding": "^1.1.5"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/@cardano-sdk/crypto": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/crypto/-/crypto-0.4.6.tgz",
+      "integrity": "sha512-dyUyj/HG8MAotVz7FzlsrFnoqKJb2YUbu89jYLSjX+V1nIdzEwauY7RjOhPvrV+P9mS/iPWtzfQoJpJvW0GpFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/util": "~0.17.1",
+        "blake2b": "^2.1.4",
+        "i": "^0.3.7",
+        "libsodium-wrappers-sumo": "0.8.4",
+        "lodash": "^4.17.21",
+        "pbkdf2": "^3.1.3",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      },
+      "peerDependencies": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-browser": "^3.1.1",
+        "@dcspark/cardano-multiplatform-lib-nodejs": "^3.1.1"
+      },
+      "peerDependenciesMeta": {
+        "@dcspark/cardano-multiplatform-lib-asmjs": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-browser": {
+          "optional": true
+        },
+        "@dcspark/cardano-multiplatform-lib-nodejs": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/libsodium-sumo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.8.4.tgz",
+      "integrity": "sha512-TMtHShQfVVsaxDygyapvUC3o7YsPgXa/hRWeIgzyFz6w5k/1hirGptCxp1U7XwW3rCskaTTYKgV10v86UiGgNw==",
+      "license": "ISC"
+    },
+    "node_modules/@cardano-sdk/key-management/node_modules/libsodium-wrappers-sumo": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.8.4.tgz",
+      "integrity": "sha512-ql7hcgulKZ3ekfa2DGAogcCKsWU0diA/0nArz1CFzh93WQdb46/Kj18ka/Hifq6uA3Ush34Pc6vU/6HXeRwUkg==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium-sumo": "^0.8.0"
+      }
+    },
+    "node_modules/@cardano-sdk/util": {
+      "version": "0.17.1",
+      "resolved": "https://registry.npmjs.org/@cardano-sdk/util/-/util-0.17.1.tgz",
+      "integrity": "sha512-TCYe+wRguW1WgRlbWqhGPhcSBkzVzdIcCVgDDN7wiQk2dew0EWVqjsKeqDZdfwzy/s2kr/ZOgXIGywBn/Bzu/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "lodash": "^4.17.21",
+        "serialize-error": "^8",
+        "ts-custom-error": "^3.2.0",
+        "ts-log": "^2.2.4"
+      },
+      "engines": {
+        "node": ">=16.20.2"
+      }
+    },
+    "node_modules/@cardanosolutions/json-bigint": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@cardanosolutions/json-bigint/-/json-bigint-1.1.0.tgz",
+      "integrity": "sha512-Pdgz18cSwLKKgheOqW/dqbzNI+CliNT4AdaKaKY/P++J9qLxIB8MITCurlzbaFWV3W4nmK0CRQwI1yvuArmjFg==",
+      "license": "MIT"
+    },
+    "node_modules/@chainsafe/is-ip": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/is-ip/-/is-ip-2.1.0.tgz",
+      "integrity": "sha512-KIjt+6IfysQ4GCv66xihEitBjvhU/bixbbbFxdJ1sqCp4uJ0wuZiYBPhksZoy4lfaF0k9cwNzY5upEW/VWdw3w==",
+      "license": "MIT"
+    },
+    "node_modules/@chainsafe/netmask": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@chainsafe/netmask/-/netmask-2.0.0.tgz",
+      "integrity": "sha512-I3Z+6SWUoaljh3TBzCnCxjlUyN8tA+NAk5L6m9IxvCf1BENQTePzPMis97CoN/iMW1St3WN+AWCCRp+TTBRiDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1"
+      }
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.4.0.tgz",
+      "integrity": "sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@connectrpc/connect-node": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-node/-/connect-node-1.4.0.tgz",
+      "integrity": "sha512-0ANnrr6SvsjevsWEgdzHy7BaHkluZyS6s4xNoVt7RBHFR5V/kT9lPokoIbYUOU9JHzdRgTaS3x5595mwUsu15g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "undici": "^5.28.3"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      },
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2",
+        "@connectrpc/connect": "1.4.0"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.4.0.tgz",
+      "integrity": "sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2",
+        "@connectrpc/connect": "1.4.0"
+      }
+    },
+    "node_modules/@dnsquery/dns-packet": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@dnsquery/dns-packet/-/dns-packet-6.1.1.tgz",
+      "integrity": "sha512-WXTuFvL3G+74SchFAtz3FgIYVOe196ycvGsMgvSH/8Goptb1qpIQtIuM4SOK9G9lhMWYpHxnXyy544ZhluFOew==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.4",
+        "utf8-codec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@emurgo/cardano-message-signing-nodejs": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@emurgo/cardano-message-signing-nodejs/-/cardano-message-signing-nodejs-1.1.0.tgz",
+      "integrity": "sha512-PQRc8K8wZshEdmQenNUzVtiI8oJNF/1uAnBhidee5C4o1l2mDLOW+ur46HWHIFKQ6x8mSJTllcjMscHgzju0gQ==",
+      "license": "MIT"
+    },
+    "node_modules/@fastify/busboy": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
+      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@foxglove/crc": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@foxglove/crc/-/crc-0.0.3.tgz",
+      "integrity": "sha512-DjIZsnL3CyP/yQ/vUYA9cjrD0a/8YXejI5ZmsaOiT16cLfZcTwaCxIN01/ys4jsy+dZCQ/9DnWFn7AEFbiMDaA==",
+      "license": "MIT"
+    },
+    "node_modules/@harmoniclabs/bigint-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/bigint-utils/-/bigint-utils-1.0.0.tgz",
+      "integrity": "sha512-OhZMHcdtH2hHKMlxWFHf71PmKHdoi9ARpjS9mUu0/cd8VWDDjT7VQoQwC5NN/68iyO4O5Dojrvrp9tjG5BDABA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@harmoniclabs/uint8array-utils": "^1.0.0"
+      }
+    },
+    "node_modules/@harmoniclabs/biguint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/biguint/-/biguint-1.0.0.tgz",
+      "integrity": "sha512-5DyCIBDL4W+7ffR1IJSbGrCG4xEYxAlFH5gCNF42qtyL5ltwZ92Ae1MyXpHM2TUPy7ocSTqlLUsOdy+SvqVVPw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@harmoniclabs/bitstream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/bitstream/-/bitstream-1.0.0.tgz",
+      "integrity": "sha512-Ed/I46IuCiytE5QiMmmUo9kPJcypM7OuUqoRaAXUALL5C6LKLpT6kYE1qeuhLkx2/WvkHT18jcOX6jhM/nmqoA==",
+      "license": "MIT",
+      "dependencies": {
+        "@harmoniclabs/uint8array-utils": "^1.0.0"
+      }
+    },
+    "node_modules/@harmoniclabs/bytestring": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/bytestring/-/bytestring-1.0.0.tgz",
+      "integrity": "sha512-d5m10O0okKc6QNX0pSRriFTkk/kNMnMBGbo5X3kEZwKaXTI4tDVoTZBL7bwbYHwOEdSxWJjVtlO9xtB7ZrYZNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@harmoniclabs/uint8array-utils": "^1.0.0"
+      }
+    },
+    "node_modules/@harmoniclabs/cbor": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/cbor/-/cbor-1.6.0.tgz",
+      "integrity": "sha512-KI25p8pHI1rmFZC9NYSxATwlCZ+KJdjydpptKebHcw03Iy7M+E8mF+hSnN5dTbS45xw5ZyKUgPLRgLo1sTuIoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@harmoniclabs/bytestring": "^1.0.0",
+        "@harmoniclabs/obj-utils": "^1.0.0",
+        "@harmoniclabs/uint8array-utils": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/HarmonicLabs"
+      }
+    },
+    "node_modules/@harmoniclabs/crypto": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/crypto/-/crypto-0.3.0.tgz",
+      "integrity": "sha512-UvmGQOLFVFhRIDYLpcWbPQLXl9advCt0h02Z/BtBuXtHiy35WRxKQ3njcUKI0v6zGITuvqQhsf6VOPMeekLdeA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@harmoniclabs/bitstream": "^1.0.0",
+        "@harmoniclabs/uint8array-utils": "^1.0.3"
+      }
+    },
+    "node_modules/@harmoniclabs/obj-utils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/obj-utils/-/obj-utils-1.0.0.tgz",
+      "integrity": "sha512-EO1bQBZAORrutcP+leP5YNDwNd/9TOE23VEvs3ktniXg6w0knUrLjUIl2Pkcbs/D1VQxqmsNpXho+vaMj00qxA==",
+      "license": "MIT"
+    },
+    "node_modules/@harmoniclabs/pair": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/pair/-/pair-1.0.0.tgz",
+      "integrity": "sha512-D9OBowsUsy1LctHxWzd9AngTzoo5x3rBiJ0gu579t41Q23pb+VNx1euEfluUEiaYbgljcl1lb/4D1fFTZd1tRQ==",
+      "license": "MIT"
+    },
+    "node_modules/@harmoniclabs/plutus-data": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/plutus-data/-/plutus-data-1.2.6.tgz",
+      "integrity": "sha512-rF046GZ07XDpjZBNybALKYSycjxCLzXKbhLylu9pRuZiii5fVXReEfgtLB29TsPBvGY6ZBeiyHgJnLgm+huZBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@harmoniclabs/biguint": "^1.0.0",
+        "@harmoniclabs/crypto": "^0.2.4",
+        "@harmoniclabs/uint8array-utils": "^1.0.0"
+      },
+      "peerDependencies": {
+        "@harmoniclabs/bytestring": "^1.0.0",
+        "@harmoniclabs/cbor": "^1.3.0"
+      }
+    },
+    "node_modules/@harmoniclabs/plutus-data/node_modules/@harmoniclabs/crypto": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/crypto/-/crypto-0.2.5.tgz",
+      "integrity": "sha512-t2saWMFWBx8tOHotiYTTfQKhPGpWT4AMLXxq3u0apShVXNV0vgL0gEgSMudBjES/wrKByCqa2xmU70gadz26hA==",
+      "license": "MIT",
+      "dependencies": {
+        "@harmoniclabs/bitstream": "^1.0.0",
+        "@harmoniclabs/uint8array-utils": "^1.0.3"
+      }
+    },
+    "node_modules/@harmoniclabs/uint8array-utils": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/uint8array-utils/-/uint8array-utils-1.0.4.tgz",
+      "integrity": "sha512-Z454prSbX4geXGHyjjcn9vm6u9NsD3VJykv8f8yE1VjIXSPitaLPEnm8u2+B+GMp1chYlLilOq+kW4OvJ6y28A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@harmoniclabs/uplc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@harmoniclabs/uplc/-/uplc-1.4.1.tgz",
+      "integrity": "sha512-sELKStjxPBPBxBMylU4oBSUe0/8eJe2HqRblNSwrMu8Fso4YpSPDqHZ33iDZ8QAadVUsT5r2EQKX0TLrj7qXvQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@harmoniclabs/bigint-utils": "^1.0.0",
+        "@harmoniclabs/uint8array-utils": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/HarmonicLabs"
+      },
+      "peerDependencies": {
+        "@harmoniclabs/bytestring": "^1.0.0",
+        "@harmoniclabs/cbor": "^1.3.0",
+        "@harmoniclabs/crypto": "^0.3.0-dev0",
+        "@harmoniclabs/pair": "^1.0.0",
+        "@harmoniclabs/plutus-data": "^1.2.4"
+      }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
+    },
+    "node_modules/@libp2p/interface": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@libp2p/interface/-/interface-3.2.4.tgz",
+      "integrity": "sha512-o/ZMbsplniVQhz0AW1CinZcfZPEfr7ttu4w7aivrFAs6xDpnJYmN3FTeEgTt93EHs+AEOcIT76V3KMFDZmIEcQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/dns": "^1.0.6",
+        "@multiformats/multiaddr": "^13.0.3",
+        "main-event": "^1.0.1",
+        "multiformats": "^14.0.0",
+        "progress-events": "^1.1.0",
+        "uint8arraylist": "^3.0.2"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/@multiformats/multiaddr": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-13.0.3.tgz",
+      "integrity": "sha512-mEqqJ4r3a/uuFMTpRkU316wGNIDQNhuVWpm+ebKTQeYsfv9jXbPONWM6VVnj3KGUrwfsX7GZOyp4TFqEA2SPCw==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "multiformats": "^14.0.0",
+        "uint8-varint": "^3.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/multiformats": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.2.tgz",
+      "integrity": "sha512-sF7F3gBKCyehzIhDwVuTRf79TZ8qWRz5NXwWYBX+4a+n22KcFqqcDYJvZr7tySrI0MhuTBXVOlo3qMTiAHC78g==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@libp2p/interface/node_modules/uint8-varint": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-3.0.0.tgz",
+      "integrity": "sha512-S4DdpXBaLwKcFo7f0bWzWfHjbZ/i3QhM842qn+ZvHjxqFCfUcEB9SQNcmI69S+zMlcmIcKxsk9Iyw77S2Kxv6Q==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arraylist": "^3.0.1",
+        "uint8arrays": "^6.1.0"
+      }
+    },
+    "node_modules/@libp2p/interface/node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/@meshsdk/common": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@meshsdk/common/-/common-1.9.1.tgz",
+      "integrity": "sha512-66l7vcY+h9w71auVaE7RLJYs87DmO+JTEmQ2xknd6F8fAcR73nMxLZunMRbygPoV9gHDBTMYfHoMBZqWt7N6EA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "bip39": "3.1.0",
+        "blake2b": "^2.1.4",
+        "blakejs": "^1.2.1"
+      }
+    },
+    "node_modules/@meshsdk/core": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@meshsdk/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-khMrEkMU71t3kn6nHM8/5rjVry055jORdln+xegP0KpVzCjWxjOe+bzyCMnQehwNT7R8OEe7wx8zYUL4qTijkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@meshsdk/common": "1.9.1",
+        "@meshsdk/core-cst": "1.9.1",
+        "@meshsdk/provider": "1.9.0-beta.101",
+        "@meshsdk/transaction": "1.9.1",
+        "@meshsdk/wallet": "1.9.1",
+        "scalus": "^0.17.0"
+      }
+    },
+    "node_modules/@meshsdk/core-cst": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@meshsdk/core-cst/-/core-cst-1.9.1.tgz",
+      "integrity": "sha512-1e72mtTehjV/XQWpxtnejhEXyhU1f8CWqoTaQfq2rfBydLJfFs/NDEYfBKBOx697MOWM7VPAHjLvVAENqS57EQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/core": "0.46.12",
+        "@cardano-sdk/crypto": "0.4.5",
+        "@cardano-sdk/input-selection": "0.14.28",
+        "@cardano-sdk/util": "0.17.1",
+        "@harmoniclabs/cbor": "1.6.0",
+        "@harmoniclabs/pair": "^1.0.0",
+        "@harmoniclabs/plutus-data": "1.2.6",
+        "@harmoniclabs/uplc": "1.4.1",
+        "@meshsdk/common": "1.9.1",
+        "@types/base32-encoding": "^1.0.2",
+        "base32-encoding": "^1.0.0",
+        "bech32": "^2.0.0",
+        "blakejs": "^1.2.1",
+        "bn.js": "^5.2.0",
+        "hash.js": "^1.1.7"
+      }
+    },
+    "node_modules/@meshsdk/provider": {
+      "version": "1.9.0-beta.101",
+      "resolved": "https://registry.npmjs.org/@meshsdk/provider/-/provider-1.9.0-beta.101.tgz",
+      "integrity": "sha512-xbb0pCDpeHk8WEzgZCUlwy1CLpOPSPNn3TPtuLuMNnebCO8lZhvP3NYZqX/CUnTkOjXP4dxu5Zbf7ipZ43V4RQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@meshsdk/common": "1.9.0-beta.100",
+        "@meshsdk/core-cst": "1.9.0-beta.100",
+        "@utxorpc/sdk": "^0.6.7",
+        "@utxorpc/spec": "^0.16.0",
+        "axios": "^1.7.2",
+        "cbor": "^10.0.9"
+      }
+    },
+    "node_modules/@meshsdk/provider/node_modules/@meshsdk/common": {
+      "version": "1.9.0-beta.100",
+      "resolved": "https://registry.npmjs.org/@meshsdk/common/-/common-1.9.0-beta.100.tgz",
+      "integrity": "sha512-H3ktKR9eheRKZupg7DLdUr8A9dsefJbu7Wc+I1suwrv+oAZWiJ2wCuF3bX2QQo3LyWrSkVCE7WEiKFfQmukIww==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "bech32": "^2.0.0",
+        "bip39": "3.1.0",
+        "blake2b": "^2.1.4",
+        "blakejs": "^1.2.1"
+      }
+    },
+    "node_modules/@meshsdk/provider/node_modules/@meshsdk/core-cst": {
+      "version": "1.9.0-beta.100",
+      "resolved": "https://registry.npmjs.org/@meshsdk/core-cst/-/core-cst-1.9.0-beta.100.tgz",
+      "integrity": "sha512-gXC7c81puzv12C3xJ6vhH/KIEc/P6ScuXsgmLlqFMpDv0SuoMg+42HgdyWi0WrccVwi8cdepsn5YhtCaYVn0nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/core": "0.46.12",
+        "@cardano-sdk/crypto": "0.4.5",
+        "@cardano-sdk/input-selection": "0.14.28",
+        "@cardano-sdk/util": "0.17.1",
+        "@harmoniclabs/cbor": "1.6.0",
+        "@harmoniclabs/pair": "^1.0.0",
+        "@harmoniclabs/plutus-data": "1.2.6",
+        "@harmoniclabs/uplc": "1.4.1",
+        "@meshsdk/common": "1.9.0-beta.100",
+        "@types/base32-encoding": "^1.0.2",
+        "base32-encoding": "^1.0.0",
+        "bech32": "^2.0.0",
+        "blakejs": "^1.2.1",
+        "bn.js": "^5.2.0",
+        "hash.js": "^1.1.7",
+        "scalus": "^0.14.2"
+      }
+    },
+    "node_modules/@meshsdk/provider/node_modules/scalus": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/scalus/-/scalus-0.14.2.tgz",
+      "integrity": "sha512-dobDMIUDUVhtxoX3ceGlaykKQGkph4HOE9hjkLsmwVgYf24fIik6YrZzVFrZSNCTvI2WN7hjEknehIrEJo1CMQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@meshsdk/transaction": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@meshsdk/transaction/-/transaction-1.9.1.tgz",
+      "integrity": "sha512-FjKSoUi2xFaKJPI1ObQ13UkrCJu+iPW6THP//ZD/f5I1NciaUz3bcoQ7xWcc7El4TCcDunBPp9di6w9JitBR6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cardano-sdk/core": "0.46.12",
+        "@cardano-sdk/input-selection": "0.14.28",
+        "@cardano-sdk/util": "0.17.1",
+        "@meshsdk/common": "1.9.1",
+        "@meshsdk/core-cst": "1.9.1",
+        "json-bigint": "^1.0.0"
+      }
+    },
+    "node_modules/@meshsdk/wallet": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@meshsdk/wallet/-/wallet-1.9.1.tgz",
+      "integrity": "sha512-lPovMk86Ex6t1s12CiSJFfxnTM31vXxwB7h0BOnznPgueBts2z0cgvQVtBMlhIKHTmPWW1/gkuEH/5dGMfZ3jA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@meshsdk/common": "1.9.1",
+        "@meshsdk/core-cst": "1.9.1",
+        "@meshsdk/transaction": "1.9.1",
+        "@simplewebauthn/browser": "^13.0.0"
+      }
+    },
+    "node_modules/@multiformats/dns": {
+      "version": "1.0.15",
+      "resolved": "https://registry.npmjs.org/@multiformats/dns/-/dns-1.0.15.tgz",
+      "integrity": "sha512-W0zAMABtAn+3chgFcPGvllKND7M6GblMAAFcJQTy+iMmGiyFErZYPzAh2b50Y3SFf340iFV7+ckVgZkGfUyxzA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@dnsquery/dns-packet": "^6.1.1",
+        "@libp2p/interface": "^3.1.0",
+        "hashlru": "^2.3.0",
+        "p-queue": "^9.0.0",
+        "progress-events": "^1.0.0",
+        "uint8arrays": "^6.1.1"
+      }
+    },
+    "node_modules/@multiformats/dns/node_modules/multiformats": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.2.tgz",
+      "integrity": "sha512-sF7F3gBKCyehzIhDwVuTRf79TZ8qWRz5NXwWYBX+4a+n22KcFqqcDYJvZr7tySrI0MhuTBXVOlo3qMTiAHC78g==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/@multiformats/dns/node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/@multiformats/mafmt": {
+      "version": "12.1.6",
+      "resolved": "https://registry.npmjs.org/@multiformats/mafmt/-/mafmt-12.1.6.tgz",
+      "integrity": "sha512-tlJRfL21X+AKn9b5i5VnaTD6bNttpSpcqwKVmDmSHLwxoz97fAHaepqFOk/l1fIu94nImIXneNbhsJx/RQNIww==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@multiformats/multiaddr": "^12.0.0"
+      }
+    },
+    "node_modules/@multiformats/multiaddr": {
+      "version": "12.5.1",
+      "resolved": "https://registry.npmjs.org/@multiformats/multiaddr/-/multiaddr-12.5.1.tgz",
+      "integrity": "sha512-+DDlr9LIRUS8KncI1TX/FfUn8F2dl6BIxJgshS/yFQCNB5IAF0OGzcwB39g5NLE22s4qqDePv0Qof6HdpJ/4aQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "@chainsafe/is-ip": "^2.0.1",
+        "@chainsafe/netmask": "^2.0.0",
+        "@multiformats/dns": "^1.0.3",
+        "abort-error": "^1.0.1",
+        "multiformats": "^13.0.0",
+        "uint8-varint": "^2.0.1",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/base": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.2.6.tgz",
+      "integrity": "sha512-g/nm5FgUa//MCj1gV09zTJTaM6KBAHqLN907YVQqf7zC49+DcO4B1so4ZX07Ef10Twr6nuqYEH9GEggFXA4Fmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@simplewebauthn/browser": {
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/@simplewebauthn/browser/-/browser-13.3.0.tgz",
+      "integrity": "sha512-BE/UWv6FOToAdVk0EokzkqQQDOWtNydYlY6+OrmiZ5SCNmb41VehttboTetUM3T/fr6EAFYVXjz4My2wg230rQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/base32-encoding": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@types/base32-encoding/-/base32-encoding-1.0.2.tgz",
+      "integrity": "sha512-6kXiZ8gETqBU/B9ddcw15nwacX4iX9mLZTU0kghWK5u+OdjfJg6vxHh/vXoURWTyLSzs2jKgcq1lS3S/Tvl4mw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/json-bigint": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@types/json-bigint/-/json-bigint-1.0.4.tgz",
+      "integrity": "sha512-ydHooXLbOmxBbubnA7Eh+RpBzuaIiQjh8WGJYQB50JFGFrdxW7JzVlyEV7fAXw0T2sqJ1ysTneJbiyNLqZRAag==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.0.1.tgz",
+      "integrity": "sha512-fc3KiUoBt6kie0N9bIW3E47vZsuaMf0PM2AaUpLCLT0s/LvX1nxAim6Fc049cNxODPpGm6qRAuUOB86SkRuPQw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@utxorpc/sdk": {
+      "version": "0.6.8",
+      "resolved": "https://registry.npmjs.org/@utxorpc/sdk/-/sdk-0.6.8.tgz",
+      "integrity": "sha512-Mff6q2o7R2aam85KmjtAZDKPhJesMmnGFbk2M54lPO0FwrrWRfUf6DYezqWfYcjXgKQSHDuklAcdtF0weEENRA==",
+      "license": "MIT",
+      "dependencies": {
+        "@connectrpc/connect": "1.4",
+        "@connectrpc/connect-node": "1.4",
+        "@connectrpc/connect-web": "1.4",
+        "@utxorpc/spec": "0.16.0",
+        "buffer": "^6.0.3"
+      }
+    },
+    "node_modules/@utxorpc/spec": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@utxorpc/spec/-/spec-0.16.0.tgz",
+      "integrity": "sha512-EK2M0TBp14MrRCYDuFeJ+bAS39RxxLLh+CD08h/YvAgxSv/4ZOBCf1/sxHAGCBGGndB4heZYFeuQ+i1i8vP5lw==",
+      "license": "MIT",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@zxing/text-encoding": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/@zxing/text-encoding/-/text-encoding-0.9.0.tgz",
+      "integrity": "sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==",
+      "license": "(Unlicense OR Apache-2.0)",
+      "optional": true
+    },
+    "node_modules/abort-error": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/abort-error/-/abort-error-1.0.2.tgz",
+      "integrity": "sha512-lVgvB2NyPLqbXXhVmXcYFTC1x5K7CiVdPgdY7LGgFQWC8506oN01sPN3i9cl9ynuwF4iJ0TS9exnR7cZ9FuX4w==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
+    "node_modules/available-typed-arrays": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
+      "integrity": "sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "possible-typed-array-names": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/b4a": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
+      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "react-native-b4a": "*"
+      },
+      "peerDependenciesMeta": {
+        "react-native-b4a": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/base32-encoding": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base32-encoding/-/base32-encoding-1.0.0.tgz",
+      "integrity": "sha512-k1gA7f00ODLY7YtuEQFz0Kn3huTCmL/JW+oQtw51ID+zxs5chj/YQ1bXN+Q0JsqiKB2Yn0oA0AA8uipFYgpagQ==",
+      "license": "ISC"
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bech32": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/bech32/-/bech32-2.0.0.tgz",
+      "integrity": "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg==",
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bip39": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/bip39/-/bip39-3.1.0.tgz",
+      "integrity": "sha512-c9kiwdk45Do5GL0vJMe7tS95VjCii65mYAH7DfWl3uW8AVzXKQVUm64i3hzVybBDMp9r7j9iNxR85+ul8MdN/A==",
+      "license": "ISC",
+      "dependencies": {
+        "@noble/hashes": "^1.2.0"
+      }
+    },
+    "node_modules/blake2b": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
+      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
+      "license": "ISC",
+      "dependencies": {
+        "blake2b-wasm": "^2.4.0",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/blake2b-wasm": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
+      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
+      "license": "MIT",
+      "dependencies": {
+        "b4a": "^1.0.1",
+        "nanoassert": "^2.0.0"
+      }
+    },
+    "node_modules/blakejs": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
+      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==",
+      "license": "MIT"
+    },
+    "node_modules/bn.js": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.4.tgz",
+      "integrity": "sha512-QL7sb18rJ1PbdsKsqPA0guxL563vIMwRHgzNrW/uzQuRGN1Cjqd/wonUBAVqHox9KwzHA6vCbM0lXx3k4iQMow==",
+      "license": "MIT"
+    },
+    "node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/call-bind": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.9.tgz",
+      "integrity": "sha512-a/hy+pNsFUTR+Iz8TCJvXudKVLAnz/DyeSUo10I5yvFDQJBFU2s9uqQpoSrJlroHUKoKqzg+epxyP9lqFdzfBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "get-intrinsic": "^1.3.0",
+        "set-function-length": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/cbor": {
+      "version": "10.0.12",
+      "resolved": "https://registry.npmjs.org/cbor/-/cbor-10.0.12.tgz",
+      "integrity": "sha512-exQDevYd7ZQLP4moMQcZkKCVZsXLAtUSflObr3xTh4xzFIv/xBCdvCd6L259kQOUP2kcTC0jvC6PpZIf/WmRXA==",
+      "license": "MIT",
+      "dependencies": {
+        "nofilter": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/chacha": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/chacha/-/chacha-2.1.0.tgz",
+      "integrity": "sha512-FhVtqaZOiHlOKUkAWfDlJ+oe/O8iPQbCC0pFXJqphr4YQBCZPXa8Mv3j35+W4eWFWCoTUcW2u5IWDDkknygvVA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.1",
+        "readable-stream": "^1.0.33"
+      },
+      "optionalDependencies": {
+        "chacha-native": "^2.0.0"
+      }
+    },
+    "node_modules/chacha-native": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/chacha-native/-/chacha-native-2.0.3.tgz",
+      "integrity": "sha512-93h+osfjhR2sMHAaapTLlL/COoBPEZ6upicPBQ4GfUyadoMb8t9/M0PKK8kC+F+DEA/Oy3Kg9w3HzY3J1foP3g==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.2.1",
+        "inherits": "^2.0.1",
+        "nan": "^2.4.0"
+      }
+    },
+    "node_modules/cipher-base": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.7.tgz",
+      "integrity": "sha512-Mz9QMT5fJe7bKI7MH31UilT5cEK5EHHRCccw/YRFsRY47AuNgaV6HY3rscp0/I4Q+tTW/5zoqpSeRRI54TkDWA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
+      "license": "MIT"
+    },
+    "node_modules/create-hash": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
+      "integrity": "sha512-z00bCGNHDG8mHAkP7CtT1qVu+bFQUPjYq/4Iv3C3kWjTFV10zIjfSoeqXo9Asws8gwSHDGj/hl2u4OGIjapeCg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.1",
+        "inherits": "^2.0.1",
+        "md5.js": "^1.3.4",
+        "ripemd160": "^2.0.1",
+        "sha.js": "^2.4.0"
+      }
+    },
+    "node_modules/create-hmac": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.7.tgz",
+      "integrity": "sha512-MJG9liiZ+ogc4TzUwuvbER1JRdgvUFSB5+VR/g5h82fGaIRWMWddtKBHi7/sVhfjQZ6SehlyhvQYrcYkaUIpLg==",
+      "license": "MIT",
+      "dependencies": {
+        "cipher-base": "^1.0.3",
+        "create-hash": "^1.1.0",
+        "inherits": "^2.0.1",
+        "ripemd160": "^2.0.0",
+        "safe-buffer": "^5.0.1",
+        "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.2.0.tgz",
+      "integrity": "sha512-Q+xVJLoGOeIMXZmbUK4HYk+69cQH6LudR0Vu/pRm2YlU/hDV9CiS0gKUMaWY5f2NeUH9C1nV3bsTlCo0FsTV1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "node-fetch": "^2.7.0"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.4.tgz",
+      "integrity": "sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dom-walk": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/for-each": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
+      "integrity": "sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-callable": "^1.2.7"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fraction.js": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.0.1.tgz",
+      "integrity": "sha512-NQYzZw8MUsxSZFQo6E8tKOlmSd/BlDTNOR4puXFSHSwFwNaIlmbortQy5PDN/KnVQ4xWG2NtN0J0hjPw7eE06A==",
+      "license": "MIT OR GPL-2.0",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/generator-function": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/generator-function/-/generator-function-2.0.1.tgz",
+      "integrity": "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-random-values": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/get-random-values/-/get-random-values-2.1.0.tgz",
+      "integrity": "sha512-q2yOLpLyA8f9unfv2LV8KVRUFeOIrQVS5cnqpbv6N+ea9j1rmW5dFKj/2Q7CK3juEfDYQgPxGt941VJcmw0jKg==",
+      "license": "MIT",
+      "dependencies": {
+        "global": "^4.4.0"
+      },
+      "engines": {
+        "node": "14 || 16 || >=18"
+      }
+    },
+    "node_modules/global": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
+      "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
+      "license": "MIT",
+      "dependencies": {
+        "min-document": "^2.19.0",
+        "process": "^0.11.10"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz",
+      "integrity": "sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hash-base": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.2.tgz",
+      "integrity": "sha512-Bb33KbowVTIj5s7Ked1OsqHUeCpz//tPwR+E2zJgJKo9Z5XolZ9b6bdUgjmYlwnWhoOQKoTd1TYToZGn5mAYOg==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "readable-stream": "^2.3.8",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/hash-base/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/hash-base/node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash-base/node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/hash-base/node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/hash.js": {
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.7.tgz",
+      "integrity": "sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.1"
+      }
+    },
+    "node_modules/hashlru": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/hashlru/-/hashlru-2.3.0.tgz",
+      "integrity": "sha512-0cMsjjIC8I+D3M44pOQdsy0OHXGLVz6Z0beRuufhKa0KfaD2wGwAev6jILzXsd3/vpnNQJmWyZtIILqM1N+n5A==",
+      "license": "MIT"
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/i": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/i/-/i-0.3.7.tgz",
+      "integrity": "sha512-FYz4wlXgkQwIPqhzC5TdNMLSE5+GS1IIDJZY/1ZiEPCT2S3COUVZeT5OW4BmW4r5LHLQuOosSwsvnroG9GR59Q==",
+      "engines": {
+        "node": ">=0.4"
+      }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-9.0.5.tgz",
+      "integrity": "sha512-zHtQzGojZXTwZTHQqra+ETKd4Sn3vgi7uBmlPoXVWZqYvuKmtI0l/VZTjqGmJY9x88GGOaZ9+G9ES8hC4T4X8g==",
+      "license": "MIT",
+      "dependencies": {
+        "jsbn": "1.1.0",
+        "sprintf-js": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/is-arguments": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-arguments/-/is-arguments-1.2.0.tgz",
+      "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-callable": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
+      "integrity": "sha512-1BC0BVFhS/p0qtw6enp8e+8OD0UrK0oFLztSjNzhcKA3WDuJxxAPXzPuPtKkjEY9UUoEWlX/8fgKeu2S8i9JTA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-generator-function": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/is-generator-function/-/is-generator-function-1.1.2.tgz",
+      "integrity": "sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.4",
+        "generator-function": "^2.0.0",
+        "get-proto": "^1.0.1",
+        "has-tostringtag": "^1.0.2",
+        "safe-regex-test": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-regex": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.2.1.tgz",
+      "integrity": "sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-typed-array": {
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
+      "integrity": "sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "which-typed-array": "^1.1.16"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/isarray": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+      "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
+      "license": "MIT"
+    },
+    "node_modules/iso-url": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/iso-url/-/iso-url-1.2.1.tgz",
+      "integrity": "sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz",
+      "integrity": "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "ws": "*"
+      }
+    },
+    "node_modules/jsbn": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-1.1.0.tgz",
+      "integrity": "sha512-4bYVV3aAMtDTTu4+xsDYa6sy9GyJ69/amsu9sYF2zqjiEoZA5xJi3BrfX3uY+/IekIu7MwdObdbDWpoZdBv3/A==",
+      "license": "MIT"
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/libsodium-sumo": {
+      "version": "0.7.16",
+      "resolved": "https://registry.npmjs.org/libsodium-sumo/-/libsodium-sumo-0.7.16.tgz",
+      "integrity": "sha512-x6atrz2AdXCJg6G709x9W9TTJRI6/0NcL5dD0l5GGVqNE48UJmDsjO4RUWYTeyXXUpg+NXZ2SHECaZnFRYzwGA==",
+      "license": "ISC"
+    },
+    "node_modules/libsodium-wrappers-sumo": {
+      "version": "0.7.10",
+      "resolved": "https://registry.npmjs.org/libsodium-wrappers-sumo/-/libsodium-wrappers-sumo-0.7.10.tgz",
+      "integrity": "sha512-1noz8Mcl/LUzO/iSO/FJzoJyIaPwxl+/+E4CoTIXtsPiEEXQx2sxalmrVWxteLpynqgX0ASo28ChB9NEVRh0Pg==",
+      "license": "ISC",
+      "dependencies": {
+        "libsodium-sumo": "^0.7.0"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
+    "node_modules/main-event": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/main-event/-/main-event-1.0.4.tgz",
+      "integrity": "sha512-sKazUjIy2Jalv5lkQ446iOcrx8Q7TkaCuk6xfnzg5uUqMusMLDMPmRDmSNE2kjSVpSTJo4j1bQZusS+Ib7Bvrg==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/md5.js": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
+      "integrity": "sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.0.0",
+        "inherits": "^2.0.1",
+        "safe-buffer": "^5.1.2"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-document": {
+      "version": "2.19.2",
+      "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
+      "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
+      "license": "MIT",
+      "dependencies": {
+        "dom-walk": "^0.1.0"
+      }
+    },
+    "node_modules/minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A==",
+      "license": "ISC"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multiformats": {
+      "version": "13.4.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-13.4.2.tgz",
+      "integrity": "sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/nan": {
+      "version": "2.28.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+      "integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/nanoassert": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
+      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA==",
+      "license": "ISC"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/nofilter": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-3.1.0.tgz",
+      "integrity": "sha512-l2NNj07e9afPnhAhvgVrCD/oy2Ai1yfLpuo3EpiO1jFTsB4sFz6oIfAfSZyQzVpkZQ9xS8ZS5g1jCBgq4Hwo0g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.19"
+      }
+    },
+    "node_modules/p-queue": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-9.3.0.tgz",
+      "integrity": "sha512-7NED7xhQ74Ngp4JP/2e0VZHp7vSWfJfqeiR92jPgxsz6m0Se4P03YoTKa9dDXyZ3r6P616gUXttrB6nnHYKang==",
+      "license": "MIT",
+      "dependencies": {
+        "eventemitter3": "^5.0.4",
+        "p-timeout": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-timeout": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-7.0.1.tgz",
+      "integrity": "sha512-AxTM2wDGORHGEkPCt8yqxOTMgpfbEHqF51f/5fJCmwFC3C/zNcGT63SymH2ttOAaiIws2zVg4+izQCjrakcwHg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/pbkdf2": {
+      "version": "3.1.6",
+      "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.6.tgz",
+      "integrity": "sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==",
+      "license": "MIT",
+      "dependencies": {
+        "create-hash": "^1.2.0",
+        "create-hmac": "^1.1.7",
+        "ripemd160": "^2.0.3",
+        "safe-buffer": "^5.2.1",
+        "sha.js": "^2.4.12",
+        "to-buffer": "^1.2.2"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/possible-typed-array-names": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
+      "integrity": "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
+    "node_modules/progress-events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/progress-events/-/progress-events-1.1.0.tgz",
+      "integrity": "sha512-82DVc5tI36neVB3IjdXR11ztwGuoBc98em9ijzubeZKxI47OlV2Znq6mlPqE5xPDzO2Uw98GHiQSjj2favBCRQ==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+      "integrity": "sha512-+MeVjFf4L44XUkhM1eYbD8fyEsxcV81pqMSR5gblfcLCHfZvbrqy4/qYHE+/R5HoBUT11WV5O08Cr1n3YXkWVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.1",
+        "isarray": "0.0.1",
+        "string_decoder": "~0.10.x"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ripemd160": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.3.tgz",
+      "integrity": "sha512-5Di9UC0+8h1L6ZD2d7awM7E/T4uA1fJRlx6zk/NvdCCVEoAnFqvHmCuNeIKoCeIixBX/q8uM+6ycDvF8woqosA==",
+      "license": "MIT",
+      "dependencies": {
+        "hash-base": "^3.1.2",
+        "inherits": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/safe-regex-test": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/safe-regex-test/-/safe-regex-test-1.1.0.tgz",
+      "integrity": "sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "is-regex": "^1.2.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/scalus": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/scalus/-/scalus-0.17.0.tgz",
+      "integrity": "sha512-74mD4wL1vw4GVh2ECemQhoB3q5Smwj5S8W7OG1j7OWuLkwJ0Mvz4LFhZPA9rZjpNvanZoKiDqc3S/qGD65uRYg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/serialize-error": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-8.1.0.tgz",
+      "integrity": "sha512-3NnuWfM6vBYoy5gZFvHiYsVbafvI9vZv/+jlIigFn4oP4zjNPK3LhcY0xSCgeb1a5L8jO71Mit9LlNoi2UfDDQ==",
+      "license": "MIT",
+      "dependencies": {
+        "type-fest": "^0.20.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/set-function-length": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.2.2.tgz",
+      "integrity": "sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.1.4",
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2",
+        "get-intrinsic": "^1.2.4",
+        "gopd": "^1.0.1",
+        "has-property-descriptors": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/sha.js": {
+      "version": "2.4.12",
+      "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.12.tgz",
+      "integrity": "sha512-8LzC5+bvI45BjpfXU8V5fdU2mfeKiQe1D1gIMn7XUlF3OTUrpdJpPPH4EMAnF0DsHHdSZqCdSss5qCmJKuiO3w==",
+      "license": "(MIT AND BSD-3-Clause)",
+      "dependencies": {
+        "inherits": "^2.0.4",
+        "safe-buffer": "^5.2.1",
+        "to-buffer": "^1.2.0"
+      },
+      "bin": {
+        "sha.js": "bin.js"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
+      "integrity": "sha512-Oo+0REFV59/rz3gfJNKQiBlwfHaSESl1pcGyABQsnnIfWOFt6JNj5gCog2U6MLZ//IGYD+nA8nI+mTShREReaA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
+      "license": "MIT"
+    },
+    "node_modules/to-buffer": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.2.2.tgz",
+      "integrity": "sha512-db0E3UJjcFhpDhAF4tLo03oli3pwl3dbnzXOUIlRKrp+ldk/VUxzpWYZENsw2SZiuBjHAk7DfB0VU7NKdpb6sw==",
+      "license": "MIT",
+      "dependencies": {
+        "isarray": "^2.0.5",
+        "safe-buffer": "^5.2.1",
+        "typed-array-buffer": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/to-buffer/node_modules/isarray": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
+      "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
+      "license": "MIT"
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-custom-error": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/ts-custom-error/-/ts-custom-error-3.3.1.tgz",
+      "integrity": "sha512-5OX1tzOjxWEgsr/YEUWSuPrQ00deKLh6D7OTWcvNHm12/7QPyRh8SYpyWvA4IZv8H/+GQWQEh/kwo95Q9OVW1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ts-log": {
+      "version": "2.2.7",
+      "resolved": "https://registry.npmjs.org/ts-log/-/ts-log-2.2.7.tgz",
+      "integrity": "sha512-320x5Ggei84AxzlXp91QkIGSw5wgaLT6GeAH0KsqDmRZdVWW2OiSeVvElVoatk3f7nicwXlElXsoFkARiGE2yg==",
+      "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/type-fest": {
+      "version": "0.20.2",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
+      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typed-array-buffer": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/typed-array-buffer/-/typed-array-buffer-1.0.3.tgz",
+      "integrity": "sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.3",
+        "es-errors": "^1.3.0",
+        "is-typed-array": "^1.1.14"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/uint8-varint": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/uint8-varint/-/uint8-varint-2.0.5.tgz",
+      "integrity": "sha512-jeFLbL/x30wBRnWjKE1qVBXeumG46r7XmYkpis955lTQ+blccGKFrOsSMHlxePwYB1pI7L8YPHz1t4jLxEs3nA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arraylist": "^2.0.0",
+        "uint8arrays": "^5.0.0"
+      }
+    },
+    "node_modules/uint8-varint/node_modules/uint8arraylist": {
+      "version": "2.4.9",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-2.4.9.tgz",
+      "integrity": "sha512-KxWjyEFzchzik3aoQlK66oaoxIReoMo5bQRm1fcjBUZvE8xv/tyR3CTKhjh6K/faV8VaF6hd5pjr45CzbwuwkA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arrays": "^5.0.1"
+      }
+    },
+    "node_modules/uint8arraylist": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/uint8arraylist/-/uint8arraylist-3.0.2.tgz",
+      "integrity": "sha512-LDVoq9BQaGJzGDUovEnoX6rpKCvnY/Jbtws4ikwnBzjRbq5qBAFpBZevUEbSmMM87aO0Sp+wOZy2ZXf5yODmXQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "uint8arrays": "^6.0.0"
+      }
+    },
+    "node_modules/uint8arraylist/node_modules/multiformats": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-14.0.2.tgz",
+      "integrity": "sha512-sF7F3gBKCyehzIhDwVuTRf79TZ8qWRz5NXwWYBX+4a+n22KcFqqcDYJvZr7tySrI0MhuTBXVOlo3qMTiAHC78g==",
+      "license": "Apache-2.0 OR MIT"
+    },
+    "node_modules/uint8arraylist/node_modules/uint8arrays": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-6.1.1.tgz",
+      "integrity": "sha512-iz7JN0XCSZYA111lhFG2Ui9EhFvTNekqSRHw3lvMHq+dzwWy1OQftxFQREEh4rffU0oSoXdQHsk2TiHKVm4fsA==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^14.0.0"
+      }
+    },
+    "node_modules/uint8arrays": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-5.1.1.tgz",
+      "integrity": "sha512-9muQwa4wZG4dKi9gMAIBtnk2Pw87SRpvWTH6lOGm19V2Uqxr4uomUf2PGqPnWc+qs06sN8owUU4jfcoWOcfwVQ==",
+      "license": "Apache-2.0 OR MIT",
+      "dependencies": {
+        "multiformats": "^13.0.0"
+      }
+    },
+    "node_modules/undici": {
+      "version": "5.29.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
+      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@fastify/busboy": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=14.0"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "license": "MIT"
+    },
+    "node_modules/utf8-codec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/utf8-codec/-/utf8-codec-1.0.0.tgz",
+      "integrity": "sha512-S/QSLezp3qvG4ld5PUfXiH7mCFxLKjSVZRFkB3DOjgwHuJPFDkInAXc/anf7BAbHt/D38ozDzL+QMZ6/7gsI6w==",
+      "license": "MIT"
+    },
+    "node_modules/util": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.12.5.tgz",
+      "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "is-arguments": "^1.0.4",
+        "is-generator-function": "^1.0.7",
+        "is-typed-array": "^1.1.3",
+        "which-typed-array": "^1.1.2"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/web-encoding": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/web-encoding/-/web-encoding-1.1.5.tgz",
+      "integrity": "sha512-HYLeVCdJ0+lBYV2FvNZmv3HJ2Nt0QYXqZojk3d9FJOLkwnuhzM9tmamh8d7HPM8QqjKH8DeHkFTx+CFlWpZZDA==",
+      "license": "MIT",
+      "dependencies": {
+        "util": "^0.12.3"
+      },
+      "optionalDependencies": {
+        "@zxing/text-encoding": "0.9.0"
+      }
+    },
+    "node_modules/webextension-polyfill": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
+      "integrity": "sha512-a19+DzlT6Kp9/UI+mF9XQopeZ+n2ussjhxHJ4/pmIGge9ijCDz7Gn93mNnjpZAk95T4Tae8iHZ6sSf869txqiQ==",
+      "license": "MPL-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/which-typed-array": {
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.22.tgz",
+      "integrity": "sha512-fvO4ExWMFsqyhG3AiPAObMuY1lxaqgYcxbc49CNdWDDECOJNgQyvsOWVwbZc+qf3rzRtxojBK+CMEv0Ld5CYpw==",
+      "license": "MIT",
+      "dependencies": {
+        "available-typed-arrays": "^1.0.7",
+        "call-bind": "^1.0.9",
+        "call-bound": "^1.0.4",
+        "for-each": "^0.3.5",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-tostringtag": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.5.11",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
+      "integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xhr2": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/xhr2/-/xhr2-0.2.1.tgz",
+      "integrity": "sha512-sID0rrVCqkVNUn8t6xuv9+6FViXjUVXq8H5rWOH2rz9fDNQEd4g0EA2XlcEdJXRz5BMEn4O1pJFdT+z4YHhoWw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6"
+      }
+    }
+  }
+}

--- a/test-examples/yano-testkit-meshjs/package.json
+++ b/test-examples/yano-testkit-meshjs/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "yano-testkit-meshjs-transfer-test",
+  "version": "1.0.0",
+  "private": true,
+  "description": "MeshJS transfer example using @bloxbean/yano-testkit.",
+  "type": "module",
+  "scripts": {
+    "test": "node src/meshjs-transfer.mjs"
+  },
+  "dependencies": {
+    "@meshsdk/core": "latest",
+    "xhr2": "^0.2.1"
+  },
+  "devDependencies": {
+    "@bloxbean/yano-testkit": "file:../../npm/yano-testkit"
+  }
+}

--- a/test-examples/yano-testkit-meshjs/src/meshjs-transfer.mjs
+++ b/test-examples/yano-testkit-meshjs/src/meshjs-transfer.mjs
@@ -1,0 +1,200 @@
+import { access } from "node:fs/promises";
+import { constants } from "node:fs";
+import { basename, dirname, resolve } from "node:path";
+
+import xhr2 from "xhr2";
+global.XMLHttpRequest = xhr2;
+
+import { BlockfrostProvider, MeshTxBuilder, MeshWallet } from "@meshsdk/core";
+import { startYanoDevnet } from "@bloxbean/yano-testkit";
+
+const TEST_MNEMONIC = (
+  process.env.TEST_MNEMONIC ||
+  "wrist approve ethics forest knife treat noise great three simple prize happy toe dynamic number hunt trigger install wrong change decorate vendor glow erosion"
+).split(" ");
+
+const blockTimeMillis = numberFromEnv("YANO_BLOCK_TIME_MILLIS", 200);
+const timeoutMs = numberFromEnv("YANO_TESTKIT_TIMEOUT_MS", 120_000);
+const fundingAda = numberFromEnv("YANO_FUNDING_ADA", 20);
+const transferAda = numberFromEnv("YANO_TRANSFER_ADA", 2);
+const verboseLogs = process.env.YANO_TESTKIT_VERBOSE === "true";
+
+let yano;
+
+try {
+  yano = await startYanoDevnet({
+    binaryPath: await defaultBinaryPath(),
+    cwd: await defaultCwd(),
+    blockTimeMillis,
+    timeoutMs,
+    onStdout: verboseLogs ? line => console.log(`[yano] ${line}`) : undefined,
+    onStderr: verboseLogs ? line => console.error(`[yano] ${line}`) : undefined
+  });
+
+  console.log("Yano devnet started");
+  console.log(`  apiBaseUrl: ${yano.apiBaseUrl}`);
+  console.log(`  storage: ${yano.storage.path}`);
+
+  await yano.await.untilReady({ timeoutMs: 10_000 });
+  await yano.assertions.nodeIsRunning();
+  await yano.assertions.runtimeNotDegraded();
+
+  const provider = new BlockfrostProvider(yano.apiBaseUrl);
+  const wallet = new MeshWallet({
+    networkId: 0,
+    fetcher: provider,
+    submitter: provider,
+    key: {
+      type: "mnemonic",
+      words: TEST_MNEMONIC
+    }
+  });
+  await wallet.init();
+
+  const walletAddress = await wallet.getChangeAddress();
+  assert(walletAddress?.startsWith("addr_test"), `Expected testnet address, got ${walletAddress}`);
+  console.log(`MeshJS wallet: ${walletAddress}`);
+
+  const params = await provider.fetchProtocolParameters();
+  assert(params?.minFeeA !== undefined, "MeshJS protocol params should include minFeeA");
+  assert(params?.minFeeB !== undefined, "MeshJS protocol params should include minFeeB");
+  console.log(`Protocol params: minFeeA=${params.minFeeA}, minFeeB=${params.minFeeB}`);
+
+  const fundResult = await yano.faucet.fundAddress(walletAddress, fundingAda);
+  console.log(`Funded wallet: ${fundResult.tx_hash}#${fundResult.index}, lovelace=${fundResult.lovelace}`);
+  await yano.await.untilTxVisible(fundResult.tx_hash, { timeoutMs: 10_000, pollIntervalMs: 200 });
+  await yano.assertions.address(walletAddress).hasAtLeastAda(fundingAda);
+
+  const fundedUtxos = await waitForMeshUtxos(provider, walletAddress);
+  const fundedBalance = balanceLovelace(fundedUtxos);
+  assert(fundedBalance >= adaToLovelace(fundingAda), `Expected funded balance >= ${fundingAda} ADA`);
+  console.log(`MeshJS sees ${fundedUtxos.length} funded UTXO(s), balance=${fundedBalance} lovelace`);
+
+  const transferLovelace = adaToLovelace(transferAda);
+  const unsignedTx = await new MeshTxBuilder({ fetcher: provider })
+    .txOut(walletAddress, [{ unit: "lovelace", quantity: transferLovelace.toString() }])
+    .changeAddress(walletAddress)
+    .selectUtxosFrom(fundedUtxos)
+    .complete();
+  assert(unsignedTx, "MeshJS should build an unsigned transaction");
+
+  const signedTx = await wallet.signTx(unsignedTx);
+  assert(signedTx, "MeshJS wallet should sign the transaction");
+
+  const txHash = await wallet.submitTx(signedTx);
+  assert(txHash, "MeshJS submitTx should return a transaction hash");
+  console.log(`Submitted MeshJS self-transfer: ${txHash}`);
+
+  await yano.await.untilTxVisible(txHash, { timeoutMs: 20_000, pollIntervalMs: 200 });
+  const yanoTx = await yano.queries.tx(txHash);
+  assert(yanoTx, "Yano query should return submitted transaction info");
+  const txUtxos = await yano.queries.txUtxos(txHash);
+  assert(hasOutputToAddress(txUtxos, walletAddress), "Submitted tx should have an output to the wallet address");
+
+  const meshTx = await provider.fetchTxInfo(txHash);
+  assert(meshTx, "MeshJS should fetch submitted transaction info");
+  const postTransferUtxos = await waitForMeshUtxos(provider, walletAddress);
+  assert(postTransferUtxos.length > 0, "Wallet should still have UTXOs after self-transfer");
+
+  await yano.assertions.address(walletAddress).hasAtLeastAda(transferAda);
+  console.log("MeshJS transfer test passed");
+} catch (error) {
+  console.error("MeshJS transfer test failed");
+  console.error(error instanceof Error ? error.stack : error);
+  if (yano) {
+    console.error("\nYano log tail:");
+    console.error(yano.logs());
+  }
+  process.exitCode = 1;
+} finally {
+  if (yano) {
+    await yano.stop();
+    console.log("Yano devnet stopped");
+  }
+}
+
+async function defaultBinaryPath() {
+  if (process.env.YANO_TESTKIT_BINARY) {
+    return undefined;
+  }
+  const candidate = process.platform === "win32"
+    ? resolve("../../app/build/yano.exe")
+    : resolve("../../app/build/yano");
+  try {
+    await access(candidate, constants.X_OK);
+    return candidate;
+  } catch {
+    return undefined;
+  }
+}
+
+async function defaultCwd() {
+  if (process.env.YANO_TESTKIT_CWD) {
+    return resolve(process.env.YANO_TESTKIT_CWD);
+  }
+  const envBinary = process.env.YANO_TESTKIT_BINARY;
+  if (envBinary) {
+    const binaryDir = dirname(resolve(envBinary));
+    if (basename(binaryDir) === "build" && basename(dirname(binaryDir)) === "app") {
+      return dirname(binaryDir);
+    }
+    return undefined;
+  }
+  const candidate = resolve("../../app");
+  try {
+    await access(resolve(candidate, "config"), constants.R_OK);
+    return candidate;
+  } catch {
+    return undefined;
+  }
+}
+
+async function waitForMeshUtxos(provider, address) {
+  let last = [];
+  const deadline = Date.now() + 10_000;
+  while (Date.now() <= deadline) {
+    last = await provider.fetchAddressUTxOs(address);
+    if (last.length > 0) {
+      return last;
+    }
+    await sleep(200);
+  }
+  throw new Error(`Timed out waiting for MeshJS UTXOs at ${address}; last=${JSON.stringify(last)}`);
+}
+
+function balanceLovelace(utxos) {
+  return utxos.reduce((sum, utxo) => {
+    const lovelace = utxo.output.amount.find(amount => amount.unit === "lovelace");
+    return sum + BigInt(lovelace?.quantity ?? "0");
+  }, 0n);
+}
+
+function hasOutputToAddress(txUtxos, address) {
+  if (!txUtxos || typeof txUtxos !== "object" || !Array.isArray(txUtxos.outputs)) {
+    return false;
+  }
+  return txUtxos.outputs.some(output => output.address === address);
+}
+
+function adaToLovelace(ada) {
+  return BigInt(Math.trunc(ada * 1_000_000));
+}
+
+function numberFromEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) {
+    return fallback;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function assert(condition, message) {
+  if (!condition) {
+    throw new Error(message);
+  }
+}

--- a/testkit/build.gradle
+++ b/testkit/build.gradle
@@ -7,3 +7,14 @@ dependencies {
     api libs.jackson.databind
     implementation libs.slf4j.api
 }
+
+publishing {
+    publications {
+        mavenJava(MavenPublication) {
+            pom {
+                name = 'Yano Testkit'
+                description = 'JUnit and JVM integration-test helpers for running Yano devnets'
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

  Implements ADR-032 for the npm/native Yano testkit.

  - Adds HTTP-backed JS helper facades for `@bloxbean/yano-testkit`:
    - `client`
    - `faucet`
    - `queries`
    - `time`
    - `snapshots`
    - `devnet`
    - `transactions`
    - `await`
    - `assertions`
  - Keeps the JS boundary address/serialized-tx only. Wallet creation, key custody, and signing remain in the JS app or Cardano SDK.
  - Adds typed HTTP client errors via `YanoHttpError`.
  - Exposes the helper facades through the Vitest adapter.
  - Adds `JS_USER_GUIDE.md` and expands npm README docs.
  - Adds test examples:
    - `test-examples/yano-testkit-js`
    - `test-examples/yano-testkit-meshjs`
  - Updates ADR-031/ADR-032 docs with npm helper behavior, response casing, best-effort time helpers, and follow-up notes.
  - Fixes release publishing metadata:
    - Adds required Maven POM name/description for `testkit` and `devnet-toolkit`.
    - Publishes npm packages from explicit local paths.
    - Maps `-pre`, `-preview`, and `-alpha` versions to the npm `preview` tag.

  ## Validation

  - `npm test`
  - `npm run typecheck`
  - `npm run pack:dry`

