### PR TITLE
 Fix Scalus native-image BLS support

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,9 +49,10 @@ jackson-databind = "com.fasterxml.jackson.core:jackson-databind:2.17.0"
 
 rocksdb="org.rocksdb:rocksdbjni:9.11.2"
 
-scala3-library = "org.scala-lang:scala3-library_3:3.3.4"
-scalus-cardano-ledger = "org.scalus:scalus-cardano-ledger_3:0.16.0"
-scalus-bloxbean-ccl = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.16.0"
+scala3-library = "org.scala-lang:scala3-library_3:3.3.8"
+scalus-cardano-ledger = "org.scalus:scalus-cardano-ledger_3:0.18.2"
+scalus-bloxbean-ccl = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.18.2"
+blst-java = "foundation.icon:blst-java:0.3.2"
 
 aiken-java-binding = "com.bloxbean.cardano:aiken-java-binding:0.1.0"
 

--- a/scalus-bridge/build.gradle
+++ b/scalus-bridge/build.gradle
@@ -20,6 +20,7 @@ dependencies {
         exclude group: 'com.bloxbean.cardano'
     }
     api libs.scalus.cardano.ledger
+    api libs.blst.java
 
     testImplementation libs.junit.jupiter.api
     testRuntimeOnly libs.junit.jupiter.engine

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/BlsBuiltinsUnavailableException.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/BlsBuiltinsUnavailableException.java
@@ -1,0 +1,7 @@
+package com.bloxbean.cardano.yano.scalusbridge;
+
+final class BlsBuiltinsUnavailableException extends Exception {
+    BlsBuiltinsUnavailableException(Throwable cause) {
+        super(ScalusNativeFailures.BLS_UNAVAILABLE_MESSAGE, cause);
+    }
+}

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluator.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluator.java
@@ -69,13 +69,20 @@ public class ScalusBasedTransactionEvaluator implements TransactionEvaluator {
 
         ProtocolParams protocolParams = protocolParamsSupplier.getProtocolParams(resolveCurrentSlot());
         var scalusSlotConfig = SlotConfigAdapters.toScalus(slotConfigSupplier.getSlotConfig());
-        // Create ScalusTransactionEvaluator and evaluate
-        var evaluator = new ScalusTransactionEvaluator(
-                scalusSlotConfig, protocolParams, utxoSupplier, scriptSupplier,
-                EvaluatorMode.EVALUATE_AND_COMPUTE_COST, false);
-
-        Result<List<com.bloxbean.cardano.client.api.model.EvaluationResult>> result =
-                evaluator.evaluateTx(txCbor, inputUtxos);
+        Result<List<com.bloxbean.cardano.client.api.model.EvaluationResult>> result;
+        try {
+            result = evaluateWithScalus(scalusSlotConfig, protocolParams, utxoSupplier, txCbor, inputUtxos);
+        } catch (LinkageError e) {
+            if (ScalusNativeFailures.isBlsUnavailable(e)) {
+                throw new BlsBuiltinsUnavailableException(e);
+            }
+            throw e;
+        } catch (RuntimeException e) {
+            if (ScalusNativeFailures.isBlsUnavailable(e)) {
+                throw new BlsBuiltinsUnavailableException(e);
+            }
+            throw e;
+        }
 
         if (!result.isSuccessful()) {
             throw new Exception("Script evaluation failed: " + result.getResponse());
@@ -89,6 +96,19 @@ public class ScalusBasedTransactionEvaluator implements TransactionEvaluator {
                         er.getExUnits().getMem().longValueExact(),
                         er.getExUnits().getSteps().longValueExact()))
                 .collect(Collectors.toList());
+    }
+
+    protected Result<List<com.bloxbean.cardano.client.api.model.EvaluationResult>> evaluateWithScalus(
+            scalus.cardano.ledger.SlotConfig scalusSlotConfig,
+            ProtocolParams protocolParams,
+            UtxoSupplier utxoSupplier,
+            byte[] txCbor,
+            Set<Utxo> inputUtxos) {
+        var evaluator = new ScalusTransactionEvaluator(
+                scalusSlotConfig, protocolParams, utxoSupplier, scriptSupplier,
+                EvaluatorMode.EVALUATE_AND_COMPUTE_COST, false);
+
+        return evaluator.evaluateTx(txCbor, inputUtxos);
     }
 
     private long resolveCurrentSlot() {

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidator.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidator.java
@@ -34,7 +34,7 @@ import java.util.function.LongSupplier;
  * {@link TransactionValidator} implementation using Scalus for full Cardano ledger rule validation.
  * Delegates to {@link LedgerBridge} which calls Scalus's CardanoMutator.transit().
  *
- * <p>Scalus v0.16.0 handles all DELEG rules (registration, deregistration, deposit/refund amounts,
+ * <p>Scalus handles all DELEG rules (registration, deregistration, deposit/refund amounts,
  * reward balance checks, withdrawal validation) with proper intra-tx state tracking. CCL supplementary
  * rules run after Scalus for gaps it doesn't cover (GOVCERT, delegatee existence, governance).
  */
@@ -213,7 +213,21 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
 
             return ValidationResult.success();
 
+        } catch (LinkageError e) {
+            if (ScalusNativeFailures.isBlsUnavailable(e)) {
+                return ValidationResult.failure(new ValidationError(
+                        ScalusNativeFailures.BLS_UNAVAILABLE_RULE,
+                        ScalusNativeFailures.BLS_UNAVAILABLE_MESSAGE,
+                        ValidationError.Phase.PHASE_2));
+            }
+            throw e;
         } catch (Exception e) {
+            if (ScalusNativeFailures.isBlsUnavailable(e)) {
+                return ValidationResult.failure(new ValidationError(
+                        ScalusNativeFailures.BLS_UNAVAILABLE_RULE,
+                        ScalusNativeFailures.BLS_UNAVAILABLE_MESSAGE,
+                        ValidationError.Phase.PHASE_2));
+            }
             return ValidationResult.failure(new ValidationError(
                     "InternalError",
                     "Validation error: " + e.getMessage(),
@@ -339,6 +353,10 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
     private ValidationError mapError(TransitResult result) {
         String className = result.errorClassName() != null ? result.errorClassName() : "Unknown";
         String message = result.errorMessage();
+
+        if (ScalusNativeFailures.BLS_UNAVAILABLE_RULE.equals(className)) {
+            return new ValidationError(className, message, ValidationError.Phase.PHASE_2);
+        }
 
         ValidationError.Phase phase = className.contains("PlutusScript") || className.contains("Script")
                 ? ValidationError.Phase.PHASE_2

--- a/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusNativeFailures.java
+++ b/scalus-bridge/src/main/java/com/bloxbean/cardano/yano/scalusbridge/ScalusNativeFailures.java
@@ -1,0 +1,39 @@
+package com.bloxbean.cardano.yano.scalusbridge;
+
+import java.util.Locale;
+
+public final class ScalusNativeFailures {
+    public static final String BLS_UNAVAILABLE_RULE = "Bls12_381BuiltinsUnavailable";
+    public static final String BLS_UNAVAILABLE_MESSAGE =
+            "BLS12-381 Plutus builtins are unavailable in this deployment: "
+                    + "the Scalus blst JNI library could not be loaded or registered.";
+
+    private ScalusNativeFailures() {
+    }
+
+    public static boolean isBlsUnavailable(Throwable error) {
+        Throwable current = error;
+        while (current != null) {
+            if (mentionsBlst(current.getClass().getName()) || mentionsBlst(current.getMessage())) {
+                return true;
+            }
+            for (StackTraceElement frame : current.getStackTrace()) {
+                if (mentionsBlst(frame.getClassName())) {
+                    return true;
+                }
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static boolean mentionsBlst(String value) {
+        if (value == null) {
+            return false;
+        }
+        String lower = value.toLowerCase(Locale.ROOT);
+        return lower.contains("supranational.blst")
+                || lower.contains("blstjni")
+                || lower.contains("libblst");
+    }
+}

--- a/scalus-bridge/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-scalus-bridge/jni-config.json
+++ b/scalus-bridge/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-scalus-bridge/jni-config.json
@@ -1,0 +1,68 @@
+[
+  {
+    "name": "supranational.blst.blstJNI",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.blst",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P1",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P1_Affine",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P2",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.P2_Affine",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.Pairing",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.PT",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.Scalar",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.SecretKey",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  },
+  {
+    "name": "supranational.blst.BLST_ERROR",
+    "allDeclaredConstructors": true,
+    "allDeclaredMethods": true,
+    "allDeclaredFields": true
+  }
+]

--- a/scalus-bridge/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-scalus-bridge/resource-config.json
+++ b/scalus-bridge/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-scalus-bridge/resource-config.json
@@ -1,0 +1,18 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "supranational/blst/Linux/amd64/libblst\\.so"
+      },
+      {
+        "pattern": "supranational/blst/Linux/aarch64/libblst\\.so"
+      },
+      {
+        "pattern": "supranational/blst/Mac/x86_64/libblst\\.dylib"
+      },
+      {
+        "pattern": "supranational/blst/Mac/aarch64/libblst\\.dylib"
+      }
+    ]
+  }
+}

--- a/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/LedgerBridge.scala
+++ b/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/LedgerBridge.scala
@@ -120,5 +120,11 @@ object LedgerBridge:
           new TransitResult(false, error.getMessage, error.getClass.getSimpleName)
 
     catch
+      case e: LinkageError if ScalusNativeFailures.isBlsUnavailable(e) =>
+        new TransitResult(false, ScalusNativeFailures.BLS_UNAVAILABLE_MESSAGE,
+          ScalusNativeFailures.BLS_UNAVAILABLE_RULE)
+      case e: RuntimeException if ScalusNativeFailures.isBlsUnavailable(e) =>
+        new TransitResult(false, ScalusNativeFailures.BLS_UNAVAILABLE_MESSAGE,
+          ScalusNativeFailures.BLS_UNAVAILABLE_RULE)
       case e: Exception =>
         new TransitResult(false, "Validation error: " + e.getMessage, e.getClass.getSimpleName)

--- a/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
+++ b/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
@@ -1,9 +1,13 @@
 package com.bloxbean.cardano.yano.scalusbridge;
 
+import com.bloxbean.cardano.client.api.UtxoSupplier;
+import com.bloxbean.cardano.client.api.model.Result;
+import com.bloxbean.cardano.client.api.model.Utxo;
 import com.bloxbean.cardano.client.api.model.ProtocolParams;
 import com.bloxbean.cardano.client.common.model.SlotConfig;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -14,6 +18,17 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ScalusBasedTransactionEvaluatorTest {
 
     private final SlotConfig slotConfig = new SlotConfig(1000, 0, 0);
+
+    @Test
+    void evaluatorConvertsBlstLinkageErrorToExplicitFailure() {
+        var evaluator = new BlstFailingEvaluator();
+
+        var ex = assertThrows(BlsBuiltinsUnavailableException.class,
+                () -> evaluator.evaluate(new byte[]{1, 2, 3}, Set.of()));
+
+        assertEquals(ScalusNativeFailures.BLS_UNAVAILABLE_MESSAGE, ex.getMessage());
+        assertTrue(ex.getCause() instanceof NoClassDefFoundError);
+    }
 
     @Test
     void runtimeEvaluatorRejectsNegativeCurrentSlot() {
@@ -106,5 +121,21 @@ class ScalusBasedTransactionEvaluatorTest {
         assertEquals(1_780_000_000_000L, scalus.zeroTime());
         assertEquals(42L, scalus.zeroSlot());
         assertEquals(2_000L, scalus.slotLength());
+    }
+
+    private class BlstFailingEvaluator extends ScalusBasedTransactionEvaluator {
+        BlstFailingEvaluator() {
+            super(slot -> new ProtocolParams(), null, slotConfig, 0, () -> 123L);
+        }
+
+        @Override
+        protected Result<List<com.bloxbean.cardano.client.api.model.EvaluationResult>> evaluateWithScalus(
+                scalus.cardano.ledger.SlotConfig scalusSlotConfig,
+                ProtocolParams protocolParams,
+                UtxoSupplier utxoSupplier,
+                byte[] txCbor,
+                Set<Utxo> inputUtxos) {
+            throw new NoClassDefFoundError("Could not initialize class supranational.blst.blstJNI");
+        }
     }
 }

--- a/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidatorTest.java
+++ b/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ScalusBasedTransactionValidatorTest.java
@@ -86,6 +86,18 @@ class ScalusBasedTransactionValidatorTest {
     }
 
     @Test
+    void validateConvertsBlstLinkageErrorToPhase2Failure() {
+        var validator = new BlstFailingValidator();
+
+        var result = validator.validate(new byte[]{1, 2, 3}, Set.of());
+
+        assertFalse(result.valid());
+        assertEquals(ScalusNativeFailures.BLS_UNAVAILABLE_RULE, result.errors().get(0).rule());
+        assertEquals(ValidationError.Phase.PHASE_2, result.errors().get(0).phase());
+        assertEquals(ScalusNativeFailures.BLS_UNAVAILABLE_MESSAGE, result.errors().get(0).message());
+    }
+
+    @Test
     void runtimeValidatorRejectsWhenLedgerStateProviderIsUnavailable() {
         var validator = new ScalusSuccessValidator(null);
 
@@ -402,6 +414,18 @@ class ScalusBasedTransactionValidatorTest {
     private static class SlotUnavailableValidator extends ScalusSuccessValidator {
         SlotUnavailableValidator(LedgerStateProvider provider) {
             super(provider, () -> -1L);
+        }
+    }
+
+    private static class BlstFailingValidator extends ScalusBasedTransactionValidator {
+        BlstFailingValidator() {
+            super(slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0, null);
+        }
+
+        @Override
+        protected TransitResult runScalusValidation(byte[] txCbor, ProtocolParams protocolParams,
+                                                   Set<Utxo> inputUtxos, long currentSlot) {
+            throw new NoClassDefFoundError("Could not initialize class supranational.blst.blstJNI");
         }
     }
 


### PR DESCRIPTION
 This PR updates Yano’s Scalus integration for native-image deployments.

###   Changes:

  - Upgrade Scalus dependencies to 0.18.2.
  - Add explicit foundation.icon:blst-java:0.3.2 dependency.
  - Add GraalVM native-image JNI metadata for supranational.blst.*.
  - Add native resource includes for bundled libblst shared libraries.
  - Add graceful degradation around Scalus evaluator/validator paths when native BLS bindings are unavailable.
  - Add tests for BLS native-linkage failure handling.
