### PR TITLE
fix(governance): count passive AlwaysAbstain pool stake as No for HardForkInitiation SPO tally

### DIFF
--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculator.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculator.java
@@ -173,8 +173,13 @@ public class VoteTallyCalculator {
                 } else {
                     noStake = noStake.add(stake);
                 }
-            } else if (drepType != null && drepType == DREP_ABSTAIN) {
-                // Delegated to AlwaysAbstain: always abstain
+            } else if (drepType != null && drepType == DREP_ABSTAIN
+                    && actionType != GovActionType.HARD_FORK_INITIATION_ACTION) {
+                // Delegated to AlwaysAbstain: abstain — except for HardForkInitiation, where a
+                // non-voting pool always counts as NO regardless of DRep delegation. Haskell
+                // (Conway Ratify.hs spoAcceptedRatio) matches the HardForkInitiation guard before
+                // consulting defaultStakePoolVote, so for HFI the stake stays in the denominator;
+                // here it falls through to the default NO branch below.
                 abstainStake = abstainStake.add(stake);
             } else {
                 // No DRep delegation or regular DRep — default behavior for non-voters

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculatorTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/ratification/VoteTallyCalculatorTest.java
@@ -282,6 +282,149 @@ class VoteTallyCalculatorTest {
         assertThat(tally.noCount()).isZero();
     }
 
+    /**
+     * Issue #33 / #34 regression — HardForkInitiation SPO tally.
+     *
+     * Haskell (Conway Ratify.hs spoAcceptedRatio): a pool that did NOT vote on a
+     * HardForkInitiation action counts as NO (stake stays in the denominator),
+     * regardless of its reward account's DRep delegation. The AlwaysAbstain default
+     * applies to every other action type only:
+     * <pre>
+     *   Nothing
+     *     | HardForkInitiation {} &lt;- pProcGovAction -&gt; (yes, abstain)
+     *     | hardforkConwayBootstrapPhase pv -&gt; (yes, abstain + stake)
+     *     | otherwise -&gt; case defaultStakePoolVote ... of
+     *         DefaultAbstain -&gt; (yes, abstain + stake)
+     *         ...
+     * </pre>
+     * Counting passive AlwaysAbstain pools as Abstain shrinks the denominator
+     * (yes / (total - abstain)) and inflates the yes ratio.
+     */
+    @Test
+    void spoTally_hardForkInitiation_passiveAlwaysAbstainPool_countsAsNo() {
+        Map<String, BigInteger> poolStakeDist = new HashMap<>();
+        poolStakeDist.put("poolYes", new BigInteger("60"));
+        poolStakeDist.put("poolPassiveAbstain", new BigInteger("40"));
+
+        Map<String, Integer> poolDRepDelegation = new HashMap<>();
+        poolDRepDelegation.put("poolPassiveAbstain", DREP_ABSTAIN);
+
+        Map<GovernanceStateStore.VoterKey, Integer> votes = new HashMap<>();
+        votes.put(new GovernanceStateStore.VoterKey(
+                VoterType.STAKING_POOL_KEY_HASH.ordinal(), "poolYes"), 1); // YES
+
+        var tally = calculator.computeSPOTally(votes, poolStakeDist, poolDRepDelegation,
+                GovActionType.HARD_FORK_INITIATION_ACTION, false);
+
+        // Passive AlwaysAbstain stake must land in NO, not Abstain
+        assertThat(tally.yesStake()).isEqualTo(new BigInteger("60"));
+        assertThat(tally.noStake()).isEqualTo(new BigInteger("40"));
+        assertThat(tally.abstainStake()).isEqualTo(BigInteger.ZERO);
+
+        // Ratio = 60/100 = 0.60: fails 0.61, passes 0.51.
+        // (Buggy behavior gave 60/60 = 1.0 and passed both.)
+        assertThat(VoteTallyCalculator.spoThresholdMet(tally, new BigDecimal("0.61"))).isFalse();
+        assertThat(VoteTallyCalculator.spoThresholdMet(tally, new BigDecimal("0.51"))).isTrue();
+    }
+
+    /**
+     * Explicit Abstain votes on HardForkInitiation still count as Abstain —
+     * only the non-voter delegation default is HFI-gated
+     * (Haskell: {@code Just Abstain -> (yes, abstain + stake)} for every action type).
+     */
+    @Test
+    void spoTally_hardForkInitiation_explicitAbstainVote_staysAbstain() {
+        Map<String, BigInteger> poolStakeDist = new HashMap<>();
+        poolStakeDist.put("poolYes", new BigInteger("60"));
+        poolStakeDist.put("poolExplicitAbstain", new BigInteger("40"));
+
+        // Delegated to AlwaysAbstain AND voted Abstain explicitly — the explicit vote wins
+        Map<String, Integer> poolDRepDelegation = new HashMap<>();
+        poolDRepDelegation.put("poolExplicitAbstain", DREP_ABSTAIN);
+
+        Map<GovernanceStateStore.VoterKey, Integer> votes = new HashMap<>();
+        votes.put(new GovernanceStateStore.VoterKey(
+                VoterType.STAKING_POOL_KEY_HASH.ordinal(), "poolYes"), 1);            // YES
+        votes.put(new GovernanceStateStore.VoterKey(
+                VoterType.STAKING_POOL_KEY_HASH.ordinal(), "poolExplicitAbstain"), 2); // ABSTAIN
+
+        var tally = calculator.computeSPOTally(votes, poolStakeDist, poolDRepDelegation,
+                GovActionType.HARD_FORK_INITIATION_ACTION, false);
+
+        assertThat(tally.abstainStake()).isEqualTo(new BigInteger("40"));
+        assertThat(tally.noStake()).isEqualTo(BigInteger.ZERO);
+        // Ratio = 60/(100-40) = 1.0
+        assertThat(VoteTallyCalculator.spoThresholdMet(tally, new BigDecimal("0.99"))).isTrue();
+    }
+
+    /**
+     * Non-HFI actions keep the AlwaysAbstain default: passive delegated stake is Abstain.
+     */
+    @Test
+    void spoTally_parameterChange_passiveAlwaysAbstainPool_staysAbstain() {
+        Map<String, BigInteger> poolStakeDist = new HashMap<>();
+        poolStakeDist.put("poolYes", new BigInteger("60"));
+        poolStakeDist.put("poolPassiveAbstain", new BigInteger("40"));
+
+        Map<String, Integer> poolDRepDelegation = new HashMap<>();
+        poolDRepDelegation.put("poolPassiveAbstain", DREP_ABSTAIN);
+
+        Map<GovernanceStateStore.VoterKey, Integer> votes = new HashMap<>();
+        votes.put(new GovernanceStateStore.VoterKey(
+                VoterType.STAKING_POOL_KEY_HASH.ordinal(), "poolYes"), 1);
+
+        var tally = calculator.computeSPOTally(votes, poolStakeDist, poolDRepDelegation,
+                GovActionType.PARAMETER_CHANGE_ACTION, false);
+
+        assertThat(tally.abstainStake()).isEqualTo(new BigInteger("40"));
+        assertThat(tally.noStake()).isEqualTo(BigInteger.ZERO);
+    }
+
+    /**
+     * Preprod epoch-291 reconstruction — gov_action108a5htqnmlp (HardForkInitiation,
+     * PV 10→11), the root cause of issues #33/#34.
+     *
+     * At the 291→292 boundary the correct SPO ratio was 0.5070 (just under the
+     * pvt_hard_fork_initiation threshold of 0.51), but ~55.96T lovelace of passive
+     * AlwaysAbstain pool stake wrongly moved to Abstain shrank the denominator and
+     * lifted the ratio to 0.5401 — ratifying the HFI one epoch early (292 instead
+     * of 293, canonical per Koios: ratified 293 / enacted 294). The one-epoch-early
+     * 100k ADA deposit refund then inflated the epoch-293 reward stake snapshot,
+     * over-distributing 27,439,938 lovelace at epoch 297 (issue #34).
+     *
+     * Magnitudes below reproduce the investigated ratios:
+     *   yes = 462.92T, passive-abstain = 55.957T, other non-voters = 394.183T
+     *   correct: 462.92 / 913.06 = 0.50699 → NOT ratified at 291
+     *   buggy:   462.92 / 857.10 = 0.54009 → ratified (the bug)
+     */
+    @Test
+    void spoTally_preprodEpoch291_hfi_mustNotPass051Threshold() {
+        Map<String, BigInteger> poolStakeDist = new HashMap<>();
+        poolStakeDist.put("poolsVotedYes", new BigInteger("462920000000000"));
+        poolStakeDist.put("poolsPassiveAlwaysAbstain", new BigInteger("55957000000000"));
+        poolStakeDist.put("poolsNonVoting", new BigInteger("394183000000000"));
+
+        Map<String, Integer> poolDRepDelegation = new HashMap<>();
+        poolDRepDelegation.put("poolsPassiveAlwaysAbstain", DREP_ABSTAIN);
+
+        Map<GovernanceStateStore.VoterKey, Integer> votes = new HashMap<>();
+        votes.put(new GovernanceStateStore.VoterKey(
+                VoterType.STAKING_POOL_KEY_HASH.ordinal(), "poolsVotedYes"), 1); // YES
+
+        var tally = calculator.computeSPOTally(votes, poolStakeDist, poolDRepDelegation,
+                GovActionType.HARD_FORK_INITIATION_ACTION, false);
+
+        // Full stake stays in the denominator: 462.92 / 913.06 ≈ 0.507 < 0.51
+        assertThat(tally.abstainStake()).isEqualTo(BigInteger.ZERO);
+        assertThat(VoteTallyCalculator.spoThresholdMet(tally, new BigDecimal("0.51"))).isFalse();
+
+        // Same distribution, non-HFI action: passive abstain excluded → ratio 0.5401 ≥ 0.51.
+        // This is exactly what the bug produced for the HFI at epoch 291.
+        var nonHfiTally = calculator.computeSPOTally(votes, poolStakeDist, poolDRepDelegation,
+                GovActionType.INFO_ACTION, false);
+        assertThat(VoteTallyCalculator.spoThresholdMet(nonHfiTally, new BigDecimal("0.51"))).isTrue();
+    }
+
     @Test
     void committeeTally_duplicateHotCredentialUsesActiveMember() {
         Map<GovernanceStateStore.VoterKey, Integer> votes = new HashMap<>();


### PR DESCRIPTION
## Summary

Fixes the HardForkInitiation SPO vote tally (#33) and, through it, the preprod epoch-297 treasury/reserves drift (#34).

`VoteTallyCalculator.computeSPOTally` counted a non-voting pool whose reward account delegates to the **AlwaysAbstain** DRep as Abstain for **all** action types. Per cardano-ledger (source of truth, Conway `Ratify.hs` `spoAcceptedRatio`), for **HardForkInitiation** a non-voting pool always counts as **No** — the HFI guard is matched before `defaultStakePoolVote` is consulted:

```haskell
Nothing
  | HardForkInitiation {} <- pProcGovAction -> (yes, abstain)   -- counts as No
  | hardforkConwayBootstrapPhase pv -> (yes, abstain + stake)
  | otherwise -> case defaultStakePoolVote poolId reStakePools reAccounts of
      DefaultAbstain -> (yes, abstain + stake)
      ...
```

Since the SPO threshold is `yes / (total − abstain)`, mis-bucketing passive-abstain stake shrinks the denominator and inflates the yes ratio. yaci-store fixed the same bug upstream in `64be7cbfc` (2026-06-11); Yano's port predated it.

## Root cause chain for #34 (verified against Koios + a validated yaci-store preprod resync)

1. At the 291→292 boundary, the correct SPO ratio for the PV 10→11 HFI (`gov_action108a5htqnmlp`) was **0.5070 < 0.51** — but with ~55.96T lovelace of passive AlwaysAbstain stake wrongly excluded from the denominator, Yano computed **0.5401** and ratified one epoch early (292 vs canonical 293; canonical ratified 293 / enacted 294 confirmed via Koios, PV bump at epoch 294).
2. Early ratification → early enactment (293) → the 100k ADA deposit refund credited one epoch early (spendable 293 instead of 294) to `stake_test1up4xt9…`.
3. The refund landed in the epoch-293 reward stake snapshot (+100,000 ADA), which feeds reward epoch 297 (snapshot key N−4).
4. Epoch-297 rewards over-distributed by exactly **27,439,938 lovelace** (100k ADA × the pool's ~0.000274 member rate), drawn from undistributed/unspendable → reserves −27,425,664 / treasury −14,274, then propagating as the growing treasury gap via τ·ρ.

The enactment/refund/snapshot code paths were verified correct and timing-uniform across action types — the tally guard is the only defect.

## Change

- `computeSPOTally`: gate the AlwaysAbstain non-voter default on `actionType != HARD_FORK_INITIATION_ACTION`; for HFI the stake falls through to the default No branch. Deliberately surgical — the broader non-voter guard-ordering alignment with `Ratify.hs` (bootstrap phase) is tracked separately in #35, and the wider governance-rules audit in #36.

## Tests

4 new tests in `VoteTallyCalculatorTest` (13/13 pass; 145/145 across governance packages):

- HFI + passive AlwaysAbstain pool → No (denominator retained)
- HFI + explicit Abstain vote → still Abstain (only the non-voter default is HFI-gated)
- non-HFI + passive AlwaysAbstain → unchanged (Abstain)
- preprod epoch-291 reconstruction with investigated magnitudes: correct ratio 0.507 fails the 0.51 threshold; the same distribution on a non-HFI action passes — the exact flip that caused the bug

## Follow-up verification (recommended)

Preprod replay from a pre-291 chainstate backup: assert the HFI ratifies 293 / enacts 294 (PV bump 294), the refund lands in the epoch-294 snapshot, and adapot treasury/reserves match Koios exactly through epoch 300.

Closes #33
Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)
