### PR TITLE
docs(appchain): add beginner-to-advanced tutorial hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ For deeper coverage of how to operate and extend Yano, see the application-level
 
 | Doc | What's inside |
 |---|---|
+| **[`docs/appchain/README.md`](docs/appchain/README.md)** | Start here for task-oriented app-chain tutorials, from a first three-member chain through evidence, domain roles, webhooks, proofs, plugins, anchoring, and pilot readiness. |
 | **[`docs/APP_CHAIN_OVERVIEW.md`](docs/APP_CHAIN_OVERVIEW.md)** | Diagram-led 10–15 minute overview of Yano App Chains: value proposition, end-to-end flow, no-code presets, effects, composite state machines, plugins, use cases, trust boundaries, and readiness. |
 | **[`docs/YANO_APP_CHAIN_OVERVIEW.pptx`](docs/YANO_APP_CHAIN_OVERVIEW.pptx)** | Editable 13-slide companion deck for a concise Yano App Chain architecture and product pitch. |
 | **[`docs/APP_CHAIN_PROFILE_GOVERNANCE.md`](docs/APP_CHAIN_PROFILE_GOVERNANCE.md)** | Operator and verifier runbook for governed composite-profile deployment, activation, recovery, and proofs. |

--- a/adr/app-layer/open_item.md
+++ b/adr/app-layer/open_item.md
@@ -209,7 +209,10 @@ implementation status.
 
 `DOC-001` was completed on 2026-07-17: historical ADRs now distinguish their
 original rationale from current delivery status without rewriting the decision
-record. Completed rows are removed from the live table by policy.
+record. `DOC-003` was completed on 2026-07-19 with the task-oriented
+`docs/appchain` start-here hub, nine progressive scenario tutorials, a tested
+approval-to-webhook exercise, and navigation from the primary app-chain docs.
+Completed rows are removed from the live table by policy.
 
 | ID | Priority | State | Item | Done when |
 |---|---:|---|---|---|

--- a/appchain/README.md
+++ b/appchain/README.md
@@ -17,6 +17,7 @@ Don't look for feature docs here — they're centralized:
 
 | Doc | Covers |
 |---|---|
+| [`docs/appchain/README.md`](../docs/appchain/README.md) | Beginner-to-advanced start-here hub and scenario tutorials for stock machines, evidence, roles, webhooks, proofs, anchoring, plugins, and pilot planning. |
 | [`docs/APP_CHAIN_OVERVIEW.md`](../docs/APP_CHAIN_OVERVIEW.md) | A diagram-led 10–15 minute explanation of the app-chain value, end-to-end flow, components, no-code path, plugins, effects, composite state machines, use cases, and readiness. |
 | [`docs/YANO_APP_CHAIN_OVERVIEW.pptx`](../docs/YANO_APP_CHAIN_OVERVIEW.pptx) | Editable 13-slide companion deck for a concise architecture and product pitch. |
 | [`docs/APP_CHAIN_USER_GUIDE.md`](../docs/APP_CHAIN_USER_GUIDE.md) | Configuration, REST, anchoring (metadata + script), operations |

--- a/docs/APP_CHAIN_OVERVIEW.md
+++ b/docs/APP_CHAIN_OVERVIEW.md
@@ -434,6 +434,8 @@ plugin.
 
 ## 14. Where to go next
 
+- [Start-here tutorial hub](appchain/README.md) — choose a business outcome
+  and follow a runnable beginner-to-advanced path.
 - [App-chain user guide](APP_CHAIN_USER_GUIDE.md) — configuration, APIs,
   anchoring, effects, composite profiles, operations, and troubleshooting.
 - [App-chain tutorial](APP_CHAIN_TUTORIAL.md) — run a cluster and build a

--- a/docs/APP_CHAIN_TUTORIAL.md
+++ b/docs/APP_CHAIN_TUTORIAL.md
@@ -1,5 +1,8 @@
 # App Chain Tutorial — Default Yano Distribution
 
+> Looking for task-oriented no-code scenarios rather than a custom-plugin
+> walkthrough? Start with the [app-chain tutorial hub](appchain/README.md).
+
 A hands-on, copy-pasteable walkthrough in two parts:
 
 - **Part 1** — run an app chain with the **out-of-the-box `ordered-log`

--- a/docs/APP_CHAIN_USER_GUIDE.md
+++ b/docs/APP_CHAIN_USER_GUIDE.md
@@ -1,5 +1,9 @@
 # Yano App Chain — Developer & User Guide
 
+> New to Yano app chains? Begin with the
+> [task-oriented tutorial hub](appchain/README.md), then return here for the
+> complete API, configuration, security, and operations reference.
+
 Yano can run an **app chain** next to Cardano L1: a sequenced, replicated,
 application-specific ledger maintained by a known-member, permissioned group
 of Yano nodes. The current pilot posture assumes trusted member operators;

--- a/docs/APP_CHAIN_USE_CASES.md
+++ b/docs/APP_CHAIN_USE_CASES.md
@@ -1,5 +1,8 @@
 # Yano App Chain — Use Cases & Practical Examples
 
+For runnable paths from these use cases to a local cluster, proofs, effects,
+and role-aware workflows, use the [app-chain tutorial hub](appchain/README.md).
+
 What you can build **today** with the app-chain framework, organized by how
 much you need to bring:
 

--- a/docs/appchain/README.md
+++ b/docs/appchain/README.md
@@ -1,0 +1,144 @@
+# Yano App Chains — Start Here
+
+This is the task-oriented entry point for Yano app chains. It is designed for
+two kinds of reader:
+
+- **New to app chains:** start a local three-member chain, submit useful data,
+  and see what is finalized before learning the internals.
+- **Experienced distributed-systems or blockchain developer:** jump directly
+  to state proofs, L1 anchoring, deterministic composition, effects, plugins,
+  governance, and operational boundaries.
+
+The tutorials use the current source tree. Yano is still pre-release; use local
+devnet or a Cardano test network, disposable application data, and non-production
+credentials unless a guide explicitly says otherwise.
+
+## Choose your first outcome
+
+| I want to… | Start with | Coding required? |
+|---|---|---:|
+| See three members finalize the same events | [Your first app chain](tutorials/01-first-app-chain.md) | No |
+| Maintain a provable owner-controlled registry | [Registry and state proofs](tutorials/02-registry-and-proofs.md) | No |
+| Select a stock ledger/workflow capability | [Stock state-machine cookbook](tutorials/03-stock-state-machines.md) | Configuration + typed commands |
+| Publish immutable evidence to object storage/IPFS and notify Kafka | [Evidence publication](tutorials/04-evidence-publication.md) | No |
+| Require manufacturers, auditors, and regulators to sign by domain role | [Domain-role approvals](tutorials/05-domain-role-approvals.md) | No for the stock scenario |
+| Call an ERP/API after a finalized decision | [Webhook effects](tutorials/06-webhook-effects.md) | Configuration; emission is stock or plugin logic |
+| Understand and verify Cardano settlement | [Anchors and independent verification](tutorials/07-anchors-and-verification.md) | No |
+| Implement new business rules without forking Yano | [Plugins and composites](tutorials/08-plugins-and-composites.md) | Small Java plugin |
+| Prepare a pilot deployment | [From demo to pilot](tutorials/09-from-demo-to-pilot.md) | Operations work |
+
+If you are unsure, complete tutorials 1, 2, 4, and 5 in that order. They show
+the progression from a replicated log to proofs, external actions, and
+business-role authorization.
+
+## What ships out of the box
+
+```text
+Deterministic state                    External action
+───────────────────────────────────    ───────────────────────────────
+ordered-log                            webhook.post
+kv-registry                            kafka.publish
+approvals                              object.put
+balances                               ipfs.pin
+doc-trail                              cardano.payment (preview profile)
+evidence-v1-gated composite
+role-evidence composite
+```
+
+The left side runs identically on every member and contributes to the state
+root. The right side runs after the relevant finality gate and reports an
+outcome through the effect system. External execution is at-least-once; effect
+outcome incorporation is exactly once. Receivers must honor the supplied
+idempotency identity.
+
+## The mental model
+
+An app chain has four layers:
+
+```mermaid
+flowchart LR
+    C[Client command] --> M[Deterministic state machine]
+    M --> F[Threshold-finalized app block]
+    F --> P[State root and MPF proofs]
+    P --> A[Cardano L1 anchor]
+    M -. effect intent .-> E[Effect runtime]
+    E --> X[Kafka, S3, IPFS, webhook, Cardano]
+    X -. acknowledged result .-> M
+```
+
+1. A member authenticates and relays a command.
+2. The proposer orders commands into an app block.
+3. A threshold of members signs the same block and state root.
+4. State and effect intents become provable against that root.
+5. An optional anchor settles the root on Cardano.
+6. Effect executors act outside consensus and report bounded outcomes.
+
+For role-aware workflows, the relay member and the business actor are separate
+identities: a node transports a command; an actor signature authorizes its
+business meaning.
+
+## Learning tracks
+
+### Beginner: operate first, understand second
+
+1. Use the self-contained devnet. No Cardano funds or external node is needed.
+2. Submit through `cluster.sh` or `demo.sh` rather than constructing wire bytes.
+3. Compare tips and roots on all members.
+4. Inspect one proof and one intentional no-op/failure.
+5. Stop while keeping data, restart, and verify the same state.
+
+### Application developer
+
+1. Choose a stock machine or committed composite profile.
+2. Use the Java client or REST API for typed commands and proof queries.
+3. Add a small composite plugin when existing components need new ordering or
+   terminal transitions.
+4. Add a custom state-machine plugin only for genuinely new state or rules.
+5. Treat any change to deterministic application semantics as a versioned
+   consensus upgrade, not an ordinary rolling code change.
+
+### Platform and security engineer
+
+1. Verify finality certificates and MPF proofs independently.
+2. Choose metadata or threshold-script anchoring and define the finality gate.
+3. Separate member keys, business-actor keys, API keys, effect credentials, and
+   anchor funds.
+4. Pin the binary, plugin catalog, committed profile, runtime, and connector
+   security profiles across members.
+5. Exercise restart, catch-up, restore, executor retry, and root-parity gates.
+
+## Prerequisites used by the tutorials
+
+- Java 25 when building from source.
+- Docker Desktop for the complete evidence/connector demo.
+- `bash`, `curl`, `jq`, `python3`, and `openssl`.
+- From source, build the runnable application once:
+
+```bash
+./gradlew :app:quarkusBuild -PskipSigning=true
+```
+
+The cluster launcher can also use a released Yano tree; see
+[`app/appchain-cluster/README.md`](../../app/appchain-cluster/README.md).
+
+## Reference shelf
+
+Tutorials deliberately stay outcome-focused. Use these references when you
+need full detail:
+
+- [10–15 minute overview](../APP_CHAIN_OVERVIEW.md)
+- [Complete user and configuration guide](../APP_CHAIN_USER_GUIDE.md)
+- [Use-case catalogue](../APP_CHAIN_USE_CASES.md)
+- [Consensus and state-machine internals](../APP_CHAIN_CONSENSUS_GUIDE.md)
+- [Profile governance runbook](../APP_CHAIN_PROFILE_GOVERNANCE.md)
+- [Domain actors and role-aware approvals](../APP_CHAIN_DOMAIN_ROLES.md)
+- [Plugin query and domain API contract](../APP_CHAIN_PLUGIN_QUERY_AND_DOMAIN_API.md)
+- [Canonical open-work tracker](../../adr/app-layer/open_item.md)
+
+## A note on “no code”
+
+No-code means the required state machine, composite, connector, and launcher
+already ship with Yano. A real application still sends typed commands and owns
+its UI, identity onboarding, key custody, and business data. Configuration
+cannot invent arbitrary consensus transitions. New combinations use a small
+composite plugin; new domain logic uses a custom state-machine plugin.

--- a/docs/appchain/tutorials/01-first-app-chain.md
+++ b/docs/appchain/tutorials/01-first-app-chain.md
@@ -1,0 +1,141 @@
+# Tutorial 1 — Your First App Chain
+
+- **Level:** beginner
+- **Time:** about 15 minutes
+- **Outcome:** three members finalize the same ordered event and expose the same
+  state root.
+
+This tutorial uses Yano's self-contained Cardano devnet and the built-in
+`ordered-log` state machine. It needs no external Cardano node, wallet, funds,
+Kafka, or plugin.
+
+## 1. Build and start
+
+From the repository root:
+
+```bash
+./gradlew :app:quarkusBuild -PskipSigning=true
+
+cd app/appchain-cluster
+export YANO_CLUSTER_DIR=/tmp/yano-tutorial-first-chain
+./cluster.sh start 3
+```
+
+The launcher starts:
+
+- node 0 as the local Cardano L1 producer and app-chain proposer;
+- nodes 1 and 2 as app-chain voting members; and
+- `orders-chain` (`ordered-log`) plus `registry-chain` (`kv-registry`).
+
+The expected HTTP ports are `7070`, `7071`, and `7072`. If those ports are
+busy, the launcher prints the free range it selected; use that range in the
+commands below.
+
+## 2. Confirm agreement
+
+```bash
+./cluster.sh status
+```
+
+Look for:
+
+```text
+orders-chain: AGREED (...)
+registry-chain: AGREED (...)
+```
+
+`AGREED` means the members expose the same authenticated application root. It
+does not merely mean that all three processes are running.
+
+Open the status pages if you prefer a UI:
+
+- <http://127.0.0.1:7070/ui/app-chain/>
+- <http://127.0.0.1:7071/ui/app-chain/>
+- <http://127.0.0.1:7072/ui/app-chain/>
+
+## 3. Submit a business event
+
+Submit through member 1 rather than directly through the proposer:
+
+```bash
+./cluster.sh submit orders-chain orders \
+  '{"event":"order-created","orderId":"A-1001","quantity":4}' \
+  --node 1
+```
+
+Member 1 authenticates and gossips the envelope. The proposer orders it, a
+threshold signs the block, and all members apply the same bytes.
+
+Wait a couple of seconds, then inspect the finalized history and agreement:
+
+```bash
+curl -s http://127.0.0.1:7070/api/v1/app-chain/chains/orders-chain/blocks | jq .
+./cluster.sh status
+```
+
+The tip advances on every member and the roots remain equal.
+
+## 4. Capture a message ID and its proof
+
+For a complete proof-oriented submission, call the same public API directly:
+
+```bash
+RESPONSE=$(curl -s -X POST \
+  http://127.0.0.1:7072/api/v1/app-chain/chains/orders-chain/messages \
+  -H 'Content-Type: application/json' \
+  -d '{"topic":"orders","body":"{\"event\":\"packed\",\"orderId\":\"A-1001\"}"}')
+
+echo "$RESPONSE" | jq .
+MESSAGE_ID=$(echo "$RESPONSE" | jq -r .messageId)
+sleep 3
+
+curl -s \
+  "http://127.0.0.1:7070/api/v1/app-chain/chains/orders-chain/proof/$MESSAGE_ID" \
+  | jq .
+```
+
+The proof response connects the message state key to the member's committed
+state root. Tutorial 7 connects that root to a Cardano anchor.
+
+## 5. Preserve and restart
+
+`stop` keeps both L1 and app-chain data:
+
+```bash
+./cluster.sh stop
+./cluster.sh start 3
+./cluster.sh status
+```
+
+The retained tips and roots should return unchanged before new traffic is
+finalized. This is a useful distinction:
+
+- **restart:** same chain identity and retained state;
+- **clean:** delete the chain and create a new identity/history.
+
+When finished:
+
+```bash
+./cluster.sh clean
+unset YANO_CLUSTER_DIR
+```
+
+## What you just proved
+
+- A submission can enter through any member.
+- A threshold, not one REST server, finalizes the ordered block.
+- All members deterministically derive the same state root.
+- A retained restart recovers the same application history.
+- A message can have an MPF inclusion proof against that root.
+
+You did **not** yet prove Cardano settlement or the truth of the order fields.
+Those are separate trust layers.
+
+## Go deeper
+
+- Change `--threshold 3` and observe that all three votes are now required.
+- Run `./cluster.sh loadtest orders-chain -n 1000 -c 20` and compare submission
+  throughput with finalization throughput.
+- Read [the consensus guide](../../APP_CHAIN_CONSENSUS_GUIDE.md) for proposer,
+  vote, certificate, replay, and catch-up mechanics.
+- Continue with [registry ownership and state proofs](02-registry-and-proofs.md).

--- a/docs/appchain/tutorials/02-registry-and-proofs.md
+++ b/docs/appchain/tutorials/02-registry-and-proofs.md
@@ -1,0 +1,118 @@
+# Tutorial 2 — A Provable Shared Registry
+
+- **Level:** beginner to intermediate
+- **Time:** about 15 minutes
+- **Outcome:** write owner-controlled data, demonstrate an unauthorized no-op,
+  and retrieve an MPF proof for the current value.
+
+The default cluster also hosts `registry-chain`, backed by the stock
+`kv-registry` state machine. The first writer becomes the key owner; only that
+member can update or delete it.
+
+## 1. Start the default cluster
+
+Skip this section if Tutorial 1's cluster is still running.
+
+```bash
+cd app/appchain-cluster
+export YANO_CLUSTER_DIR=/tmp/yano-tutorial-registry
+./cluster.sh start 3
+```
+
+## 2. Create a registry entry
+
+Write through node 1 so that node 1 becomes the authenticated owner:
+
+```bash
+./cluster.sh kv registry-chain set supplier-42 active --node 1
+sleep 3
+./cluster.sh status
+```
+
+The command body is CBOR, but the launcher builds it for you. Application
+clients can use the standard-library encoder instead of hand-writing CBOR.
+
+## 3. Prove the current value
+
+The physical state key is the UTF-8 business key. Convert it to hex for the
+proof endpoint:
+
+```bash
+KEY_HEX=$(python3 -c 'print("supplier-42".encode().hex())')
+
+curl -s \
+  "http://127.0.0.1:7070/api/v1/app-chain/chains/registry-chain/proof/$KEY_HEX" \
+  | jq .
+```
+
+The proven value contains both owner identity and registry value. A verifier
+must verify the MPF path against the expected state root; displaying JSON from
+one node alone is not independent verification.
+
+## 4. Demonstrate authorization as a deterministic no-op
+
+Capture the root, attempt an update through node 2, and compare:
+
+```bash
+ROOT_BEFORE=$(curl -s http://127.0.0.1:7070/api/v1/app-chain/chains \
+  | jq -r '.[] | select(.chainId == "registry-chain") | .stateRoot')
+
+./cluster.sh kv registry-chain set supplier-42 suspended --node 2
+sleep 3
+
+ROOT_AFTER=$(curl -s http://127.0.0.1:7070/api/v1/app-chain/chains \
+  | jq -r '.[] | select(.chainId == "registry-chain") | .stateRoot')
+
+printf 'before=%s\nafter =%s\n' "$ROOT_BEFORE" "$ROOT_AFTER"
+```
+
+The unauthorized command can appear in a finalized block, but it must not
+change the registry entry. This is intentional: the deterministic application
+result, not “the HTTP call succeeded” or “the block height increased,” is the
+authorization decision.
+
+Check the value again:
+
+```bash
+curl -s \
+  "http://127.0.0.1:7070/api/v1/app-chain/chains/registry-chain/proof/$KEY_HEX" \
+  | jq .
+```
+
+Now update through the owner and verify the proof changes:
+
+```bash
+./cluster.sh kv registry-chain set supplier-42 suspended --node 1
+sleep 3
+curl -s \
+  "http://127.0.0.1:7070/api/v1/app-chain/chains/registry-chain/proof/$KEY_HEX" \
+  | jq .
+```
+
+## 5. Clean up
+
+```bash
+./cluster.sh clean
+unset YANO_CLUSTER_DIR
+```
+
+## Where this pattern fits
+
+- consortium allow-lists;
+- product, asset, credential, or DID-document registries;
+- shared configuration with explicit ownership;
+- a current pointer whose exact value must be proven to a third party.
+
+It does not provide organization roles, multi-party policy governance, or
+arbitrary document indexing. Use the role workflow or a domain plugin when the
+authorization model is richer than “first writer owns this key.”
+
+## Go deeper
+
+- Verify the returned `proofWireHex` using the Java app-chain client rather
+  than trusting the serving node.
+- Start with `--anchor-mode metadata`, fund the printed anchor wallet on a
+  public test network, and connect the proof root to its anchor.
+- Review `kv-registry.value-format` (`raw`, `utf8`, or `cbor`) in the
+  [user guide](../../APP_CHAIN_USER_GUIDE.md).
+- Continue with the [stock state-machine cookbook](03-stock-state-machines.md).

--- a/docs/appchain/tutorials/03-stock-state-machines.md
+++ b/docs/appchain/tutorials/03-stock-state-machines.md
@@ -1,0 +1,123 @@
+# Tutorial 3 — Choose a Stock State Machine
+
+- **Level:** beginner for selection, advanced for wire integration
+- **Outcome:** choose the smallest built-in deterministic model that matches
+  your application before writing a plugin.
+
+Selecting a state machine is a consensus decision. Every member must use the
+same id and deterministic settings. For a new chain it is configuration; for
+an existing chain, changing semantics requires a governed/versioned profile
+activation or a new chain.
+
+## Selection guide
+
+| Machine | Use it when | Authorization model | Proven state |
+|---|---|---|---|
+| `ordered-log` | You need immutable ordered opaque events | Any admitted member | Message by message ID |
+| `kv-registry` | You need mutable named records | First writer owns a key | Current owner/value per key |
+| `approvals` | Validator members are the approvers | Distinct member keys | Status and decision trail |
+| `balances` | You need internal credits/netting | A member spends its own account | Balance per account |
+| `doc-trail` | You need ordered history per product/case | Admitted member appends | Count and chained trail head |
+| `evidence-v1-gated` | Approval coordinates S3/IPFS/Kafka publication | Stock composite workflow | One root across components/effects |
+| `role-evidence` | Business actors differ from validator members | Governed actors, organizations, roles | Registry, policy, decisions, evidence |
+
+## Configure a new standalone chain
+
+The local launcher reads `app/config/application-appchain.yml`. A standalone
+deployment can configure one machine directly:
+
+```yaml
+yano:
+  app-chain:
+    chain-id: workflow-chain
+    state-machine: approvals
+    members: <comma-separated-member-public-keys>
+    threshold: 2
+    signing-key: <this-member-seed-from-a-secret-source>
+```
+
+The cluster launcher's multi-chain form is:
+
+```yaml
+yano:
+  app-chain:
+    chains[2]:
+      chain-id: workflow-chain
+      state-machine: approvals
+      block:
+        interval-ms: 1000
+```
+
+The launcher injects members, threshold, signing key, peers, and fixed
+proposer. Do not duplicate that injected material in the shared demo YAML.
+
+## Typed command contracts
+
+Stock machines interpret bounded CBOR commands. Use their Java encoders or a
+compatible implementation; do not serialize arbitrary Java objects.
+
+### Member approvals
+
+```text
+[0, itemId, payloadBytes, requiredApprovals, deadlineMillis]  propose
+[1, itemId]                                                   approve
+[2, itemId]                                                   reject
+```
+
+The state key is UTF-8 `i/<itemId>`. Approvers are deduplicated by member key,
+one rejection is terminal, and deadlines use the finalized block timestamp.
+Use this only when consortium node members intentionally are the business
+approvers.
+
+### Balances
+
+```text
+[0, destinationAccount, positiveAmount]  mint
+[1, destinationAccount, positiveAmount]  transfer from sender's account
+```
+
+The state key is UTF-8 `b/<account>`. A configured minter can restrict minting;
+a transfer that would overdraw is a deterministic no-op.
+
+### Document trail
+
+```text
+[entityId, entryHashBytes, optionalReference]
+```
+
+The state key is UTF-8 `e/<entityId>`. The machine stores a count and running
+Blake2b-256 head over previous head, entry hash, and author. Documents remain
+off chain; retrieve event bodies from block history and prove the current head.
+
+## Configuration is not arbitrary workflow composition
+
+Configuration can select and parameterize already implemented semantics. It
+cannot safely express arbitrary component order or terminal transitions,
+because those affect every member's state root.
+
+Use:
+
+1. **stock configuration** when one machine/profile already matches;
+2. **a small composite plugin** when existing components need a new committed
+   order or transition; or
+3. **a custom state-machine plugin** for new business state or rules.
+
+## Common mistakes
+
+- Treating a REST API key as an approval identity.
+- Changing machine settings on one member only.
+- Considering an accepted envelope proof that the command changed state.
+- Putting large or secret documents in replicated command bodies.
+- Adding network, wall-clock, DNS, or random behavior inside `apply()`.
+- Reusing a machine id after changing its deterministic behavior.
+
+## Go deeper
+
+- Exact state layouts and Java helper methods are documented in the
+  [consensus guide](../../APP_CHAIN_CONSENSUS_GUIDE.md).
+- The [user guide](../../APP_CHAIN_USER_GUIDE.md) covers configuration and
+  payment-effect activation for `approvals`.
+- For organization-distinct business authorization, continue with
+  [domain-role approvals](05-domain-role-approvals.md).
+- For coordinated document publication, continue with
+  [the evidence scenario](04-evidence-publication.md).

--- a/docs/appchain/tutorials/04-evidence-publication.md
+++ b/docs/appchain/tutorials/04-evidence-publication.md
@@ -1,0 +1,179 @@
+# Tutorial 4 — Publish and Verify Immutable Evidence
+
+- **Level:** beginner to advanced
+- **Time:** about 30 minutes for the first build
+- **Outcome:** publish one immutable document through a threshold-approved
+  workflow, preserve it in S3-compatible storage and IPFS, notify Kafka, and
+  verify the chain, connector, proof, and Cardano-anchor evidence.
+
+This is Yano's most complete no-code vertical scenario. Docker Compose starts
+three Yano members plus Kafka, RustFS (S3-compatible object storage), Kubo
+IPFS, and the Evidence Explorer.
+
+## 1. Start a fresh direct-continuation profile
+
+```bash
+cd app/appchain-effects-demo
+
+./demo.sh up \
+  --instance tutorial-evidence \
+  --continuation direct
+```
+
+`direct` means the deterministic workflow emits the next result-driven
+transition directly. `explicit` is the legacy compatibility mode where a
+separate notify command advances that continuation. The choice is part of the
+fresh chain's committed profile; pass the same option to every later command.
+
+Expected local endpoints:
+
+- Yano members: <http://127.0.0.1:7070/ui/app-chain/>, `:7071`, `:7072`
+- Evidence Explorer: <http://127.0.0.1:7080/>
+
+If startup fails, the launcher rolls back the partial deployment. Use the
+reported container health/log command rather than repeatedly deleting random
+directories; retained L1 and app-chain identities are deliberately checked.
+
+## 2. Publish version 1
+
+```bash
+./demo.sh publish \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --evidence-id product-passport-001 \
+  --sample-file samples/inspection-certificate.json
+```
+
+The runner waits for the dependency-ordered workflow:
+
+```text
+publish command
+    ↓ finalized application state
+prerequisites and approval
+    ↓ authorized evidence release
+object.put + ipfs.pin
+    ↓ acknowledged connector results
+kafka.publish
+    ↓ final state/proof verification
+Cardano devnet anchor
+```
+
+The source document itself is not put into consensus state. The chain commits
+its business identity, version, hashes, workflow decisions, effect intents,
+and acknowledged outcomes.
+
+## 3. Verify without changing anything
+
+```bash
+./demo.sh verify \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --evidence-id product-passport-001 \
+  --business-version 1
+```
+
+`verify` is read-only. It does not submit an app message, stage an object, pin
+content, publish Kafka data, or force another anchor. It re-reads the immutable
+object and IPFS content, checks their hashes, checks the Kafka acknowledgement,
+and validates application finality, state/effect proofs, and anchor linkage.
+
+Open the Evidence Explorer and select the record. The JSON preview is a
+bounded presentation copy produced only after the runner re-downloads and
+verifies the external bytes; it is not the browser's original submission.
+
+## 4. Demonstrate immutability and versioning
+
+Publishing different bytes under the same evidence ID and business version is
+rejected as an external-state mismatch. To add a legitimate revision, create
+the exact next immutable version:
+
+```bash
+./demo.sh republish \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --evidence-id product-passport-001 \
+  --business-version 2 \
+  --sample-file samples/inspection-certificate-product-a-v2.json
+
+./demo.sh verify \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --evidence-id product-passport-001 \
+  --business-version 1
+
+./demo.sh verify \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --evidence-id product-passport-001 \
+  --business-version 2
+```
+
+Both versions remain independently selectable and verifiable.
+
+## 5. Demonstrate idempotent replay
+
+```bash
+./demo.sh replay \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --evidence-id product-passport-001 \
+  --business-version 2 \
+  --sample-file samples/inspection-certificate-product-a-v2.json
+```
+
+The replay envelope may finalize, but the accepted business record, effect
+set, and logical external outcomes do not duplicate.
+
+## 6. Optional bounded parallel workload
+
+Start small and use a fresh prefix:
+
+```bash
+./demo.sh load \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --load-mode pipeline \
+  --count 8 \
+  --concurrency 8 \
+  --max-in-flight 8 \
+  --id-prefix tutorial-load \
+  --sample-file samples/inspection-certificate.json
+
+./demo.sh verify \
+  --instance tutorial-evidence \
+  --continuation direct \
+  --evidence-id tutorial-load-000008 \
+  --business-version 1
+```
+
+This measures a full workflow with approvals, external actions, proofs, and
+anchors—not raw HTTP admission TPS.
+
+## 7. Stop and retain the scenario
+
+```bash
+./demo.sh status --instance tutorial-evidence --continuation direct
+./demo.sh stop --instance tutorial-evidence --continuation direct
+```
+
+Run `up` with the same instance/profile to resume retained data. Use the
+launcher's explicit `clean --scope ... --yes` workflow only when you intend to
+retire that chain identity and have chosen a replacement instance.
+
+## What is and is not proven
+
+The scenario proves that the approved bytes and connector outcomes are bound
+to threshold-finalized application state and an L1 anchor. It does not prove
+that an inspection statement is factually true, that an actor had a legal
+credential, or that every future copy of a referenced document remains
+available. Those require domain onboarding, custody, retention, and possibly
+independent real-world auditing.
+
+## Go deeper
+
+- Read the [plain-language evidence flow](../../EVIDENCE_CHAIN_DEMO.md).
+- Compare lifecycle and pipeline scheduling.
+- Stop one member and exercise catch-up using the isolated E2E gate.
+- Replace RustFS with a tested S3-compatible production service while keeping
+  the `object.put` contract unchanged.
+- Continue with [domain-role authorization](05-domain-role-approvals.md).

--- a/docs/appchain/tutorials/05-domain-role-approvals.md
+++ b/docs/appchain/tutorials/05-domain-role-approvals.md
@@ -1,0 +1,135 @@
+# Tutorial 5 — Domain Actors and Role-Aware Approval
+
+- **Level:** beginner for the stock demo, advanced for identity governance
+- **Time:** about 30 minutes
+- **Outcome:** authorize evidence with business actors and organization-distinct
+  roles rather than treating validator nodes as employees or auditors.
+
+This tutorial uses the stock `role-evidence` profile. The scenario separates:
+
+- **member identity:** which consortium node relayed an envelope; and
+- **actor identity:** which manufacturer, auditor, or regulator signed the
+  exact business statement.
+
+## 1. Start a fresh role profile
+
+```bash
+cd app/appchain-effects-demo
+
+./demo.sh up \
+  --instance tutorial-roles \
+  --machine role \
+  --continuation direct
+```
+
+The profile commits its organization/actor registry, policy, component order,
+routes, effect workflow, administrator threshold, and deterministic limits.
+It is not a local YAML toggle for an existing chain.
+
+## 2. Publish actor-authorized evidence
+
+```bash
+./demo.sh publish \
+  --instance tutorial-roles \
+  --machine role \
+  --continuation direct \
+  --evidence-id regulated-product-001 \
+  --sample-file samples/inspection-certificate.json
+```
+
+The stock policy requires a manufacturer proposal, two independent auditor
+organizations, and a regulator. The runner also submits negative controls:
+
+- an actor with the wrong role;
+- an approval bound to the wrong payload; and
+- two actors from the same organization attempting to satisfy an
+  organization-distinct clause.
+
+Those envelopes can finalize, but they are deterministic no-ops. Only eligible
+signed decisions contribute to the policy result.
+
+## 3. Inspect and verify
+
+```bash
+./demo.sh verify \
+  --instance tutorial-roles \
+  --machine role \
+  --continuation direct \
+  --evidence-id regulated-product-001
+```
+
+Open <http://127.0.0.1:7080/>. The report distinguishes relay member, actor,
+organization, role, policy revision, clause, and signed decision. Current
+actor/policy projections include both the immutable revision proof and the
+same-root current-pointer proof, so “this revision exists” cannot be confused
+with “this is the current governed revision.”
+
+## 4. Exercise rotation and revocation
+
+```bash
+./demo.sh role-lifecycle \
+  --instance tutorial-roles \
+  --machine role \
+  --continuation direct
+```
+
+The idempotent lifecycle uses a dedicated recovery actor and demonstrates:
+
+1. governed onboarding with proof-of-possession;
+2. signing-key rotation;
+3. rejection of the old actor revision/key;
+4. acceptance of the new revision/key;
+5. revocation;
+6. rejection after revocation; and
+7. historical revision and decision proofs.
+
+This is not app-chain membership rotation. Business credentials and validator
+membership are intentionally governed through separate mechanisms.
+
+## 5. Stop and retain
+
+```bash
+./demo.sh stop \
+  --instance tutorial-roles \
+  --machine role \
+  --continuation direct
+```
+
+## Reuse levels
+
+### Configuration only
+
+Use a stock profile when its action and terminal transition already match.
+Governed data can define actors, organizations, roles, policies, counts,
+organization distinctness, deadlines, and connector targets.
+
+### Small composite plugin
+
+Use existing registry/approval/evidence/payment components in a new explicit
+order or connect approval to a different terminal action. Component order and
+cross-component transitions affect consensus, so they remain reviewed Java
+composition rather than dynamic YAML wiring.
+
+### Custom state-machine plugin
+
+Use this only for new state or business rules, such as insurance claim
+calculation or supply-chain ownership transfer.
+
+## Production boundaries
+
+- The demo uses locally held deterministic actor seeds. Production signing
+  belongs in KMS/HSM/Vault or an actor-owned signing service.
+- Yano proves that registered keys authorized exact bytes under a governed
+  policy. Legal identity and real-world truth remain onboarding/audit duties.
+- The v1 actor record retains at most 16 key epochs. Plan successor identity or
+  governed contract evolution before reaching that limit.
+- Administrator authority is profile-committed; changing it uses governed
+  profile evolution, not an ordinary actor mutation.
+
+## Go deeper
+
+- Read the complete [domain-role guide](../../APP_CHAIN_DOMAIN_ROLES.md).
+- Verify signed actor commands independently with the published golden vectors.
+- Inspect the plugin domain API and exact MPF proof keys.
+- Run the isolated three-member restart/catch-up gate documented in the role
+  guide.

--- a/docs/appchain/tutorials/06-webhook-effects.md
+++ b/docs/appchain/tutorials/06-webhook-effects.md
@@ -1,0 +1,216 @@
+# Tutorial 6 — Invoke an External HTTP Endpoint Safely
+
+- **Level:** intermediate to advanced
+- **Outcome:** understand when to use a finalized-block webhook sink versus an
+  acknowledged `webhook.post` effect, and run the latter from a stock approval
+  transition.
+
+Yano provides two HTTP delivery shapes with different guarantees.
+
+| Capability | Use it for | Result committed to app state? |
+|---|---|---:|
+| Finalized-block webhook sink | Projection/indexing of every finalized block | No |
+| `webhook.post` effect | One business action after a deterministic transition | Yes, for `CHAIN` results |
+
+## Option A — observe every finalized block
+
+Configure a cursor-backed sink:
+
+```yaml
+yano.app-chain.webhooks: https://projection.example/yano/finalized-blocks
+```
+
+Delivery is ordered and at-least-once. A persistent sink cursor resumes after
+restart. This is the simplest option when the receiver wants all finalized
+history and does not need a per-action result fed back into the state machine.
+
+## Option B — execute one acknowledged action
+
+The built-in executor supports `webhook.post`:
+
+```yaml
+yano.app-chain.effects.executors.webhook.url: https://erp.example/hooks/yano
+yano.app-chain.effects.executors.webhook.timeout-ms: 10000
+```
+
+It sends:
+
+- `Idempotency-Key`: deterministic effect-id hash;
+- `X-App-Chain-Id`;
+- `X-Effect-Id`, `X-Effect-Type`, and `X-Effect-Scope`.
+
+Response semantics are:
+
+- `2xx` → confirmed;
+- `4xx` → failed without automatic retry; and
+- `5xx` or transport failure → retryable with bounded backoff/parking.
+
+The receiver must deduplicate by `Idempotency-Key`, because execution is
+at-least-once even though outcome incorporation is exactly once.
+
+## Runnable local approval-to-webhook exercise
+
+The stock `approvals` machine can emit a configured effect when a proposal
+reaches its threshold. This avoids writing a custom state machine for the
+tutorial.
+
+### 1. Start a receiver in a separate terminal
+
+```bash
+python3 - <<'PY'
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+seen = set()
+
+class Receiver(BaseHTTPRequestHandler):
+    def do_POST(self):
+        key = self.headers.get("Idempotency-Key", "")
+        body = self.rfile.read(int(self.headers.get("Content-Length", "0")))
+        duplicate = key in seen
+        seen.add(key)
+        print({"idempotencyKey": key, "duplicate": duplicate,
+               "contentType": self.headers.get("Content-Type"),
+               "body": body.decode("utf-8", errors="replace")}, flush=True)
+        self.send_response(200)
+        self.send_header("Location", f"local://receipt/{key}")
+        self.end_headers()
+
+    def log_message(self, *_):
+        pass
+
+ThreadingHTTPServer(("127.0.0.1", 8099), Receiver).serve_forever()
+PY
+```
+
+### 2. Create private per-node overrides
+
+Start from a clean tutorial cluster and create three owner-only property files.
+All members receive the same consensus settings; only node 0 runs the
+executor. Each file must begin with `config_ordinal=275`.
+
+Common settings for `node0.properties`, `node1.properties`, and
+`node2.properties`:
+
+```properties
+config_ordinal=275
+yano.app-chain.chains[0].state-machine=approvals
+yano.app-chain.chains[0].effects.enabled=true
+yano.app-chain.chains[0].machines.approvals.payments=true
+yano.app-chain.chains[0].machines.approvals.activations.payments=1
+yano.app-chain.chains[0].machines.approvals.payment-type=webhook.post
+yano.app-chain.chains[0].machines.approvals.payment-gate=app-final
+```
+
+Append these node-local settings only to `node0.properties`:
+
+```properties
+yano.app-chain.chains[0].effects.executor.enabled=true
+yano.app-chain.chains[0].effects.executor.types=webhook.post
+yano.app-chain.chains[0].effects.executors.webhook.url=http://127.0.0.1:8099/yano
+yano.app-chain.chains[0].effects.executors.webhook.timeout-ms=5000
+```
+
+The repository includes those exact tutorial files. Install owner-only copies
+and start the fresh cluster:
+
+```bash
+cd app/appchain-cluster
+install -d -m 700 /tmp/yano-tutorial-webhook-config
+install -m 600 \
+  ../../docs/appchain/tutorials/config/webhook/node*.properties \
+  /tmp/yano-tutorial-webhook-config/
+
+export YANO_CLUSTER_DIR=/tmp/yano-tutorial-webhook
+export YANO_CLUSTER_NODE_CONFIG_DIR=/tmp/yano-tutorial-webhook-config
+./cluster.sh start 3
+```
+
+The chain id remains `orders-chain`, but its fresh deterministic profile is
+now `approvals`. Never apply this override to retained `ordered-log` state.
+
+### 3. Encode and submit a proposal
+
+From `app/appchain-cluster`, encode the supplied HTTP body fixture and canonical
+stock commands:
+
+```bash
+TOOL=../../docs/appchain/tutorials/tools/stdlib_command.py
+WEBHOOK_HEX=$(python3 "$TOOL" webhook \
+  --body-file ../../docs/appchain/tutorials/config/webhook/request.json \
+  --content-type application/json)
+
+PROPOSE_HEX=$(python3 "$TOOL" approvals propose erp-release-001 \
+  --required 2 --payload-hex "$WEBHOOK_HEX")
+APPROVE_HEX=$(python3 "$TOOL" approvals approve erp-release-001)
+
+curl -s -X POST \
+  http://127.0.0.1:7070/api/v1/app-chain/chains/orders-chain/messages \
+  -H 'Content-Type: application/json' \
+  -d "{\"topic\":\"approvals\",\"bodyHex\":\"$PROPOSE_HEX\"}" | jq .
+
+curl -s -X POST \
+  http://127.0.0.1:7071/api/v1/app-chain/chains/orders-chain/messages \
+  -H 'Content-Type: application/json' \
+  -d "{\"topic\":\"approvals\",\"bodyHex\":\"$APPROVE_HEX\"}" | jq .
+
+curl -s -X POST \
+  http://127.0.0.1:7072/api/v1/app-chain/chains/orders-chain/messages \
+  -H 'Content-Type: application/json' \
+  -d "{\"topic\":\"approvals\",\"bodyHex\":\"$APPROVE_HEX\"}" | jq .
+```
+
+After finality and the executor tick, the receiver prints exactly one logical
+effect identity. A crash at the acknowledgement boundary may produce another
+physical POST with the same idempotency key; that is why the receiver keeps a
+deduplication set.
+
+Inspect effect records and execution status:
+
+```bash
+sleep 6
+curl -s \
+  -H 'X-API-Key: yano-local-cluster-full-key' \
+  'http://127.0.0.1:7070/api/v1/app-chain/chains/orders-chain/effects?fromHeight=1&limit=20' \
+  | jq .
+
+curl -s \
+  http://127.0.0.1:7070/api/v1/app-chain/chains/orders-chain/status \
+  | jq '.effects.executor | {executed, openOnChain, executionTotals, executorOperations}'
+```
+
+The tested success shape has one confirmed execution and zero open on-chain
+effects after the `~fx/result` message is incorporated.
+
+### 4. Clean up
+
+```bash
+./cluster.sh clean
+unset YANO_CLUSTER_DIR YANO_CLUSTER_NODE_CONFIG_DIR
+rm -rf /tmp/yano-tutorial-webhook-config
+```
+
+Stop the receiver with `Ctrl-C`. Remove the private override directory after
+the cluster is stopped.
+
+## Security and product boundary
+
+`webhook.post` is intentionally small: one POST to a configured endpoint. It
+does not yet provide named target aliases, OAuth/API-key/mTLS profiles,
+arbitrary methods, response-body contracts, or asynchronous operation polling.
+Keep `allow-payload-url=false` unless a separately reviewed allow-list and SSRF
+boundary exists.
+
+For a product API such as uVerify, prefer a dedicated executor when durable
+acceptance requires several API calls, polling, reconciliation, or a typed
+receipt. Use the generic webhook only when one idempotent POST and its immediate
+status are the real business contract.
+
+## Go deeper
+
+- Read [Effects §18](../../APP_CHAIN_USER_GUIDE.md) for quarantine, requeue,
+  cancellation, proof, and external executor APIs.
+- Kill the receiver temporarily, observe retries/parking, restore it, and use
+  the operator requeue endpoint.
+- Build a custom executor plugin with named target aliases and secret-backed
+  authentication rather than putting URLs or credentials in replicated
+  payloads.

--- a/docs/appchain/tutorials/07-anchors-and-verification.md
+++ b/docs/appchain/tutorials/07-anchors-and-verification.md
@@ -1,0 +1,140 @@
+# Tutorial 7 — Connect an App Proof to Cardano
+
+- **Level:** intermediate to advanced
+- **Time:** about 20 minutes on local devnet
+- **Outcome:** bootstrap a threshold-enforced script anchor, advance it after app
+  blocks finalize, and understand the independent verification chain.
+
+An app-chain finality certificate proves that the configured member threshold
+approved a block. An L1 anchor makes a later application position durable and
+discoverable through Cardano. These are related but distinct proofs.
+
+## 1. Start an anchored local cluster
+
+```bash
+cd app/appchain-cluster
+export YANO_CLUSTER_DIR=/tmp/yano-tutorial-anchor
+
+./cluster.sh start 3 \
+  --anchor-mode script \
+  --anchor-every 2
+```
+
+Script mode uses a thread NFT and a Plutus V3 validator. The local launcher has
+a deterministic demo anchor seed and can fund it from the self-contained
+devnet faucet.
+
+## 2. Bootstrap one chain's immutable anchor identity
+
+```bash
+./cluster.sh anchor-bootstrap orders-chain
+```
+
+Bootstrap consumes a seed UTxO, mints the one-shot thread NFT, and creates the
+genesis datum. It establishes identity; it does not let the wallet alone claim
+an arbitrary application tip.
+
+Inspect the L1 Anchor card on <http://127.0.0.1:7070/ui/app-chain/>. It should
+show the thread policy, script address, wallet, anchored height, transaction,
+and lag.
+
+## 3. Produce application progress
+
+```bash
+./cluster.sh submit orders-chain audit '{"event":"certificate-issued","id":"C-1"}'
+./cluster.sh submit orders-chain audit '{"event":"certificate-published","id":"C-1"}'
+./cluster.sh submit orders-chain audit '{"event":"certificate-acknowledged","id":"C-1"}'
+```
+
+Wait for app finality and the local L1 transaction:
+
+```bash
+sleep 20
+./cluster.sh status
+
+curl -s \
+  http://127.0.0.1:7070/api/v1/app-chain/chains/orders-chain/status \
+  | jq .anchor
+```
+
+All members independently reconcile the authenticated script UTxO from their
+own L1 view. Node-local “confirmed since restart” counters may differ after a
+restart; the durable anchored height, transaction, and lag should converge.
+
+## 4. The independent verification chain
+
+For one application record, a verifier needs:
+
+```text
+record/value
+   │ MPF or messages-root proof
+   ▼
+state root / certified app block
+   │ threshold finality certificate + block hash chain
+   ▼
+anchored descendant
+   │ exact thread NFT + validator address + inline datum
+   ▼
+Cardano transaction confirmed by an independent L1 source
+```
+
+The checks are:
+
+1. Recompute the record/message commitment.
+2. Verify its MPF or messages-root path against the correct app-block root.
+3. Verify the app block's threshold signatures using an independently trusted
+   chain profile.
+4. When the record predates the anchor, verify the certified block-hash chain
+   to the anchored descendant.
+5. Fetch the Cardano transaction/UTxO independently.
+6. Require the expected validator address and state-thread asset.
+7. Decode the exact inline datum and match chain id, height, block hash, state
+   root, member set, and threshold.
+
+A transaction hash appearing in a Yano JSON response is not, by itself,
+independent anchor verification.
+
+## Metadata versus script anchoring
+
+| Property | Metadata | Script |
+|---|---|---|
+| Setup | Fund wallet | Fund wallet + bootstrap |
+| L1 enforcement | Data commitment only | Monotonic thread + threshold member signatures |
+| Main safety authority | Anchor wallet | On-chain validator and member threshold |
+| Typical use | Low-cost timestamp/discovery | Strong consortium settlement boundary |
+
+Both modes commit application data; only script mode enforces the threshold
+and monotonic successor rules on chain.
+
+## Public test networks
+
+For preview or preprod:
+
+- generate a dedicated raw 32-byte anchor seed;
+- provide it through the owner-only anchor-key file mechanism;
+- fund the printed enterprise address with test ADA;
+- use an explicit public-network confirmation before the demo spends; and
+- increase cadence/stability settings to match real L1 timing and fees.
+
+Do not reuse a wallet mnemonic, validator member seed, actor signing key, or
+API key as the anchor wallet.
+
+## 5. Clean up
+
+```bash
+./cluster.sh clean
+unset YANO_CLUSTER_DIR
+```
+
+Local devnet state is disposable. A public script anchor is permanent Cardano
+history even after local files are deleted.
+
+## Go deeper
+
+- Follow [L1 anchoring §5](../../APP_CHAIN_USER_GUIDE.md) for portable evidence
+  bundles and exact trust-context construction.
+- Use `EvidenceVerifier` and `EffectProofVerifier` rather than trusting server
+  booleans.
+- Test L1 rollback and anchor resubmission before a pilot.
+- Review the bundled Java/julc and Aiken validator twins and their pinned
+  hashes before depending on a released script identity.

--- a/docs/appchain/tutorials/08-plugins-and-composites.md
+++ b/docs/appchain/tutorials/08-plugins-and-composites.md
@@ -1,0 +1,147 @@
+# Tutorial 8 — Extend Yano Without Forking It
+
+- **Level:** Java application developer
+- **Time:** 30–60 minutes for a first plugin
+- **Outcome:** choose the correct extension level and deploy versioned business
+  logic as a plugin JAR on the standard JVM distribution.
+
+Yano's core provides ordering, threshold finality, deterministic state,
+proofs, anchoring, effects, plugin lifecycle, health, and metrics. Application
+teams normally extend the application layer, not the consensus runtime.
+
+## Choose the smallest extension
+
+```text
+Does a stock machine/profile already model the outcome?
+  ├─ yes → configuration only
+  └─ no
+      Are all required components already available?
+        ├─ yes → small composite plugin
+        └─ no  → custom state-machine component/plugin
+```
+
+Other independent plugin SPIs cover effect executors, finalized stream sinks,
+domain APIs, signers, sequencer mode, and L1 observers.
+
+## Path A — configuration only
+
+Select one built-in id or profile identically on every member:
+
+```yaml
+yano.app-chain.state-machine: kv-registry
+```
+
+For stock composite/role profiles, the profile identifier and configuration
+digest become part of chain identity. Select them only for a fresh chain or a
+governed activation.
+
+## Path B — a small composite plugin
+
+A composite explicitly defines:
+
+- component ids and versions;
+- deterministic application order;
+- routed public topics;
+- per-component quotas;
+- workflow transitions between components; and
+- one committed profile identity/digest.
+
+This Java class is intentionally small but consensus-critical. YAML cannot
+dynamically insert arbitrary component plugins into a frozen profile, because
+two members discovering a different order would derive different roots.
+
+Reuse the effect-gated evidence and role-evidence presets as reference
+implementations. Package the provider, manifest, service entry, and components
+in one reviewed bundle.
+
+## Path C — a custom state-machine plugin
+
+The complete hands-on implementation is in the existing
+[default-distribution tutorial, Part 2](../../APP_CHAIN_TUTORIAL.md). The core
+shape is:
+
+```java
+public final class ShipmentStateMachine implements AppStateMachine {
+    @Override
+    public String id() {
+        return "shipment-v1";
+    }
+
+    @Override
+    public AdmissionResult validate(AppMessage message) {
+        // Bounded structural validation only; never perform I/O here.
+        return decodeSafely(message.getBody())
+                ? AdmissionResult.accept()
+                : AdmissionResult.reject("invalid shipment command");
+    }
+
+    @Override
+    public void apply(AppBlock block, AppStateWriter state) {
+        // Deterministic bounded transitions only.
+    }
+}
+```
+
+Contribute it through `AppStateMachineProvider`, add the service entry and
+plugin manifest, then copy the bundle JAR into the configured plugin directory.
+Yano itself does not need recompilation for a JVM deployment.
+
+Native images cannot discover a new directory JAR after build. Include the
+plugin when producing the native image or use the JVM distribution for dynamic
+plugin installation.
+
+## Consensus rules for application plugins
+
+- The same bundle, machine/profile id, and committed settings run on every
+  voting member.
+- `apply()` must not use wall clock, randomness, DNS, filesystem, database, or
+  network I/O.
+- Invalid finalized bytes become deterministic no-ops, not escaping
+  exceptions.
+- Bound message bytes, decode depth/items, collections, state growth, and work
+  per block.
+- Never silently change semantics behind an existing machine/component id.
+- Use activation heights/profile governance for compatible evolution and a
+  new namespace/migration plan for incompatible state.
+- Every state write belongs to the authenticated writer; do not maintain
+  hidden consensus state in static fields or node-local storage.
+
+## Add external actions correctly
+
+Do not call Kafka, S3, IPFS, Cardano, or an ERP from `apply()`. Emit an
+`EffectIntent`; let an executor act after its finality gate; incorporate the
+result through `onEffectResult` when the outcome affects business state.
+
+Create a custom executor plugin when the action needs typed target aliases,
+authentication, polling, reconciliation, or a domain-specific receipt. Keep
+endpoints and secrets in node-local executor configuration, never replicated
+effect payloads.
+
+## Testing ladder
+
+1. Unit-test codecs and deterministic transitions.
+2. Run the state-machine conformance and replay matrix.
+3. Test malformed and hostile finalized input through `apply()`.
+4. Start an embedded multi-member cluster with `appchain-testkit`.
+5. Verify root parity, proof keys, restart, catch-up, rollback/reapply, and
+   plugin packaging.
+6. For effects, test crash-before-send, send-before-ack, retry, reconciliation,
+   parking, requeue, and duplicate idempotency.
+7. Run a packaged JVM cluster; add native coverage when native is supported.
+
+## Deployment and operations
+
+- Give every bundle a stable plugin id and semantic version.
+- Verify catalog state and health on every member before admitting traffic.
+- Treat plugin removal or drift as a deployment error, not automatic fallback.
+- Namespace configuration and metrics by plugin/contribution.
+- Keep plugin domain APIs read-only unless commands still enter through the
+  authenticated app-chain submission path.
+
+## Go deeper
+
+- [Plugin query and domain APIs](../../APP_CHAIN_PLUGIN_QUERY_AND_DOMAIN_API.md)
+- [Plugin operations](../../PLUGIN_OPERATIONS.md)
+- [Composite implementation guide](../../../appchain/appchain-composite/README.md)
+- [Plugin template scaffold](../../../scaffolds/plugin-template/)
+- [Testkit](../../../appchain/appchain-testkit/README.md)

--- a/docs/appchain/tutorials/09-from-demo-to-pilot.md
+++ b/docs/appchain/tutorials/09-from-demo-to-pilot.md
@@ -1,0 +1,124 @@
+# Tutorial 9 — From Local Demo to a Permissioned Pilot
+
+- **Level:** platform, security, and application leads
+- **Outcome:** turn a successful tutorial into an explicit deployment plan
+  without inheriting local-demo assumptions.
+
+This is a decision checklist rather than one launch command. Yano remains
+pre-release; the target posture is a controlled permissioned pilot, not an
+unqualified production or trustless-public-chain claim.
+
+## 1. Freeze the application contract
+
+Record and review:
+
+- chain id and network;
+- member public keys, threshold, proposer/sequencer mode;
+- state-machine or composite profile id and digest;
+- deterministic limits and activation schedule;
+- command/state/effect contract versions;
+- anchor mode, validator identity, cadence, and stability depth; and
+- effect outcome trust policy.
+
+All consensus-affecting values must be identical and profile-committed where
+required. Node-local YAML drift must not decide application semantics.
+
+## 2. Separate every identity and secret
+
+| Material | Purpose | Recommended owner/storage |
+|---|---|---|
+| Member signing key | App-block votes and envelopes | One per member, KMS/HSM/secret manager |
+| Business actor key | Domain authorization | Actor organization or delegated signing service |
+| API key | REST authorization/scopes | API gateway/secret manager |
+| Anchor wallet key | Cardano fees/collateral | Capped hot wallet on anchor leader |
+| Connector credential | Kafka/S3/IPFS/API access | Executor host only |
+| TLS key/trust roots | Transport identity | Platform PKI |
+
+Never copy the deterministic demo keys, launcher API key, sample actor seeds,
+or local connector credentials into a shared environment.
+
+## 3. Choose the trust statement
+
+Document what the system actually proves:
+
+- threshold members finalized exact application state;
+- actor signatures authorized exact statements under a governed policy;
+- an MPF proof connects a record to a state root;
+- an L1 anchor connects a certified descendant to Cardano; and
+- an effect result is a member/executor attestation unless independently
+  verified.
+
+Do not claim that an inspection, oracle value, shipment, API response, or
+payment outcome is independently true unless a separate auditor/source check
+establishes it.
+
+## 4. Replace demo infrastructure deliberately
+
+| Demo component | Pilot decision |
+|---|---|
+| RustFS | AWS S3 or reviewed compatible service; versioning/retention policy |
+| Single Kubo | Managed/redundant IPFS pinning and retrieval policy |
+| Local Kafka | TLS/mTLS/SASL cluster, ACLs, consumer deduplication |
+| Local webhook | Named allow-listed target, authentication, idempotent receiver |
+| Devnet anchor wallet | Dedicated funded preview/preprod key with spend cap |
+| Docker-local secrets | KMS/HSM/Vault or orchestrator secret mounts |
+
+Changing an executor destination does not change deterministic effect intent,
+but it does change operational identity, reconciliation, and credentials.
+
+## 5. Establish operations before traffic
+
+- Health/readiness for every member and plugin.
+- Root/profile parity gate across members.
+- Metrics and alerts for app lag, finality, pool pressure, anchor lag, effect
+  backlog/age/retries/parking, sink lag, and disk pressure.
+- Snapshot, restore, member onboarding, and retained-state identity runbooks.
+- Member-key and actor-key rotation/revocation exercises.
+- Connector outage and executor crash recovery.
+- Anchor-leader failure/recovery.
+- Evidence/proof archival before configured pruning horizons.
+- Explicit maintenance and governed-upgrade process.
+
+## 6. Run acceptance in layers
+
+1. Clean deterministic unit/conformance suites.
+2. Three-member packaged local cluster.
+3. Restart one member and prove catch-up/root parity.
+4. Stop/restart the full deployment from retained state.
+5. Connector fault matrix and duplicate-boundary tests.
+6. Load/soak test with recorded topology, rate, payloads, duration, lag,
+   resources, and failures.
+7. Preview/preprod anchor smoke with independent L1 verification.
+8. Restore rehearsal from the retained backup procedure.
+
+Keep acceptance artifacts with the release rather than relying on screenshots
+or a remembered manual session.
+
+## 7. Know the current escalation gates
+
+- Material Cardano funds require the production action hardening tracked for
+  `cardano.payment` and native assets.
+- Semi-trusted members/executors require governed result-signer policy and
+  independent outcome auditing before receipts are marketed as independently
+  verified.
+- Regulated personal data requires encryption/erasure guidance; immutable
+  object/IPFS/on-chain digests are not a deletion mechanism.
+- Public validator participation and general BFT view change are outside the
+  current permissioned model.
+
+## 8. Choose the deployment shape
+
+- **JVM distribution:** supports plugin-directory installation and is the
+  simplest extensible pilot shape.
+- **Native image:** plugins must be included at build time; validate each
+  advertised runtime/platform and plugin contribution.
+- **Embedded library:** appropriate when an application team owns lifecycle,
+  configuration, APIs, and dependency integration in one Java service.
+
+## Go deeper
+
+- [Full user/operations guide](../../APP_CHAIN_USER_GUIDE.md)
+- [Profile-governance runbook](../../APP_CHAIN_PROFILE_GOVERNANCE.md)
+- [Canonical app-layer open items](../../../adr/app-layer/open_item.md)
+- [Evidence flow and trust limits](../../EVIDENCE_CHAIN_DEMO.md)
+- [Domain-role production signing and recovery](../../APP_CHAIN_DOMAIN_ROLES.md)

--- a/docs/appchain/tutorials/README.md
+++ b/docs/appchain/tutorials/README.md
@@ -1,0 +1,42 @@
+# App-Chain Tutorials
+
+These tutorials are progressive but independently usable. Each one has a
+beginner path and a **Go deeper** section for readers who want the trust,
+consensus, proof, or operational details.
+
+| Tutorial | Typical time | Primary outcome |
+|---|---:|---|
+| [1. Your first app chain](01-first-app-chain.md) | 15 min | Three members finalize the same event history |
+| [2. Registry and proofs](02-registry-and-proofs.md) | 15 min | Owner-controlled data with an MPF proof |
+| [3. Stock state machines](03-stock-state-machines.md) | 20 min | Choose the smallest built-in application model |
+| [4. Evidence publication](04-evidence-publication.md) | 30 min | S3/IPFS/Kafka effects plus proofs and an anchor |
+| [5. Domain-role approvals](05-domain-role-approvals.md) | 30 min | Business actors and organization-distinct authorization |
+| [6. Webhook effects](06-webhook-effects.md) | 20 min | Finalized decision invokes an external HTTP endpoint |
+| [7. Anchors and verification](07-anchors-and-verification.md) | 20 min | Connect an application proof to Cardano settlement |
+| [8. Plugins and composites](08-plugins-and-composites.md) | 30–60 min | Extend Yano without rebuilding or forking core |
+| [9. From demo to pilot](09-from-demo-to-pilot.md) | planning | Convert local assumptions into an operable deployment |
+
+## Tutorial conventions
+
+- Commands are shown from the repository root unless a preceding `cd` changes
+  directory.
+- Local devnet data is disposable. `stop` preserves it; `clean` deletes it.
+- Ports `7070`–`7072` are the expected member HTTP ports and `7080` is the
+  Evidence Explorer. Launchers report a different range if defaults are busy.
+- Demo credentials are intentionally known or generated locally. Never reuse
+  them outside an isolated development environment.
+- A successful HTTP submission means “accepted for sequencing,” not “already
+  finalized.” Wait for the block/tip or use the scenario verifier.
+- An invalid but finalized command can be a deterministic no-op. Always verify
+  state, not merely the HTTP response or block height.
+
+## Confidence levels used here
+
+- **Shipped:** present in the current branch and covered by module tests.
+- **Demo-proven:** exercised by the packaged multi-member demo and its
+  connector/proof verification.
+- **Preview:** useful for devnet/testnet or a tightly controlled pilot, with a
+  named production-hardening boundary.
+- **Experimental:** not a production claim; follow its dedicated guide.
+
+Return to the [start-here hub](../README.md).

--- a/docs/appchain/tutorials/config/webhook/node0.properties
+++ b/docs/appchain/tutorials/config/webhook/node0.properties
@@ -1,0 +1,11 @@
+config_ordinal=275
+yano.app-chain.chains[0].state-machine=approvals
+yano.app-chain.chains[0].effects.enabled=true
+yano.app-chain.chains[0].machines.approvals.payments=true
+yano.app-chain.chains[0].machines.approvals.activations.payments=1
+yano.app-chain.chains[0].machines.approvals.payment-type=webhook.post
+yano.app-chain.chains[0].machines.approvals.payment-gate=app-final
+yano.app-chain.chains[0].effects.executor.enabled=true
+yano.app-chain.chains[0].effects.executor.types=webhook.post
+yano.app-chain.chains[0].effects.executors.webhook.url=http://127.0.0.1:8099/yano
+yano.app-chain.chains[0].effects.executors.webhook.timeout-ms=5000

--- a/docs/appchain/tutorials/config/webhook/node1.properties
+++ b/docs/appchain/tutorials/config/webhook/node1.properties
@@ -1,0 +1,7 @@
+config_ordinal=275
+yano.app-chain.chains[0].state-machine=approvals
+yano.app-chain.chains[0].effects.enabled=true
+yano.app-chain.chains[0].machines.approvals.payments=true
+yano.app-chain.chains[0].machines.approvals.activations.payments=1
+yano.app-chain.chains[0].machines.approvals.payment-type=webhook.post
+yano.app-chain.chains[0].machines.approvals.payment-gate=app-final

--- a/docs/appchain/tutorials/config/webhook/node2.properties
+++ b/docs/appchain/tutorials/config/webhook/node2.properties
@@ -1,0 +1,7 @@
+config_ordinal=275
+yano.app-chain.chains[0].state-machine=approvals
+yano.app-chain.chains[0].effects.enabled=true
+yano.app-chain.chains[0].machines.approvals.payments=true
+yano.app-chain.chains[0].machines.approvals.activations.payments=1
+yano.app-chain.chains[0].machines.approvals.payment-type=webhook.post
+yano.app-chain.chains[0].machines.approvals.payment-gate=app-final

--- a/docs/appchain/tutorials/config/webhook/request.json
+++ b/docs/appchain/tutorials/config/webhook/request.json
@@ -1,0 +1,1 @@
+{"action":"release-order","orderId":"A-1001"}

--- a/docs/appchain/tutorials/tools/stdlib_command.py
+++ b/docs/appchain/tutorials/tools/stdlib_command.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Dependency-free canonical CBOR command encoder for Yano tutorials.
+
+This is a teaching/CLI convenience, not a replacement for the versioned Java
+contract codecs. It intentionally supports only the stock tutorial commands.
+"""
+
+from __future__ import annotations
+
+import argparse
+import pathlib
+import sys
+
+
+def head(major: int, value: int) -> bytes:
+    if value < 0:
+        raise ValueError("CBOR values must be non-negative")
+    if value < 24:
+        return bytes([(major << 5) | value])
+    if value <= 0xFF:
+        return bytes([(major << 5) | 24, value])
+    if value <= 0xFFFF:
+        return bytes([(major << 5) | 25]) + value.to_bytes(2, "big")
+    if value <= 0xFFFFFFFF:
+        return bytes([(major << 5) | 26]) + value.to_bytes(4, "big")
+    if value <= 0xFFFFFFFFFFFFFFFF:
+        return bytes([(major << 5) | 27]) + value.to_bytes(8, "big")
+    raise ValueError("tutorial encoder supports unsigned values up to uint64")
+
+
+def uint(value: int) -> bytes:
+    return head(0, value)
+
+
+def bstr(value: bytes) -> bytes:
+    return head(2, len(value)) + value
+
+
+def tstr(value: str) -> bytes:
+    encoded = value.encode("utf-8")
+    return head(3, len(encoded)) + encoded
+
+
+def array(*values: bytes) -> bytes:
+    return head(4, len(values)) + b"".join(values)
+
+
+def map_canonical(values: dict[str, bytes]) -> bytes:
+    encoded = [(tstr(key), value) for key, value in values.items()]
+    encoded.sort(key=lambda item: (len(item[0]), item[0]))
+    return head(5, len(encoded)) + b"".join(key + value for key, value in encoded)
+
+
+def bounded_text(value: str, label: str) -> str:
+    if not value or len(value.encode("utf-8")) > 1024:
+        raise ValueError(f"{label} must be 1..1024 UTF-8 bytes")
+    return value
+
+
+def payload(args: argparse.Namespace) -> bytes:
+    choices = [args.payload_text is not None, args.payload_file is not None,
+               args.payload_hex is not None]
+    if sum(choices) > 1:
+        raise ValueError("choose only one payload source")
+    if args.payload_file is not None:
+        value = pathlib.Path(args.payload_file).read_bytes()
+    elif args.payload_hex is not None:
+        value = bytes.fromhex(args.payload_hex)
+    elif args.payload_text is not None:
+        value = args.payload_text.encode("utf-8")
+    else:
+        value = b""
+    if len(value) > 16 * 1024 * 1024:
+        raise ValueError("tutorial payload exceeds 16 MiB")
+    return value
+
+
+def encode(args: argparse.Namespace) -> bytes:
+    if args.machine == "approvals":
+        item = tstr(bounded_text(args.item_id, "item id"))
+        if args.operation == "propose":
+            if args.required <= 0:
+                raise ValueError("required approvals must be positive")
+            return array(uint(0), item, bstr(payload(args)),
+                         uint(args.required), uint(args.deadline_millis))
+        return array(uint(1 if args.operation == "approve" else 2), item)
+
+    if args.machine == "balances":
+        if args.amount <= 0:
+            raise ValueError("amount must be positive")
+        operation = 0 if args.operation == "mint" else 1
+        return array(uint(operation),
+                     tstr(bounded_text(args.account, "account")),
+                     uint(args.amount))
+
+    if args.machine == "doc-trail":
+        entry_hash = bytes.fromhex(args.entry_hash)
+        if not entry_hash:
+            raise ValueError("entry hash must not be empty")
+        return array(tstr(bounded_text(args.entity_id, "entity id")),
+                     bstr(entry_hash), tstr(args.reference))
+
+    if args.machine == "webhook":
+        body = pathlib.Path(args.body_file).read_bytes()
+        values = {
+            "body": bstr(body),
+            "content-type": tstr(args.content_type),
+        }
+        if args.url:
+            values["url"] = tstr(args.url)
+        return map_canonical(values)
+
+    raise ValueError(f"unsupported tutorial machine: {args.machine}")
+
+
+def parser() -> argparse.ArgumentParser:
+    root = argparse.ArgumentParser(
+        description="Encode canonical CBOR commands used by Yano tutorials")
+    machines = root.add_subparsers(dest="machine", required=True)
+
+    approvals = machines.add_parser("approvals")
+    approval_ops = approvals.add_subparsers(dest="operation", required=True)
+    propose = approval_ops.add_parser("propose")
+    propose.add_argument("item_id")
+    propose.add_argument("--required", type=int, default=2)
+    propose.add_argument("--deadline-millis", type=int, default=0)
+    propose_payload = propose.add_mutually_exclusive_group()
+    propose_payload.add_argument("--payload-text")
+    propose_payload.add_argument("--payload-file")
+    propose_payload.add_argument("--payload-hex")
+    for operation in ("approve", "reject"):
+        command = approval_ops.add_parser(operation)
+        command.add_argument("item_id")
+
+    balances = machines.add_parser("balances")
+    balance_ops = balances.add_subparsers(dest="operation", required=True)
+    for operation in ("mint", "transfer"):
+        command = balance_ops.add_parser(operation)
+        command.add_argument("account")
+        command.add_argument("amount", type=int)
+
+    trail = machines.add_parser("doc-trail")
+    trail.add_argument("entity_id")
+    trail.add_argument("entry_hash", help="hex-encoded application hash")
+    trail.add_argument("--reference", default="")
+
+    webhook = machines.add_parser("webhook")
+    webhook.add_argument("--body-file", required=True)
+    webhook.add_argument("--content-type", default="application/json")
+    webhook.add_argument("--url", default="")
+    return root
+
+
+def main() -> int:
+    try:
+        print(encode(parser().parse_args()).hex())
+        return 0
+    except (OSError, UnicodeError, ValueError) as failure:
+        print(f"error: {failure}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- add a start-here app-chain documentation hub and a guided nine-part tutorial path
- cover first-chain setup, authenticated state/proofs, stock machines, evidence publishing, domain roles, webhook effects, anchors, plugins, and pilot readiness
- include runnable tutorial fixtures and a dependency-free CBOR command helper
- connect existing overview, guide, use-case, ADR tracker, and README navigation to the new hub

## Validation

- checked all local Markdown links across the new and updated documentation
- compared tutorial helper CBOR output with the Java contract encoders
- exercised the webhook tutorial on a three-node cluster, including two-member approval, delivery, confirmation, and effect incorporation
- verified the staged diff with git diff --cached --check before commit

## PR relationship

Stacked on #42. This PR intentionally targets feat/appchain-domain-roles so its diff contains only the documentation/tutorial work.