### PR TITLE
fix(app): support standalone appchain in native distributions

### DIFF
--- a/app/bin/README.md
+++ b/app/bin/README.md
@@ -53,6 +53,25 @@ Run a standalone local blockchain with automatic block production.
 - Time advance: `POST http://localhost:8080/api/v1/devnet/time/advance`
 - Rollback: `POST http://localhost:8080/api/v1/devnet/rollback`
 
+### Standalone App-Chain Demo
+
+Add the `appchain` profile to start the bundled `orders-chain` and
+`registry-chain` demos as single-member chains:
+
+```bash
+# Local devnet block producer + standalone app chains
+./yano.sh start:devnet,appchain
+
+# Public-network sync + standalone app chains
+./yano.sh start:preprod,appchain
+```
+
+Both chains use threshold `1` and a deterministic demo identity from
+`config/application-appchain.yml`. That identity is for testing only and must
+not be used in production. For a multi-node demo, use
+`./appchain-cluster/cluster.sh start 3`; the cluster launcher overrides the
+standalone identity with per-node keys, membership, peers, and threshold.
+
 ## Key Features
 
 - **REST API** (port 8080) — blocks, transactions, UTXOs, epochs, protocol params

--- a/app/config/application-appchain.yml
+++ b/app/config/application-appchain.yml
@@ -2,16 +2,21 @@
 # App-chain cluster demo config  (external — lives in app/config, NOT bundled
 # in the jar). Activated with the `appchain` Quarkus profile, e.g.
 #   -Dquarkus.profile=devnet,appchain
-# The cluster launcher (app/appchain-cluster/cluster.sh) adds this profile for
-# you and injects the per-node/topology values.
+# Direct use via `./yano.sh start:devnet,appchain` starts a standalone,
+# single-member demo using the deterministic identity below. The cluster
+# launcher overrides that identity and injects the per-node/topology values.
 #
 # WHAT THIS FILE DEFINES (shared, identical on every node): the per-chain
 # "flavor" — chain-id, state machine, block cadence, and sequencer intent.
 #
-# WHAT THE LAUNCHER INJECTS (differs per node / per cluster size): members,
+# STANDALONE DEFAULT IDENTITY (TESTING ONLY — NEVER USE IN PRODUCTION):
+# seed  = 0101010101010101010101010101010101010101010101010101010101010101
+# pub   = 8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c
+#
+# WHAT THE LAUNCHER OVERRIDES (differs per node / per cluster size): members,
 # threshold, this node's signing-key, peers, and — for fixed-proposer chains —
-# the proposer. So the SAME file runs unchanged on a 3-node or a 9-node
-# cluster; you never hand-edit member lists here.
+# the proposer. So the SAME file runs standalone or as a 3-node/9-node cluster;
+# you never hand-edit member lists here.
 #
 # ADD / REMOVE CHAINS FREELY: any chains[i] with a chain-id is hosted. The
 # launcher auto-discovers however many you define (indices must start at 0 and
@@ -23,21 +28,28 @@ yano:
     # --- Chain 0: an append-only ordered log, fixed proposer (node 0) --------
     chains[0]:
       chain-id: "orders-chain"
+      signing-key: "0101010101010101010101010101010101010101010101010101010101010101"
+      members: "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+      threshold: 1
       state-machine: ordered-log        # built-in: append-only log (default)
       block:
         interval-ms: 1000               # propose a block every ~1s
         # block.max-bytes (default 4 MiB) is the primary size cap; the proposer
         # trims each block to fit it. max-messages (default 5000) is a safety
         # backstop against tiny-message floods. Tune either for throughput.
-      # No sequencer.mode → fixed proposer; the launcher injects
-      # sequencer.proposer = node 0's member key. To rotate instead, add:
-      #   sequencer:
-      #     mode: rotating
-      #     window-slots: 10
+      # No sequencer.mode → fixed proposer. The cluster launcher overrides this
+      # with node 0's member key. To rotate instead, replace proposer with:
+      sequencer:
+        proposer: "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+        # mode: rotating
+        # window-slots: 10
 
     # --- Chain 1: a key/value registry, rotating sequencer -------------------
     chains[1]:
       chain-id: "registry-chain"
+      signing-key: "0101010101010101010101010101010101010101010101010101010101010101"
+      members: "8a88e3dd7409f195fd52db2d3cba5d72ca6709bf1d94121bf3748801b40f6f5c"
+      threshold: 1
       state-machine: kv-registry        # built-in: owner-guarded K/V registry
       block:
         interval-ms: 2000

--- a/app/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-app/reflect-config.json
+++ b/app/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-app/reflect-config.json
@@ -205,6 +205,54 @@
     "allDeclaredConstructors": true
   },
   {
+    "name": "com.bloxbean.cardano.yano.api.model.NodePeers",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.api.model.NodePeers$NodePeer",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.app.api.appchain.AppChainResource$ChainScopedResource",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.app.api.appchain.AppChainResource$ChainScopedResource$SubmitRequest",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.app.api.appchain.AppChainResource$ChainScopedResource$SnapshotRequest",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.app.api.appchain.AppChainResource$ChainScopedResource$MemberRequest",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.app.api.appchain.AppChainResource$ChainScopedResource$ThresholdRequest",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.api.appchain.MessageRef",
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
     "name": "com.bloxbean.cardano.yaci.core.storage.ChainTip",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
@@ -782,6 +830,22 @@
     "name": "com.bloxbean.cardano.yano.ledgerstate.AccountHistoryEventHandler",
     "allDeclaredFields": true,
     "allDeclaredMethods": true,
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.appchain.stdlib.StdlibStateMachineProviders$KvRegistryProvider",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.appchain.stdlib.StdlibStateMachineProviders$ApprovalsProvider",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.appchain.stdlib.StdlibStateMachineProviders$BalancesProvider",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.appchain.stdlib.StdlibStateMachineProviders$DocTrailProvider",
     "allDeclaredConstructors": true
   },
   {


### PR DESCRIPTION
## Summary

- register REST/Jackson app-chain models and node peer models for GraalVM native images
- retain all bundled standard-library state-machine providers used through `ServiceLoader`
- add a testing-only single-member app-chain identity with threshold 1 for direct `yano.sh` startup
- document standalone devnet and public-network app-chain commands while preserving `cluster.sh` overrides

## Validation

- built `:app:yanoNativeDistZip` successfully with GraalVM
- extracted the native ZIP and ran `./yano.sh start:devnet,appchain`
- verified node status, node peers, chain list, and both chain status endpoints return HTTP 200
- submitted an orders-chain message (HTTP 202) and observed the tip advance to height 1
- initialized the native `preprod,appchain` profile and exercised the final standard-library provider
- verified `cluster.sh`-style system properties override the standalone identity
- verified direct JVM devnet and preprod app-chain startup

## Notes

The bundled signing seed is deterministic and explicitly intended only for local/demo testing. Multi-node launches continue to inject per-node identities, membership, peers, proposer, and threshold through `cluster.sh`.