### PR TITLE
feat(showcase): deliver ADR-033 capability catalog

### DIFF
--- a/.agents/skills/deploy-showcase-devnet-cluster/SKILL.md
+++ b/.agents/skills/deploy-showcase-devnet-cluster/SKILL.md
@@ -36,6 +36,8 @@ changing cluster identity or data.
 - N2N: `13337-13339`
 - Nodes/threshold: `3/2`
 - Anchors: SCRIPT mode, every configured chain
+- Catalog: packaged `catalog/showcase-catalog-v1.json`; retained order and
+  declared capabilities are validated against it
 - Per-node stores: `chainstate`, `appchain-chainstate`, `appchain-indexers`
 
 Override the repository, target, or instance only when the user explicitly
@@ -53,6 +55,8 @@ places a different deployment in scope. Run `deploy.sh --help` for options.
   verified Cardano anchor.
 - Follower status may omit `.anchor`; node 0 owns the anchor writer. Require
   identical tip/root/profile/genesis values on all three nodes.
+- Require identical capability-manifest digests on all three nodes and verify
+  every catalog-declared capability from status.
 - Reject a derived-index checkpoint above its authoritative app-chain tip and
   reject any legacy derived index below the L1 chainstate root.
 

--- a/.agents/skills/deploy-showcase-devnet-cluster/scripts/deploy.sh
+++ b/.agents/skills/deploy-showcase-devnet-cluster/scripts/deploy.sh
@@ -85,6 +85,7 @@ if [ "$SMOKE" = true ]; then
   ./showcase.sh run orders --instance "$INSTANCE"
   ./showcase.sh run registry --instance "$INSTANCE"
   ./showcase.sh run authenticated-map --instance "$INSTANCE"
+  ./showcase.sh run document-review --instance "$INSTANCE"
 fi
 
 "$SCRIPT_DIR/validate_cluster.sh" "$TARGET" "$INSTANCE" 7070

--- a/.agents/skills/deploy-showcase-devnet-cluster/scripts/validate_cluster.sh
+++ b/.agents/skills/deploy-showcase-devnet-cluster/scripts/validate_cluster.sh
@@ -5,7 +5,11 @@ TARGET="${1:?target is required}"
 INSTANCE="${2:?instance is required}"
 HTTP_BASE="${3:?HTTP base is required}"
 MARKER="$TARGET/data/showcase/$INSTANCE/showcase-identity.json"
+CATALOG="$TARGET/catalog/showcase-catalog-v1.json"
 [ -f "$MARKER" ] || { echo "Missing retained identity: $MARKER" >&2; exit 66; }
+[ -f "$CATALOG" ] || { echo "Missing showcase catalog: $CATALOG" >&2; exit 66; }
+diff -u <(python3 "$TARGET/tools/showcase_catalog.py" "$CATALOG" list) \
+  <(jq -r '.chainIds[]' "$MARKER")
 
 CLUSTER_ROOT="$TARGET/data/showcase/$INSTANCE/cluster"
 for NODE in 0 1 2; do
@@ -33,7 +37,14 @@ while IFS= read -r CHAIN; do
   printf '%s' "$LEADER" | jq -e \
     '.anchor.enabled == true and .anchor.mode == "script" and
      .anchor.bootstrapped == true and
+     (.capabilityManifest.manifestDigest | test("^[0-9a-f]{64}$")) and
      (.anchor.lastAnchorTx | test("^[0-9a-f]{64}$"))' >/dev/null
+  while IFS= read -r CAPABILITY; do
+    printf '%s' "$LEADER" | jq -e --arg capability "$CAPABILITY" \
+      '.capabilityManifest.crossCutting
+       | any(.capabilityId == $capability and .enabled == true)' >/dev/null
+  done < <(jq -r --arg chain "$CHAIN" \
+    '.chains[] | select(.chainId == $chain) | .expectedCapabilities[]' "$CATALOG")
 
   REFERENCE=""
   for PORT in "$HTTP_BASE" "$((HTTP_BASE + 1))" "$((HTTP_BASE + 2))"; do
@@ -45,7 +56,7 @@ while IFS= read -r CHAIN; do
        (.stateCommitment.genesisId | test("^[0-9a-f]{64}$"))' >/dev/null
     CURRENT="$(printf '%s' "$STATUS" | jq -r \
       '[.tipHeight,.stateRoot,.stateCommitment.profile,
-        .stateCommitment.genesisId] | @tsv')"
+        .stateCommitment.genesisId,.capabilityManifest.manifestDigest] | @tsv')"
     [ -n "$REFERENCE" ] || REFERENCE="$CURRENT"
     [ "$REFERENCE" = "$CURRENT" ] || {
       echo "State disagreement for $CHAIN on HTTP $PORT" >&2

--- a/.agents/skills/deploy-showcase-devnet-cluster/scripts/write_runbook.sh
+++ b/.agents/skills/deploy-showcase-devnet-cluster/scripts/write_runbook.sh
@@ -35,8 +35,13 @@ cd {target}
 ./showcase.sh run orders --instance {instance}
 ./showcase.sh run registry --instance {instance}
 ./showcase.sh run authenticated-map --instance {instance}
+./showcase.sh run document-review --instance {instance}
 ./showcase.sh run all --instance {instance}
 ```
+
+Use `./showcase.sh describe light` for the authoritative twelve-chain catalog.
+The console capability matrix at `http://127.0.0.1:7070/ui/app-chain/` is
+manifest-driven and separates membership governance from business approval.
 
 All configured chains use SCRIPT anchors. Check or bootstrap them with:
 

--- a/.agents/skills/deploy-showcase-preprod-cluster/SKILL.md
+++ b/.agents/skills/deploy-showcase-preprod-cluster/SKILL.md
@@ -42,12 +42,19 @@ validation separate from fresh deployment or smoke traffic.
 - N2N: `17337-17339`
 - Nodes/threshold: `3/2`
 
-The script makes three independent APFS clone-on-write L1 stores while
-excluding any legacy `chainstate/appchains` content, creates cluster identity
-markers before adopting them, copies keys with owner-only permissions, deploys
-the operator-specific production settlement profile, and adopts its generated
-config block. Each node must expose sibling `chainstate`,
+The script uses a disposable bootstrap instance to deploy the operator-specific
+production settlement identity, adopts its generated config block at the
+catalog position, then creates the final twelve-chain app-chain generation
+from scratch. It makes three independent APFS clone-on-write L1 stores while
+excluding any legacy `chainstate/appchains` content and copies keys with
+owner-only permissions. No app-chain state or identity is migrated from the
+bootstrap instance. Each final node must expose sibling `chainstate`,
 `appchain-chainstate`, and `appchain-indexers` roots.
+
+The non-secret settlement deployment record is retained beside the source
+keys, including after a partial bootstrap. A later clean deployment reuses
+that record so the one-shot L1 mint resumes the same identity instead of
+selecting new seed UTxOs.
 
 ## Safety and proof rules
 
@@ -58,6 +65,8 @@ config block. Each node must expose sibling `chainstate`,
 - Never regenerate retained state, anchor, or settlement identity.
 - Require the three nodes to agree on tip/root/profile/genesis for each chain.
   Only node 0 needs an anchor writer view.
+- Require the retained chain order and capability manifests to match the
+  packaged ADR-033 catalog.
 - Reject a derived-index checkpoint above its authoritative app-chain tip and
   reject any legacy derived index below the L1 chainstate root.
 - A caller-pinned proof verifies mechanics, not L1 trust. Call a proof anchored

--- a/.agents/skills/deploy-showcase-preprod-cluster/scripts/adopt_settlement_config.py
+++ b/.agents/skills/deploy-showcase-preprod-cluster/scripts/adopt_settlement_config.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import os
+import json
 import pathlib
 import re
 import sys
@@ -14,12 +15,19 @@ def fail(message: str) -> None:
     raise SystemExit(message)
 
 
-if len(sys.argv) != 3:
-    fail("usage: adopt_settlement_config.py <application-appchain.yml> <bootstrap.log>")
+if len(sys.argv) != 4:
+    fail("usage: adopt_settlement_config.py <application-appchain.yml> <bootstrap.log> <catalog.json>")
 
 config_path = pathlib.Path(sys.argv[1])
 log_path = pathlib.Path(sys.argv[2])
+catalog_path = pathlib.Path(sys.argv[3])
 config = config_path.read_text(encoding="utf-8")
+catalog = json.loads(catalog_path.read_text(encoding="utf-8"))
+catalog_ids = [chain["chainId"] for chain in catalog.get("chains", [])]
+try:
+    settlement_index = catalog_ids.index("payment-chain-settlement")
+except ValueError:
+    fail("catalog contains no payment-chain-settlement")
 if re.search(r'^\s*chain-id:\s*["\']?payment-chain-settlement["\']?\s*$',
              config, re.MULTILINE):
     print("payment-chain-settlement already exists; no change")
@@ -47,11 +55,39 @@ if len(block) < 20 or not any("expected-profile-digest:" in line for line in blo
 if not any('profile: "yano-eutxo-v3-bridge-settlement"' in line for line in block):
     fail("generated settlement ConfigBlock is not the production profile")
 
-indexes = [int(value) for value in re.findall(r"^\s*chains\[(\d+)]\s*:",
-                                               config, re.MULTILINE)]
-next_index = max(indexes, default=-1) + 1
-block[0] = f"    chains[{next_index}]:"
-updated = config.rstrip() + "\n" + "\n".join(block) + "\n"
+# Insert at the catalog position and shift later blocks. Public prepare has
+# removed the devnet settlement block, so document-review currently occupies
+# the settlement slot. This preserves catalog order without migrating any
+# app-chain state.
+def shift(match: re.Match[str]) -> str:
+    index = int(match.group(1))
+    return f"    chains[{index + 1 if index >= settlement_index else index}]:"
+
+config = re.sub(r"^    chains\[(\d+)]\s*:", shift, config, flags=re.MULTILINE)
+block[0] = f"    chains[{settlement_index}]:"
+block_text = "\n".join(block)
+next_header = f"    chains[{settlement_index + 1}]:"
+if re.search(rf"^{re.escape(next_header)}\s*$", config, re.MULTILINE):
+    # Keep textual YAML order aligned with numeric/catalog order. Appending the
+    # adopted block after the shifted successor gives valid indexed keys but a
+    # misleading chain declaration order and fails retained-identity checks.
+    updated = re.sub(
+        rf"^{re.escape(next_header)}\s*$",
+        block_text + "\n" + next_header,
+        config,
+        count=1,
+        flags=re.MULTILINE,
+    ).rstrip() + "\n"
+else:
+    updated = config.rstrip() + "\n" + block_text + "\n"
+# Only the chain declaration directly under ``chains[n]`` is a catalog entry.
+# Production settlement profiles also contain nested observer/indexer
+# ``chain-id`` fields; treating those as peers in the catalog rejects a valid
+# ConfigBlock after the L1 bootstrap has already spent funds.
+configured_ids = re.findall(
+    r'^ {6}chain-id:\s*["\']?([^"\'\s]+)["\']?\s*$', updated, re.MULTILINE)
+if configured_ids != catalog_ids:
+    fail("adopted settlement config does not match catalog order")
 
 mode = config_path.stat().st_mode & 0o777
 with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=config_path.parent,
@@ -60,4 +96,4 @@ with tempfile.NamedTemporaryFile("w", encoding="utf-8", dir=config_path.parent,
     temporary = pathlib.Path(handle.name)
 os.chmod(temporary, mode)
 os.replace(temporary, config_path)
-print(f"adopted payment-chain-settlement as chains[{next_index}]")
+print(f"adopted payment-chain-settlement as chains[{settlement_index}]")

--- a/.agents/skills/deploy-showcase-preprod-cluster/scripts/deploy.sh
+++ b/.agents/skills/deploy-showcase-preprod-cluster/scripts/deploy.sh
@@ -78,6 +78,7 @@ if [ -e "$TARGET" ]; then
     ./showcase.sh run orders --instance "$INSTANCE"
     ./showcase.sh run registry --instance "$INSTANCE"
     ./showcase.sh run authenticated-map --instance "$INSTANCE"
+    ./showcase.sh run document-review --instance "$INSTANCE"
   fi
   "$SCRIPT_DIR/validate_cluster.sh" "$TARGET" "$INSTANCE" 17070
   "$SCRIPT_DIR/write_runbook.sh" "$TARGET" "$INSTANCE"
@@ -105,13 +106,23 @@ mkdir -m 700 private-anchor private-settlement
 cp "$SOURCE_KEYS/anchor.seed" private-anchor/anchor.seed
 cp "$SOURCE_KEYS/operator.seed" private-settlement/operator.seed
 chmod 600 private-anchor/anchor.seed private-settlement/operator.seed
+SETTLEMENT_RECORD="settlement-deployment-payment-chain-settlement.properties"
+if [ -f "$SOURCE_KEYS/$SETTLEMENT_RECORD" ]; then
+  cp "$SOURCE_KEYS/$SETTLEMENT_RECORD" "private-settlement/$SETTLEMENT_RECORD"
+  chmod 600 "private-settlement/$SETTLEMENT_RECORD"
+fi
 
+# Deploy the operator-specific L1 settlement identity from a disposable
+# eleven-chain bootstrap instance. The final app-chain instance is created
+# only after the production settlement block is in the catalog position; no
+# app-chain marker, root, or ledger is migrated into the final deployment.
+BOOTSTRAP_INSTANCE="${INSTANCE}-settlement-bootstrap"
 ./showcase.sh prepare --profile light --network preprod --nodes 3 \
-  --instance "$INSTANCE" --http-base 17070 --server-base 17337 \
+  --instance "$BOOTSTRAP_INSTANCE" --http-base 17070 --server-base 17337 \
   --anchor-chain all --anchor-key-file "$PWD/private-anchor/anchor.seed" \
   --confirm-public-anchor preprod
 
-CLUSTER_ROOT="$TARGET/data/showcase/$INSTANCE/cluster"
+CLUSTER_ROOT="$TARGET/data/showcase/$BOOTSTRAP_INSTANCE/cluster"
 for NODE in 0 1 2; do
   mkdir -p "$CLUSTER_ROOT/node$NODE"
   cp -cR "$SOURCE_STATE" "$CLUSTER_ROOT/node$NODE/chainstate-import"
@@ -124,6 +135,50 @@ for NODE in 0 1 2; do
 done
 
 # Create and retain deployment/L1 identity markers before adopting copied DBs.
+./showcase.sh up --instance "$BOOTSTRAP_INSTANCE"
+./showcase.sh stop --instance "$BOOTSTRAP_INSTANCE"
+for NODE in 0 1 2; do
+  mv "$CLUSTER_ROOT/node$NODE/chainstate" \
+    "$CLUSTER_ROOT/node$NODE/chainstate-bootstrap-empty"
+  mv "$CLUSTER_ROOT/node$NODE/chainstate-import" \
+    "$CLUSTER_ROOT/node$NODE/chainstate"
+done
+./showcase.sh up --instance "$BOOTSTRAP_INSTANCE"
+
+SETTLEMENT_LOG="$TARGET/settlement-bootstrap.log"
+set +e
+./showcase.sh settlement bootstrap --instance "$BOOTSTRAP_INSTANCE" \
+  --settlement-key-file "$PWD/private-settlement/operator.seed" \
+  --confirm-public-settlement preprod 2>&1 | tee "$SETTLEMENT_LOG"
+SETTLEMENT_STATUS="${PIPESTATUS[0]}"
+set -e
+if [ -f "private-settlement/$SETTLEMENT_RECORD" ]; then
+  cp "private-settlement/$SETTLEMENT_RECORD" "$SOURCE_KEYS/$SETTLEMENT_RECORD"
+  chmod 600 "$SOURCE_KEYS/$SETTLEMENT_RECORD"
+fi
+[ "$SETTLEMENT_STATUS" -eq 0 ] || exit "$SETTLEMENT_STATUS"
+python3 "$SCRIPT_DIR/adopt_settlement_config.py" \
+  yano/config/application-appchain.yml "$SETTLEMENT_LOG" \
+  catalog/showcase-catalog-v1.json
+./showcase.sh stop --instance "$BOOTSTRAP_INSTANCE"
+./showcase.sh reset --instance "$BOOTSTRAP_INSTANCE" --yes
+
+# Create the final twelve-chain deployment from a clean app-chain generation.
+./showcase.sh prepare --profile light --network preprod --nodes 3 \
+  --instance "$INSTANCE" --http-base 17070 --server-base 17337 \
+  --anchor-chain all --anchor-key-file "$PWD/private-anchor/anchor.seed" \
+  --confirm-public-anchor preprod
+
+CLUSTER_ROOT="$TARGET/data/showcase/$INSTANCE/cluster"
+for NODE in 0 1 2; do
+  mkdir -p "$CLUSTER_ROOT/node$NODE"
+  cp -cR "$SOURCE_STATE" "$CLUSTER_ROOT/node$NODE/chainstate-import"
+  LEGACY_APPCHAINS="$CLUSTER_ROOT/node$NODE/chainstate-import/appchains"
+  if [ -d "$LEGACY_APPCHAINS" ]; then
+    find "$LEGACY_APPCHAINS" -depth -delete
+  fi
+done
+
 ./showcase.sh up --instance "$INSTANCE"
 ./showcase.sh stop --instance "$INSTANCE"
 for NODE in 0 1 2; do
@@ -133,25 +188,13 @@ for NODE in 0 1 2; do
     "$CLUSTER_ROOT/node$NODE/chainstate"
 done
 ./showcase.sh up --instance "$INSTANCE"
-
 ./showcase.sh anchor bootstrap all --instance "$INSTANCE"
-
-SETTLEMENT_LOG="$TARGET/data/showcase/$INSTANCE/settlement-bootstrap.log"
-./showcase.sh settlement bootstrap --instance "$INSTANCE" \
-  --settlement-key-file "$PWD/private-settlement/operator.seed" \
-  --confirm-public-settlement preprod 2>&1 | tee "$SETTLEMENT_LOG"
-python3 "$SCRIPT_DIR/adopt_settlement_config.py" \
-  yano/config/application-appchain.yml "$SETTLEMENT_LOG"
-./showcase.sh chain add payment-chain-settlement --instance "$INSTANCE"
-./showcase.sh anchor enable payment-chain-settlement --instance "$INSTANCE" \
-  --anchor-key-file "$PWD/private-anchor/anchor.seed" \
-  --confirm-public-anchor preprod
-./showcase.sh anchor bootstrap payment-chain-settlement --instance "$INSTANCE"
 
 if [ "$SMOKE" = true ]; then
   ./showcase.sh run orders --instance "$INSTANCE"
   ./showcase.sh run registry --instance "$INSTANCE"
   ./showcase.sh run authenticated-map --instance "$INSTANCE"
+  ./showcase.sh run document-review --instance "$INSTANCE"
 fi
 
 "$SCRIPT_DIR/validate_cluster.sh" "$TARGET" "$INSTANCE" 17070

--- a/.agents/skills/deploy-showcase-preprod-cluster/scripts/validate_cluster.sh
+++ b/.agents/skills/deploy-showcase-preprod-cluster/scripts/validate_cluster.sh
@@ -5,7 +5,14 @@ TARGET="${1:?target is required}"
 INSTANCE="${2:?instance is required}"
 HTTP_BASE="${3:?HTTP base is required}"
 MARKER="$TARGET/data/showcase/$INSTANCE/showcase-identity.json"
+CATALOG="$TARGET/catalog/showcase-catalog-v1.json"
 [ -f "$MARKER" ] || { echo "Missing retained identity: $MARKER" >&2; exit 66; }
+[ -f "$CATALOG" ] || { echo "Missing showcase catalog: $CATALOG" >&2; exit 66; }
+# A public-network bootstrap may temporarily omit settlement until the
+# operator-specific production profile is adopted. A qualified cluster must
+# converge to the full catalog before validation succeeds.
+diff -u <(python3 "$TARGET/tools/showcase_catalog.py" "$CATALOG" list) \
+  <(jq -r '.chainIds[]' "$MARKER")
 
 CLUSTER_ROOT="$TARGET/data/showcase/$INSTANCE/cluster"
 for NODE in 0 1 2; do
@@ -33,7 +40,14 @@ while IFS= read -r CHAIN; do
   printf '%s' "$LEADER" | jq -e \
     '.anchor.enabled == true and .anchor.mode == "script" and
      .anchor.bootstrapped == true and
+     (.capabilityManifest.manifestDigest | test("^[0-9a-f]{64}$")) and
      (.anchor.lastAnchorTx | test("^[0-9a-f]{64}$"))' >/dev/null
+  while IFS= read -r CAPABILITY; do
+    printf '%s' "$LEADER" | jq -e --arg capability "$CAPABILITY" \
+      '.capabilityManifest.crossCutting
+       | any(.capabilityId == $capability and .enabled == true)' >/dev/null
+  done < <(jq -r --arg chain "$CHAIN" \
+    '.chains[] | select(.chainId == $chain) | .expectedCapabilities[]' "$CATALOG")
 
   REFERENCE=""
   for PORT in "$HTTP_BASE" "$((HTTP_BASE + 1))" "$((HTTP_BASE + 2))"; do
@@ -45,7 +59,7 @@ while IFS= read -r CHAIN; do
        (.stateCommitment.genesisId | test("^[0-9a-f]{64}$"))' >/dev/null
     CURRENT="$(printf '%s' "$STATUS" | jq -r \
       '[.tipHeight,.stateRoot,.stateCommitment.profile,
-        .stateCommitment.genesisId] | @tsv')"
+        .stateCommitment.genesisId,.capabilityManifest.manifestDigest] | @tsv')"
     [ -n "$REFERENCE" ] || REFERENCE="$CURRENT"
     [ "$REFERENCE" = "$CURRENT" ] || {
       echo "State disagreement for $CHAIN on HTTP $PORT" >&2

--- a/.agents/skills/deploy-showcase-preprod-cluster/scripts/write_runbook.sh
+++ b/.agents/skills/deploy-showcase-preprod-cluster/scripts/write_runbook.sh
@@ -43,10 +43,15 @@ transactions:
 ./showcase.sh run orders --instance {instance}
 ./showcase.sh run registry --instance {instance}
 ./showcase.sh run authenticated-map --instance {instance}
+./showcase.sh run document-review --instance {instance}
 ```
 
 Do not use a settlement deposit or withdrawal as a health check; those are real
 preprod custody flows.
+
+Use `./showcase.sh describe light` for the authoritative twelve-chain catalog.
+The console capability matrix at `http://127.0.0.1:17070/ui/app-chain/` is
+derived from each chain's immutable capability manifest.
 
 ## Validate from the repository
 

--- a/adr/app-layer/033-showcase-reference-catalog-and-capability-discovery.md
+++ b/adr/app-layer/033-showcase-reference-catalog-and-capability-discovery.md
@@ -1,6 +1,6 @@
 # ADR app-layer/033: Showcase reference catalog and capability discovery
 
-**Status:** Accepted — implementation pending
+**Status:** Accepted — implemented
 **Date:** 2026-08-09
 **Scope:** App-chain showcase catalog, reusable-capability visibility, console presentation, and
 optional finalized-message indexing
@@ -210,8 +210,11 @@ The app-chain overview will render `capabilityManifest` as:
 * whether each item is intrinsic, composed, or launcher-enabled.
 
 A compact capability matrix across all running chains will make the showcase story visible without
-selecting chains one by one. Membership governance and executable-profile governance appear in a
-separate governance group so they are not labeled as business approval.
+selecting chains one by one. It lives in a dedicated **Capabilities** tab within the app-chain page,
+so the default **Operations** tab retains its operational density and vertical space. The matrix is
+loaded on demand, and each row links back to that chain's operational view. Membership governance
+and executable-profile governance appear in a separate governance group so they are not labeled as
+business approval.
 
 ### 5.2 Finalized-message proof lab
 
@@ -380,6 +383,53 @@ need catalog updates; their submission engines do not change.
     or move funds.
 
 ## 10. Consequences
+
+### Implementation record (2026-08-09)
+
+All phases are complete on `feat/033_refactor_showcase`:
+
+* the light profile is catalog-driven and starts twelve chains, with seven foundations, three
+  business reference compositions, one JMT backend-comparison chain, and one distinct L1 boundary;
+* `document-review-chain` composes the existing domain-actor, role-approval, role-authorization,
+  document-transition, and approval-consumption capabilities without a parallel role model;
+* every `AppStateMachine` exposes a deterministic `AppCapabilityManifest`; stock, composite,
+  launcher, state-backend, effect, and L1-observer capabilities appear in the existing status
+  response and the console consumes that manifest;
+* the generic finalized-message decorator, reserved key derivation, state-generation binding,
+  retained launcher selection, selected/all validation, and proof-subject discovery are implemented;
+* the console includes an on-demand Capabilities tab with the cross-chain matrix and composition
+  view, plus a compact message proof and optional state-proof lab, explicit availability warning,
+  and committed-receipt workflow traces;
+* scripts, distribution contracts, load aliases, catalog documentation, runbooks, and the devnet
+  and preprod deployment skills consume or validate the packaged catalog.
+
+Live qualification used fresh three-node devnet instances in default, selected
+(`documents-chain,workflow-chain`), and all-chain index modes. All twelve chains agreed on height,
+root, state genesis, commitment profile, and manifest digest. Selected and all modes survived
+three-node restart. A selected document message produced both a compact `messagesRoot` proof and an
+MPF inclusion proof; an unselected registry message produced the compact proof and an MPF exclusion
+proof for the same typed subject. The all mode also produced and verified the corresponding JMT
+inclusion proof off-chain. MPF reference on-chain-verifier regressions pass.
+
+A fresh public-preprod qualification then started three nodes with the twelve-chain catalog and the
+owner-supplied anchor and settlement keys. The production settlement identity was deployed once and
+retained outside the disposable node state. All twelve SCRIPT anchors were bootstrapped and observed
+on L1. The orders, registry, authenticated-map, and document-review scenarios completed, and every
+node exposed identical roots, identities, profiles, and manifests. No deposit or withdrawal was
+performed. During this qualification:
+
+* the production settlement adoption helper was fixed to insert at catalog order and to distinguish
+  top-level chain declarations from nested observer/indexer `chain-id` fields;
+* settlement bootstrap was made resumable across partial public-network completion by detecting the
+  already-held root and complete shard-token set, rejecting partial shard sets, and waiting for token
+  ownership rather than an intermediate change output; and
+* the non-secret settlement deployment identity is retained next to the owner-supplied keys so a
+  clean cluster recreation reuses the deployed contracts instead of minting a new identity.
+
+Final fresh devnet and preprod deployments both passed the catalog, three-node agreement, anchor,
+storage-layout, capability, and reference-workflow validators. The release candidate also passed
+`./gradlew clean build` and the packaged showcase distribution contract. The staged ZIP SHA-256 is
+`52dbfaf24768630cc35b83e08a5d6dc21fa730d46416b1f8a1281531133062a4`.
 
 ### Positive
 

--- a/appchain/appchain-client/src/main/java/com/bloxbean/cardano/yano/appchain/client/ProofSubjects.java
+++ b/appchain/appchain-client/src/main/java/com/bloxbean/cardano/yano/appchain/client/ProofSubjects.java
@@ -25,14 +25,16 @@ public final class ProofSubjects {
     public static StateProofSubject<FinalizedMessageIndex.MessageRecord> finalizedMessage(
             byte[] messageId
     ) {
-        return subject("finalized-message-v1", exact32(messageId, "messageId"),
+        return subject("finalized-message-v1",
+                FinalizedMessageIndex.messageKey(exact32(messageId, "messageId")),
                 FinalizedMessageIndex::decode);
     }
 
     public static StateProofSubject<FinalizedMessageIndex.MessageRecord>
     compositeFinalizedMessage(String componentId, byte[] messageId) {
         return componentSubject("finalized-message-v1", componentId,
-                exact32(messageId, "messageId"), FinalizedMessageIndex::decode);
+                FinalizedMessageIndex.messageKey(exact32(messageId, "messageId")),
+                FinalizedMessageIndex::decode);
     }
 
     public static StateProofSubject<DocTrailContract.Head> documentHead(

--- a/appchain/appchain-client/src/test/java/com/bloxbean/cardano/yano/appchain/client/ProofSubjectsTest.java
+++ b/appchain/appchain-client/src/test/java/com/bloxbean/cardano/yano/appchain/client/ProofSubjectsTest.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yano.appchain.client;
 
 import com.bloxbean.cardano.yano.appchain.composite.contracts.CompositeCommitmentV1;
+import com.bloxbean.cardano.yano.api.appchain.transition.FinalizedMessageIndex;
 import com.bloxbean.cardano.yano.appchain.roles.contracts.ApprovalPolicyV1;
 import com.bloxbean.cardano.yano.appchain.roles.contracts.ApprovalProposalV1;
 import com.bloxbean.cardano.yano.appchain.roles.contracts.RecordStatus;
@@ -22,7 +23,7 @@ class ProofSubjectsTest {
         byte[] messageId = filled(1, 32);
         assertThat(ProofSubjects.compositeFinalizedMessage("ordered-log", messageId)
                 .canonicalKey()).containsExactly(CompositeCommitmentV1.componentKey(
-                "ordered-log", messageId));
+                "ordered-log", FinalizedMessageIndex.messageKey(messageId)));
         assertThat(ProofSubjects.documentHead("doc-trail", "invoice-7").canonicalKey())
                 .containsExactly(CompositeCommitmentV1.componentKey(
                         "doc-trail", DocTrailContract.entityKey("invoice-7")));

--- a/appchain/appchain-composite/src/main/java/com/bloxbean/cardano/yano/appchain/composite/CompositeStateMachine.java
+++ b/appchain/appchain-composite/src/main/java/com/bloxbean/cardano/yano/appchain/composite/CompositeStateMachine.java
@@ -3,6 +3,8 @@ package com.bloxbean.cardano.yano.appchain.composite;
 import com.bloxbean.cardano.yano.api.appchain.AppBlock;
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
 import com.bloxbean.cardano.yano.api.appchain.AppChainInfo;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityIds;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppQueryContext;
 import com.bloxbean.cardano.yano.api.appchain.AppQueryException;
 import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
@@ -28,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /** Deterministic routing, isolation, query, and effect-ownership boundary. */
 public final class CompositeStateMachine implements AppStateMachine {
@@ -403,6 +406,71 @@ public final class CompositeStateMachine implements AppStateMachine {
             status.put("components", Map.copyOf(componentStatuses));
         }
         return Map.copyOf(status);
+    }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        AppCapabilityManifest.Builder manifest = AppCapabilityManifest.builder(
+                machineId, profile.profileVersion());
+        for (ComponentDescriptor component : profile.components()) {
+            manifest.component(new AppCapabilityManifest.Component(
+                    component.componentId(), component.semanticVersion(),
+                    component.configurationId(),
+                    "component/" + component.componentId() + "/v1",
+                    component.topics(), component.queryPaths(),
+                    AppCapabilityManifest.Origin.COMPOSED));
+        }
+        for (WorkflowDescriptor workflow : profile.workflows()) {
+            manifest.workflow(new AppCapabilityManifest.Workflow(
+                    workflow.workflowId(), workflow.semanticVersion(),
+                    workflow.participants().stream()
+                            .map(ComponentGeneration::componentId).distinct().toList(),
+                    workflow.topic(), workflow.maxEffectsPerBlock() > 0
+                    ? List.of("outbox") : List.of(),
+                    AppCapabilityManifest.Origin.COMPOSED));
+        }
+        Set<String> componentIds = profile.components().stream()
+                .map(ComponentDescriptor::componentId).collect(java.util.stream.Collectors.toSet());
+        if (componentIds.contains("approvals")) {
+            manifest.crossCutting(capability(AppCapabilityIds.BASIC_APPROVAL,
+                    "composite-profile:" + HexFormat.of().formatHex(profile.digest())));
+        }
+        if (componentIds.contains("domain-actors")
+                && componentIds.contains("role-approvals")) {
+            manifest.crossCutting(capability(AppCapabilityIds.ACTOR_ROLE_APPROVAL,
+                    "composite-profile:" + HexFormat.of().formatHex(profile.digest())));
+        }
+        if (componentIds.contains("authenticated-map")
+                && componentIds.contains("domain-actors")) {
+            manifest.crossCutting(capability(AppCapabilityIds.DIRECT_ROLE,
+                    "composite-profile:" + HexFormat.of().formatHex(profile.digest())));
+        }
+        if (profile.components().stream().anyMatch(value -> value.maxEffectsPerBlock() > 0)
+                || profile.workflows().stream().anyMatch(value -> value.maxEffectsPerBlock() > 0)) {
+            manifest.crossCutting(capability(AppCapabilityIds.OUTBOX_EFFECTS,
+                    "composite-profile:" + HexFormat.of().formatHex(profile.digest())));
+        }
+        for (ComponentDescriptor component : profile.components()) {
+            for (String path : component.queryPaths()) {
+                manifest.proofSubject(new AppCapabilityManifest.ProofSubject(
+                        proofSubjectId(component.componentId(), path), component.componentId(),
+                        "component/" + component.componentId() + "/v1",
+                        "state-proof"));
+            }
+        }
+        return manifest.build();
+    }
+
+    private static AppCapabilityManifest.CrossCutting capability(
+            String id, String configurationDigest) {
+        return new AppCapabilityManifest.CrossCutting(id, "1.0.0", true,
+                configurationDigest, Map.of(), AppCapabilityManifest.Origin.COMPOSED);
+    }
+
+    private static String proofSubjectId(String component, String path) {
+        return ("query:" + component + ":" + path)
+                .toLowerCase(java.util.Locale.ROOT)
+                .replaceAll("[^a-z0-9:._-]", "-");
     }
 
     @Override

--- a/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/ApprovalsStateMachine.java
+++ b/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/ApprovalsStateMachine.java
@@ -9,6 +9,8 @@ import com.bloxbean.cardano.client.crypto.Blake2bUtil;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yano.api.appchain.AppBlock;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityIds;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
 import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
 import com.bloxbean.cardano.yano.api.appchain.AppStateReader;
@@ -97,6 +99,18 @@ public final class ApprovalsStateMachine implements AppStateMachine {
     @Override
     public String id() {
         return ID;
+    }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        return StdlibCapabilityManifests.component(ID, ApprovalsContract.DEFAULT_TOPIC)
+                .crossCutting(new AppCapabilityManifest.CrossCutting(
+                        AppCapabilityIds.BASIC_APPROVAL, "1.0.0", true,
+                        "approvals-state-v1", java.util.Map.of(),
+                        AppCapabilityManifest.Origin.INTRINSIC))
+                .proofSubject(new AppCapabilityManifest.ProofSubject(
+                        "basic-approval-outcome-v1", "", "i/", "state-proof"))
+                .build();
     }
 
     @Override

--- a/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/BalancesStateMachine.java
+++ b/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/BalancesStateMachine.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yano.appchain.stdlib;
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yano.api.appchain.AppBlock;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
 import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
 import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
@@ -62,6 +63,16 @@ public final class BalancesStateMachine implements AppStateMachine {
     @Override
     public String id() {
         return ID;
+    }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        return StdlibCapabilityManifests.component(
+                        ID, com.bloxbean.cardano.yano.appchain.stdlib.contracts
+                                .BalancesContract.DEFAULT_TOPIC)
+                .proofSubject(new AppCapabilityManifest.ProofSubject(
+                        "account-balance-v1", "", "b/", "state-proof"))
+                .build();
     }
 
     @Override

--- a/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/DocTrailStateMachine.java
+++ b/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/DocTrailStateMachine.java
@@ -2,7 +2,10 @@ package com.bloxbean.cardano.yano.appchain.stdlib;
 
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
 import com.bloxbean.cardano.yano.api.appchain.AppBlock;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
+import com.bloxbean.cardano.yano.api.appchain.AppQueryContext;
+import com.bloxbean.cardano.yano.api.appchain.AppQueryException;
 import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
 import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
 import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
@@ -12,6 +15,9 @@ import com.bloxbean.cardano.yano.api.appchain.transition.TransitionPlans;
 import com.bloxbean.cardano.yano.appchain.stdlib.contracts.DocTrailContract;
 
 import java.util.List;
+import java.nio.ByteBuffer;
+import java.nio.charset.CodingErrorAction;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Standard-library state machine {@code doc-trail} (ADR app-layer/006 E2.4):
@@ -36,11 +42,21 @@ import java.util.List;
 public final class DocTrailStateMachine implements AppStateMachine {
 
     public static final String ID = "doc-trail";
+    public static final String QUERY_HEAD = "head";
     private final DocTrailTransitions transitions = new DocTrailTransitions();
 
     @Override
     public String id() {
         return ID;
+    }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        return StdlibCapabilityManifests.component(
+                        ID, DocTrailContract.DEFAULT_TOPIC, List.of(QUERY_HEAD))
+                .proofSubject(new AppCapabilityManifest.ProofSubject(
+                        "document-head-v1", "", "e/", "state-proof"))
+                .build();
     }
 
     @Override
@@ -70,6 +86,24 @@ public final class DocTrailStateMachine implements AppStateMachine {
                     TransitionContext.of(block, originalIndex, message),
                     DocTrailTransitions.facts(writer, command));
             TransitionPlans.commitIfApproved(decision, writer, effects);
+        }
+    }
+
+    @Override
+    public byte[] query(String path, byte[] params, AppQueryContext state) {
+        if (!QUERY_HEAD.equals(path)) {
+            throw new AppQueryException(AppQueryException.Code.UNSUPPORTED,
+                    "unsupported document-trail query");
+        }
+        try {
+            String entityId = StandardCharsets.UTF_8.newDecoder()
+                    .onMalformedInput(CodingErrorAction.REPORT)
+                    .onUnmappableCharacter(CodingErrorAction.REPORT)
+                    .decode(ByteBuffer.wrap(params)).toString();
+            return state.get(DocTrailContract.entityKey(entityId)).orElse(new byte[0]);
+        } catch (Exception invalid) {
+            throw new AppQueryException(AppQueryException.Code.INVALID_REQUEST,
+                    "document head query requires a bounded UTF-8 entity id");
         }
     }
 

--- a/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/KvRegistryStateMachine.java
+++ b/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/KvRegistryStateMachine.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yano.appchain.stdlib;
 
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
 import com.bloxbean.cardano.yano.api.appchain.AppBlock;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
 import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
 import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
@@ -54,6 +55,16 @@ public final class KvRegistryStateMachine implements AppStateMachine {
     @Override
     public String id() {
         return ID;
+    }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        return StdlibCapabilityManifests.component(
+                        ID, com.bloxbean.cardano.yano.appchain.stdlib.contracts
+                                .KvRegistryContract.DEFAULT_TOPIC)
+                .proofSubject(new AppCapabilityManifest.ProofSubject(
+                        "registry-entry-v1", "", "kv/", "state-proof"))
+                .build();
     }
 
     @Override

--- a/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/StdlibCapabilityManifests.java
+++ b/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/StdlibCapabilityManifests.java
@@ -1,0 +1,23 @@
+package com.bloxbean.cardano.yano.appchain.stdlib;
+
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
+
+import java.util.List;
+
+final class StdlibCapabilityManifests {
+    private StdlibCapabilityManifests() {
+    }
+
+    static AppCapabilityManifest.Builder component(String id, String topic) {
+        return component(id, topic, List.of());
+    }
+
+    static AppCapabilityManifest.Builder component(
+            String id, String topic, List<String> querySubjects
+    ) {
+        return AppCapabilityManifest.builder(id, "1.0.0")
+                .component(new AppCapabilityManifest.Component(
+                        id, "1.0.0", "intrinsic-v1", "application/v1",
+                        List.of(topic), querySubjects, AppCapabilityManifest.Origin.INTRINSIC));
+    }
+}

--- a/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/StdlibStateMachineProviders.java
+++ b/appchain/appchain-stdlib/src/main/java/com/bloxbean/cardano/yano/appchain/stdlib/StdlibStateMachineProviders.java
@@ -9,6 +9,7 @@ import com.bloxbean.cardano.yano.api.appchain.AppStateMachineProvider;
 import com.bloxbean.cardano.yano.api.appchain.state.StateCommitmentProfile;
 import com.bloxbean.cardano.yano.api.appchain.state.StateCommitmentIdentity;
 import com.bloxbean.cardano.yano.api.appchain.state.StateCommitmentProfiles;
+import com.bloxbean.cardano.yano.api.appchain.transition.FinalizedMessageIndexedStateMachine;
 import com.bloxbean.cardano.yano.appchain.config.AppChainApprovalsConfig;
 import com.bloxbean.cardano.yano.appchain.stdlib.contracts.AuthenticatedMapContract;
 
@@ -73,15 +74,23 @@ public final class StdlibStateMachineProviders {
             }
             StateCommitmentIdentity stateIdentity = context.stateCommitmentIdentity()
                     .orElseGet(() -> StateCommitmentIdentity.fromSettings(context.settings()));
-            if (!stateIdentity.profile().equals(profile)
-                    || !Arrays.equals(stateIdentity.genesisId(),
-                    AuthenticatedMapContract.genesisId(genesis))) {
-                throw new IllegalArgumentException(
-                        "authenticated-map genesis differs from the runtime state commitment identity");
-            }
             AppChainConsensusProfile consensus = context.consensusProfile()
                     .orElseThrow(() -> new IllegalArgumentException(
                             "authenticated-map requires the normalized consensus profile"));
+            StateCommitmentIdentity baseIdentity =
+                    StateCommitmentIdentity.explicit(
+                            profile, AuthenticatedMapContract.genesisId(genesis));
+            StateCommitmentIdentity expectedIdentity =
+                    FinalizedMessageIndexedStateMachine.configuration(
+                            context.settings(), consensus.maxBlockMessages())
+                    .map(index -> baseIdentity.withApplicationProfile(index.digest()))
+                    .orElse(baseIdentity);
+            if (!stateIdentity.profile().equals(profile)
+                    || !Arrays.equals(stateIdentity.genesisId(),
+                    expectedIdentity.genesisId())) {
+                throw new IllegalArgumentException(
+                        "authenticated-map genesis differs from the runtime state commitment identity");
+            }
             if (!Arrays.equals(AppChainConsensusProfileCommitment.digest(consensus),
                     genesis.frameworkConsensusProfileDigest())) {
                 throw new IllegalArgumentException(

--- a/appchain/authenticated-map-validators/src/main/java/com/bloxbean/cardano/yano/appchain/authmap/validators/Gs1GtinValidatorFactory.java
+++ b/appchain/authenticated-map-validators/src/main/java/com/bloxbean/cardano/yano/appchain/authmap/validators/Gs1GtinValidatorFactory.java
@@ -39,7 +39,22 @@ public final class Gs1GtinValidatorFactory
             throw new IllegalArgumentException(
                     "gs1-gtin-v1 requires its exact provider, contract, and empty parameters");
         }
-        return Gs1GtinValidatorFactory::validateGtin;
+        // A factory invocation belongs to one configured chain. Do not return a
+        // non-capturing method-reference here: the JVM may cache it as a singleton,
+        // which would leak the same plugin product across MPF/JMT chain instances.
+        return new Gs1GtinValidator();
+    }
+
+    private static final class Gs1GtinValidator
+            implements AuthenticatedMapValueValidator {
+        @Override
+        public ValidatorVerdict validate(
+                String collectionId,
+                byte[] applicationKey,
+                byte[] value
+        ) {
+            return validateGtin(collectionId, applicationKey, value);
+        }
     }
 
     private static ValidatorVerdict validateGtin(

--- a/appchain/authenticated-map-validators/src/test/java/com/bloxbean/cardano/yano/appchain/authmap/validators/Gs1GtinValidatorFactoryTest.java
+++ b/appchain/authenticated-map-validators/src/test/java/com/bloxbean/cardano/yano/appchain/authmap/validators/Gs1GtinValidatorFactoryTest.java
@@ -48,6 +48,11 @@ class Gs1GtinValidatorFactoryTest {
                 .hasMessageContaining("empty parameters");
     }
 
+    @Test
+    void createsAnIndependentValidatorForEveryConfiguredChain() {
+        assertThat(factory()).isNotSameAs(factory());
+    }
+
     private static AuthenticatedMapValueValidator factory() {
         return new Gs1GtinValidatorFactory().create(new ValidatorInitContext(
                 "gtin", Gs1GtinValidatorFactory.ID,

--- a/appchain/examples/appchain-showcase/DEMO_SHOWCASE.md
+++ b/appchain/examples/appchain-showcase/DEMO_SHOWCASE.md
@@ -1,7 +1,7 @@
 # Yano App-Chain Showcase — Full Demo Guide
 
 One guide to demonstrate every app-chain capability with the packaged
-showcase: all eleven chains and their state machines, regular and bulk
+showcase: all twelve chains and their state machines, regular and bulk
 submission, deterministic effects, L1 anchoring on devnet and preprod,
 verifiable reads with historical versioning, the browser console, and the
 Java client (including a runnable fat jar).
@@ -20,12 +20,13 @@ Last verified live: 2026-08-05 on a 3-node cluster.
    - [approvals-chain — threshold approvals](#approvals-chain--threshold-approvals)
    - [balances-chain — token balances](#balances-chain--token-balances)
    - [documents-chain — document trail](#documents-chain--document-trail)
+   - [document-review-chain — roles + approval + documents](#document-review-chain--roles--approval--documents)
    - [workflow-chain — composite + effects](#workflow-chain--composite--effects)
    - [roles-chain — role approvals](#roles-chain--role-approvals)
    - [payments-chain — EUTxO ledger](#payments-chain--eutxo-ledger)
    - [payment-chain-settlement — L1 custody boundary](#payment-chain-settlement--l1-custody-boundary)
    - [authenticated-map-chain — governed MPF map](#authenticated-map-chain--governed-mpf-map)
-   - [authenticated-map-jmt-chain — basic classic-JMT map](#authenticated-map-jmt-chain--basic-classic-jmt-map)
+   - [authenticated-map-jmt-chain — governed classic-JMT contrast](#authenticated-map-jmt-chain--governed-classic-jmt-contrast)
 6. [Deterministic effects deep-dive](#6-deterministic-effects-deep-dive)
 7. [Bulk load and soak](#7-bulk-load-and-soak)
 8. [Java client (fat jar)](#8-java-client-fat-jar)
@@ -75,17 +76,17 @@ chmod 600 ./private-anchor/anchor.seed
 ```
 
 Node 0's API is `http://127.0.0.1:7070/api/v1` (`--http-base` shifts it).
-All eleven chains report at `GET /api/v1/app-chain/chains`.
+All twelve chains report at `GET /api/v1/app-chain/chains`.
 
 ### The ADR-031 capability story
 
 Present the chains as foundations plus a small number of meaningful
-compositions, not as eleven unrelated state-machine implementations:
+compositions, not as twelve unrelated state-machine implementations:
 
 | Demo | Composition or boundary |
 |---|---|
 | `workflow-chain` | orders + approval + audit + deterministic effect intent/result |
-| role-evidence profile today; target `document-review-chain` in ADR-033 | documents + domain actors/roles + actor approval and one-use consumption |
+| `document-review-chain` | documents + domain actors/roles + actor approval and one-use consumption |
 | `authenticated-map-chain` | authenticated map + direct actor/role evidence + multi-organization approval |
 | `authenticated-map-jmt-chain` | backend comparison; ADR-033 makes its business policy identical to the MPF chain |
 | `payment-chain-settlement` | EUTxO + stability-gated L1 observers + settlement effects + derived lifecycle index |
@@ -94,6 +95,13 @@ All of these remain `AppStateMachine` applications. Membership governance is
 shown separately because it is not a substitute for business authorization or
 approval. `payment-chain-settlement` starts with light; public-network script
 deployment and fund-moving operations remain explicit.
+
+For the cross-chain capability table, optional finalized-message-index setup,
+and proof-lab narration, use
+[`docs/CAPABILITY_CATALOG.md`](docs/CAPABILITY_CATALOG.md). The index is off by
+default for non-intrinsic applications; the launcher accepts either the
+all-chain flag or a canonical comma-separated chain selection for a fresh
+instance.
 
 ## 3. Everyday cluster operations
 
@@ -131,9 +139,9 @@ curl -X POST http://127.0.0.1:7070/api/v1/app-chain/chains/orders-chain/messages
 | `/ui/status/` , `/ui/observability/` | L1 node status, Prometheus charts |
 | `/ui/plugins/` | plugin operations (privileged; needs API key) |
 
-The current console shows effects, proofs, role proposals, authenticated-map
-governance, and EUTxO lifecycle data. ADR-033 adds a manifest-driven capability
-matrix, composition/workflow view, and a finalized-message proof lab so custom
+The console shows effects, proofs, role proposals, authenticated-map
+governance, EUTxO lifecycle data, a manifest-driven capability matrix,
+composition/workflow views, and a finalized-message proof lab. Custom
 machines are not classified by hard-coded state-machine names.
 
 ## 5. Chain-by-chain demos
@@ -186,6 +194,18 @@ Hash-committed document references per entity.
 
 ```bash
 ./showcase.sh run documents --instance demo
+```
+
+### document-review-chain — roles + approval + documents
+
+This reference application reuses the actor registry, role-aware approval,
+role authorization, and document-transition components. The scripted path
+proposes as the issuer, obtains approvals from two auditor organizations,
+mutates the document head, writes a one-use consumption receipt, and proves
+the committed document leaf.
+
+```bash
+./showcase.sh run document-review --instance demo
 ```
 
 ### workflow-chain — composite + effects
@@ -246,30 +266,17 @@ every offline-signing step. Private key: `--seed-file <64-hex raw Ed25519
 seed>` for a real actor; without it the deterministic DEMO seed for the named
 showcase actor is derived (showcase-only material). Full curl anatomy: §11.
 
-### authenticated-map-jmt-chain — basic classic-JMT map
+### authenticated-map-jmt-chain — governed classic-JMT contrast
 
-The contrast chain: `jmt-blake2b256-v1` backend, ungoverned collections
-`kv-open` (open) / `documents` (owner) / `notes` (member, canonical-CBOR).
-Console shows basic-only views — compare side by side with the governed MPF
-chain.
+The contrast chain has the same collections, policies, actors, commands, and
+receipt semantics as `authenticated-map-chain`. Only the commitment backend
+changes to `jmt-blake2b256-v1`: verification is off-chain-only, while MPF also
+has the reference on-chain verifier.
 
 ```bash
-# ships in new builds; adopt on an EXISTING instance (history retained):
-#   copy showcase.sh, tools/showcase_identity.py,
-#   yano/config/application-appchain.yml and the showcase plugin bundle jar
-#   from a newly built ZIP, then:
-./showcase.sh chain add authenticated-map-jmt-chain --instance demo
-./showcase.sh governance activate --instance demo     # first block
-
-./showcase.sh authmap put kv-open k1 "v1" --chain authenticated-map-jmt-chain --instance demo
-./showcase.sh authmap put notes note-1 \
-  "$(python3 tools/showcase_codec.py authmap-value event audit-note 1)" \
-  --chain authenticated-map-jmt-chain --instance demo   # member-gated, CBOR value
+./showcase.sh authmap put attachments k1 "v1" \
+  --chain authenticated-map-jmt-chain --instance demo
 ```
-
-Authorization modes on this chain: `kv-open` anyone writes; `documents`
-first writer owns the key; `notes` only current chain members write
-(height-versioned membership — rotated-out members lose access).
 
 ### payment-chain-settlement — L1 custody boundary
 
@@ -353,7 +360,7 @@ page has an Effects panel showing the same lifecycle.
 
 # authenticated-map bulk load via the Java client (see §8):
 java -jar yano-showcase-client-*-all.jar authmap http://127.0.0.1:7070/api/v1 \
-  authenticated-map-jmt-chain load kv-open 100
+  authenticated-map-jmt-chain load attachments 100
 ```
 
 The Java `load` prints submit throughput, applied/rejected counts, end-to-end
@@ -372,11 +379,11 @@ application looks like, using the release-matched `appchain-client`.
 JAR=yano-showcase-client-*-all.jar
 API=http://127.0.0.1:7070/api/v1
 
-java -jar $JAR authmap $API authenticated-map-jmt-chain basic-put kv-open jk1 jv1
+java -jar $JAR authmap $API authenticated-map-jmt-chain basic-put attachments jk1 jv1
 java -jar $JAR authmap $API authenticated-map-chain     governed-put gk1 gv1
-java -jar $JAR authmap $API authenticated-map-jmt-chain reads kv-open jk1
-java -jar $JAR authmap $API authenticated-map-jmt-chain verified-entry kv-open jk1
-java -jar $JAR authmap $API authenticated-map-jmt-chain load kv-open 100
+java -jar $JAR authmap $API authenticated-map-jmt-chain reads attachments jk1
+java -jar $JAR authmap $API authenticated-map-jmt-chain verified-entry attachments jk1
+java -jar $JAR authmap $API authenticated-map-jmt-chain load attachments 100
 ```
 
 - Writes print the four trust levels: accepted → finalized → APPLIED/REJECTED
@@ -423,7 +430,7 @@ Entries carry a logical `revision`; old values are read at **previous
 heights**, each with a merkle proof against that height's co-signed root:
 
 ```bash
-PK=$(curl -s "$DOMAIN/authenticated-map/entries/kv-open/$(printf 'k1' | xxd -p)?chain=authenticated-map-jmt-chain" | jq -r .proofKey)
+PK=$(curl -s "$DOMAIN/authenticated-map/entries/attachments/$(printf 'k1' | xxd -p)?chain=authenticated-map-jmt-chain" | jq -r .proofKey)
 C=$BASE/app-chain/chains/authenticated-map-jmt-chain
 curl -s "$C/state/proof/$PK"            | jq '{h:.committedHeight, presence, valueHex}'   # current revision
 curl -s "$C/state/proof/$PK?height=3"   | jq '{h:.committedHeight, presence, valueHex}'   # value as of height 3

--- a/appchain/examples/appchain-showcase/README.md
+++ b/appchain/examples/appchain-showcase/README.md
@@ -9,7 +9,7 @@ with [MASTER_DEMO.md](docs/MASTER_DEMO.md), use the
 ./showcase.sh quickstart --profile light --nodes 3 --instance demo
 ```
 
-The light profile runs eleven app chains on one local multi-node Yano cluster,
+The light profile runs twelve app chains on one local multi-node Yano cluster,
 including `payment-chain-settlement`, with no Kafka, object store, IPFS, or
 separate effect service. Seven chains present standalone foundations; the
 remaining reference chains demonstrate how ADR-031 composes those foundations
@@ -18,14 +18,13 @@ with cross-cutting concerns instead of creating another application SPI:
 | Reference application | Reused capabilities |
 |---|---|
 | `workflow-chain` | orders + basic approval + audit + finality-gated outbox effect |
+| `document-review-chain` | document trail + domain actors/roles + actor approval + one-use receipt |
 | `authenticated-map-chain` | authenticated map + direct actor/role authorization + multi-organization approval |
 | `payment-chain-settlement` | EUTxO + L1 observers + settlement effects + rebuildable lifecycle index |
 
-The ADR-033 target light catalog adds `document-review-chain` as the third
-business-composition example: document trail + domain actors/roles + actor
-approval. That workflow already has a proven reusable implementation in the
-role-evidence product, but it is not claimed as a light-profile chain until the
-ADR-033 catalog implementation lands.
+`authenticated-map-jmt-chain` uses the same collections, policies, actors,
+commands, and receipts as the MPF chain; only its commitment backend and
+off-chain-only verification target differ.
 
 The built-in `authenticated-map` scenario demonstrates multiple collections,
 opaque and canonical-CBOR values, a declarative schema, the first-party GS1
@@ -76,8 +75,9 @@ State stays below `data/showcase/<instance>/` by default. `stop` preserves it;
 `restart` validates the retained deployment marker and reuses it. The marker
 also binds the generated authenticated-map settings and genesis to the actual
 bootstrap members and release validator digest. Identity drift fails closed;
-the only supported marker evolution is an explicit, additive `anchor enable`
-migration. `reset --instance <name> --yes` is the only showcase command that
+the finalized-message-index scope is also retained and changes the state
+generation identity. The only supported marker evolution is explicit,
+additive `anchor enable`. `reset --instance <name> --yes` is the only showcase command that
 deletes the named instance.
 
 ```bash
@@ -123,6 +123,7 @@ other nodes still validate the effect intent and its incorporated result.
 ## Profiles and docs
 
 - [LIGHT_PROFILE.md](docs/LIGHT_PROFILE.md)
+- [CAPABILITY_CATALOG.md](docs/CAPABILITY_CATALOG.md)
 - [EVIDENCE_PROFILE.md](docs/EVIDENCE_PROFILE.md)
 - [EUTXO_PROFILE.md](docs/EUTXO_PROFILE.md)
 - [GOVERNANCE_DEMO.md](docs/GOVERNANCE_DEMO.md)
@@ -135,7 +136,6 @@ other nodes still validate the effect intent and its incorporated result.
 - [TROUBLESHOOTING.md](docs/TROUBLESHOOTING.md)
 - [PRESENTERS.md](docs/PRESENTERS.md)
 
-Architecture and product/demo boundaries are recorded in ADR-023 in the Yano
-source repository. The post-ADR-031 reference catalog and capability-discovery
-plan are recorded in ADR app-layer/033. No Yano consensus/core code is changed
-by this module.
+Architecture and product/demo boundaries are recorded in ADR-023. ADR-033
+defines the catalog, manifest discovery contract, generic finalized-message
+index wrapper, console presentation, and qualification requirements.

--- a/appchain/examples/appchain-showcase/build.gradle
+++ b/appchain/examples/appchain-showcase/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     compileOnly project(':appchain-stdlib')
     compileOnly project(':appchain-stdlib-contracts')
     compileOnly project(':appchain-role-workflow-contracts')
+    compileOnly project(':appchain-role-workflow')
     compileOnly project(':appchain-config')
     compileOnly project(':appchain-eutxo-contracts')
     compileOnly libs.cbor
@@ -28,6 +29,7 @@ dependencies {
     testImplementation project(':appchain-stdlib')
     testImplementation project(':appchain-stdlib-contracts')
     testImplementation project(':appchain-role-workflow-contracts')
+    testImplementation project(':appchain-role-workflow')
     testImplementation project(':appchain-config')
     testImplementation project(':appchain-eutxo-contracts')
     // ADR-UTXO-008: golden derivation of the bridge chain's deterministic
@@ -150,6 +152,9 @@ distributions {
             from('src/main/showcase/config/application-appchain.yml') {
                 into 'yano/config'
             }
+            from('src/main/showcase/config/showcase-catalog-v1.json') {
+                into 'catalog'
+            }
             from(project(':app').file('config/application-appchain.yml')) {
                 into 'yano/config'
                 rename { 'application-appchain-standard.yml' }
@@ -251,6 +256,7 @@ tasks.register('verifyShowcasePluginArtifact') {
                         effectExecutorService,
                         pluginManifest,
                         'com/bloxbean/cardano/yano/appchain/showcase/ShowcaseCompositeStateMachineProvider.class',
+                        'com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewStateMachineProvider.class',
                         'com/bloxbean/cardano/yano/appchain/showcase/ShowcaseAuthenticatedMapConfig.class',
                         'com/bloxbean/cardano/yano/appchain/showcase/ShowcaseOutboxExecutorFactory.class',
                         'com/bloxbean/cardano/yano/appchain/showcase/ShowcaseEutxoTransactions.class'
@@ -272,6 +278,7 @@ tasks.register('verifyShowcasePluginArtifact') {
                         || manifest.version != project.version.toString()
                         || contributions != Set.of(
                         'app-state-machine:showcase-composite',
+                        'app-state-machine:document-review',
                         'effect-executor:showcase-outbox')) {
                     throw new GradleException('Unexpected showcase plugin manifest')
                 }

--- a/appchain/examples/appchain-showcase/docs/CAPABILITY_CATALOG.md
+++ b/appchain/examples/appchain-showcase/docs/CAPABILITY_CATALOG.md
@@ -1,0 +1,72 @@
+# ADR-033 Capability Catalog and Proof Lab
+
+Use this page as the short presenter narrative for the default `light`
+profile. The machine-readable source of truth is
+`catalog/showcase-catalog-v1.json` in the distribution; `showcase.sh describe
+light` renders it directly.
+
+| Chain | Kind | Demonstrates | Proof target |
+|---|---|---|---|
+| `orders-chain` | foundation | ordered log + intrinsic finalized-message record | MPF, off-chain + on-chain |
+| `registry-chain` | foundation | conditional key/value state | MPF, off-chain + on-chain |
+| `approvals-chain` | foundation | basic sender-quorum approval | MPF, off-chain + on-chain |
+| `balances-chain` | foundation | deterministic balances | MPF, off-chain + on-chain |
+| `documents-chain` | foundation | document head/history transitions | MPF, off-chain + on-chain |
+| `workflow-chain` | composition | orders + approval + audit + effects | MPF, off-chain + on-chain |
+| `roles-chain` | foundation | actors, roles, policies, actor approvals | MPF, off-chain + on-chain |
+| `payments-chain` | foundation | virtual no-real-funds EUTxO | MPF, off-chain + on-chain |
+| `authenticated-map-chain` | composition | authenticated map + direct roles + approval | MPF, off-chain + on-chain |
+| `authenticated-map-jmt-chain` | backend contrast | identical map business profile on classic JMT | JMT, off-chain only |
+| `payment-chain-settlement` | L1 boundary | L1 observers + EUTxO + settlement effects/indexer | MPF, off-chain + on-chain |
+| `document-review-chain` | composition | documents + roles + approval + consumption receipt | MPF, off-chain + on-chain |
+
+The console’s matrix and composition panel are populated from each
+application’s `capabilityManifest`. Membership governance and executable
+profile governance are displayed separately from business authorization and
+approval.
+
+## Optional finalized-message state proof
+
+Every finalized block already has a message-inclusion path to `messagesRoot`.
+The optional index additionally stores a compact authenticated record
+containing height, original message index, topic, and sender. It does not copy
+the body and does not prove continued body availability.
+
+```bash
+# Default: off for non-intrinsic applications.
+./showcase.sh up --instance default
+
+# Selected applications.
+./showcase.sh up --instance selected \
+  --enable-finalized-message-index=documents-chain,workflow-chain
+
+# Every configured application. orders-chain remains intrinsically indexed.
+./showcase.sh up --instance all-indexed \
+  --enable-finalized-message-index
+```
+
+The scope, policy, cost bound, and digest are retained in
+`showcase-identity.json`; selected applications receive a distinct
+state-generation identity. Restart with a conflicting option fails closed.
+
+In the UI, select a message, inspect its block inclusion, choose “Use message
+state key,” retrieve the authenticated state proof, and compare the state root
+with the latest applicable L1 anchor. MPF proof wires can also be consumed by
+the reference on-chain verifier. JMT proofs are intentionally off-chain-only.
+
+## Three composition traces
+
+```bash
+./showcase.sh run composite --instance demo
+./showcase.sh run document-review --instance demo
+./showcase.sh run authenticated-map --instance demo
+```
+
+Explain each as a committed trace, not a log-derived claim:
+
+```text
+command -> authorization/approval -> application mutation -> effect/consumption receipt
+```
+
+`payment-chain-settlement` starts in light for discoverability, but public
+script deployment, owner keys, deposits, and withdrawals remain explicit.

--- a/appchain/examples/appchain-showcase/docs/LIGHT_PROFILE.md
+++ b/appchain/examples/appchain-showcase/docs/LIGHT_PROFILE.md
@@ -12,7 +12,7 @@ standard library; there is no `pip` install or virtual environment.
 ./showcase.sh status --instance five-node
 ```
 
-The shared YAML starts eleven chains. `payment-chain-settlement` is part of the
+The shared YAML starts twelve chains. `payment-chain-settlement` is part of the
 default light profile; it does not need a separate chain-start command.
 Membership, keys, peers, proposer, and threshold are injected by the maintained
 cluster launcher; the same YAML works at every node count.
@@ -21,13 +21,27 @@ cluster launcher; the same YAML works at every node count.
 |---|---|---|
 | Standalone foundations | `orders-chain`, `registry-chain`, `approvals-chain`, `balances-chain`, `documents-chain`, `roles-chain`, `payments-chain` | one stock application behavior at a time |
 | Cross-cutting application | `workflow-chain` | orders + approval + audit + outbox effects |
+| Cross-cutting application | `document-review-chain` | documents + actors/roles + approval + consumption receipt |
 | Authorization application/backend comparison | `authenticated-map-chain`, `authenticated-map-jmt-chain` | direct actor/role authorization and approval, with MPF/JMT proof behavior |
 | L1 application boundary | `payment-chain-settlement` | L1 observers + EUTxO + settlement effects + derived indexer |
 
-ADR app-layer/033 adds `document-review-chain` to the target light catalog for
-the remaining deliberate composition: document trail + domain actors/roles +
-actor approval. It will reuse the ADR-019/031 components rather than copy the
-role-evidence workflow or introduce another approval implementation.
+`document-review-chain` reuses the ADR-019/031 actor registry, role-aware
+approvals, role authorization capability, and document transitions. It does
+not copy the role-evidence workflow or introduce another approval model.
+
+Every status response includes an immutable `capabilityManifest`. The console
+uses it for the cross-chain matrix and composition panels; it does not infer
+business capabilities from a state-machine name. Start an indexed generation
+with either opt-in form:
+
+```bash
+./showcase.sh up --instance indexed --enable-finalized-message-index
+./showcase.sh up --instance selected \
+  --enable-finalized-message-index=documents-chain,workflow-chain
+```
+
+The selection is consensus state, not the rebuildable SQL indexer. It is
+retained in the instance identity and cannot be changed on restart.
 
 `membership.mode=governed` is enabled independently on the chains. That is
 app-chain member-set governance, not application actor authorization or

--- a/appchain/examples/appchain-showcase/docs/LOAD_AND_SOAK.md
+++ b/appchain/examples/appchain-showcase/docs/LOAD_AND_SOAK.md
@@ -10,10 +10,11 @@ result/proof. Use it to demonstrate correctness under repeated business flows.
 
 ```bash
 ./showcase.sh load orders --count 25 --instance demo
+./showcase.sh load document-review --count 5 --instance demo
 ./showcase.sh load composite --count 10 --instance demo
 ```
 
-Approval and composite iterations intentionally contain several dependent
+Approval, document-review, and composite iterations intentionally contain several dependent
 messages and finality waits. Their iteration rate is not raw message throughput.
 
 ## Parallel burst

--- a/appchain/examples/appchain-showcase/docs/MASTER_DEMO.md
+++ b/appchain/examples/appchain-showcase/docs/MASTER_DEMO.md
@@ -11,9 +11,9 @@ MPF proofs, plugins, effects, and Cardano anchoring. The light showcase
 assembles existing capabilities through one `AppStateMachine` contract. Its
 three deliberate business compositions are orders + approval + effects,
 documents + roles + approval, and authenticated map + direct role/approval.
-The current light distribution directly contains the first and third; ADR-033
-adds the lean `document-review-chain` form of the already proven role-evidence
-reuse path. It does not introduce another consensus implementation.”
+All three are present in the light catalog. `document-review-chain` is the lean
+form of the proven role-evidence reuse path and does not introduce another
+consensus or approval implementation.”
 
 Also explain that `payment-chain-settlement` starts in the default light
 profile. It demonstrates L1 observers and settlement effects, but it does not
@@ -43,6 +43,7 @@ converged roots, and prints the UI URL.
 Expected checkpoints:
 
 - all three nodes become ready;
+- all twelve catalog chains expose deterministic capability manifests;
 - every named chain reports the same root on all nodes;
 - opaque, canonical-CBOR, schema-validated, and plugin-validated map values
   finalize while two deliberately invalid values are filtered before
@@ -157,6 +158,18 @@ balance negative; it finalizes as a deterministic no-op.
 
 Expected: a per-entity count/head-hash state leaf and proof. Documents remain
 off-chain; hashes and references form the ordered trail.
+
+### Document review — reused roles + approval + document transitions
+
+```bash
+./showcase.sh run document-review --instance master-demo
+```
+
+Narrate the committed trace: issuer proposal → two auditor organizations →
+approved role proposal → document-head mutation → one-use application receipt.
+The application is a normal `AppStateMachine` assembled from the same actor,
+role-approval, authorization, and document-transition implementations used by
+the standalone foundations.
 
 ## 10. Composite approval → effect flow, one step at a time
 

--- a/appchain/examples/appchain-showcase/docs/PRESENTERS.md
+++ b/appchain/examples/appchain-showcase/docs/PRESENTERS.md
@@ -11,12 +11,13 @@ The core story is:
 
 1. three members sequence and threshold-finalize independent app chains;
 2. all nodes derive the same state root and MPF-provable state;
-3. business approval messages are separate from MPF finality votes;
-4. the composite release emits an immutable effect intent;
-5. node 0 writes one idempotent local receipt after app finality;
-6. the result re-enters the chain and changes root-attested release state;
-7. a Cardano anchor commits the finalized L2 root; and
-8. governed members can add a node and change threshold without editing live
+3. every application declares its components and cross-cutting capabilities;
+4. business approval messages are separate from MPF finality votes;
+5. the composite release emits an immutable effect intent;
+6. node 0 writes one idempotent local receipt after app finality;
+7. the result re-enters the chain and changes root-attested release state;
+8. a Cardano anchor commits the finalized L2 root; and
+9. governed members can add a node and change threshold without editing live
    membership state by hand.
 
 For the governed portion, always activate one scheduled epoch before creating
@@ -34,6 +35,7 @@ If time is short, run only `quickstart`, open the UI, then show:
 
 ```bash
 ./showcase.sh run composite --instance demo
+./showcase.sh run document-review --instance demo
 ./showcase.sh config show --instance demo
 ./showcase.sh status --instance demo
 ```

--- a/appchain/examples/appchain-showcase/src/distributionTest/scripts/distribution-contract.sh
+++ b/appchain/examples/appchain-showcase/src/distributionTest/scripts/distribution-contract.sh
@@ -73,6 +73,10 @@ grep -q 'Python 3 standard library only' "$ROOT/README.md"
 "$ROOT/showcase.sh" prepare --instance distribution-contract --nodes 3 \
   --http-base 29770 --server-base 29370 >/dev/null
 MAP_ROOT="$ROOT/data/showcase/distribution-contract"
+jq -e '.schemaVersion == 1 and .profileId == "light-v1" and (.chains | length) == 12' \
+  "$ROOT/catalog/showcase-catalog-v1.json" >/dev/null
+grep -q 'chain-id: "document-review-chain"' "$ROOT/yano/config/application-appchain.yml"
+grep -q 'document-review-chain' "$ROOT/docs/CAPABILITY_CATALOG.md"
 [ -s "$MAP_ROOT/authenticated-map.properties" ]
 [ -s "$MAP_ROOT/authenticated-map-genesis.hex" ]
 [ "$(grep -c '^yano.app-chain.chains\[8\]\.' \
@@ -102,8 +106,10 @@ JMT_INFO="$("$ROOT/yano/yano.sh" appchain state validators \
 printf '%s' "$JMT_INFO" | jq -e '
   .chainId == "authenticated-map-jmt-chain" and
   .profile == "jmt-blake2b256-v1" and
-  .validatorCount == 0 and
-  ([.collections[].id] | sort == ["documents", "kv-open", "notes"])
+  .validatorCount == 2 and
+  ([.collections[].id] | sort ==
+    ["attachments", "canonical-events", "governed-catalog", "gtins",
+     "products", "released-products"])
 ' >/dev/null
 
 # ADR-UTXO-008: the packaged light profile carries the bridge chain with its

--- a/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewCommandV1.java
+++ b/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewCommandV1.java
@@ -1,0 +1,96 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.DataItem;
+import co.nstant.in.cbor.model.UnicodeString;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.client.crypto.Blake2bUtil;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+import com.bloxbean.cardano.yano.appchain.roles.contracts.ApprovalReferenceV1;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/** Canonical demo command binding one approved proposal to one document append. */
+public record DocumentReviewCommandV1(
+        String proposalId,
+        String policyId,
+        long policyRevision,
+        String documentEntityId,
+        byte[] documentHash,
+        String documentRef
+) implements ApprovalReferenceV1 {
+    public static final String TOPIC = "document-review.release.v1";
+    public static final String PAYLOAD_DOMAIN = "document.review.release.v1";
+
+    public DocumentReviewCommandV1 {
+        proposalId = identifier(proposalId, "proposalId");
+        policyId = identifier(policyId, "policyId");
+        documentEntityId = identifier(documentEntityId, "documentEntityId");
+        documentRef = Objects.requireNonNull(documentRef, "documentRef");
+        documentHash = Objects.requireNonNull(documentHash, "documentHash").clone();
+        if (policyRevision < 1 || documentHash.length != 32
+                || documentRef.getBytes(java.nio.charset.StandardCharsets.UTF_8).length > 512) {
+            throw new IllegalArgumentException("invalid document-review command");
+        }
+    }
+
+    @Override public byte[] documentHash() { return documentHash.clone(); }
+
+    @Override public byte[] actionCommitment() { return Blake2bUtil.blake2bHash256(encode()); }
+
+    public byte[] encode() {
+        Array value = new Array();
+        value.add(new UnsignedInteger(1));
+        value.add(new UnicodeString(proposalId));
+        value.add(new UnicodeString(policyId));
+        value.add(new UnsignedInteger(policyRevision));
+        value.add(new UnicodeString(documentEntityId));
+        value.add(new ByteString(documentHash));
+        value.add(new UnicodeString(documentRef));
+        return CborSerializationUtil.serialize(value);
+    }
+
+    public static DocumentReviewCommandV1 decode(byte[] encoded) {
+        DataItem item = CborSerializationUtil.deserializeOne(encoded);
+        if (!(item instanceof Array array) || array.getDataItems().size() != 7) {
+            throw new IllegalArgumentException("invalid document-review command");
+        }
+        List<DataItem> values = array.getDataItems();
+        if (!(values.get(0) instanceof UnsignedInteger version)
+                || version.getValue().intValueExact() != 1) {
+            throw new IllegalArgumentException("unsupported document-review command version");
+        }
+        DocumentReviewCommandV1 command = new DocumentReviewCommandV1(
+                text(values.get(1)), text(values.get(2)), uint(values.get(3)),
+                text(values.get(4)), bytes(values.get(5)), text(values.get(6)));
+        if (!Arrays.equals(encoded, command.encode())) {
+            throw new IllegalArgumentException("document-review command is not canonical");
+        }
+        return command;
+    }
+
+    private static String identifier(String value, String field) {
+        if (value == null || !value.matches("[a-z0-9][a-z0-9._-]{0,127}")) {
+            throw new IllegalArgumentException("invalid " + field);
+        }
+        return value;
+    }
+
+    private static String text(DataItem value) {
+        if (!(value instanceof UnicodeString text)) throw new IllegalArgumentException("expected text");
+        return text.getString();
+    }
+
+    private static long uint(DataItem value) {
+        if (!(value instanceof UnsignedInteger number)) throw new IllegalArgumentException("expected uint");
+        return number.getValue().longValueExact();
+    }
+
+    private static byte[] bytes(DataItem value) {
+        if (!(value instanceof ByteString bytes)) throw new IllegalArgumentException("expected bytes");
+        return bytes.getBytes();
+    }
+}

--- a/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewPreset.java
+++ b/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewPreset.java
@@ -1,0 +1,106 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import com.bloxbean.cardano.client.crypto.Blake2bUtil;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachineContext;
+import com.bloxbean.cardano.yano.appchain.composite.ComponentDescriptor;
+import com.bloxbean.cardano.yano.appchain.composite.ComponentGeneration;
+import com.bloxbean.cardano.yano.appchain.composite.ComposableAppStateMachine;
+import com.bloxbean.cardano.yano.appchain.composite.CompositeStateMachine;
+import com.bloxbean.cardano.yano.appchain.composite.WorkflowDescriptor;
+import com.bloxbean.cardano.yano.appchain.roles.DomainActorRegistryComponent;
+import com.bloxbean.cardano.yano.appchain.roles.GovernedRoleApprovalWorkflow;
+import com.bloxbean.cardano.yano.appchain.roles.RoleAwareApprovalsComponent;
+import com.bloxbean.cardano.yano.appchain.roles.contracts.GovernedGenesisV1;
+import com.bloxbean.cardano.yano.appchain.stdlib.DocTrailStateMachine;
+
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Objects;
+
+/** Committed lean document + role + approval reference composition. */
+public final class DocumentReviewPreset {
+    public static final String PROFILE_ID = "document-role-approval-v1";
+    public static final String PROFILE_VERSION = "1.0.0";
+    public static final String POLICY_ID = "document-release";
+    public static final String DOCUMENTS_COMPONENT_ID = "documents";
+
+    private DocumentReviewPreset() {
+    }
+
+    public static CompositeStateMachine create(AppStateMachineContext context) {
+        Objects.requireNonNull(context, "context");
+        GovernedGenesisV1 genesis = ShowcaseAuthenticatedMapConfig.documentReviewGenesis(
+                context.chainId());
+        byte[] applicationId = Blake2bUtil.blake2bHash256(genesis.encode());
+        String configurationId = PROFILE_ID + ":" + HexFormat.of().formatHex(applicationId);
+
+        ComponentDescriptor actorsDescriptor = descriptor(
+                DomainActorRegistryComponent.COMPONENT_ID, configurationId,
+                "domain-actors-state-v1", List.of(DomainActorRegistryComponent.TOPIC),
+                List.of(DomainActorRegistryComponent.QUERY_ACTOR,
+                        DomainActorRegistryComponent.QUERY_ACTOR_CURRENT,
+                        DomainActorRegistryComponent.QUERY_ORGANIZATION,
+                        DomainActorRegistryComponent.QUERY_ORGANIZATION_CURRENT), 0);
+        ComponentDescriptor approvalsDescriptor = descriptor(
+                RoleAwareApprovalsComponent.COMPONENT_ID, configurationId,
+                "role-approvals-state-v1", List.of(),
+                List.of(RoleAwareApprovalsComponent.QUERY_POLICY,
+                        RoleAwareApprovalsComponent.QUERY_POLICY_CURRENT,
+                        RoleAwareApprovalsComponent.QUERY_PROPOSAL,
+                        RoleAwareApprovalsComponent.QUERY_STATS), 0);
+        ComponentDescriptor documentsDescriptor = descriptor(
+                DOCUMENTS_COMPONENT_ID, "approval-gated-v1",
+                "document-trail-state-v1", List.of(),
+                List.of(DocTrailStateMachine.QUERY_HEAD), 0);
+        ComponentDescriptor receiptsDescriptor = descriptor(
+                DocumentReviewReceiptStateMachine.ID, "approval-consumption-v1",
+                "document-review-receipts-state-v1", List.of(),
+                List.of(DocumentReviewReceiptStateMachine.QUERY_RECEIPT), 0);
+
+        DomainActorRegistryComponent actors = DomainActorRegistryComponent.genesisBound(
+                actorsDescriptor, context.chainId(), genesis, applicationId);
+        RoleAwareApprovalsComponent approvals = new RoleAwareApprovalsComponent(
+                approvalsDescriptor, genesis);
+        DocTrailStateMachine documents = new DocTrailStateMachine();
+        DocumentReviewReceiptStateMachine receipts = new DocumentReviewReceiptStateMachine();
+        ComponentGeneration actorsGeneration = actorsDescriptor.generation();
+        ComponentGeneration approvalsGeneration = approvalsDescriptor.generation();
+        ComponentGeneration documentsGeneration = documentsDescriptor.generation();
+        ComponentGeneration receiptsGeneration = receiptsDescriptor.generation();
+
+        WorkflowDescriptor roleDescriptor = new WorkflowDescriptor(
+                GovernedRoleApprovalWorkflow.WORKFLOW_ID,
+                GovernedRoleApprovalWorkflow.PRODUCT_VERSION,
+                GovernedRoleApprovalWorkflow.TOPIC, 1, 0,
+                List.of(actorsGeneration, approvalsGeneration), 0);
+        GovernedRoleApprovalWorkflow roles = new GovernedRoleApprovalWorkflow(
+                roleDescriptor, actorsGeneration, approvalsGeneration,
+                context.chainId(), applicationId, genesis,
+                DocumentReviewCommandV1.PAYLOAD_DOMAIN);
+        WorkflowDescriptor reviewDescriptor = new WorkflowDescriptor(
+                DocumentReviewWorkflow.ID, DocumentReviewWorkflow.VERSION,
+                DocumentReviewCommandV1.TOPIC, 1, 0,
+                List.of(approvalsGeneration, documentsGeneration, receiptsGeneration), 0);
+        DocumentReviewWorkflow review = new DocumentReviewWorkflow(
+                reviewDescriptor, approvalsGeneration, documentsGeneration,
+                receiptsGeneration, context.chainId());
+
+        return ComposableAppStateMachine.builder(DocumentReviewStateMachineProvider.ID,
+                        context, PROFILE_ID, PROFILE_VERSION)
+                .machine(actorsDescriptor, actors)
+                .machine(approvalsDescriptor, approvals)
+                .machine(documentsDescriptor, documents)
+                .machine(receiptsDescriptor, receipts)
+                .workflow(roles)
+                .workflow(review)
+                .build();
+    }
+
+    private static ComponentDescriptor descriptor(
+            String id, String configurationId, String stateCompatibilityId,
+            List<String> topics, List<String> queries, int effects
+    ) {
+        return new ComponentDescriptor(id, PROFILE_VERSION, configurationId,
+                stateCompatibilityId, 1, 0, topics, queries, effects);
+    }
+}

--- a/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewReceiptStateMachine.java
+++ b/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewReceiptStateMachine.java
@@ -1,0 +1,51 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
+import com.bloxbean.cardano.yano.api.appchain.AppQueryContext;
+import com.bloxbean.cardano.yano.api.appchain.AppQueryException;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
+import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
+import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
+
+import java.nio.charset.StandardCharsets;
+
+/** State owner for document-review approval-consumption receipts. */
+final class DocumentReviewReceiptStateMachine implements AppStateMachine {
+    static final String ID = "document-review-receipts";
+    static final String QUERY_RECEIPT = "receipt";
+    private static final byte[] PREFIX = "approval/".getBytes(StandardCharsets.US_ASCII);
+
+    @Override public String id() { return ID; }
+
+    @Override
+    public void apply(AppBlockExecutionContext context, AppStateWriter writer, AppEffectEmitter effects) {
+        // Writes are owned by DocumentReviewWorkflow.
+    }
+
+    @Override
+    public byte[] query(String path, byte[] params, AppQueryContext state) {
+        if (!QUERY_RECEIPT.equals(path)) {
+            throw new AppQueryException(AppQueryException.Code.UNSUPPORTED,
+                    "unsupported document-review query");
+        }
+        return state.get(receiptKey(asciiId(params))).orElse(new byte[0]);
+    }
+
+    static byte[] receiptKey(String proposalId) {
+        byte[] id = asciiId(proposalId.getBytes(StandardCharsets.US_ASCII))
+                .getBytes(StandardCharsets.US_ASCII);
+        byte[] key = new byte[PREFIX.length + id.length];
+        System.arraycopy(PREFIX, 0, key, 0, PREFIX.length);
+        System.arraycopy(id, 0, key, PREFIX.length, id.length);
+        return key;
+    }
+
+    private static String asciiId(byte[] value) {
+        String id = new String(value, StandardCharsets.US_ASCII);
+        if (!id.matches("[a-z0-9][a-z0-9._-]{0,127}")) {
+            throw new AppQueryException(AppQueryException.Code.INVALID_REQUEST,
+                    "receipt query requires a canonical proposal id");
+        }
+        return id;
+    }
+}

--- a/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewReceiptV1.java
+++ b/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewReceiptV1.java
@@ -1,0 +1,43 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import co.nstant.in.cbor.model.Array;
+import co.nstant.in.cbor.model.ByteString;
+import co.nstant.in.cbor.model.UnicodeString;
+import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
+
+/** Application-owned proof that one approval was consumed by one document append. */
+public record DocumentReviewReceiptV1(
+        String proposalId,
+        String documentEntityId,
+        byte[] actionCommitment,
+        String policyId,
+        long policyRevision,
+        long appliedHeight,
+        byte[] messageId
+) {
+    public DocumentReviewReceiptV1 {
+        actionCommitment = actionCommitment.clone();
+        messageId = messageId.clone();
+        if (actionCommitment.length != 32 || messageId.length != 32
+                || policyRevision < 1 || appliedHeight < 1) {
+            throw new IllegalArgumentException("invalid document-review receipt");
+        }
+    }
+
+    @Override public byte[] actionCommitment() { return actionCommitment.clone(); }
+    @Override public byte[] messageId() { return messageId.clone(); }
+
+    public byte[] encode() {
+        Array value = new Array();
+        value.add(new UnsignedInteger(1));
+        value.add(new UnicodeString(proposalId));
+        value.add(new UnicodeString(documentEntityId));
+        value.add(new ByteString(actionCommitment));
+        value.add(new UnicodeString(policyId));
+        value.add(new UnsignedInteger(policyRevision));
+        value.add(new UnsignedInteger(appliedHeight));
+        value.add(new ByteString(messageId));
+        return CborSerializationUtil.serialize(value);
+    }
+}

--- a/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewStateMachineProvider.java
+++ b/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewStateMachineProvider.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachineContext;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachineProvider;
+
+/** Demo provider for document trail + domain actors + role-aware approval composition. */
+public final class DocumentReviewStateMachineProvider implements AppStateMachineProvider {
+    public static final String ID = "document-review";
+
+    @Override public String id() { return ID; }
+
+    @Override
+    public AppStateMachine create() {
+        throw new IllegalStateException("document-review requires app-chain context");
+    }
+
+    @Override
+    public AppStateMachine create(AppStateMachineContext context) {
+        return DocumentReviewPreset.create(context);
+    }
+}

--- a/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewWorkflow.java
+++ b/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewWorkflow.java
@@ -1,0 +1,107 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yano.api.appchain.AppBlock;
+import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
+import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
+import com.bloxbean.cardano.yano.api.appchain.transition.TransitionContext;
+import com.bloxbean.cardano.yano.api.appchain.transition.TransitionPlans;
+import com.bloxbean.cardano.yano.appchain.composite.ComponentGeneration;
+import com.bloxbean.cardano.yano.appchain.composite.CompositeWorkflow;
+import com.bloxbean.cardano.yano.appchain.composite.CompositeWorkflowContext;
+import com.bloxbean.cardano.yano.appchain.composite.WorkflowDescriptor;
+import com.bloxbean.cardano.yano.appchain.roles.RoleAuthorizationCapability;
+import com.bloxbean.cardano.yano.appchain.stdlib.DocTrailStateMachine;
+import com.bloxbean.cardano.yano.appchain.stdlib.DocTrailTransitions;
+
+import java.util.List;
+import java.util.Objects;
+
+/** Atomic approval consumption and document-head transition. */
+final class DocumentReviewWorkflow implements CompositeWorkflow {
+    static final String ID = "document-review-release";
+    static final String VERSION = "1.0.0";
+
+    private final WorkflowDescriptor descriptor;
+    private final ComponentGeneration approvals;
+    private final ComponentGeneration documents;
+    private final ComponentGeneration receipts;
+    private final RoleAuthorizationCapability authorization;
+    private final DocTrailTransitions documentTransitions = new DocTrailTransitions();
+
+    DocumentReviewWorkflow(WorkflowDescriptor descriptor,
+                           ComponentGeneration approvals,
+                           ComponentGeneration documents,
+                           ComponentGeneration receipts,
+                           String chainId) {
+        this.descriptor = Objects.requireNonNull(descriptor, "descriptor");
+        this.approvals = Objects.requireNonNull(approvals, "approvals");
+        this.documents = Objects.requireNonNull(documents, "documents");
+        this.receipts = Objects.requireNonNull(receipts, "receipts");
+        this.authorization = new RoleAuthorizationCapability(chainId);
+        if (!ID.equals(descriptor.workflowId())
+                || !DocumentReviewCommandV1.TOPIC.equals(descriptor.topic())
+                || !descriptor.participants().equals(List.of(approvals, documents, receipts))) {
+            throw new IllegalArgumentException("invalid document-review workflow descriptor");
+        }
+    }
+
+    @Override public WorkflowDescriptor descriptor() { return descriptor; }
+
+    @Override
+    public AppStateMachine.AdmissionResult validate(AppMessage message) {
+        try {
+            DocumentReviewCommandV1.decode(message.getBody());
+            return AppStateMachine.AdmissionResult.accept();
+        } catch (RuntimeException malformed) {
+            return AppStateMachine.AdmissionResult.reject("INVALID_DOCUMENT_REVIEW_COMMAND");
+        }
+    }
+
+    @Override
+    public void apply(AppBlockExecutionContext execution, CompositeWorkflowContext context) {
+        AppBlock block = execution.block();
+        int visibleIndex = 0;
+        for (AppMessage source : execution.messages()) {
+            int originalIndex = execution.originalMessageIndex(visibleIndex++);
+            DocumentReviewCommandV1 command;
+            try {
+                command = DocumentReviewCommandV1.decode(source.getBody());
+            } catch (RuntimeException malformed) {
+                continue;
+            }
+            var approvalState = context.state(approvals);
+            var documentState = context.state(documents);
+            var receiptState = context.state(receipts);
+            byte[] receiptKey = DocumentReviewReceiptStateMachine.receiptKey(command.proposalId());
+            byte[] commitment = command.actionCommitment();
+            var verified = authorization.verifyApproval(
+                    command, DocumentReviewCommandV1.PAYLOAD_DOMAIN,
+                    commitment, commitment, block.height(),
+                    receiptState.get(receiptKey).isPresent(), approvalState);
+            if (!verified.accepted()
+                    || context.claim(command.proposalId(), commitment)
+                    != CompositeWorkflowContext.ClaimResult.CLAIMED) {
+                continue;
+            }
+
+            byte[] body = DocTrailStateMachine.append(command.documentEntityId(),
+                    command.documentHash(), command.documentRef());
+            TransitionPlans.commitIfApproved(documentTransitions.decide(body,
+                            new TransitionContext(block.height(), block.timestamp(), originalIndex,
+                                    source.getMessageId(), "doc-trail.command.v1", source.getSender()),
+                            documentState),
+                    documentState,
+                    AppEffectEmitter.rejecting("document review does not emit effects"));
+
+            DocumentReviewReceiptV1 receipt = new DocumentReviewReceiptV1(
+                    command.proposalId(), command.documentEntityId(), commitment,
+                    command.policyId(), command.policyRevision(), block.height(),
+                    source.getMessageId());
+            var plan = authorization.planApprovalConsumption(
+                    verified, receiptKey, receipt.encode());
+            receiptState.put(plan.replayKey(), plan.applicationReceipt());
+        }
+    }
+}

--- a/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseAuthenticatedMapConfig.java
+++ b/appchain/examples/appchain-showcase/src/main/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseAuthenticatedMapConfig.java
@@ -62,13 +62,13 @@ public final class ShowcaseAuthenticatedMapConfig {
             Options options = Options.parse(arguments);
             Map<String, String> settings;
             String prefix;
+            byte[] closureDigest = catalogArtifactClosure(
+                    options.runtimeJar(), VALIDATOR_BUNDLE_ID);
             if (JMT_CHAIN_ID.equals(options.chainId())) {
-                settings = jmtSettings(
-                        options.chainId(), options.members(), options.threshold());
+                settings = jmtSettings(options.chainId(), options.members(),
+                        options.threshold(), closureDigest);
                 prefix = JMT_PREFIX;
             } else {
-                byte[] closureDigest = catalogArtifactClosure(
-                        options.runtimeJar(), VALIDATOR_BUNDLE_ID);
                 settings = settings(options.chainId(), options.members(),
                         options.threshold(), closureDigest);
                 prefix = PREFIX;
@@ -80,14 +80,13 @@ public final class ShowcaseAuthenticatedMapConfig {
         }
     }
 
-    /**
-     * The contrasting second map chain: classic-JMT backend with a basic
-     * (ungoverned) authorization profile — open, owner, and member
-     * collections and no genesis validators — so the console's basic-only
-     * views and the JMT commitment identity can be demonstrated next to the
-     * governed MPF chain.
-     */
     static Map<String, String> jmtSettings(String chainId, List<String> members, int threshold) {
+        return jmtSettings(chainId, members, threshold, new byte[32]);
+    }
+
+    /** Same governed business profile as MPF, with only the proof backend changed. */
+    static Map<String, String> jmtSettings(
+            String chainId, List<String> members, int threshold, byte[] validatorArtifactClosure) {
         if (!JMT_CHAIN_ID.equals(chainId)) {
             throw new IllegalArgumentException("unexpected authenticated-map JMT chain id");
         }
@@ -105,21 +104,14 @@ public final class ShowcaseAuthenticatedMapConfig {
                 .stateMachineId(AuthenticatedMapContract.STATE_MACHINE_ID)
                 .pluginSettings(Map.of("membership.mode", "governed"))
                 .build();
-        List<AuthenticatedMapContract.CollectionDescriptor> collections = List.of(
-                collection("kv-open", AuthenticatedMapContract.AUTH_OPEN,
-                        64, 1_024, AuthenticatedMapContract.VALUE_ENCODING_OPAQUE, ""),
-                collection("documents", AuthenticatedMapContract.AUTH_OWNER,
-                        64, 8_192, AuthenticatedMapContract.VALUE_ENCODING_OPAQUE, ""),
-                collection("notes", AuthenticatedMapContract.AUTH_MEMBER,
-                        64, 2_048, AuthenticatedMapContract.VALUE_ENCODING_CANONICAL_CBOR,
-                        ""));
+        Profile profile = businessProfile(validatorArtifactClosure);
         AuthenticatedMapContract.Genesis genesis = AuthenticatedMapGenesisFactory.classicJmt(
                 config,
                 new byte[32],
                 32,
                 AppChainConfig.DEFAULT_MAX_MESSAGE_BYTES,
-                collections,
-                List.of());
+                profile.collections(), profile.validators(), List.of(),
+                governedGenesis(chainId));
         return Collections.unmodifiableMap(
                 new TreeMap<>(AuthenticatedMapGenesisFactory.settings(genesis)));
     }
@@ -149,16 +141,26 @@ public final class ShowcaseAuthenticatedMapConfig {
                 .pluginSettings(Map.of("membership.mode", "governed"))
                 .build();
 
+        Profile profile = businessProfile(validatorArtifactClosure);
+        AuthenticatedMapContract.Genesis genesis = AuthenticatedMapGenesisFactory.mpf(
+                config,
+                new byte[32],
+                32,
+                AppChainConfig.DEFAULT_MAX_MESSAGE_BYTES,
+                profile.collections(), profile.validators(), List.of(),
+                governedGenesis(chainId));
+        return Collections.unmodifiableMap(
+                new TreeMap<>(AuthenticatedMapGenesisFactory.settings(genesis)));
+    }
+
+    private static Profile businessProfile(byte[] validatorArtifactClosure) {
         AuthenticatedMapContract.ValidatorDescriptor productSchema =
                 AuthenticatedMapContract.ValidatorDescriptor.schema(
                         "product-v1", productSchemaDefinition());
         AuthenticatedMapContract.ValidatorDescriptor gtinValidator =
                 AuthenticatedMapContract.ValidatorDescriptor.plugin(
-                        VALIDATOR_DESCRIPTOR_ID,
-                        VALIDATOR_PROVIDER_ID,
-                        validatorArtifactClosure,
-                        EMPTY_CBOR_MAP);
-
+                        VALIDATOR_DESCRIPTOR_ID, VALIDATOR_PROVIDER_ID,
+                        validatorArtifactClosure, EMPTY_CBOR_MAP);
         List<AuthenticatedMapContract.CollectionDescriptor> collections = List.of(
                 collection("attachments", AuthenticatedMapContract.AUTH_OWNER,
                         64, 32_768, AuthenticatedMapContract.VALUE_ENCODING_OPAQUE, ""),
@@ -178,18 +180,7 @@ public final class ShowcaseAuthenticatedMapConfig {
                         "released-products", AuthenticatedMapContract.AUTH_APPROVAL,
                         APPROVAL_POLICY_ID, false, 64, 4_096,
                         AuthenticatedMapContract.VALUE_ENCODING_OPAQUE, ""));
-
-        AuthenticatedMapContract.Genesis genesis = AuthenticatedMapGenesisFactory.mpf(
-                config,
-                new byte[32],
-                32,
-                AppChainConfig.DEFAULT_MAX_MESSAGE_BYTES,
-                collections,
-                List.of(gtinValidator, productSchema),
-                List.of(),
-                governedGenesis(chainId));
-        return Collections.unmodifiableMap(
-                new TreeMap<>(AuthenticatedMapGenesisFactory.settings(genesis)));
+        return new Profile(collections, List.of(gtinValidator, productSchema));
     }
 
     static final String DIRECT_POLICY_ID = "issuer-write";
@@ -219,6 +210,20 @@ public final class ShowcaseAuthenticatedMapConfig {
      * distinct organizations before an approved action executes.
      */
     static GovernedGenesisV1 governedGenesis(String chainId) {
+        return governedGenesis(chainId, List.of(new DirectRolePolicyV1(
+                        DIRECT_POLICY_ID, 1, RecordStatus.ACTIVE, "issuer", 100)),
+                APPROVAL_POLICY_ID);
+    }
+
+    static GovernedGenesisV1 documentReviewGenesis(String chainId) {
+        return governedGenesis(chainId, List.of(), DocumentReviewPreset.POLICY_ID);
+    }
+
+    private static GovernedGenesisV1 governedGenesis(
+            String chainId,
+            List<DirectRolePolicyV1> directPolicies,
+            String approvalPolicyId
+    ) {
         OrganizationRecordV1 manufacturer = new OrganizationRecordV1(
                 "acme-manufacturing", 1, RecordStatus.ACTIVE, new byte[0]);
         OrganizationRecordV1 guildA = new OrganizationRecordV1(
@@ -236,17 +241,15 @@ public final class ShowcaseAuthenticatedMapConfig {
                         guildB.organizationId(), List.of("auditor")));
         AdministratorAuthorityV1 authority = new AdministratorAuthorityV1(
                 AUTHORITY_ID, 1, List.of("registry-admin-a"), 1, 1_000);
-        DirectRolePolicyV1 directPolicy = new DirectRolePolicyV1(
-                DIRECT_POLICY_ID, 1, RecordStatus.ACTIVE, "issuer", 100);
         ApprovalPolicyV1 approvalPolicy = new ApprovalPolicyV1(
-                APPROVAL_POLICY_ID, 1, RecordStatus.ACTIVE, List.of("issuer"),
+                approvalPolicyId, 1, RecordStatus.ACTIVE, List.of("issuer"),
                 List.of(new ApprovalPolicyV1.RequiredClause(
                         "independent-auditors", "auditor", 2,
                         ApprovalPolicyV1.DistinctBy.ORGANIZATION)),
                 ApprovalPolicyV1.RejectionMode.ANY_ELIGIBLE, 600);
         return new GovernedGenesisV1(
                 chainId, authority, List.of(manufacturer, guildA, guildB), actors,
-                List.of(directPolicy), List.of(approvalPolicy),
+                directPolicies, List.of(approvalPolicy),
                 GovernedAuthorizationLimitsV1.defaults());
     }
 
@@ -359,6 +362,11 @@ public final class ShowcaseAuthenticatedMapConfig {
             }
         }
         return List.copyOf(unique);
+    }
+
+    private record Profile(
+            List<AuthenticatedMapContract.CollectionDescriptor> collections,
+            List<AuthenticatedMapContract.ValidatorDescriptor> validators) {
     }
 
     private record Options(Path runtimeJar, String chainId, List<String> members, int threshold) {

--- a/appchain/examples/appchain-showcase/src/main/resources/META-INF/services/com.bloxbean.cardano.yano.api.appchain.AppStateMachineProvider
+++ b/appchain/examples/appchain-showcase/src/main/resources/META-INF/services/com.bloxbean.cardano.yano.api.appchain.AppStateMachineProvider
@@ -1,1 +1,2 @@
 com.bloxbean.cardano.yano.appchain.showcase.ShowcaseCompositeStateMachineProvider
+com.bloxbean.cardano.yano.appchain.showcase.DocumentReviewStateMachineProvider

--- a/appchain/examples/appchain-showcase/src/main/resources/META-INF/yano/plugins/com.bloxbean.cardano.yano.appchain.showcase.json
+++ b/appchain/examples/appchain-showcase/src/main/resources/META-INF/yano/plugins/com.bloxbean.cardano.yano.appchain.showcase.json
@@ -8,6 +8,11 @@
       "id": "com.bloxbean.cardano.yano.appchain.stdlib",
       "minVersion": "${showcaseVersion}",
       "maxVersionExclusive": "0.2.0"
+    },
+    {
+      "id": "com.bloxbean.cardano.yano.appchain.role-workflow",
+      "minVersion": "${showcaseVersion}",
+      "maxVersionExclusive": "0.2.0"
     }
   ],
   "contributions": [
@@ -15,6 +20,11 @@
       "kind": "app-state-machine",
       "name": "showcase-composite",
       "provider": "com.bloxbean.cardano.yano.appchain.showcase.ShowcaseCompositeStateMachineProvider"
+    },
+    {
+      "kind": "app-state-machine",
+      "name": "document-review",
+      "provider": "com.bloxbean.cardano.yano.appchain.showcase.DocumentReviewStateMachineProvider"
     },
     {
       "kind": "effect-executor",

--- a/appchain/examples/appchain-showcase/src/main/showcase/config/application-appchain.yml
+++ b/appchain/examples/appchain-showcase/src/main/showcase/config/application-appchain.yml
@@ -240,3 +240,18 @@ yano:
             vault-script-file: "${yano.home}/config/settlement/settlement-vault.script"
             shard-script-file: "${yano.home}/config/settlement/settlement-shard.script"
             round-timeout-ms: "15000"
+
+    # ADR-033: lean composition of the stock domain-actor registry,
+    # role-aware approvals, document-trail transitions, and an
+    # application-owned one-use approval-consumption receipt.
+    chains[11]:
+      chain-id: "document-review-chain"
+      state-machine: "document-review"
+      state:
+        commitment-profile: "mpf-blake2b256-v1"
+        format-fingerprint: "91ee14091200f1e24659112d640e877e9177779dcc81dd06117f013e9190082b"
+        genesis-id: "ebf7c4423f5ca66ed1d37fe6c0cef9473e734e723f812d8bcd17692f0aaff63a"
+      membership:
+        mode: "governed"
+      block:
+        interval-ms: "1000"

--- a/appchain/examples/appchain-showcase/src/main/showcase/config/showcase-catalog-v1.json
+++ b/appchain/examples/appchain-showcase/src/main/showcase/config/showcase-catalog-v1.json
@@ -1,0 +1,18 @@
+{
+  "schemaVersion": 1,
+  "profileId": "light-v1",
+  "chains": [
+    {"chainId":"orders-chain","scenarioId":"orders","classification":"foundation","stateMachine":"ordered-log","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"orders","expectedCapabilities":["state-index:finalized-message-v1","state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"registry-chain","scenarioId":"registry","classification":"foundation","stateMachine":"kv-registry","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"registry","expectedCapabilities":["state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"approvals-chain","scenarioId":"approvals","classification":"foundation","stateMachine":"approvals","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"approvals","expectedCapabilities":["approval:basic-quorum-v1","state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"balances-chain","scenarioId":"balances","classification":"foundation","stateMachine":"balances","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"balances","expectedCapabilities":["state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"documents-chain","scenarioId":"documents","classification":"foundation","stateMachine":"doc-trail","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"documents","expectedCapabilities":["state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"workflow-chain","scenarioId":"order-release","classification":"reference","stateMachine":"showcase-composite","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"composite","expectedCapabilities":["approval:basic-quorum-v1","effects:outbox-v1","state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"roles-chain","scenarioId":"role-approvals","classification":"foundation","stateMachine":"role-approvals","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"roles","expectedCapabilities":["approval:actor-role-v1","state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"payments-chain","scenarioId":"virtual-payment","classification":"foundation","stateMachine":"eutxo-ledger","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"eutxo","expectedCapabilities":["state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"authenticated-map-chain","scenarioId":"governed-authenticated-map","classification":"reference","stateMachine":"authenticated-map","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"authenticated-map","expectedCapabilities":["authorization:direct-role-v1","approval:actor-role-v1","state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"authenticated-map-jmt-chain","scenarioId":"governed-authenticated-map","classification":"backend-comparison","stateMachine":"authenticated-map","proofBackend":"jmt","anchorEligible":true,"smokeHandler":"authenticated-map-jmt","expectedCapabilities":["authorization:direct-role-v1","approval:actor-role-v1","state-commitment:jmt-blake2b256-v1"]},
+    {"chainId":"payment-chain-settlement","scenarioId":"l1-settlement","classification":"l1-boundary","stateMachine":"eutxo-ledger","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"settlement","expectedCapabilities":["effects:outbox-v1","l1-observer:eutxo-vault-deposit-v1","l1-observer:eutxo-withdrawal-confirmation-v1","state-commitment:mpf-blake2b256-v1"]},
+    {"chainId":"document-review-chain","scenarioId":"document-review","classification":"reference","stateMachine":"document-review","proofBackend":"mpf","anchorEligible":true,"smokeHandler":"document-review","expectedCapabilities":["approval:actor-role-v1","state-commitment:mpf-blake2b256-v1"]}
+  ]
+}

--- a/appchain/examples/appchain-showcase/src/main/showcase/demos/submit-document-review.sh
+++ b/appchain/examples/appchain-showcase/src/main/showcase/demos/submit-document-review.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+ROOT="$(cd "$(dirname "$0")/.." && pwd -P)"
+exec "$ROOT/showcase.sh" run document-review --instance "${1:?instance required}" "${2:-}"

--- a/appchain/examples/appchain-showcase/src/main/showcase/showcase.sh
+++ b/appchain/examples/appchain-showcase/src/main/showcase/showcase.sh
@@ -7,11 +7,13 @@ YANO_HOME="$SHOWCASE_HOME/yano"
 CLUSTER="$YANO_HOME/appchain-cluster/cluster.sh"
 CODEC="$SHOWCASE_HOME/tools/showcase_codec.py"
 IDENTITY="$SHOWCASE_HOME/tools/showcase_identity.py"
+CATALOG="$SHOWCASE_HOME/catalog/showcase-catalog-v1.json"
+CATALOG_TOOL="$SHOWCASE_HOME/tools/showcase_catalog.py"
 VERSION="$(tr -d '\r\n' < "$SHOWCASE_HOME/VERSION" 2>/dev/null || printf development)"
 API_KEY="${YANO_CLUSTER_API_KEY:-yano-local-cluster-full-key}"
-LIGHT_CHAINS=(orders-chain registry-chain approvals-chain balances-chain
-  documents-chain workflow-chain roles-chain payments-chain authenticated-map-chain
-  authenticated-map-jmt-chain payment-chain-settlement)
+LIGHT_CHAINS=()
+while IFS= read -r chain_id; do LIGHT_CHAINS+=("$chain_id"); done \
+  < <(python3 "$CATALOG_TOOL" "$CATALOG" list)
 AUTHMAP_GENERATOR=com.bloxbean.cardano.yano.appchain.showcase.ShowcaseAuthenticatedMapConfig
 AUTHMAP_CHAIN_INDEX=8
 AUTHMAP_JMT_CHAIN_INDEX=9
@@ -56,6 +58,8 @@ RATE=25
 SAMPLE=5
 SPREAD=false
 REPORT_DIR=""
+FINALIZED_INDEX_SELECTION=""
+FINALIZED_INDEX_EXPLICIT=false
 FOLLOW=false
 YES=false
 OUTPUT=""
@@ -89,6 +93,10 @@ parse() {
       --sample) SAMPLE="${2:-}"; shift 2;;
       --spread) SPREAD=true; shift;;
       --report-dir) REPORT_DIR="${2:-}"; shift 2;;
+      --enable-finalized-message-index)
+        FINALIZED_INDEX_SELECTION=all; FINALIZED_INDEX_EXPLICIT=true; shift;;
+      --enable-finalized-message-index=*)
+        FINALIZED_INDEX_SELECTION="${1#*=}"; FINALIZED_INDEX_EXPLICIT=true; shift;;
       --chain) AUTHMAP_CHAIN="${2:-}"; shift 2;;
       --collection) AUTHMAP_COLLECTION="${2:-}"; shift 2;;
       --actor) AUTHMAP_ACTOR="${2:-}"; shift 2;;
@@ -126,6 +134,30 @@ canonical_anchor_chains() {
   printf '%s' "$result"
 }
 
+canonical_finalized_index_chains() {
+  local requested="$1" item cid seen="" result=""
+  local -a values=()
+  [ -n "$requested" ] || { printf ''; return; }
+  [ "$requested" != all ] || requested="$(IFS=,; printf '%s' "${LIGHT_CHAINS[*]}")"
+  [ -n "$requested" ] || die "finalized-message index scope cannot be empty"
+  IFS=',' read -r -a values <<< "$requested"
+  for item in "${values[@]}"; do
+    [[ "$item" =~ ^[A-Za-z0-9._~-]{1,128}$ ]] \
+      || die "invalid finalized-message index chain id: $item"
+    [ "$item" != all ] || die "finalized-message index cannot mix all with chain ids"
+    chain_in_csv "$seen" "$item" \
+      && die "duplicate finalized-message index chain: $item"
+    seen+="${seen:+,}$item"
+    local found=false
+    for cid in "${LIGHT_CHAINS[@]}"; do [ "$cid" != "$item" ] || found=true; done
+    [ "$found" = true ] || die "unknown finalized-message index chain: $item"
+  done
+  for cid in "${LIGHT_CHAINS[@]}"; do
+    chain_in_csv "$seen" "$cid" && result+="${result:+,}$cid"
+  done
+  printf '%s' "$result"
+}
+
 validate_common() {
   [[ "$INSTANCE" =~ ^[a-z0-9][a-z0-9-]{0,31}$ ]] || die "invalid instance name"
   case "$PROFILE" in light|evidence|eutxo) ;; *) die "profile must be light, evidence, or eutxo";; esac
@@ -148,6 +180,10 @@ validate_common() {
     [ -n "$ANCHOR_KEY_FILE" ] || die "preprod anchoring requires --anchor-key-file"
   fi
   case "$ANCHOR_MODE" in script|metadata) ;; *) die "anchor mode must be script or metadata";; esac
+  [ "$FINALIZED_INDEX_EXPLICIT" != true ] || [ -n "$FINALIZED_INDEX_SELECTION" ] \
+    || die "finalized-message index selection cannot be empty"
+  FINALIZED_INDEX_SELECTION="$(canonical_finalized_index_chains \
+    "$FINALIZED_INDEX_SELECTION")"
 }
 
 instance_root() {
@@ -315,6 +351,10 @@ load_marker_chains() {
   LIGHT_CHAINS=("${configured[@]}")
 }
 
+marker_finalized_index_chains() {
+  jq -r '.finalizedMessageIndex.chainIds | join(",")' "$(marker)"
+}
+
 adopt_marker() {
   [ -f "$(marker)" ] || return 0
   PROFILE="$(marker_value profile)"
@@ -325,6 +365,13 @@ adopt_marker() {
   HTTP_BASE="$(marker_value httpBase)"
   SERVER_BASE="$(marker_value serverBase)"
   load_marker_chains
+  local retained_finalized
+  retained_finalized="$(marker_finalized_index_chains)"
+  if [ "$FINALIZED_INDEX_EXPLICIT" = true ] \
+      && [ "$FINALIZED_INDEX_SELECTION" != "$retained_finalized" ]; then
+    die "requested finalized-message index scope differs from retained identity; use a new instance or reset"
+  fi
+  FINALIZED_INDEX_SELECTION="$retained_finalized"
   ANCHOR="$(marker_value anchor.enabled)"
   ANCHOR_MODE="$(marker_value anchor.mode)"
   [ "$ANCHOR_MODE" = none ] && ANCHOR_MODE=script
@@ -361,12 +408,23 @@ write_node_configs() {
       while IFS= read -r property || [ -n "$property" ]; do
         printf '%s\n' "$property"
       done < "$(authenticated_map_properties)"
-      # Legacy nine-chain instances have no JMT contrast chain; the chain add
-      # migration installs this file before it regenerates node configs.
       if [ -f "$(authenticated_map_jmt_properties)" ]; then
         while IFS= read -r property || [ -n "$property" ]; do
           printf '%s\n' "$property"
         done < "$(authenticated_map_jmt_properties)"
+      fi
+      if [ -n "$FINALIZED_INDEX_SELECTION" ]; then
+        local index cid
+        for ((index=0;index<${#LIGHT_CHAINS[@]};index++)); do
+          cid="${LIGHT_CHAINS[$index]}"
+          chain_in_csv "$FINALIZED_INDEX_SELECTION" "$cid" || continue
+          # ordered-log already owns this intrinsic state index and retains
+          # its ALL policy; the launcher selection records it but adds no wrapper.
+          [ "$cid" = orders-chain ] && continue
+          printf 'yano.app-chain.chains[%d].machines.finalized-message-index.enabled=true\n' "$index"
+          printf 'yano.app-chain.chains[%d].machines.finalized-message-index.policy=APPLICATION_ONLY\n' "$index"
+          printf 'yano.app-chain.chains[%d].machines.finalized-message-index.max-messages-per-block=1000\n' "$index"
+        done
       fi
     } > "$file"
     chmod 600 "$file"
@@ -387,12 +445,13 @@ prepare_light() {
   candidate="$(generate_authenticated_map_candidate)"
   local jmt_candidate
   jmt_candidate="$(generate_authenticated_map_jmt_candidate)" || { rm -f -- "$candidate"; return 1; }
-  args=(ensure --marker "$(marker)" --version "$VERSION" --profile light
+  args=(ensure --marker "$(marker)" --catalog "$CATALOG" --version "$VERSION" --profile light
     --variant default --network "$NETWORK" --nodes "$NODES" --threshold "$THRESHOLD"
     --http-base "$HTTP_BASE" --server-base "$SERVER_BASE"
     --config "$YANO_HOME/config/application-appchain.yml" --plugin "$plugin"
     --authenticated-map-config "$candidate"
-    --authenticated-map-jmt-config "$jmt_candidate")
+    --authenticated-map-jmt-config "$jmt_candidate"
+    --finalized-message-index-selection "$FINALIZED_INDEX_SELECTION")
   if [ "$ANCHOR" = true ]; then args+=(--anchor --anchor-mode "$ANCHOR_MODE"); fi
   if [ "$ANCHOR" = true ]; then
     local -a anchor_chains=()
@@ -921,6 +980,65 @@ run_documents() {
     | jq '{chainId,committedHeight,stateRoot,valueHex}'
 }
 
+document_review_statement() {
+  local actor="$1" action="$2" proposal="$3" payload_hash="$4" deadline="$5" clause="$6"
+  local seed_file seed="$7" yano="$YANO_HOME/yano.sh"
+  seed_file="$(mktemp "$(instance_root)/.document-review-seed.XXXXXX")"
+  chmod 600 "$seed_file"; printf '%s' "$seed" > "$seed_file"
+  local args=(appchain role sign --action "$action"
+    --chain document-review-chain --proposal "$proposal"
+    --policy document-release --policy-revision 1
+    --payload-domain document.review.release.v1 --payload-hash "$payload_hash"
+    --deadline-height "$deadline" --actor "$actor" --actor-revision 1
+    --key "$actor-k1" --seed-file "$seed_file")
+  [ -z "$clause" ] || args+=(--clause "$clause")
+  "$yano" "${args[@]}"
+  rm -f -- "$seed_file"
+}
+
+document_review_propose() {
+  local proposal="$1" payload_hash="$2" height deadline statement id
+  height="$(curl -fsS "http://127.0.0.1:$HTTP_BASE/api/v1/app-chain/chains/document-review-chain/tip" | jq -r .height)"
+  deadline=$((height + 300))
+  statement="$(document_review_statement issuer-a PROPOSE "$proposal" "$payload_hash" \
+    "$deadline" '' "$(demo_actor_seed issuer-a)")"
+  id="$(submit_hex document-review-chain role-approvals.command.v1 "$statement" 0)"
+  wait_message document-review-chain "$id" >/dev/null
+  printf '%s:%s' "$deadline" "$id"
+}
+
+run_document_review() {
+  local suffix="${1:-$(date +%s)}" proposal entity content_hash command commitment
+  local proposed deadline id statement receipt local_key physical_key auditor
+  proposal="document-review-$suffix"; entity="document-$suffix"
+  content_hash="$(python3 -c 'import hashlib,sys;print(hashlib.sha256(sys.argv[1].encode()).hexdigest())' \
+    "approved-document-$suffix")"
+  command="$(python3 "$CODEC" document-review "$proposal" "$entity" "$content_hash" \
+    "showcase://documents/$entity")"
+  commitment="$(python3 "$CODEC" blake2b-hex "$command")"
+  proposed="$(document_review_propose "$proposal" "$commitment")"
+  deadline="${proposed%%:*}"
+  for auditor in auditor-a auditor-b; do
+    statement="$(document_review_statement "$auditor" APPROVE "$proposal" "$commitment" \
+      "$deadline" independent-auditors "$(demo_actor_seed "$auditor")")"
+    id="$(submit_hex document-review-chain role-approvals.command.v1 "$statement" 0)"
+    wait_message document-review-chain "$id" >/dev/null
+  done
+  id="$(submit_hex document-review-chain document-review.release.v1 "$command" 0)"
+  wait_message document-review-chain "$id" >/dev/null
+  receipt="$(curl -fsS -X POST \
+    "http://127.0.0.1:$HTTP_BASE/api/v1/app-chain/chains/document-review-chain/query/components/document-review-receipts/receipt" \
+    -H 'Content-Type: application/json' -d "$(jq -nc --arg p "$(printf '%s' "$proposal" | od -An -v -tx1 | tr -d ' \n')" '{paramsHex:$p}')")"
+  [ -n "$(printf '%s' "$receipt" | jq -r '.payloadHex // empty')" ] \
+    || die "document-review approval-consumption receipt is absent"
+  local_key="$(python3 "$CODEC" state-key document "$entity")"
+  physical_key="$(python3 "$CODEC" composite-key documents "$local_key")"
+  note "DOCUMENT REVIEW: issuer proposed, two organizations approved, document head mutated, approval consumed once"
+  printf '%s' "$receipt" | jq '{chainId,stateMachineId,committedHeight,stateRoot,payloadHex}'
+  proof_key document-review-chain "$physical_key" \
+    | jq '{chainId,committedHeight,stateRoot,presence,valueHex}'
+}
+
 composite_register() {
   local key="$1" order="$2" canonical body id
   canonical="$(python3 "$CODEC" order "$order")"
@@ -1176,6 +1294,9 @@ activation_submit() {
     roles-chain)
       body="$(python3 "$CODEC" role-probe "$suffix")"
       submit_hex "$cid" actors.command.v1 "$body" 0;;
+    document-review-chain)
+      body="$(python3 -c 'import hashlib,sys;print(hashlib.blake2b(sys.argv[1].encode(),digest_size=32).hexdigest())' "$suffix")"
+      document_review_propose "$suffix" "$body" | cut -d: -f2;;
     payments-chain)
       result="$(submit_eutxo_payment)"
       wait_message "$cid" "$(printf '%s' "$result" | jq -r .messageId)" >/dev/null
@@ -1188,8 +1309,8 @@ activation_submit() {
       submit_hex "$cid" authenticated-map.command.v1 "$body" 0;;
     authenticated-map-jmt-chain)
       value="$(python3 "$CODEC" authmap-value opaque "$suffix")"
-      body="$(authmap_basic_body open \
-        "$(python3 "$CODEC" authmap put kv-open "$suffix" "$value")")"
+      body="$(authmap_basic_body owner \
+        "$(python3 "$CODEC" authmap put attachments "$suffix" "$value")")"
       submit_hex "$cid" authenticated-map.command.v1 "$body" 0;;
     "$SETTLEMENT_CHAIN_ID")
       # The settlement chain admits only eutxo transactions and proposer-injected
@@ -1367,8 +1488,8 @@ settlement_script_dir() { printf '%s/config/settlement' "$YANO_HOME"; }
 # The packaged settlement chain carries the DEVNET-only profile and demo
 # identity. If it ever activates on a public network the chain-id retains that
 # profile digest, and the real identity can never be adopted under the same id.
-# Strip it before any node starts; it is the last chain, so indices stay
-# contiguous. The bootstrapped block is adopted afterwards.
+# Strip it before any node starts and close the following chain-index gap.
+# The bootstrapped public-network block is adopted afterwards.
 strip_devnet_settlement_chain() {
   local config="$YANO_HOME/config/application-appchain.yml" tmp
   grep -q "chain-id: \"$SETTLEMENT_CHAIN_ID\"" "$config" 2>/dev/null || return 0
@@ -1381,7 +1502,10 @@ strip_devnet_settlement_chain() {
   awk -v cid="$SETTLEMENT_CHAIN_ID" '
     function flush(   i) {
       if (nbuf > 0) {
-        if (keep) { printf "%s", pending; for (i = 1; i <= nbuf; i++) print buf[i] }
+        if (keep) {
+          gsub("chains\\[11\\]", "chains[10]", buf[1])
+          printf "%s", pending; for (i = 1; i <= nbuf; i++) print buf[i]
+        }
         nbuf = 0
       }
       pending = ""
@@ -1564,8 +1688,8 @@ run_settlement_bootstrap() {
       --network "$NETWORK" --operator-seed-file "$SETTLEMENT_KEY_FILE" \
       $(settlement_member_args) \
       --output "$(settlement_script_dir)"
-    note "bootstrap complete. Adopt the generated chain block, then restart:"
-    note "  ./showcase.sh chain add $SETTLEMENT_CHAIN_ID --instance $INSTANCE"
+    note "bootstrap complete. Adopt the generated production config block, then start a fresh"
+    note "preview instance; ADR-033 deliberately provides no app-chain state migration."
     return 0
   fi
   note "deploying the settlement identity on the devnet L1 (idempotent)..."
@@ -1709,7 +1833,7 @@ anchor_enable() {
   IFS=',' read -r -a desired_chains <<< "$desired"
   for target in "${desired_chains[@]}"; do migrate+=(--anchor-chain "$target"); done
   [ -z "$ANCHOR_KEY_FILE" ] || migrate+=(--anchor-key-file "$ANCHOR_KEY_FILE")
-  python3 "$IDENTITY" "${migrate[@]}" >/dev/null
+  python3 "$IDENTITY" "${migrate[@]}" --catalog "$CATALOG" >/dev/null
 
   adopt_marker
   up_light
@@ -1770,12 +1894,11 @@ Yano unified app-chain showcase
   ./showcase.sh prepare|up|quickstart [--profile light] [--nodes 3|5|7]
   ./showcase.sh status|ui|logs|restart|stop|reset [--instance name]
   ./showcase.sh config show|paths|export <file>
-  ./showcase.sh run orders|registry|authenticated-map|approvals|balances|documents|composite|roles|eutxo|anchor|all
+  ./showcase.sh run orders|registry|authenticated-map|approvals|balances|documents|document-review|composite|roles|eutxo|anchor|all
   ./showcase.sh authmap put <collection> <key> <value> [--chain id]
   ./showcase.sh authmap governed-put <key> <value> [--chain id] [--collection C] [--actor A] [--seed-file F]
   ./showcase.sh authmap entry <collection> <key> [--chain id]
   ./showcase.sh authmap receipt <message-id> [--chain id]
-  ./showcase.sh chain add authenticated-map-jmt-chain|payment-chain-settlement
   ./showcase.sh settlement info                      (vault/shard/root facts + next steps)
   ./showcase.sh settlement bootstrap                 (deploy the L1 settlement identity, devnet)
   ./showcase.sh settlement deposit|withdraw|status   (L1 deposit, L2 claim, autonomous settlement)
@@ -1787,7 +1910,7 @@ Yano unified app-chain showcase
   ./showcase.sh composite approve <id> <member-node>
   ./showcase.sh composite release <release> <key> <proposal>
   ./showcase.sh composite verify <release>
-  ./showcase.sh load <orders|registry|approvals|documents|composite> --count N
+  ./showcase.sh load <orders|registry|approvals|documents|document-review|composite> --count N
   ./showcase.sh load-test <orders|registry> --count N [--concurrency N] [--spread]
   ./showcase.sh soak-test orders [--duration SEC] [--rate MSG_PER_SEC] [--spread]
   ./showcase.sh member join <next-index>
@@ -1798,7 +1921,8 @@ Yano unified app-chain showcase
 
 Common options: --instance, --network devnet|preprod, --nodes, --threshold,
 --http-base, --server-base, --data-dir, --variant, --anchor-mode, --anchor-chain,
---anchor-key-file, --confirm-public-anchor preprod. Load options:
+--anchor-key-file, --confirm-public-anchor preprod,
+--enable-finalized-message-index[=chain-id,chain-id]. Load options:
 --concurrency, --payload-bytes, --duration, --rate, --sample, --spread,
 --node, and --report-dir.
 EOF
@@ -1816,7 +1940,9 @@ case "$COMMAND" in
     note "eutxo     maintained virtual-ledger, bridge, and ZK demos (ledger|bridge|zk)";;
   describe)
     case "${POSITIONAL[0]:-$PROFILE}" in
-      light) note "Nine chains, including authenticated-map collections/validation, MPF proofs, governance, effects, and optional L1 anchor.";;
+      light)
+        note "Twelve-chain reference catalog: foundations, three reusable compositions, MPF/JMT proof contrast, and safe L1 settlement."
+        python3 "$CATALOG_TOOL" "$CATALOG" describe;;
       evidence) note "Maintained evidence product deployment; Docker required. Evidence is the product, this is its demo harness.";;
       eutxo) note "Maintained experimental EUTxO scenarios; no real funds in the ledger variant.";;
       *) die "unknown profile";; esac;;
@@ -1897,9 +2023,10 @@ PY
         orders) run_orders "${POSITIONAL[1]:-}";; registry) run_registry "${POSITIONAL[1]:-}" "${POSITIONAL[2]:-}";;
         authenticated-map|authmap) run_authenticated_map "${POSITIONAL[1]:-}";;
         approvals) run_approvals "${POSITIONAL[1]:-}";; balances) run_balances;;
-        documents) run_documents "${POSITIONAL[1]:-}";; composite) run_composite "${POSITIONAL[1]:-}";;
+        documents) run_documents "${POSITIONAL[1]:-}";; document-review) run_document_review "${POSITIONAL[1]:-}";;
+        composite) run_composite "${POSITIONAL[1]:-}";;
         roles) run_roles;; eutxo) run_eutxo;; anchor) cluster_env; "$CLUSTER" status;;
-        all) run_orders; run_registry; run_authenticated_map; run_approvals; run_balances; run_documents; run_composite; run_roles; run_eutxo;;
+        all) run_orders; run_registry; run_authenticated_map; run_approvals; run_balances; run_documents; run_document_review; run_composite; run_roles; run_eutxo;;
         *) die "unknown run scenario";; esac
     fi;;
   approvals)
@@ -1923,80 +2050,10 @@ PY
     for ((load_index=1;load_index<=COUNT;load_index++)); do
       suffix="load-$(date +%s)-$load_index"
       case "${POSITIONAL[0]:-}" in orders) run_orders "$suffix";; registry) run_registry "$suffix" "value-$load_index";;
-        approvals) run_approvals "$suffix";; documents) run_documents "$suffix";; composite) run_composite "$suffix";;
+        approvals) run_approvals "$suffix";; documents) run_documents "$suffix";;
+        document-review) run_document_review "$suffix";; composite) run_composite "$suffix";;
         *) die "unsupported load scenario";; esac
     done;;
-  chain)
-    adopt_marker
-    [ "${POSITIONAL[0]:-}" = add ] \
-      || die "usage: chain add authenticated-map-jmt-chain|payment-chain-settlement"
-    [ "$PROFILE" = light ] || die "chain add applies only to the light profile"
-    case "${POSITIONAL[1]:-}" in
-    authenticated-map-jmt-chain)
-      grep -q 'chain-id: "authenticated-map-jmt-chain"' \
-        "$YANO_HOME/config/application-appchain.yml" \
-        || die "packaged application-appchain.yml lacks the JMT chain; replace showcase.sh, tools/, yano/config/application-appchain.yml, and the plugin bundle from a newly built showcase ZIP first"
-      cluster_env; "$CLUSTER" stop || true
-      chain_add_candidate="$(generate_authenticated_map_jmt_candidate)"
-      if ! chain_add_state="$(python3 "$IDENTITY" chain-add --marker "$(marker)" \
-          --config "$YANO_HOME/config/application-appchain.yml" \
-          --plugin "$(plugin_file)" \
-          --authenticated-map-config "$(authenticated_map_properties)" \
-          --authenticated-map-jmt-config "$chain_add_candidate" \
-          --cluster-marker "$(cluster_dir)/cluster-appchain-identity.json")"; then
-        rm -f -- "$chain_add_candidate"
-        die "chain add migration failed; the instance identity is unchanged"
-      fi
-      if [ "$chain_add_state" = already-migrated ] \
-          && [ "$(jq -r '.chainIds | length' "$(marker)")" != "${#LIGHT_CHAINS[@]}" ]; then
-        rm -f -- "$chain_add_candidate"
-        up_light
-        resume_joined_nodes
-        die "instance already has the JMT chain but predates payment-chain-settlement; run: ./showcase.sh chain add payment-chain-settlement --instance $INSTANCE"
-      fi
-      install_authenticated_map_jmt_candidate "$chain_add_candidate"
-      write_node_configs "$NODES"
-      up_light
-      resume_joined_nodes
-      note "authenticated-map-jmt-chain added; verify with: ./showcase.sh status --instance $INSTANCE";;
-    "$SETTLEMENT_CHAIN_ID")
-      # On a public network the chain block is generated by `settlement
-      # bootstrap` from the operator's OWN identity and adopted by hand. This
-      # command then migrates the instance marker to match it — it never
-      # splices the packaged devnet block.
-      if [ "$NETWORK" != devnet ]; then
-        grep -q "chain-id: \"$SETTLEMENT_CHAIN_ID\"" \
-          "$YANO_HOME/config/application-appchain.yml" || die \
-          "on $NETWORK you must adopt your own settlement block first:" \
-          "  ./showcase.sh settlement bootstrap --instance $INSTANCE --settlement-key-file <file> --confirm-public-settlement $NETWORK" \
-          "then append the printed configBlock to $YANO_HOME/config/application-appchain.yml (docs/PREPROD_SETTLEMENT.md)"
-        grep -q 'profile: "yano-eutxo-v3-bridge-settlement-devnet"' \
-          "$YANO_HOME/config/application-appchain.yml" && die \
-          "the adopted settlement block carries the DEVNET-only profile; on $NETWORK it must be yano-eutxo-v3-bridge-settlement"
-      fi
-      grep -q 'chain-id: "payment-chain-settlement"' \
-        "$YANO_HOME/config/application-appchain.yml" \
-        || die "packaged application-appchain.yml lacks the settlement chain; replace showcase.sh, tools/, yano/config/application-appchain.yml, and the plugin bundle from a newly built showcase ZIP first"
-      [ -f "$(authenticated_map_jmt_properties)" ] \
-        || die "this instance predates the JMT chain; run: ./showcase.sh chain add authenticated-map-jmt-chain --instance $INSTANCE (it adopts the settlement chain too)"
-      cluster_env; "$CLUSTER" stop || true
-      if ! settlement_add_state="$(python3 "$IDENTITY" chain-add-settlement --marker "$(marker)" \
-          --config "$YANO_HOME/config/application-appchain.yml" \
-          --plugin "$(plugin_file)" \
-          --authenticated-map-config "$(authenticated_map_properties)" \
-          --authenticated-map-jmt-config "$(authenticated_map_jmt_properties)" \
-          --cluster-marker "$(cluster_dir)/cluster-appchain-identity.json")"; then
-        die "chain add migration failed; the instance identity is unchanged"
-      fi
-      [ "$settlement_add_state" != already-migrated ] \
-        || note "instance already has $SETTLEMENT_CHAIN_ID; refreshing configs and restarting"
-      write_node_configs "$NODES"
-      up_light
-      resume_joined_nodes
-      note "$SETTLEMENT_CHAIN_ID added (config-only; bootstrap the L1 identity next)"
-      note "next: ./showcase.sh settlement bootstrap --instance $INSTANCE";;
-    *) die "chain add currently supports: authenticated-map-jmt-chain, payment-chain-settlement";;
-    esac;;
   authmap)
     adopt_marker
     case "${POSITIONAL[0]:-}" in

--- a/appchain/examples/appchain-showcase/src/main/showcase/tools/showcase_catalog.py
+++ b/appchain/examples/appchain-showcase/src/main/showcase/tools/showcase_catalog.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Read and validate the ADR-033 showcase catalog without third-party modules."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+
+
+def load(path: Path) -> dict:
+    value = json.loads(path.read_text(encoding="utf-8"))
+    if value.get("schemaVersion") != 1 or value.get("profileId") != "light-v1":
+        raise ValueError("unsupported showcase catalog")
+    chains = value.get("chains")
+    if not isinstance(chains, list) or len(chains) != 12:
+        raise ValueError("light-v1 catalog must contain twelve chains")
+    ids: set[str] = set()
+    scenarios: set[tuple[str, str]] = set()
+    for chain in chains:
+        chain_id = chain.get("chainId")
+        if not isinstance(chain_id, str) or not re.fullmatch(r"[A-Za-z0-9._~-]{1,128}", chain_id):
+            raise ValueError("invalid catalog chain id")
+        if chain_id in ids:
+            raise ValueError("duplicate catalog chain id")
+        ids.add(chain_id)
+        pair = (str(chain.get("scenarioId")), str(chain.get("proofBackend")))
+        if pair in scenarios and chain.get("classification") != "backend-comparison":
+            raise ValueError("duplicate catalog scenario/backend")
+        scenarios.add(pair)
+        if not isinstance(chain.get("expectedCapabilities"), list):
+            raise ValueError("catalog capabilities must be a list")
+    return value
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("catalog", type=Path)
+    parser.add_argument("command", choices=("list", "describe", "json"))
+    args = parser.parse_args()
+    catalog = load(args.catalog)
+    if args.command == "list":
+        print("\n".join(chain["chainId"] for chain in catalog["chains"]))
+    elif args.command == "describe":
+        for chain in catalog["chains"]:
+            capabilities = ", ".join(chain["expectedCapabilities"])
+            print(f"{chain['chainId']:<32} {chain['classification']:<18} "
+                  f"{chain['scenarioId']:<28} {chain['proofBackend'].upper():<3}  {capabilities}")
+    else:
+        print(json.dumps(catalog, sort_keys=True, separators=(",", ":")))
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except (OSError, ValueError, json.JSONDecodeError) as failure:
+        raise SystemExit(f"error: {failure}")

--- a/appchain/examples/appchain-showcase/src/main/showcase/tools/showcase_codec.py
+++ b/appchain/examples/appchain-showcase/src/main/showcase/tools/showcase_codec.py
@@ -92,6 +92,16 @@ def main() -> None:
     order.add_argument("json")
     digest = sub.add_parser("blake2b")
     digest.add_argument("value")
+    digest_hex = sub.add_parser("blake2b-hex")
+    digest_hex.add_argument("value")
+    review = sub.add_parser("document-review")
+    review.add_argument("proposal")
+    review.add_argument("entity")
+    review.add_argument("document_hash")
+    review.add_argument("reference")
+    composite_key = sub.add_parser("composite-key")
+    composite_key.add_argument("component")
+    composite_key.add_argument("local_key_hex")
     state_key = sub.add_parser("state-key")
     state_key.add_argument("kind", choices=("approval", "balance", "document", "release"))
     state_key.add_argument("value")
@@ -139,6 +149,29 @@ def main() -> None:
         print(canonical_order(args.json).decode("utf-8"))
     elif args.command == "blake2b":
         print(hashlib.blake2b(args.value.encode(), digest_size=32).hexdigest())
+    elif args.command == "blake2b-hex":
+        if re.fullmatch(r"(?:[0-9a-f]{2})+", args.value) is None:
+            raise ValueError("blake2b-hex requires canonical non-empty hex")
+        print(hashlib.blake2b(bytes.fromhex(args.value), digest_size=32).hexdigest())
+    elif args.command == "document-review":
+        if re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,127}", args.proposal) is None \
+                or re.fullmatch(r"[a-z0-9][a-z0-9._-]{0,127}", args.entity) is None \
+                or re.fullmatch(r"[0-9a-f]{64}", args.document_hash) is None:
+            raise ValueError("invalid document-review fields")
+        emit(array(uint(1), text(args.proposal), text("document-release"), uint(1),
+                   text(args.entity), bstr(bytes.fromhex(args.document_hash)),
+                   text(args.reference)))
+    elif args.command == "composite-key":
+        if re.fullmatch(r"[a-z][a-z0-9-]{0,62}", args.component) is None \
+                or re.fullmatch(r"(?:[0-9a-f]{2})+", args.local_key_hex) is None:
+            raise ValueError("invalid composite key fields")
+        domain = b"yano-composite-state-v1\0"
+        component = args.component.encode("ascii")
+        local = bytes.fromhex(args.local_key_hex)
+        if len(domain) + 1 + len(component) + 2 + len(local) > 256:
+            raise ValueError("composite key exceeds 256 bytes")
+        emit(domain + bytes([len(component)]) + component
+             + len(local).to_bytes(2, "big") + local)
     elif args.command == "state-key":
         prefixes = {"approval": "i/", "balance": "b/", "document": "e/", "release": "r/"}
         print((prefixes[args.kind] + args.value).encode().hex())

--- a/appchain/examples/appchain-showcase/src/main/showcase/tools/showcase_identity.py
+++ b/appchain/examples/appchain-showcase/src/main/showcase/tools/showcase_identity.py
@@ -13,19 +13,25 @@ import stat
 import sys
 
 
-LIGHT_CHAINS = [
-    "orders-chain", "registry-chain", "approvals-chain", "balances-chain",
-    "documents-chain", "workflow-chain", "roles-chain", "payments-chain",
-    "authenticated-map-chain", "authenticated-map-jmt-chain",
-    "payment-chain-settlement",
-]
-# Instances prepared before the ADR-UTXO-009 settlement chain existed.
-LIGHT_CHAINS_V10 = LIGHT_CHAINS[:-1]
-# Instances prepared before the classic-JMT contrast chain existed.
-LEGACY_LIGHT_CHAINS = LIGHT_CHAINS[:-2]
+LIGHT_CHAINS: list[str] = []
+LIGHT_CHAINS_WITHOUT_SETTLEMENT: list[str] = []
 CHAIN_ID = re.compile(r"[A-Za-z0-9._~-]{1,128}")
 HEX_32 = re.compile(r"[0-9a-f]{64}")
 CONFIG_CHAIN_ID = re.compile(r'^\s{6}chain-id:\s*"([A-Za-z0-9._~-]{1,128})"\s*$', re.MULTILINE)
+
+
+def load_catalog(path: pathlib.Path) -> list[str]:
+    catalog = json.loads(path.read_text(encoding="utf-8"), object_pairs_hook=unique_object)
+    chains = catalog.get("chains") if isinstance(catalog, dict) else None
+    if (catalog.get("schemaVersion") != 1 or catalog.get("profileId") != "light-v1"
+            or not isinstance(chains, list) or len(chains) != 12):
+        raise ValueError("unsupported showcase catalog")
+    ids = [chain.get("chainId") for chain in chains if isinstance(chain, dict)]
+    if (len(ids) != 12 or len(ids) != len(set(ids))
+            or any(not isinstance(chain, str) or not CHAIN_ID.fullmatch(chain) for chain in ids)
+            or "payment-chain-settlement" not in ids):
+        raise ValueError("showcase catalog contains an invalid chain set")
+    return ids
 
 
 def sha256(path: pathlib.Path) -> str:
@@ -56,7 +62,7 @@ def requested_anchor_chains(values: list[str], configured: list[str]) -> list[st
 def configured_chain_ids(path: pathlib.Path) -> list[str]:
     chains = CONFIG_CHAIN_ID.findall(path.read_text(encoding="utf-8"))
     if (not chains or len(chains) != len(set(chains))
-            or chains not in (LIGHT_CHAINS, LIGHT_CHAINS_V10, LEGACY_LIGHT_CHAINS)):
+            or chains not in (LIGHT_CHAINS, LIGHT_CHAINS_WITHOUT_SETTLEMENT)):
         raise ValueError("showcase config contains an unsupported chain set")
     return chains
 
@@ -104,6 +110,17 @@ def document(args: argparse.Namespace) -> dict:
     plugin = pathlib.Path(args.plugin).resolve()
     chains = configured_chain_ids(config) if args.profile == "light" else []
     selected = requested_anchor_chains(args.anchor_chain, chains) if args.anchor else []
+    finalized = ([] if not args.finalized_message_index_selection else
+                 args.finalized_message_index_selection.split(","))
+    if (len(finalized) != len(set(finalized))
+            or any(chain not in chains for chain in finalized)
+            or finalized != [chain for chain in chains if chain in set(finalized)]):
+        raise ValueError("finalized-message index selection is not canonical")
+    finalized_digest = hashlib.sha256(canonical({
+        "policy": "APPLICATION_ONLY",
+        "maxMessagesPerBlock": 1000,
+        "chainIds": finalized,
+    })).hexdigest()
     return {
         "schemaVersion": 2 if len(selected) > 1 else 1,
         "kind": "yano.showcase.deployment",
@@ -124,6 +141,12 @@ def document(args: argparse.Namespace) -> dict:
             pathlib.Path(args.authenticated_map_config).resolve()),
         "authenticatedMapJmtConfigSha256": sha256(
             pathlib.Path(args.authenticated_map_jmt_config).resolve()),
+        "finalizedMessageIndex": {
+            "chainIds": finalized,
+            "configurationDigest": finalized_digest,
+            "policy": "APPLICATION_ONLY",
+            "maxMessagesPerBlock": 1000,
+        },
         "anchor": anchor_identity(
             args.anchor,
             args.anchor_mode,
@@ -229,18 +252,27 @@ def validate_deployment_identity(document: dict) -> None:
         "protocolMagic", "bootstrapNodeCount", "bootstrapThreshold", "httpBase",
         "serverBase", "runtime", "chainIds", "configSha256", "pluginSha256", "anchor",
         "authenticatedMapConfigSha256",
+        "authenticatedMapJmtConfigSha256", "finalizedMessageIndex",
     }
-    if document.get("chainIds") in (LIGHT_CHAINS, LIGHT_CHAINS_V10):
-        expected = expected | {"authenticatedMapJmtConfigSha256"}
-        if (not isinstance(document.get("authenticatedMapJmtConfigSha256"), str)
-                or not HEX_32.fullmatch(document["authenticatedMapJmtConfigSha256"])):
-            raise ValueError("showcase deployment identity is malformed")
+    finalized = document.get("finalizedMessageIndex")
+    if (not isinstance(document.get("authenticatedMapJmtConfigSha256"), str)
+            or not HEX_32.fullmatch(document["authenticatedMapJmtConfigSha256"])
+            or not isinstance(finalized, dict)
+            or set(finalized) != {"chainIds", "configurationDigest", "policy",
+                                  "maxMessagesPerBlock"}
+            or not isinstance(finalized.get("chainIds"), list)
+            or finalized.get("chainIds") != [chain for chain in document.get("chainIds", [])
+                                               if chain in set(finalized.get("chainIds", []))]
+            or finalized.get("policy") != "APPLICATION_ONLY"
+            or finalized.get("maxMessagesPerBlock") != 1000
+            or not isinstance(finalized.get("configurationDigest"), str)
+            or not HEX_32.fullmatch(finalized["configurationDigest"])):
+        raise ValueError("showcase finalized-message index identity is malformed")
     anchor = document.get("anchor")
     if (set(document) != expected or document.get("profile") != "light"
             or document.get("network") not in ("devnet", "preprod")
             or document.get("protocolMagic") != (1 if document.get("network") == "preprod" else 42)
-            or document.get("chainIds") not in (
-                LIGHT_CHAINS, LIGHT_CHAINS_V10, LEGACY_LIGHT_CHAINS)
+            or document.get("chainIds") not in (LIGHT_CHAINS, LIGHT_CHAINS_WITHOUT_SETTLEMENT)
             or not isinstance(document.get("authenticatedMapConfigSha256"), str)
             or not HEX_32.fullmatch(document["authenticatedMapConfigSha256"])
             or type(document.get("bootstrapNodeCount")) is not int
@@ -360,8 +392,7 @@ def migrate_anchor(args: argparse.Namespace) -> None:
         raise ValueError("authenticated-map genesis differs from the retained showcase identity")
     configured = deployment.get("chainIds")
     if (deployment.get("profile") != "light" or not isinstance(configured, list)
-            or configured not in (
-                LIGHT_CHAINS, LIGHT_CHAINS_V10, LEGACY_LIGHT_CHAINS)):
+            or configured not in (LIGHT_CHAINS, LIGHT_CHAINS_WITHOUT_SETTLEMENT)):
         raise ValueError("anchor enable is supported only for the maintained light profile")
     if "authenticatedMapJmtConfigSha256" in deployment:
         if (not args.authenticated_map_jmt_config
@@ -425,113 +456,9 @@ def migrate_anchor(args: argparse.Namespace) -> None:
     print(",".join(selected))
 
 
-def migrate_chain_add(args: argparse.Namespace) -> None:
-    """Additive migration: adopt the classic-JMT contrast chain on a legacy
-    nine-chain instance. Re-records the packaged config/plugin digests (the
-    upgrade replaced those files) after verifying the retained
-    authenticated-map genesis is untouched."""
-    marker = pathlib.Path(args.marker)
-    deployment = parsed_identity(marker, "yano.showcase.deployment")
-    validate_deployment_identity(deployment)
-    required = (args.config, args.plugin, args.authenticated_map_config,
-                args.authenticated_map_jmt_config)
-    if not all(required):
-        raise ValueError("chain-add requires --config, --plugin, "
-                         "--authenticated-map-config, and --authenticated-map-jmt-config")
-    if (sha256(pathlib.Path(args.authenticated_map_config).resolve())
-            != deployment.get("authenticatedMapConfigSha256")):
-        raise ValueError("retained authenticated-map genesis does not match the marker; "
-                         "refusing to migrate a tampered instance")
-    jmt_sha = sha256(pathlib.Path(args.authenticated_map_jmt_config).resolve())
-    if deployment.get("chainIds") in (LIGHT_CHAINS, LIGHT_CHAINS_V10):
-        if deployment.get("authenticatedMapJmtConfigSha256") != jmt_sha:
-            raise ValueError("instance already has a different JMT chain identity")
-        print("already-migrated")
-        return
-    if deployment.get("chainIds") != LEGACY_LIGHT_CHAINS:
-        raise ValueError("chain add supports only the maintained light profile")
-    deployment["chainIds"] = list(LIGHT_CHAINS)
-    deployment["configSha256"] = sha256(pathlib.Path(args.config).resolve())
-    deployment["pluginSha256"] = sha256(pathlib.Path(args.plugin).resolve())
-    deployment["authenticatedMapJmtConfigSha256"] = jmt_sha
-    validate_deployment_identity(deployment)
-    if args.cluster_marker and pathlib.Path(args.cluster_marker).exists():
-        cluster_marker_path = pathlib.Path(args.cluster_marker)
-        cluster = parsed_identity(cluster_marker_path, "yano.cluster.appchain-identity")
-        validate_cluster_identity(cluster, LEGACY_LIGHT_CHAINS)
-        cluster["chainIds"] = list(LIGHT_CHAINS)
-        validate_cluster_identity(cluster, list(LIGHT_CHAINS))
-        write_atomic(cluster_marker_path, canonical(cluster))
-    write_atomic(marker, canonical(deployment))
-    print("migrated")
-
-
-def migrate_chain_add_settlement(args: argparse.Namespace) -> None:
-    """Additive migration: adopt the ADR-UTXO-009 settlement chain on an
-    instance that already has the classic-JMT chain (10 chains). The chain
-    is config-only (its L1 identity is deployed separately by
-    `settlement bootstrap`), so no new genesis is generated; the packaged
-    config/plugin digests are re-recorded after verifying both retained
-    authenticated-map geneses are untouched."""
-    marker = pathlib.Path(args.marker)
-    deployment = parsed_identity(marker, "yano.showcase.deployment")
-    validate_deployment_identity(deployment)
-    required = (args.config, args.plugin, args.authenticated_map_config,
-                args.authenticated_map_jmt_config)
-    if not all(required):
-        raise ValueError("chain-add requires --config, --plugin, "
-                         "--authenticated-map-config, and --authenticated-map-jmt-config")
-    if (sha256(pathlib.Path(args.authenticated_map_config).resolve())
-            != deployment.get("authenticatedMapConfigSha256")):
-        raise ValueError("retained authenticated-map genesis does not match the marker; "
-                         "refusing to migrate a tampered instance")
-    if deployment.get("chainIds") == LIGHT_CHAINS:
-        # Already listed. Re-record the packaged digests so an operator who
-        # legitimately edited the config — on a public network the settlement
-        # block is generated from THEIR identity and adopted by hand — is not
-        # locked out by the retained-config check.
-        deployment["configSha256"] = sha256(pathlib.Path(args.config).resolve())
-        deployment["pluginSha256"] = sha256(pathlib.Path(args.plugin).resolve())
-        validate_deployment_identity(deployment)
-        # The cluster marker is bound to the chain set too. An instance whose
-        # settlement chain was adopted after creation (public networks) still
-        # carries the pre-adoption list, so bring it forward as well.
-        if args.cluster_marker and pathlib.Path(args.cluster_marker).exists():
-            cluster_path = pathlib.Path(args.cluster_marker)
-            cluster = parsed_identity(cluster_path, "yano.cluster.appchain-identity")
-            if cluster.get("chainIds") != list(LIGHT_CHAINS):
-                cluster["chainIds"] = list(LIGHT_CHAINS)
-                validate_cluster_identity(cluster, list(LIGHT_CHAINS))
-                write_atomic(cluster_path, canonical(cluster))
-        write_atomic(marker, canonical(deployment))
-        print("already-migrated")
-        return
-    if deployment.get("chainIds") != LIGHT_CHAINS_V10:
-        raise ValueError("chain add payment-chain-settlement requires the JMT chain first; "
-                         "run: chain add authenticated-map-jmt-chain")
-    if (sha256(pathlib.Path(args.authenticated_map_jmt_config).resolve())
-            != deployment.get("authenticatedMapJmtConfigSha256")):
-        raise ValueError("retained authenticated-map JMT genesis does not match the marker; "
-                         "refusing to migrate a tampered instance")
-    deployment["chainIds"] = list(LIGHT_CHAINS)
-    deployment["configSha256"] = sha256(pathlib.Path(args.config).resolve())
-    deployment["pluginSha256"] = sha256(pathlib.Path(args.plugin).resolve())
-    validate_deployment_identity(deployment)
-    if args.cluster_marker and pathlib.Path(args.cluster_marker).exists():
-        cluster_marker_path = pathlib.Path(args.cluster_marker)
-        cluster = parsed_identity(cluster_marker_path, "yano.cluster.appchain-identity")
-        validate_cluster_identity(cluster, LIGHT_CHAINS_V10)
-        cluster["chainIds"] = list(LIGHT_CHAINS)
-        validate_cluster_identity(cluster, list(LIGHT_CHAINS))
-        write_atomic(cluster_marker_path, canonical(cluster))
-    write_atomic(marker, canonical(deployment))
-    print("migrated")
-
-
 def main() -> None:
     parser = argparse.ArgumentParser()
-    parser.add_argument("action", choices=("ensure", "show", "export", "anchor-enable",
-                                           "chain-add", "chain-add-settlement"))
+    parser.add_argument("action", choices=("ensure", "show", "export", "anchor-enable"))
     parser.add_argument("--marker", required=True)
     parser.add_argument("--version", default="development")
     parser.add_argument("--profile", default="light")
@@ -545,6 +472,7 @@ def main() -> None:
     parser.add_argument("--plugin")
     parser.add_argument("--authenticated-map-config")
     parser.add_argument("--authenticated-map-jmt-config")
+    parser.add_argument("--finalized-message-index-selection", default="")
     parser.add_argument("--anchor", action="store_true")
     parser.add_argument("--anchor-mode", default="script")
     parser.add_argument("--anchor-chain", action="append", default=[])
@@ -552,18 +480,21 @@ def main() -> None:
     parser.add_argument("--cluster-marker")
     parser.add_argument("--cluster-env")
     parser.add_argument("--output")
+    parser.add_argument("--catalog")
     args = parser.parse_args()
+    global LIGHT_CHAINS, LIGHT_CHAINS_WITHOUT_SETTLEMENT
+    if args.action not in ("show", "export"):
+        if not args.catalog:
+            raise ValueError("this action requires --catalog")
+        LIGHT_CHAINS = load_catalog(pathlib.Path(args.catalog).resolve())
+        LIGHT_CHAINS_WITHOUT_SETTLEMENT = [
+            chain for chain in LIGHT_CHAINS if chain != "payment-chain-settlement"
+        ]
     marker = pathlib.Path(args.marker)
     if args.action == "anchor-enable":
         if not args.cluster_marker or not args.cluster_env:
             raise ValueError("anchor-enable requires --cluster-marker and --cluster-env")
         migrate_anchor(args)
-        return
-    if args.action == "chain-add":
-        migrate_chain_add(args)
-        return
-    if args.action == "chain-add-settlement":
-        migrate_chain_add_settlement(args)
         return
     if args.action == "show":
         parsed = json.loads(secure_existing(marker))

--- a/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewPresetTest.java
+++ b/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/DocumentReviewPresetTest.java
@@ -1,0 +1,65 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import com.bloxbean.cardano.yano.api.appchain.AppChainConsensusProfile;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachineContext;
+import com.bloxbean.cardano.yano.appchain.composite.CompositeStateMachine;
+import com.bloxbean.cardano.yano.appchain.testkit.AppChainTestProfiles;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DocumentReviewPresetTest {
+    @Test
+    void presetComposesStockRoleApprovalAndDocumentCapabilities() {
+        CompositeStateMachine machine = DocumentReviewPreset.create(context());
+
+        assertThat(machine.id()).isEqualTo("document-review");
+        assertThat(machine.profile().profileId()).isEqualTo("document-role-approval-v1");
+        assertThat(machine.profile().components())
+                .extracting(component -> component.componentId())
+                .containsExactly("domain-actors", "role-approvals", "documents",
+                        "document-review-receipts");
+        assertThat(machine.profile().workflows())
+                .extracting(workflow -> workflow.workflowId())
+                .containsExactly("role-approval-v1", "document-review-release");
+        assertThat(machine.profile().components().stream()
+                .filter(component -> component.componentId().equals("documents"))
+                .findFirst().orElseThrow().queryPaths()).containsExactly("head");
+        assertThat(ShowcaseAuthenticatedMapConfig.documentReviewGenesis(
+                "document-review-chain").approvalPolicy(DocumentReviewPreset.POLICY_ID))
+                .isNotNull();
+    }
+
+    @Test
+    void commandIsCanonicalAndBindsItsApprovalCommitment() {
+        DocumentReviewCommandV1 command = new DocumentReviewCommandV1(
+                "review-1", "document-release", 1, "document-1",
+                new byte[32], "showcase://documents/1");
+
+        DocumentReviewCommandV1 decoded = DocumentReviewCommandV1.decode(command.encode());
+        assertThat(decoded.proposalId()).isEqualTo(command.proposalId());
+        assertThat(decoded.policyId()).isEqualTo(command.policyId());
+        assertThat(decoded.documentEntityId()).isEqualTo(command.documentEntityId());
+        assertThat(decoded.documentHash()).containsExactly(command.documentHash());
+        assertThat(decoded.actionCommitment()).containsExactly(command.actionCommitment());
+        byte[] trailing = java.util.Arrays.copyOf(command.encode(), command.encode().length + 1);
+        assertThatThrownBy(() -> DocumentReviewCommandV1.decode(trailing))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    private static AppStateMachineContext context() {
+        Map<String, String> settings = Map.of("membership.mode", "governed");
+        AppChainConsensusProfile profile = AppChainTestProfiles.fromSettings(settings);
+        return new AppStateMachineContext() {
+            @Override public String chainId() { return "document-review-chain"; }
+            @Override public Map<String, String> settings() { return settings; }
+            @Override public Optional<AppChainConsensusProfile> consensusProfile() {
+                return Optional.of(profile);
+            }
+        };
+    }
+}

--- a/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseAuthenticatedMapConfigTest.java
+++ b/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseAuthenticatedMapConfigTest.java
@@ -132,7 +132,7 @@ class ShowcaseAuthenticatedMapConfigTest {
     }
 
     @Test
-    void buildsBasicClassicJmtGenesisForTheContrastChain() {
+    void buildsBusinessEquivalentClassicJmtGenesisForTheContrastChain() {
         Map<String, String> settings = ShowcaseAuthenticatedMapConfig.jmtSettings(
                 ShowcaseAuthenticatedMapConfig.JMT_CHAIN_ID,
                 List.of("11".repeat(32), "22".repeat(32), "33".repeat(32)),
@@ -142,16 +142,29 @@ class ShowcaseAuthenticatedMapConfigTest {
                         StdlibStateMachineProviders.AUTHENTICATED_MAP_GENESIS_SETTING)));
         assertThat(genesis.chainId()).isEqualTo("authenticated-map-jmt-chain");
         assertThat(genesis.commitmentProfileId()).isEqualTo("jmt-blake2b256-v1");
-        assertThat(genesis.collections())
-                .extracting(AuthenticatedMapContract.CollectionDescriptor::id)
-                .containsExactly("documents", "kv-open", "notes");
-        assertThat(genesis.collections())
-                .extracting(AuthenticatedMapContract.CollectionDescriptor::authorization)
-                .containsExactly(AuthenticatedMapContract.AUTH_OWNER,
-                        AuthenticatedMapContract.AUTH_OPEN,
-                        AuthenticatedMapContract.AUTH_MEMBER);
-        assertThat(genesis.validators()).isEmpty();
-        assertThat(genesis.governedGenesis()).isNull();
+        Map<String, String> mpfSettings = ShowcaseAuthenticatedMapConfig.settings(
+                ShowcaseAuthenticatedMapConfig.CHAIN_ID,
+                List.of("11".repeat(32), "22".repeat(32), "33".repeat(32)),
+                2, new byte[32]);
+        AuthenticatedMapContract.Genesis mpf = AuthenticatedMapContract.decodeGenesis(
+                HexFormat.of().parseHex(mpfSettings.get(
+                        StdlibStateMachineProviders.AUTHENTICATED_MAP_GENESIS_SETTING)));
+        assertThat(genesis.collections()).isEqualTo(mpf.collections());
+        assertThat(genesis.validators())
+                .extracting(AuthenticatedMapContract.ValidatorDescriptor::id,
+                        AuthenticatedMapContract.ValidatorDescriptor::kind,
+                        AuthenticatedMapContract.ValidatorDescriptor::providerId,
+                        AuthenticatedMapContract.ValidatorDescriptor::contractVersion)
+                .containsExactlyElementsOf(mpf.validators().stream()
+                        .map(value -> org.assertj.core.groups.Tuple.tuple(
+                                value.id(), value.kind(), value.providerId(),
+                                value.contractVersion()))
+                        .toList());
+        assertThat(genesis.governedGenesis()).isNotNull();
+        assertThat(genesis.governedGenesis().directPolicies())
+                .isEqualTo(mpf.governedGenesis().directPolicies());
+        assertThat(genesis.governedGenesis().approvalPolicies())
+                .isEqualTo(mpf.governedGenesis().approvalPolicies());
         assertThat(settings.get("state.commitment-profile")).isEqualTo("jmt-blake2b256-v1");
         assertThatThrownBy(() -> ShowcaseAuthenticatedMapConfig.jmtSettings(
                 "authenticated-map-chain", List.of("11".repeat(32)), 1))

--- a/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseCatalogCharacterizationTest.java
+++ b/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseCatalogCharacterizationTest.java
@@ -1,0 +1,83 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** ADR-033 catalog/YAML parity and stable presentation order. */
+class ShowcaseCatalogCharacterizationTest {
+    private static final Path CONFIG = Path.of(
+            "src/main/showcase/config/application-appchain.yml");
+    private static final Pattern CHAIN = Pattern.compile(
+            "(?ms)^    chains\\[(\\d+)]:\\n(.*?)(?=^    chains\\[|\\z)");
+    private static final Pattern CHAIN_ID = Pattern.compile(
+            "(?m)^      chain-id: \"?([^\"\\s]+)\"?$");
+    private static final Pattern STATE_MACHINE = Pattern.compile(
+            "(?m)^      state-machine: \"?([^\"\\s]+)\"?$");
+
+    @Test
+    void lightProfilePinsTwelveNamedApplicationsInPresentationOrder() throws Exception {
+        Map<String, String> applications = applications(Files.readString(CONFIG));
+
+        assertThat(applications.keySet()).containsExactly(
+                "orders-chain", "registry-chain", "approvals-chain", "balances-chain",
+                "documents-chain", "workflow-chain", "roles-chain", "payments-chain",
+                "authenticated-map-chain", "authenticated-map-jmt-chain",
+                "payment-chain-settlement", "document-review-chain");
+        assertThat(applications).containsAllEntriesOf(Map.ofEntries(
+                Map.entry("orders-chain", "ordered-log"),
+                Map.entry("registry-chain", "kv-registry"),
+                Map.entry("approvals-chain", "approvals"),
+                Map.entry("balances-chain", "balances"),
+                Map.entry("documents-chain", "doc-trail"),
+                Map.entry("workflow-chain", "showcase-composite"),
+                Map.entry("roles-chain", "role-approvals"),
+                Map.entry("payments-chain", "eutxo-ledger"),
+                Map.entry("authenticated-map-chain", "authenticated-map"),
+                Map.entry("authenticated-map-jmt-chain", "authenticated-map"),
+                Map.entry("payment-chain-settlement", "eutxo-ledger"),
+                Map.entry("document-review-chain", "document-review"))).hasSize(12);
+    }
+
+    @Test
+    void currentReferenceApplicationsAndSettlementAreConfigurationNotAnotherRuntimeKind()
+            throws Exception {
+        String yaml = Files.readString(CONFIG);
+        Map<String, String> applications = applications(yaml);
+
+        assertThat(applications).containsAllEntriesOf(Map.of(
+                "workflow-chain", "showcase-composite",
+                "authenticated-map-chain", "authenticated-map",
+                "payment-chain-settlement", "eutxo-ledger",
+                "document-review-chain", "document-review"));
+        assertThat(yaml).contains("preset: order-approval-outbox-v1")
+                .contains("type: \"eutxo-vault-deposit-v1\"")
+                .contains("type: \"eutxo-batch-withdrawal-confirmation-v1\"")
+                .contains("state-machine: \"document-review\"");
+    }
+
+    private static Map<String, String> applications(String yaml) {
+        Matcher chains = CHAIN.matcher(yaml);
+        Map<Integer, Map.Entry<String, String>> indexed = new LinkedHashMap<>();
+        while (chains.find()) {
+            Matcher chainId = CHAIN_ID.matcher(chains.group(2));
+            Matcher stateMachine = STATE_MACHINE.matcher(chains.group(2));
+            assertThat(chainId.find()).as("chain id at index %s", chains.group(1)).isTrue();
+            assertThat(stateMachine.find()).as("state machine at index %s", chains.group(1)).isTrue();
+            indexed.put(Integer.parseInt(chains.group(1)),
+                    Map.entry(chainId.group(1), stateMachine.group(1)));
+        }
+        assertThat(indexed.keySet()).containsExactlyElementsOf(
+                java.util.stream.IntStream.range(0, indexed.size()).boxed().toList());
+        Map<String, String> result = new LinkedHashMap<>();
+        indexed.values().forEach(entry -> result.put(entry.getKey(), entry.getValue()));
+        return result;
+    }
+}

--- a/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseCatalogManifestTest.java
+++ b/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseCatalogManifestTest.java
@@ -1,0 +1,54 @@
+package com.bloxbean.cardano.yano.appchain.showcase;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShowcaseCatalogManifestTest {
+    private static final Path CATALOG = Path.of(
+            "src/main/showcase/config/showcase-catalog-v1.json");
+    private static final Path YAML = Path.of(
+            "src/main/showcase/config/application-appchain.yml");
+
+    @Test
+    void catalogIsTheOrderedTwelveChainSourceOfTruthForLightYaml() throws Exception {
+        JsonNode root = new ObjectMapper().readTree(Files.readString(CATALOG));
+        String capabilityGuide = Files.readString(Path.of("docs/CAPABILITY_CATALOG.md"));
+        assertThat(root.path("schemaVersion").asInt()).isEqualTo(1);
+        assertThat(root.path("profileId").asText()).isEqualTo("light-v1");
+        List<String> catalogIds = new ArrayList<>();
+        Map<String, Integer> classifications = new HashMap<>();
+        for (JsonNode chain : root.path("chains")) {
+            catalogIds.add(chain.path("chainId").asText());
+            assertThat(capabilityGuide).contains("`" + chain.path("chainId").asText() + "`");
+            assertThat(chain.path("scenarioId").asText()).isNotBlank();
+            assertThat(chain.path("classification").asText()).isNotBlank();
+            classifications.merge(chain.path("classification").asText(), 1, Integer::sum);
+            assertThat(chain.path("proofBackend").asText()).isIn("mpf", "jmt");
+            assertThat(chain.path("expectedCapabilities").isArray()).isTrue();
+            assertThat(chain.path("expectedCapabilities").size()).isPositive();
+        }
+        assertThat(classifications).containsExactlyInAnyOrderEntriesOf(Map.of(
+                "foundation", 7,
+                "reference", 3,
+                "backend-comparison", 1,
+                "l1-boundary", 1));
+        Matcher matcher = Pattern.compile(
+                "(?m)^      chain-id: \\\"?([^\\\"\\s]+)\\\"?$")
+                .matcher(Files.readString(YAML));
+        List<String> yamlIds = new ArrayList<>();
+        while (matcher.find()) yamlIds.add(matcher.group(1));
+        assertThat(catalogIds).hasSize(12).containsExactlyElementsOf(yamlIds);
+    }
+}

--- a/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseStateCommitmentConfigTest.java
+++ b/appchain/examples/appchain-showcase/src/test/java/com/bloxbean/cardano/yano/appchain/showcase/ShowcaseStateCommitmentConfigTest.java
@@ -58,7 +58,7 @@ class ShowcaseStateCommitmentConfigTest {
         }
 
         assertThat(seenIndexes).containsExactlyInAnyOrderElementsOf(
-                java.util.stream.IntStream.rangeClosed(0, 10).boxed().toList());
-        assertThat(genesisIds).hasSize(9);
+                java.util.stream.IntStream.rangeClosed(0, 11).boxed().toList());
+        assertThat(genesisIds).hasSize(10);
     }
 }

--- a/appchain/examples/appchain-showcase/src/test/scripts/showcase-contract.sh
+++ b/appchain/examples/appchain-showcase/src/test/scripts/showcase-contract.sh
@@ -1,13 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 MODULE="$(cd "$(dirname "$0")/../../.." && pwd -P)"
+REPO="$(cd "$MODULE/../../.." && pwd -P)"
 WORK="$(mktemp -d "${TMPDIR:-/tmp}/yano-showcase-contract.XXXXXX")"
 trap 'rm -rf "$WORK"' EXIT INT TERM
 ROOT="$WORK/showcase"
 mkdir -p "$ROOT/yano/appchain-cluster" "$ROOT/yano/config" "$ROOT/yano/plugins" "$ROOT/tools" \
+  "$ROOT/catalog" \
   "$ROOT/profiles/evidence/demo/config" "$ROOT/profiles/evidence/artifacts" "$WORK/bin"
 cp -R "$MODULE/src/main/showcase/." "$ROOT/"
 cp "$MODULE/src/main/showcase/config/application-appchain.yml" "$ROOT/yano/config/"
+cp "$MODULE/src/main/showcase/config/showcase-catalog-v1.json" "$ROOT/catalog/"
 printf 'fake jar\n' > "$ROOT/yano/yano.jar"
 printf 'fake plugin\n' > "$ROOT/yano/plugins/yano-appchain-showcase-test-bundle.jar"
 cat > "$ROOT/yano/appchain-cluster/cluster.sh" <<'SH'
@@ -104,9 +107,9 @@ grep -q '^light' <<< "$PROFILES"
 grep -q 'governance activate' <<< "$("$ROOT/showcase.sh" help)"
 "$ROOT/showcase.sh" prepare --instance three --nodes 3 --http-base 19770 --server-base 19370
 [ -f "$ROOT/data/showcase/three/showcase-identity.json" ]
-jq -e '.chainIds | length == 11' \
+jq -e '.chainIds | length == 12' \
   "$ROOT/data/showcase/three/showcase-identity.json" >/dev/null
-jq -e '.chainIds[10] == "payment-chain-settlement"' \
+jq -e '.chainIds[10] == "payment-chain-settlement" and .chainIds[11] == "document-review-chain"' \
   "$ROOT/data/showcase/three/showcase-identity.json" >/dev/null
 jq -e '.authenticatedMapConfigSha256 | test("^[0-9a-f]{64}$")' \
   "$ROOT/data/showcase/three/showcase-identity.json" >/dev/null
@@ -159,30 +162,27 @@ if "$ROOT/showcase.sh" prepare --instance three --nodes 5 --http-base 19770 --se
 fi
 grep -q 'differs from retained showcase identity' "$WORK/drift.log"
 
-# ADR-UTXO-009: chain add payment-chain-settlement migrates a retained
-# 10-chain (V10) instance to the packaged 11-chain set without touching the
-# retained authenticated-map geneses.
-python3 - "$ROOT/data/showcase/three/showcase-identity.json" \
-  "$ROOT/data/showcase/three/cluster/cluster-appchain-identity.json" <<'PY'
-import json, pathlib, sys
-marker = pathlib.Path(sys.argv[1])
-doc = json.loads(marker.read_text())
-assert doc["chainIds"][-1] == "payment-chain-settlement"
-doc["chainIds"] = doc["chainIds"][:-1]
-marker.write_text(json.dumps(doc, sort_keys=True, separators=(",", ":")) + "\n")
-cluster = pathlib.Path(sys.argv[2])
-if cluster.exists():
-    cdoc = json.loads(cluster.read_text())
-    cdoc["chainIds"] = cdoc["chainIds"][:-1]
-    cluster.write_text(json.dumps(cdoc, sort_keys=True, separators=(",", ":")) + "\n")
-PY
-"$ROOT/showcase.sh" chain add payment-chain-settlement --instance three
-jq -e '.chainIds | length == 11' \
-  "$ROOT/data/showcase/three/showcase-identity.json" >/dev/null
-jq -e '.chainIds[10] == "payment-chain-settlement"' \
-  "$ROOT/data/showcase/three/showcase-identity.json" >/dev/null
-SETTLEMENT_ADD_AGAIN="$("$ROOT/showcase.sh" chain add payment-chain-settlement --instance three)"
-grep -q 'already has payment-chain-settlement' <<< "$SETTLEMENT_ADD_AGAIN"
+# ADR-033: selected/all index scopes are canonical, retained, and exported to
+# every node as consensus settings. Drift and malformed scopes fail closed.
+"$ROOT/showcase.sh" prepare --instance indexed --http-base 19570 --server-base 19170 \
+  --enable-finalized-message-index=documents-chain,workflow-chain
+jq -e '.finalizedMessageIndex.chainIds == ["documents-chain", "workflow-chain"]' \
+  "$ROOT/data/showcase/indexed/showcase-identity.json" >/dev/null
+grep -q 'chains\[4\].machines.finalized-message-index.enabled=true' \
+  "$ROOT/data/showcase/indexed/node-config/node0.properties"
+grep -q 'chains\[5\].machines.finalized-message-index.enabled=true' \
+  "$ROOT/data/showcase/indexed/node-config/node2.properties"
+if "$ROOT/showcase.sh" prepare --instance indexed \
+    --enable-finalized-message-index=workflow-chain >"$WORK/index-drift.log" 2>&1; then
+  echo "finalized-message index drift was accepted" >&2; exit 1
+fi
+grep -q 'differs from retained showcase identity' "$WORK/index-drift.log"
+if "$ROOT/showcase.sh" prepare --instance invalid-index \
+    --enable-finalized-message-index=documents-chain,documents-chain \
+    >"$WORK/index-invalid.log" 2>&1; then
+  echo "duplicate finalized-message index scope was accepted" >&2; exit 1
+fi
+grep -q 'duplicate finalized-message index chain' "$WORK/index-invalid.log"
 
 # Anchoring is an additive retained-identity migration. Start with the default
 # workflow scope, add one existing chain, then expand to all chains without
@@ -192,7 +192,7 @@ grep -q 'already has payment-chain-settlement' <<< "$SETTLEMENT_ADD_AGAIN"
 ANCHOR_ROOT="$ROOT/data/showcase/anchor-expand"
 # Fresh instances anchor-ENABLE every chain by default (config-only; spending
 # starts at per-chain bootstrap).
-jq -e '.schemaVersion == 2 and (.anchor.chainIds | length == 11)' \
+jq -e '.schemaVersion == 2 and (.anchor.chainIds | length == 12)' \
   "$ANCHOR_ROOT/showcase-identity.json" >/dev/null
 # Downgrade the retained scope to the legacy workflow-only shape so the
 # additive enable migrations below keep their pre-default coverage.
@@ -223,7 +223,7 @@ document = {
     "chainIds": ["orders-chain", "registry-chain", "approvals-chain", "balances-chain",
                  "documents-chain", "workflow-chain", "roles-chain", "payments-chain",
                  "authenticated-map-chain", "authenticated-map-jmt-chain",
-                 "payment-chain-settlement"],
+                 "payment-chain-settlement", "document-review-chain"],
     "anchor": {"enabled": True, "mode": "script", "signerFingerprint": fingerprint,
                "chainId": "workflow-chain"},
 }
@@ -248,11 +248,11 @@ grep -q '^ANCHOR_CHAINS=registry-chain,workflow-chain$' \
 grep -q -- '--anchor-chain registry-chain --anchor-chain workflow-chain' "$WORK/cluster.log"
 
 "$ROOT/showcase.sh" anchor enable all --instance anchor-expand
-jq -e '.anchor.chainIds | length == 11' "$ANCHOR_ROOT/showcase-identity.json" >/dev/null
-jq -e '.anchor.chainIds | length == 11' \
+jq -e '.anchor.chainIds | length == 12' "$ANCHOR_ROOT/showcase-identity.json" >/dev/null
+jq -e '.anchor.chainIds | length == 12' \
   "$ANCHOR_ROOT/cluster/cluster-appchain-identity.json" >/dev/null
 PATH="$WORK/bin:$PATH" "$ROOT/showcase.sh" anchor bootstrap all --instance anchor-expand
-[ "$(grep -c '^anchor-bootstrap .*' "$WORK/cluster.log")" = 11 ]
+[ "$(grep -c '^anchor-bootstrap .*' "$WORK/cluster.log")" = 12 ]
 
 "$ROOT/showcase.sh" prepare --instance five --nodes 5 --http-base 19870 --server-base 19470
 [ "$(find "$ROOT/data/showcase/five/node-config" -type f -name 'node*.properties' | wc -l | tr -d ' ')" = 5 ]
@@ -312,11 +312,54 @@ grep -q "^evidence prepare .* --network preprod .* --anchor-key-file $WORK/ancho
   --instance light-preprod --http-base 17070 --server-base 17337 \
   --anchor-chain all --anchor-key-file "$WORK/anchor.seed" \
   --confirm-public-anchor preprod
-jq -e '.network == "preprod" and (.chainIds | length) == 10
-  and (.anchor.chainIds | length) == 10
+jq -e '.network == "preprod" and (.chainIds | length) == 11
+  and (.anchor.chainIds | length) == 11
   and (.chainIds | index("payment-chain-settlement")) == null' \
   "$ROOT/data/showcase/light-preprod/showcase-identity.json" >/dev/null
 ! grep -q 'chain-id: "payment-chain-settlement"' \
   "$ROOT/yano/config/application-appchain.yml"
 
-echo "PASS: showcase facade preserves identity, scaling, redaction, join, and governance contracts"
+# The production settlement ConfigBlock has nested observer/indexer chain-id
+# fields. Adoption validates only declarations directly under chains[n], so a
+# valid public bootstrap is not rejected after it has submitted its L1 tx.
+cat > "$WORK/settlement-bootstrap.log" <<'LOG'
+ConfigBlock : chains[0]:
+      chain-id: "payment-chain-settlement"
+      state-machine: "eutxo-ledger"
+      state:
+        commitment-profile: "mpf-blake2b256-v1"
+      machines:
+        eutxo:
+          profile: "yano-eutxo-v3-bridge-settlement"
+          expected-profile-digest: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+          l1:
+            deposits:
+              chain-id: "nested-deposit-source"
+            withdrawals:
+              chain-id: "nested-withdrawal-source"
+          settlement:
+            enabled: true
+            operator-key-id: "contract"
+            vault-script-hash: "0123456789abcdef"
+            thread-policy-id: "0123456789abcdef"
+            thread-asset-name: "contract"
+            confirmations: 1
+            scan-depth: 100
+            effect-type: "eutxo.settlement.v1"
+            indexer-enabled: true
+            observer-enabled: true
+
+LOG
+python3 "$REPO/.agents/skills/deploy-showcase-preprod-cluster/scripts/adopt_settlement_config.py" \
+  "$ROOT/yano/config/application-appchain.yml" "$WORK/settlement-bootstrap.log" \
+  "$ROOT/catalog/showcase-catalog-v1.json" >/dev/null
+python3 - "$ROOT/yano/config/application-appchain.yml" \
+  "$ROOT/catalog/showcase-catalog-v1.json" <<'PY'
+import json,pathlib,re,sys
+config = pathlib.Path(sys.argv[1]).read_text()
+actual = re.findall(r'^ {6}chain-id:\s*["\']?([^"\'\s]+)', config, re.MULTILINE)
+expected = [row['chainId'] for row in json.loads(pathlib.Path(sys.argv[2]).read_text())['chains']]
+assert actual == expected, (actual, expected)
+PY
+
+echo "PASS: showcase facade preserves catalog, index identity, scaling, redaction, join, and governance contracts"

--- a/appchain/extensions/appchain-zk/src/test/java/com/bloxbean/cardano/yano/appchain/zk/ZkApplyConsensusTest.java
+++ b/appchain/extensions/appchain-zk/src/test/java/com/bloxbean/cardano/yano/appchain/zk/ZkApplyConsensusTest.java
@@ -9,6 +9,7 @@ import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
 import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
 import com.bloxbean.cardano.yano.api.appchain.FinalityCert;
 import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
+import com.bloxbean.cardano.yano.api.appchain.transition.FinalizedMessageIndex;
 import com.bloxbean.cardano.zeroj.bbs.BbsKeyPair;
 import com.bloxbean.cardano.zeroj.verifier.core.VerifierRegistry;
 import org.junit.jupiter.api.Test;
@@ -45,7 +46,7 @@ class ZkApplyConsensusTest {
         byte[] forged = new ZkProofBody("demo", "groth16", "bls12381",
                 "FORGED".getBytes(StandardCharsets.UTF_8), List.of()).encode();
         apply(machine, block(forged), writer);
-        assertThat(writer.map.keySet()).containsOnly("~tip"); // only the tip marker, no message record
+        assertThat(writer.map.keySet()).containsOnly(stateKey(FinalizedMessageIndex.TIP_KEY));
 
         // A valid proof IS recorded
         MapWriter writer2 = new MapWriter();
@@ -158,6 +159,10 @@ class ZkApplyConsensusTest {
         byte[] seed = new byte[32];
         java.util.Arrays.fill(seed, (byte) fill);
         return seed;
+    }
+
+    private static String stateKey(byte[] key) {
+        return new String(key, StandardCharsets.UTF_8);
     }
 
     /** Minimal in-memory writer standing in for the MPF staged writer. */

--- a/appchain/extensions/eutxo/appchain-eutxo-demo/src/main/java/com/bloxbean/cardano/yano/appchain/eutxo/demo/SettlementBootstrapWorkflow.java
+++ b/appchain/extensions/eutxo/appchain-eutxo-demo/src/main/java/com/bloxbean/cardano/yano/appchain/eutxo/demo/SettlementBootstrapWorkflow.java
@@ -17,9 +17,11 @@ import com.bloxbean.cardano.client.transaction.spec.Asset;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.HexFormat;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 
 /**
  * ADR-UTXO-009: deploys a settlement identity's L1 side — the two one-shot
@@ -110,23 +112,52 @@ public final class SettlementBootstrapWorkflow {
         String rootUnit = plan.rootThreadPolicyIdHex()
                 + HexFormat.of().formatHex(
                 ShowcaseSettlementPlan.ROOT_TOKEN.getBytes());
-        submit(quickTx, operatorAddress, operator, new ScriptTx()
-                .collectFrom(utxoAt(backend, operatorAddress, rootSeed))
-                .mintAsset(plan.rootThreadPolicy(),
-                        List.of(new Asset(ShowcaseSettlementPlan.ROOT_TOKEN,
-                                BigInteger.ONE)),
-                        BigIntPlutusData.of(0),
-                        operatorAddress));
-        List<Asset> shardAssets = new ArrayList<>();
-        for (int index = 0; index < 16; index++) {
-            shardAssets.add(new Asset(
-                    "0x" + HexFormat.of().formatHex(new byte[] {(byte) index}),
-                    BigInteger.ONE));
+        Set<String> heldUnits = heldUnits(backend, operatorAddress);
+        if (!heldUnits.contains(rootUnit)) {
+            submit(quickTx, operatorAddress, operator,
+                    new ScriptTx()
+                            .collectFrom(utxoAt(
+                                    backend, operatorAddress, rootSeed))
+                            .mintAsset(plan.rootThreadPolicy(),
+                                    List.of(new Asset(
+                                            ShowcaseSettlementPlan.ROOT_TOKEN,
+                                            BigInteger.ONE)),
+                                    BigIntPlutusData.of(0), operatorAddress));
+            awaitUnits(backend, operatorAddress, Set.of(rootUnit));
         }
-        submit(quickTx, operatorAddress, operator, new ScriptTx()
-                .collectFrom(utxoAt(backend, operatorAddress, shardSeed))
-                .mintAsset(plan.shardThreadPolicy(), shardAssets,
-                        BigIntPlutusData.of(0), operatorAddress));
+        List<Asset> shardAssets = new ArrayList<>();
+        Set<String> shardUnits = new HashSet<>();
+        for (int index = 0; index < 16; index++) {
+            String assetName = HexFormat.of().formatHex(
+                    new byte[] {(byte) index});
+            shardAssets.add(new Asset(
+                    "0x" + assetName,
+                    BigInteger.ONE));
+            shardUnits.add(plan.shardThreadPolicyIdHex() + assetName);
+        }
+        heldUnits = heldUnits(backend, operatorAddress);
+        long heldShardCount = shardUnits.stream().filter(heldUnits::contains).count();
+        if (heldShardCount != 0 && heldShardCount != SHARD_COUNT) {
+            throw new IllegalStateException(
+                    "operator address holds only " + heldShardCount + " of "
+                            + SHARD_COUNT + " settlement shard tokens");
+        }
+        if (heldShardCount == 0) {
+            submit(quickTx, operatorAddress, operator,
+                    new ScriptTx()
+                            .collectFrom(utxoAt(
+                                    backend, operatorAddress, shardSeed))
+                            .mintAsset(plan.shardThreadPolicy(), shardAssets,
+                                    BigIntPlutusData.of(0), operatorAddress));
+            awaitUnits(backend, operatorAddress, shardUnits);
+        }
+
+        heldUnits = heldUnits(backend, operatorAddress);
+        if (!heldUnits.contains(rootUnit)
+                || !heldUnits.containsAll(shardUnits)) {
+            throw new IllegalStateException(
+                    "settlement mint outputs are not yet visible at the operator address");
+        }
 
         Tx genesis = new Tx()
                 .payToContract(plan.rootAddress(),
@@ -224,5 +255,36 @@ public final class SettlementBootstrapWorkflow {
         }
         throw new IllegalStateException(
                 "transaction " + transactionId + " did not appear at " + address);
+    }
+
+    private static Set<String> heldUnits(
+            BackendService backend, String address) throws Exception {
+        Set<String> units = new HashSet<>();
+        for (Utxo utxo : new DefaultUtxoSupplier(backend.getUtxoService())
+                .getAll(address)) {
+            for (Amount amount : utxo.getAmount()) {
+                if (amount.getUnit() != null
+                        && !"lovelace".equals(amount.getUnit())
+                        && amount.getQuantity() != null
+                        && amount.getQuantity().signum() > 0) {
+                    units.add(amount.getUnit());
+                }
+            }
+        }
+        return units;
+    }
+
+    private static void awaitUnits(
+            BackendService backend, String address, Set<String> expected)
+            throws Exception {
+        long deadline = System.currentTimeMillis() + 120_000;
+        while (System.currentTimeMillis() < deadline) {
+            if (heldUnits(backend, address).containsAll(expected)) {
+                return;
+            }
+            Thread.sleep(1_000);
+        }
+        throw new IllegalStateException(
+                "settlement mint units did not appear at " + address);
     }
 }

--- a/appchain/extensions/eutxo/appchain-eutxo-ledger/src/main/java/com/bloxbean/cardano/yano/appchain/eutxo/ledger/EutxoStateMachine.java
+++ b/appchain/extensions/eutxo/appchain-eutxo-ledger/src/main/java/com/bloxbean/cardano/yano/appchain/eutxo/ledger/EutxoStateMachine.java
@@ -2,6 +2,7 @@ package com.bloxbean.cardano.yano.appchain.eutxo.ledger;
 
 import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
 import com.bloxbean.cardano.yano.api.appchain.AppBlock;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
 import com.bloxbean.cardano.yano.api.appchain.AppQueryContext;
 import com.bloxbean.cardano.yano.api.appchain.AppQueryException;
@@ -144,6 +145,18 @@ public final class EutxoStateMachine implements AppStateMachine {
     @Override
     public String id() {
         return ID;
+    }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        return AppCapabilityManifest.builder(ID, profile.id())
+                .component(new AppCapabilityManifest.Component(
+                        ID, profile.id(), profile.digestHex(), "application/v1",
+                        List.of(TOPIC), List.of("transactions/receipt", "utxos/address"),
+                        AppCapabilityManifest.Origin.INTRINSIC))
+                .proofSubject(new AppCapabilityManifest.ProofSubject(
+                        "eutxo-transaction-receipt-v1", "", "tx/", "state-proof"))
+                .build();
     }
 
     @Override

--- a/appchain/products/appchain-evidence-client/build.gradle
+++ b/appchain/products/appchain-evidence-client/build.gradle
@@ -1,5 +1,11 @@
 dependencies {
-    api project(':appchain-client')
+    // This companion uses AppChainClient's transport/value API but deliberately
+    // does not activate the node/runtime SPI carried by core-api. Keep the rest
+    // of the lightweight client verifier closure transitive.
+    api(project(':appchain-client')) {
+        exclude group: 'com.bloxbean.cardano', module: 'core-api'
+    }
+    compileOnly project(':core-api')
     api project(':appchain-evidence-contracts')
     api project(':appchain-composite-contracts')
 
@@ -7,6 +13,7 @@ dependencies {
     testRuntimeOnly libs.junit.jupiter.engine
     testRuntimeOnly libs.junit.platform.launcher
     testImplementation libs.assertj.core
+    testImplementation project(':core-api')
 }
 
 java {

--- a/console-ui/frontend/src/lib/api/client.ts
+++ b/console-ui/frontend/src/lib/api/client.ts
@@ -232,6 +232,10 @@ export class YanoApi {
   chainMessage(chainId: string, messageId: string, signal?: AbortSignal) {
     return this.json<AppChainMessage>(`${chainPath(chainId)}/messages/${encodeURIComponent(messageId)}`, signal);
   }
+  chainMessageProof(chainId: string, messageId: string, signal?: AbortSignal) {
+    return this.json<import('./types').MessageInclusionProof>(
+      `${chainPath(chainId)}/messages/${encodeURIComponent(messageId)}/proof`, signal);
+  }
   chainEffects(chainId: string, signal?: AbortSignal) {
     return this.json<EffectPage>(`${chainPath(chainId)}/effects?fromHeight=0&limit=100`, signal);
   }

--- a/console-ui/frontend/src/lib/api/types.ts
+++ b/console-ui/frontend/src/lib/api/types.ts
@@ -154,6 +154,19 @@ export interface AppChainMessage {
   bodyHex?: string;
 }
 
+export interface MessageInclusionProof {
+  schemaVersion: number;
+  treeId: string;
+  chainId: string;
+  blockHeight: number;
+  blockHash: string;
+  messagesRoot: string;
+  messageId: string;
+  messageIndex: number;
+  leafCount: number;
+  siblings: string[];
+}
+
 export interface AppChainBlockDetail {
   chainId: string;
   height: number;
@@ -197,6 +210,53 @@ export interface AppChainStatus {
   effects?: Record<string, unknown>;
   stateMachineStatus?: Record<string, unknown>;
   stateCommitment?: StateCommitmentStatus;
+  capabilityManifest?: AppCapabilityManifest;
+}
+
+export interface AppCapabilityComponent {
+  id: string;
+  version: string;
+  configurationId: string;
+  stateNamespace: string;
+  topics: string[];
+  querySubjects: string[];
+  origin: 'INTRINSIC' | 'COMPOSED' | 'LAUNCHER_ENABLED' | 'RUNTIME_CONFIGURED';
+}
+
+export interface AppCapabilityWorkflow {
+  id: string;
+  version: string;
+  participantComponentIds: string[];
+  topic: string;
+  effectTypes: string[];
+  origin: AppCapabilityComponent['origin'];
+}
+
+export interface AppCrossCuttingCapability {
+  capabilityId: string;
+  version: string;
+  enabled: boolean;
+  configurationDigest: string;
+  attributes: Record<string, string>;
+  origin: AppCapabilityComponent['origin'];
+}
+
+export interface AppProofSubject {
+  subjectId: string;
+  componentId: string;
+  keyNamespace: string;
+  verificationTarget: string;
+}
+
+export interface AppCapabilityManifest {
+  schemaVersion: number;
+  applicationId: string;
+  applicationVersion: string;
+  manifestDigest: string;
+  components: AppCapabilityComponent[];
+  workflows: AppCapabilityWorkflow[];
+  crossCutting: AppCrossCuttingCapability[];
+  proofSubjects: AppProofSubject[];
 }
 
 export interface PluginOperationsSummary {

--- a/console-ui/frontend/src/lib/appchain/capabilities.test.ts
+++ b/console-ui/frontend/src/lib/appchain/capabilities.test.ts
@@ -1,41 +1,46 @@
 import { describe, expect, it } from 'vitest';
+import type { AppCapabilityManifest } from '$lib/api/types';
 import { discoverChainCapabilities } from './capabilities';
 
+const manifest = (components: string[], capabilities: string[]): AppCapabilityManifest => ({
+  schemaVersion: 1,
+  applicationId: 'custom-application',
+  applicationVersion: '1.0.0',
+  manifestDigest: 'ab'.repeat(32),
+  components: components.map((id) => ({ id, version: '1.0.0', configurationId: 'test',
+    stateNamespace: `${id}/`, topics: [], querySubjects: [], origin: 'COMPOSED' })),
+  workflows: [],
+  crossCutting: capabilities.map((capabilityId) => ({ capabilityId, version: '1.0.0',
+    enabled: true, configurationDigest: 'test', attributes: {}, origin: 'COMPOSED' })),
+  proofSubjects: []
+});
+
 describe('app-chain capability discovery', () => {
-  it('does not render optional panels from deployment assumptions', () => {
+  it('does not infer reusable capabilities from state-machine names', () => {
     const capabilities = discoverChainCapabilities({ chainId: 'orders', stateMachine: 'ordered-log' });
     expect(capabilities.effects).toBe(false);
     expect(capabilities.eutxoExplorer).toBe(false);
     expect(capabilities.roleApprovals).toBe(false);
-    expect(capabilities.evidenceBundles).toBe(true);
+    expect(capabilities.sources).toContain('capability manifest unavailable');
   });
 
-  it('discovers effects and generic role approvals from chain status and confirms the bundle catalog', () => {
+  it('discovers effects, role approval and proof target from the manifest', () => {
     const capabilities = discoverChainCapabilities({
-      chainId: 'approvals', stateMachine: 'role-approvals', effects: { enabled: true }
-    }, ['com.bloxbean.cardano.yano.appchain.role-workflow']);
+      chainId: 'custom', stateMachine: 'unknown', capabilityManifest: manifest(
+        ['domain-actors', 'role-approvals'],
+        ['approval:actor-role-v1', 'effects:outbox-v1', 'state-commitment:mpf-blake2b256-v1'])
+    });
     expect(capabilities.effects).toBe(true);
     expect(capabilities.roleDomainBundle).toContain('role-workflow');
-    expect(capabilities.sources).toContain('plugin-catalog:com.bloxbean.cardano.yano.appchain.role-workflow');
+    expect(capabilities.commitmentTarget).toBe('off-chain + on-chain');
   });
 
-  it('gates the stock EUTxO explorer on the state-machine identity', () => {
-    expect(discoverChainCapabilities({
-      chainId: 'payments', stateMachine: 'eutxo-ledger'
+  it('gates specialized explorers on declared components', () => {
+    expect(discoverChainCapabilities({ chainId: 'custom', stateMachine: 'unknown',
+      capabilityManifest: manifest(['eutxo-ledger', 'authenticated-map'], [])
     }).eutxoExplorer).toBe(true);
-    expect(discoverChainCapabilities({
-      chainId: 'payments', stateMachine: 'custom-eutxo'
+    expect(discoverChainCapabilities({ chainId: 'named-only', stateMachine: 'eutxo-ledger',
+      capabilityManifest: manifest([], [])
     }).eutxoExplorer).toBe(false);
-  });
-
-  it('gates the authenticated-map console on the state-machine identity', () => {
-    const capabilities = discoverChainCapabilities({
-      chainId: 'map-chain', stateMachine: 'authenticated-map'
-    });
-    expect(capabilities.authenticatedMap).toBe(true);
-    expect(capabilities.sources).toContain('status:stateMachine=authenticated-map');
-    expect(discoverChainCapabilities({
-      chainId: 'map-chain', stateMachine: 'kv-registry'
-    }).authenticatedMap).toBe(false);
   });
 });

--- a/console-ui/frontend/src/lib/appchain/capabilities.ts
+++ b/console-ui/frontend/src/lib/appchain/capabilities.ts
@@ -1,4 +1,4 @@
-import type { AppChainStatus } from '$lib/api/types';
+import type { AppCapabilityManifest, AppChainStatus } from '$lib/api/types';
 
 export interface ChainCapabilities {
   effects: boolean;
@@ -8,37 +8,33 @@ export interface ChainCapabilities {
   roleDomainBundle: string | null;
   evidenceBundles: boolean;
   stateProofs: boolean;
+  finalizedMessageIndex: boolean;
+  commitmentTarget: string;
   sources: string[];
 }
 
 const ROLE_BUNDLE = 'com.bloxbean.cardano.yano.appchain.role-workflow';
-const EVIDENCE_BUNDLE = 'com.bloxbean.cardano.yano.appchain.evidence-profile';
-const AUTHENTICATED_MAP_MACHINE = 'authenticated-map';
+const hasCapability = (manifest: AppCapabilityManifest | undefined, id: string) =>
+  manifest?.crossCutting.some((capability) => capability.enabled && capability.capabilityId === id) === true;
+const hasComponent = (manifest: AppCapabilityManifest | undefined, id: string) =>
+  manifest?.components.some((component) => component.id === id) === true;
 
 export function discoverChainCapabilities(status: AppChainStatus | null,
-                                          pluginBundleIds: readonly string[] = []): ChainCapabilities {
-  const machine = status?.stateMachine ?? '';
-  const effects = isObject(status?.effects) && status?.effects?.enabled === true;
-  const roleDomainBundle = machine === 'role-approvals' ? ROLE_BUNDLE
-    : machine === 'role-evidence' ? EVIDENCE_BUNDLE : null;
-  const catalogConfirmed = roleDomainBundle !== null && pluginBundleIds.includes(roleDomainBundle);
-  const authenticatedMap = machine === AUTHENTICATED_MAP_MACHINE;
-  const sources = ['app-chain core'];
-  if (effects) sources.push('status:effects.enabled');
-  if (roleDomainBundle || authenticatedMap) sources.push(`status:stateMachine=${machine}`);
-  if (catalogConfirmed) sources.push(`plugin-catalog:${roleDomainBundle}`);
+                                          _pluginBundleIds: readonly string[] = []): ChainCapabilities {
+  const manifest = status?.capabilityManifest;
+  const roleApprovals = hasCapability(manifest, 'approval:actor-role-v1');
+  const mpf = hasCapability(manifest, 'state-commitment:mpf-blake2b256-v1');
+  const jmt = hasCapability(manifest, 'state-commitment:jmt-blake2b256-v1');
   return {
-    effects,
-    eutxoExplorer: machine === 'eutxo-ledger',
-    authenticatedMap,
-    roleApprovals: roleDomainBundle !== null,
-    roleDomainBundle,
+    effects: hasCapability(manifest, 'effects:outbox-v1'),
+    eutxoExplorer: hasComponent(manifest, 'eutxo-ledger'),
+    authenticatedMap: hasComponent(manifest, 'authenticated-map'),
+    roleApprovals,
+    roleDomainBundle: roleApprovals ? ROLE_BUNDLE : null,
     evidenceBundles: !!status?.chainId,
-    stateProofs: !!status?.chainId,
-    sources
+    stateProofs: mpf || jmt,
+    finalizedMessageIndex: hasCapability(manifest, 'state-index:finalized-message-v1'),
+    commitmentTarget: mpf ? 'off-chain + on-chain' : jmt ? 'off-chain only' : 'not declared',
+    sources: manifest ? [`capabilityManifest:${manifest.manifestDigest}`] : ['capability manifest unavailable']
   };
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return value !== null && typeof value === 'object' && !Array.isArray(value);
 }

--- a/console-ui/frontend/src/lib/appchain/verification.ts
+++ b/console-ui/frontend/src/lib/appchain/verification.ts
@@ -20,6 +20,18 @@ export async function hexSha256(value: string): Promise<string> {
   return Array.from(digest, (item) => item.toString(16).padStart(2, '0')).join('');
 }
 
+export async function finalizedMessageStateKey(messageId: string): Promise<string> {
+  if (!SHA256.test(messageId)) throw new Error('Message id must be 64 lowercase hex characters');
+  const namespace = new TextEncoder().encode('~yano/finalized-message/v1/');
+  const material = new Uint8Array(namespace.length + 32);
+  material.set(namespace);
+  for (let index = 0; index < 32; index++) {
+    material[namespace.length + index] = Number.parseInt(messageId.slice(index * 2, index * 2 + 2), 16);
+  }
+  const digest = new Uint8Array(await crypto.subtle.digest('SHA-256', material));
+  return Array.from(digest, (item) => item.toString(16).padStart(2, '0')).join('');
+}
+
 export function boundedPretty(value: unknown, max = 32 * 1024): string {
   const rendered = JSON.stringify(value, null, 2) ?? String(value);
   return rendered.length <= max ? rendered : `${rendered.slice(0, max)}\n… output truncated in console …`;

--- a/console-ui/frontend/src/lib/authmap/model.test.ts
+++ b/console-ui/frontend/src/lib/authmap/model.test.ts
@@ -132,8 +132,15 @@ describe('authenticated-map envelope identity gates', () => {
 
 describe('capability and labelling helpers', () => {
   it('detects the state machine and direct-submit authorization modes', () => {
-    expect(isAuthenticatedMapChain({ stateMachine: 'authenticated-map' })).toBe(true);
-    expect(isAuthenticatedMapChain({ stateMachine: 'eutxo-ledger' })).toBe(false);
+    const manifest = {
+      schemaVersion: 1, applicationId: 'custom-map', applicationVersion: '1',
+      manifestDigest: 'aa'.repeat(32),
+      components: [{ id: 'authenticated-map', version: '1', configurationId: 'demo',
+        stateNamespace: 'application/v1', topics: [], querySubjects: [], origin: 'COMPOSED' as const }],
+      workflows: [], crossCutting: [], proofSubjects: []
+    };
+    expect(isAuthenticatedMapChain({ stateMachine: 'custom', capabilityManifest: manifest })).toBe(true);
+    expect(isAuthenticatedMapChain({ stateMachine: 'authenticated-map' })).toBe(false);
     expect(directSubmitAllowed(PRODUCTS)).toBe(true);
     expect(directSubmitAllowed({ ...PRODUCTS, authorization: 3 })).toBe(false);
     expect(directSubmitAllowed(undefined)).toBe(false);

--- a/console-ui/frontend/src/lib/authmap/model.ts
+++ b/console-ui/frontend/src/lib/authmap/model.ts
@@ -30,7 +30,8 @@ const MAX_BATCH_BYTES = 1_048_576;
 const STATE_MACHINE_VERSION = 1;
 
 export function isAuthenticatedMapChain(status: AppChainStatus | null): boolean {
-  return status?.stateMachine === AUTHMAP_STATE_MACHINE_ID;
+  return status?.capabilityManifest?.components.some(
+    (component) => component.id === AUTHMAP_STATE_MACHINE_ID) === true;
 }
 
 const AUTHORIZATION_LABELS = ['open', 'owner', 'member', 'governed-role', 'approval'];

--- a/console-ui/frontend/src/lib/components/AppChainCapabilityMatrix.svelte
+++ b/console-ui/frontend/src/lib/components/AppChainCapabilityMatrix.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { base } from '$app/paths';
+  import type { AppChainStatus } from '$lib/api/types';
+
+  export let statuses: AppChainStatus[] = [];
+  const short = (id: string) => id
+    .replace('state-commitment:', '')
+    .replace('state-index:', '')
+    .replace('approval:', '')
+    .replace('authorization:', '')
+    .replace('l1-observer:', '')
+    .replace('effects:', '');
+</script>
+
+<div class="section-title">Reference capability matrix</div>
+<section class="card overflow-hidden">
+  <div class="border-b border-slate-800 px-4 py-3">
+    <h2 class="m-0 text-sm font-semibold">Running applications</h2>
+    <p class="m-0 mt-1 text-xs text-slate-500">Declared by each application manifest; membership governance is intentionally separate.</p>
+  </div>
+  <div class="overflow-x-auto">
+    <table class="w-full min-w-[760px] text-left text-xs">
+      <thead class="text-slate-500"><tr><th class="p-3">Chain / application</th><th>Components</th><th>Business capabilities</th><th>Proof target</th></tr></thead>
+      <tbody>
+        {#each statuses as status}
+          <tr class="border-t border-slate-800/60 align-top">
+            <td class="p-3"><a class="font-semibold text-violet-300 no-underline hover:text-violet-200"
+                                 href={`${base}/app-chain/?chain=${encodeURIComponent(status.chainId ?? '')}`}>{status.chainId ?? 'unknown chain'}</a><div class="mt-1 text-slate-500">{status.capabilityManifest?.applicationId ?? 'manifest unavailable'}</div></td>
+            <td class="py-3">{status.capabilityManifest?.components.map((item) => item.id).join(', ') || 'standalone state'}</td>
+            <td class="py-3"><div class="flex max-w-xl flex-wrap gap-1">
+              {#each status.capabilityManifest?.crossCutting.filter((item) => item.enabled && !item.capabilityId.startsWith('state-commitment:')) ?? [] as capability}
+                <span class="badge">{short(capability.capabilityId)}</span>
+              {:else}<span class="text-slate-500">none declared</span>{/each}
+            </div></td>
+            <td class="py-3 pr-3">{status.capabilityManifest?.crossCutting.some((item) => item.capabilityId === 'state-commitment:mpf-blake2b256-v1')
+              ? 'MPF · off-chain + on-chain' : status.capabilityManifest?.crossCutting.some((item) => item.capabilityId === 'state-commitment:jmt-blake2b256-v1')
+                ? 'JMT · off-chain' : 'not declared'}</td>
+          </tr>
+        {:else}<tr><td colspan="4" class="p-4 text-slate-500">Loading capability manifests…</td></tr>{/each}
+      </tbody>
+    </table>
+  </div>
+</section>

--- a/console-ui/frontend/src/lib/components/AppChainCapabilityPanels.svelte
+++ b/console-ui/frontend/src/lib/components/AppChainCapabilityPanels.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
   import { onMount } from 'svelte';
-  import type { AnchorCommitment, AppChainStatus, ProofVerificationResult,
+  import type { AnchorCommitment, AppCapabilityManifest, AppChainStatus, ProofVerificationResult,
     StateProofEnvelope } from '$lib/api/types';
   import { YanoApi, apiFailureMessage } from '$lib/api/client';
   import { discoverChainCapabilities } from '$lib/appchain/capabilities';
   import { effectStatsView } from '$lib/appchain/effect-stats';
   import { assessProofBinding, parseProofEnvelope } from '$lib/appchain/proof-verification';
-  import { asciiHex, boundedPretty, hexSha256, PRODUCT_ID, SHA256, STATE_KEY } from '$lib/appchain/verification';
+  import { asciiHex, boundedPretty, finalizedMessageStateKey, hexSha256, PRODUCT_ID, SHA256, STATE_KEY } from '$lib/appchain/verification';
   import { numberValue, objectList, objectValue, shortHash, stringValue } from '$lib/appchain/value';
   import CopyValue from './CopyValue.svelte';
   import MetricCard from './MetricCard.svelte';
@@ -28,11 +28,14 @@
   let proposalId = $state('');
   let proposal = $state('');
   let proposalError = $state('');
+  let documentEntityId = $state('');
+  let documentReviewState = $state('');
   let messageId = $state('');
   let stateKey = $state('');
   let expectedPayloadHash = $state('');
   let expectedProofValueHash = $state('');
   let evidence = $state('');
+  let messageProof = $state('');
   let proof = $state('');
   let proofEnvelope = $state<StateProofEnvelope>();
   let expectedProofRoot = $state('');
@@ -45,6 +48,7 @@
   let verificationError = $state('');
   let busy = $state(false);
   let capabilities = $derived(discoverChainCapabilities(status, pluginBundleIds));
+  let manifest: AppCapabilityManifest | undefined = $derived(status.capabilityManifest);
   let effectView = $derived(effectStatsView(effectStats));
   let showOverview = $derived(section === 'all' || section === 'overview');
   let showVerification = $derived(section === 'all' || section === 'verification');
@@ -108,14 +112,38 @@
     } catch (cause) { proposalError = apiFailureMessage(cause, 'Proposal unavailable'); }
   }
 
+  async function queryDocumentReview(): Promise<void> {
+    documentReviewState = '';
+    proposalError = '';
+    if (!PRODUCT_ID.test(proposalId) || !PRODUCT_ID.test(documentEntityId)) {
+      proposalError = 'Enter canonical proposal and document entity ids.';
+      return;
+    }
+    try {
+      const [policy, proposalResult, head, receipt] = await Promise.all([
+        api.chainQuery(chainId, 'components/role-approvals/policy',
+          asciiHex('document-release')),
+        api.chainQuery(chainId, 'components/role-approvals/proposal', asciiHex(proposalId)),
+        api.chainQuery(chainId, 'components/documents/head', asciiHex(documentEntityId)),
+        api.chainQuery(chainId, 'components/document-review-receipts/receipt', asciiHex(proposalId))
+      ]);
+      documentReviewState = boundedPretty({ policy, proposal: proposalResult,
+        documentHead: head, approvalConsumptionReceipt: receipt });
+    } catch (cause) {
+      proposalError = apiFailureMessage(cause, 'Document-review state unavailable');
+    }
+  }
+
   async function loadEvidence(): Promise<void> {
-    evidence = ''; payloadDigest = ''; verificationError = '';
+    evidence = ''; messageProof = ''; payloadDigest = ''; verificationError = '';
     if (!SHA256.test(messageId)) { verificationError = 'Message id must be 64 lowercase hex characters.'; return; }
     try {
-      const [bundle, message] = await Promise.all([
-        api.chainEvidence(chainId, messageId), api.chainMessage(chainId, messageId)
+      const [bundle, message, inclusion] = await Promise.all([
+        api.chainEvidence(chainId, messageId), api.chainMessage(chainId, messageId),
+        api.chainMessageProof(chainId, messageId)
       ]);
       evidence = boundedPretty(bundle);
+      messageProof = boundedPretty(inclusion);
       if (typeof message.bodyHex === 'string') payloadDigest = await hexSha256(message.bodyHex);
     } catch (cause) { verificationError = apiFailureMessage(cause, 'Evidence unavailable'); }
   }
@@ -217,6 +245,15 @@
     proofVerification = undefined;
   }
 
+  async function useFinalizedMessageStateKey(): Promise<void> {
+    if (!SHA256.test(messageId)) {
+      verificationError = 'Message id must be 64 lowercase hex characters.';
+      return;
+    }
+    stateKey = await finalizedMessageStateKey(messageId);
+    verificationError = '';
+  }
+
   const match = (digest: string, expected: string) => !expected ? 'computed locally'
     : !SHA256.test(expected) ? 'invalid expected hash'
       : digest === expected ? 'MATCH' : 'MISMATCH';
@@ -229,9 +266,51 @@
       <span class="badge badge-ok">EVIDENCE BUNDLES</span><span class="badge badge-ok">STATE PROOFS</span>
       {#if capabilities.effects}<span class="badge badge-ok">EFFECTS</span>{/if}
       {#if capabilities.roleApprovals}<span class="badge badge-ok">ROLE APPROVALS</span>{/if}
+      {#if capabilities.finalizedMessageIndex}<span class="badge badge-ok">MESSAGE STATE INDEX</span>{/if}
+      <span class="badge">{capabilities.commitmentTarget.toUpperCase()}</span>
     </div>
     <p class="mb-0 mt-3 text-xs text-slate-500">Source: {capabilities.sources.join(' · ')}</p>
   </section>
+
+  {#if manifest}
+    <div class="section-title">Application composition</div>
+    <section class="card p-5">
+      <div class="flex flex-wrap items-center justify-between gap-2">
+        <div><strong>{manifest.applicationId}</strong>
+          <span class="ml-2 text-xs text-slate-500">v{manifest.applicationVersion}</span></div>
+        <CopyValue value={manifest.manifestDigest} width={22} label="capability manifest digest" />
+      </div>
+      <div class="mt-4 grid gap-4 lg:grid-cols-3">
+        <div><h3 class="mt-0 text-xs uppercase tracking-wide text-slate-500">Components</h3>
+          {#each manifest.components as component}
+            <div class="mb-2 rounded-lg border border-slate-800 p-2 text-xs">
+              <strong>{component.id}</strong><div class="text-slate-500">{component.origin} · {component.stateNamespace}</div>
+            </div>
+          {:else}<p class="text-xs text-slate-500">Standalone application state.</p>{/each}
+        </div>
+        <div><h3 class="mt-0 text-xs uppercase tracking-wide text-slate-500">Workflows</h3>
+          {#each manifest.workflows as workflow}
+            <div class="mb-2 rounded-lg border border-slate-800 p-2 text-xs">
+              <strong>{workflow.id}</strong><div class="text-slate-500">{workflow.participantComponentIds.join(' → ')}</div>
+            </div>
+          {:else}<p class="text-xs text-slate-500">No cross-component workflow.</p>{/each}
+        </div>
+        <div><h3 class="mt-0 text-xs uppercase tracking-wide text-slate-500">Cross-cutting</h3>
+          {#each manifest.crossCutting.filter((item) => item.enabled) as capability}
+            <div class="mb-2 rounded-lg border border-slate-800 p-2 text-xs">
+              <strong>{capability.capabilityId}</strong><div class="text-slate-500">{capability.origin}</div>
+            </div>
+          {/each}
+        </div>
+      </div>
+      {#if manifest.workflows.length}
+        <div class="mt-4 rounded-lg border border-violet-500/25 bg-violet-500/5 p-3 text-xs">
+          <span class="text-slate-400">Committed transition trace:</span>
+          <strong class="ml-2">command → authorization / approval → application mutation → consumption / effect receipt</strong>
+        </div>
+      {/if}
+    </section>
+  {/if}
 
   {#if capabilities.roleApprovals}
     <div class="section-title">Committed proposal</div>
@@ -241,6 +320,23 @@
         <button class="rounded-lg bg-violet-500 px-4 py-2 text-sm font-semibold" onclick={queryProposal}>Query</button></div>
       {#if proposalError}<p class="text-sm text-rose-300">{proposalError}</p>{/if}
       {#if proposal}<pre class="mt-4 max-h-96 overflow-auto rounded-lg bg-slate-950 p-3 text-xs">{proposal}</pre>{/if}
+    </section>
+  {/if}
+
+  {#if manifest?.applicationId === 'document-review'}
+    <div class="section-title">Document-review transition trace</div>
+    <section class="card p-5">
+      <p class="mt-0 text-sm text-slate-400">Reads the committed stock role policy and proposal, reused document head, and application-owned approval-consumption receipt at root-fixed heights.</p>
+      <div class="grid gap-2 md:grid-cols-[1fr_1fr_auto]">
+        <input class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2"
+               bind:value={proposalId} placeholder="proposal id" />
+        <input class="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2"
+               bind:value={documentEntityId} placeholder="document entity id" />
+        <button class="rounded-lg bg-violet-500 px-4 py-2 text-sm font-semibold"
+                onclick={queryDocumentReview}>Read trace</button>
+      </div>
+      {#if proposalError}<p class="text-sm text-rose-300">{proposalError}</p>{/if}
+      {#if documentReviewState}<pre class="mt-4 max-h-96 overflow-auto rounded-lg bg-slate-950 p-3 text-xs">{documentReviewState}</pre>{/if}
     </section>
   {/if}
 {/if}
@@ -397,6 +493,9 @@
     <p class="text-xs text-slate-500">Fetch the finalized bundle and message, then SHA-256 the exact payload bytes in this browser.</p>
     <div class="flex gap-2"><input class="min-w-0 flex-1 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-xs" bind:value={messageId} placeholder="64-character message id" />
       <button type="button" class="rounded-lg bg-blue-500 px-3 py-2 text-sm font-semibold" onclick={loadEvidence}>Load</button></div>
+    <p class="mb-0 mt-3 rounded-lg border border-amber-500/20 bg-amber-500/5 p-2 text-xs text-amber-100">
+      Finality and state inclusion prove identity and position, not continued message-body availability.
+    </p>
     <label class="mt-3 block text-xs text-slate-400">Expected payload SHA-256 (optional)
       <input class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 font-mono"
              bind:value={expectedPayloadHash} placeholder="64 lowercase hex characters" />
@@ -410,14 +509,25 @@
         <div class="mt-1 flex justify-start"><CopyValue value={payloadDigest} width={64} label="payload SHA-256" /></div>
       </div>
     {/if}
-    {#if evidence}<pre class="mt-4 max-h-96 overflow-auto rounded-lg bg-slate-950 p-3 text-xs">{evidence}</pre>{/if}
+    {#if messageProof}
+      <h3 class="mb-1 mt-4 text-xs uppercase tracking-wide text-slate-500">Message → messagesRoot path</h3>
+      <pre class="max-h-64 overflow-auto rounded-lg bg-slate-950 p-3 text-xs">{messageProof}</pre>
+    {/if}
+    {#if evidence}
+      <h3 class="mb-1 mt-4 text-xs uppercase tracking-wide text-slate-500">Signed block / finality evidence</h3>
+      <pre class="max-h-96 overflow-auto rounded-lg bg-slate-950 p-3 text-xs">{evidence}</pre>
+    {/if}
   </section>
   <section class="card p-5">
     <h2 class="mt-0 text-sm font-semibold">Profile-aware state proof</h2>
     <p class="text-xs text-slate-500">Dispatches to this release's bounded MPF or classic-JMT verifier. Mathematical validity is reported separately from chain/profile/root/height trust.</p>
     <input class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 font-mono text-xs"
-           bind:value={stateKey} placeholder="state key hex (message id for ordered-log)" />
+           bind:value={stateKey} placeholder="state key hex" />
     <div class="mt-2 flex flex-wrap gap-2">
+      {#if capabilities.finalizedMessageIndex}
+        <button type="button" class="rounded-lg border border-violet-500/50 px-3 py-2 text-sm text-violet-200"
+                onclick={useFinalizedMessageStateKey}>Use message state key</button>
+      {/if}
       <button type="button" class="rounded-lg bg-cyan-500 px-3 py-2 text-sm font-semibold text-slate-950"
               onclick={loadProof}>Load current proof</button>
       <button type="button" class="rounded-lg border border-cyan-500/50 px-3 py-2 text-sm text-cyan-200"

--- a/console-ui/frontend/src/lib/eutxo/model.test.ts
+++ b/console-ui/frontend/src/lib/eutxo/model.test.ts
@@ -6,8 +6,15 @@ import {
 
 describe('EUTxO console model', () => {
   it('recognizes only the bundled EUTxO state machine', () => {
-    expect(isEutxoChain({ stateMachine: 'eutxo-ledger' })).toBe(true);
-    expect(isEutxoChain({ stateMachine: 'ordered-log' })).toBe(false);
+    const manifest = {
+      schemaVersion: 1, applicationId: 'eutxo-ledger', applicationVersion: '1',
+      manifestDigest: 'aa'.repeat(32),
+      components: [{ id: 'eutxo-ledger', version: '1', configurationId: 'demo',
+        stateNamespace: 'application/v1', topics: [], querySubjects: [], origin: 'INTRINSIC' as const }],
+      workflows: [], crossCutting: [], proofSubjects: []
+    };
+    expect(isEutxoChain({ stateMachine: 'custom', capabilityManifest: manifest })).toBe(true);
+    expect(isEutxoChain({ stateMachine: 'eutxo-ledger' })).toBe(false);
     expect(isEutxoChain(null)).toBe(false);
   });
 

--- a/console-ui/frontend/src/lib/eutxo/model.ts
+++ b/console-ui/frontend/src/lib/eutxo/model.ts
@@ -6,7 +6,8 @@ const IDENTIFIER = /^[0-9a-f]{64}$/;
 const OUTPOINT = /^([0-9a-f]{64})#([0-9]|[1-9][0-9]{0,4})$/;
 
 export function isEutxoChain(status: AppChainStatus | null): boolean {
-  return status?.stateMachine === EUTXO_STATE_MACHINE_ID;
+  return status?.capabilityManifest?.components.some(
+    (component) => component.id === EUTXO_STATE_MACHINE_ID) === true;
 }
 
 export function canonicalEutxoIdentifier(value: string): string {

--- a/console-ui/frontend/src/routes/app-chain/+page.svelte
+++ b/console-ui/frontend/src/routes/app-chain/+page.svelte
@@ -7,6 +7,7 @@
   import CopyValue from '$lib/components/CopyValue.svelte';
   import Pager from '$lib/components/Pager.svelte';
   import AppChainCapabilityPanels from '$lib/components/AppChainCapabilityPanels.svelte';
+  import AppChainCapabilityMatrix from '$lib/components/AppChainCapabilityMatrix.svelte';
   import { apiFailureMessage, resolveApiBase, YanoApi } from '$lib/api/client';
   import type {
     AppChainBlock, AppChainBlockDetail, AppChainBlocks, AppChainMessage, AppChainStatus,
@@ -26,6 +27,7 @@
   const CHAIN_KEY = 'yano.console.app-chain.selected.v1';
   const PAGE_SIZE = 25;
   const MESSAGE_WINDOW = 50;
+  type AppChainView = 'operations' | 'capabilities';
   let api: YanoApi | null = null;
   let apiBase = '/api/v1';
   let config: NodeConfig | null = null;
@@ -62,6 +64,10 @@
   let inspectedBlockError = '';
   let inspectedBlockLoading = false;
   let pluginBundleIds: string[] = [];
+  let capabilityStatuses: AppChainStatus[] = [];
+  let capabilityMatrixLoading = false;
+  let capabilityMatrixError = '';
+  let activeView: AppChainView = 'operations';
   const cursor = new StreamCursor();
 
   const fmt = (value: unknown) => Number.isFinite(Number(value)) ? Number(value).toLocaleString() : '-';
@@ -109,7 +115,10 @@
             .filter((id) => id !== '');
         }).catch(() => { pluginBundleIds = []; });
         if (disposed) return;
-        const queryChain = new URLSearchParams(location.search).get('chain');
+        const parameters = new URLSearchParams(location.search);
+        activeView = parameters.get('view') === 'capabilities' ? 'capabilities' : 'operations';
+        if (activeView === 'capabilities') void loadCapabilityMatrix();
+        const queryChain = parameters.get('chain');
         const remembered = localStorage.getItem(CHAIN_KEY);
         selectedChain = chains.some((chain) => chain.chainId === queryChain) ? queryChain!
           : chains.some((chain) => chain.chainId === remembered) ? remembered! : chains[0]?.chainId ?? '';
@@ -166,6 +175,9 @@
       historyState = result.state;
       samples = mergeSamples(durableSamples, history?.values() ?? []);
       status = nextStatus;
+      capabilityStatuses = capabilityStatuses.some((item) => item.chainId === nextStatus.chainId)
+        ? capabilityStatuses.map((item) => item.chainId === nextStatus.chainId ? nextStatus : item)
+        : [...capabilityStatuses, nextStatus];
       latestBlocks = nextBlocks;
       if (blockPageIndex === 0) {
         // Keep one coherent tip snapshot while the operator pages backward.
@@ -181,6 +193,30 @@
         pageError = apiFailureMessage(cause, 'App-chain status request failed');
       }
     }
+  }
+
+  async function loadCapabilityMatrix(): Promise<void> {
+    if (!api) return;
+    capabilityMatrixLoading = true;
+    capabilityMatrixError = '';
+    try {
+      const results = await Promise.allSettled(chains.map((chain) => api!.chainStatus(chain.chainId)));
+      capabilityStatuses = results.flatMap((result) => result.status === 'fulfilled' ? [result.value] : []);
+      const failures = results.length - capabilityStatuses.length;
+      if (failures > 0) capabilityMatrixError = `${failures} capability manifest${failures === 1 ? '' : 's'} could not be loaded.`;
+    } finally {
+      capabilityMatrixLoading = false;
+    }
+  }
+
+  function selectView(view: AppChainView): void {
+    activeView = view;
+    const parameters = new URLSearchParams(location.search);
+    if (view === 'capabilities') parameters.set('view', view);
+    else parameters.delete('view');
+    const query = parameters.toString();
+    window.history.replaceState({}, '', `${base}/app-chain/${query ? `?${query}` : ''}`);
+    if (view === 'capabilities') void loadCapabilityMatrix();
   }
 
   async function loadDurableHistory(chainId: string): Promise<void> {
@@ -341,9 +377,9 @@
 <div data-console-route="app-chain" class="mb-4 flex flex-wrap items-end justify-between gap-3">
   <div>
     <p class="m-0 text-xs font-semibold uppercase tracking-[.18em] text-violet-400">Application ledger</p>
-    <h1 class="mt-1 text-2xl font-bold">App-chain operations</h1>
+    <h1 class="mt-1 text-2xl font-bold">{activeView === 'operations' ? 'App-chain operations' : 'App-chain capabilities'}</h1>
   </div>
-  <div class="flex flex-wrap items-end gap-2">
+  {#if activeView === 'operations'}<div class="flex flex-wrap items-end gap-2">
     <label class="text-xs text-slate-400">Chain
       <select class="ml-2 rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-slate-100"
               value={selectedChain} onchange={(event) => activateChain(event.currentTarget.value)}>
@@ -362,10 +398,33 @@
          href={`${base}/app-chain/authenticated-map/?chain=${encodeURIComponent(selectedChain)}`}>Authenticated Map</a>
     {/if}
     <span class="rounded-md border border-slate-700 px-2 py-1 text-xs font-mono text-slate-400">{requestMs || '-'} ms</span>
-  </div>
+  </div>{/if}
 </div>
 
 {#if pageError}<div class="mb-4 rounded-xl border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-300">{pageError}</div>{/if}
+
+<nav aria-label="App-chain views" class="mb-5 flex w-fit rounded-xl border border-slate-800 bg-slate-900/70 p-1">
+  <button type="button"
+          class="rounded-lg px-4 py-2 text-sm font-semibold transition {activeView === 'operations' ? 'bg-violet-500/20 text-violet-200' : 'text-slate-400 hover:text-slate-200'}"
+          aria-current={activeView === 'operations' ? 'page' : undefined}
+          onclick={() => selectView('operations')}>Operations</button>
+  <button type="button"
+          class="rounded-lg px-4 py-2 text-sm font-semibold transition {activeView === 'capabilities' ? 'bg-violet-500/20 text-violet-200' : 'text-slate-400 hover:text-slate-200'}"
+          aria-current={activeView === 'capabilities' ? 'page' : undefined}
+          onclick={() => selectView('capabilities')}>Capabilities</button>
+</nav>
+
+{#if activeView === 'capabilities'}
+  <div class="mb-3 flex flex-wrap items-center justify-between gap-3">
+    <p class="m-0 max-w-3xl text-sm text-slate-400">Compare the reusable components, cross-cutting concerns, and verification profiles declared by every running application.</p>
+    <button type="button" class="rounded-lg border border-slate-700 px-3 py-2 text-xs font-semibold text-slate-300 hover:border-slate-500"
+            disabled={capabilityMatrixLoading} onclick={() => void loadCapabilityMatrix()}>
+      {capabilityMatrixLoading ? 'Refreshing…' : 'Refresh manifests'}
+    </button>
+  </div>
+  {#if capabilityMatrixError}<div class="mb-4 text-xs text-amber-300">{capabilityMatrixError}</div>{/if}
+  <AppChainCapabilityMatrix statuses={capabilityStatuses} />
+{:else}
 {#if streamError}<div class="mb-4 text-xs text-amber-300">Live feed reconnecting: {streamError}</div>{/if}
 
 <section class="card overflow-hidden p-5">
@@ -580,6 +639,7 @@
                                 section="effects" />
     </div>
   {/key}
+{/if}
 {/if}
 
 <dialog bind:this={dialog} class="m-auto w-[min(900px,calc(100%-2rem))] rounded-2xl border border-slate-700 bg-slate-900 p-0 text-slate-100 backdrop:bg-slate-950/80">

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/AppCapabilityIds.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/AppCapabilityIds.java
@@ -1,0 +1,18 @@
+package com.bloxbean.cardano.yano.api.appchain;
+
+/** Stable public IDs used by the v1 application capability manifest. */
+public final class AppCapabilityIds {
+    public static final String DIRECT_ROLE = "authorization:direct-role-v1";
+    public static final String BASIC_APPROVAL = "approval:basic-quorum-v1";
+    public static final String ACTOR_ROLE_APPROVAL = "approval:actor-role-v1";
+    public static final String OUTBOX_EFFECTS = "effects:outbox-v1";
+    public static final String L1_VAULT_DEPOSIT = "l1-observer:eutxo-vault-deposit-v1";
+    public static final String L1_WITHDRAWAL_CONFIRMATION =
+            "l1-observer:eutxo-withdrawal-confirmation-v1";
+    public static final String FINALIZED_MESSAGE = "state-index:finalized-message-v1";
+    public static final String MPF = "state-commitment:mpf-blake2b256-v1";
+    public static final String JMT = "state-commitment:jmt-blake2b256-v1";
+
+    private AppCapabilityIds() {
+    }
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/AppCapabilityManifest.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/AppCapabilityManifest.java
@@ -1,0 +1,282 @@
+package com.bloxbean.cardano.yano.api.appchain;
+
+import com.bloxbean.cardano.client.crypto.Blake2bUtil;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeMap;
+
+/**
+ * Immutable v1 discovery description for one application profile.
+ * Operational counters deliberately do not belong here.
+ */
+public record AppCapabilityManifest(
+        int schemaVersion,
+        String applicationId,
+        String applicationVersion,
+        String manifestDigest,
+        List<Component> components,
+        List<Workflow> workflows,
+        List<CrossCutting> crossCutting,
+        List<ProofSubject> proofSubjects
+) {
+    public static final int SCHEMA_VERSION = 1;
+
+    public AppCapabilityManifest {
+        if (schemaVersion != SCHEMA_VERSION) {
+            throw new IllegalArgumentException("unsupported capability manifest version");
+        }
+        applicationId = id(applicationId, "applicationId");
+        applicationVersion = text(applicationVersion, "applicationVersion");
+        components = sortedUnique(components, Component::id, "component");
+        workflows = sortedUnique(workflows, Workflow::id, "workflow");
+        crossCutting = sortedUnique(crossCutting, CrossCutting::capabilityId, "capability");
+        proofSubjects = sortedUnique(proofSubjects, ProofSubject::subjectId, "proof subject");
+        String expected = digest(schemaVersion, applicationId, applicationVersion,
+                components, workflows, crossCutting, proofSubjects);
+        if (manifestDigest == null || manifestDigest.isEmpty()) {
+            manifestDigest = expected;
+        } else if (!manifestDigest.equals(expected)) {
+            throw new IllegalArgumentException("capability manifest digest mismatch");
+        }
+    }
+
+    public static Builder builder(String applicationId, String applicationVersion) {
+        return new Builder(applicationId, applicationVersion);
+    }
+
+    public static AppCapabilityManifest application(String applicationId) {
+        return builder(applicationId, "1.0.0").build();
+    }
+
+    public AppCapabilityManifest withCrossCutting(CrossCutting capability) {
+        List<CrossCutting> values = new ArrayList<>(crossCutting);
+        values.add(Objects.requireNonNull(capability, "capability"));
+        return new AppCapabilityManifest(SCHEMA_VERSION, applicationId, applicationVersion,
+                "", components, workflows, values, proofSubjects);
+    }
+
+    public AppCapabilityManifest withProofSubject(ProofSubject proofSubject) {
+        List<ProofSubject> values = new ArrayList<>(proofSubjects);
+        values.add(Objects.requireNonNull(proofSubject, "proofSubject"));
+        return new AppCapabilityManifest(SCHEMA_VERSION, applicationId, applicationVersion,
+                "", components, workflows, crossCutting, values);
+    }
+
+    public enum Origin {
+        INTRINSIC,
+        COMPOSED,
+        LAUNCHER_ENABLED,
+        RUNTIME_CONFIGURED
+    }
+
+    public record Component(
+            String id,
+            String version,
+            String configurationId,
+            String stateNamespace,
+            List<String> topics,
+            List<String> querySubjects,
+            Origin origin
+    ) {
+        public Component {
+            id = AppCapabilityManifest.id(id, "component id");
+            version = text(version, "component version");
+            configurationId = text(configurationId, "configurationId");
+            stateNamespace = text(stateNamespace, "stateNamespace");
+            topics = sortedStrings(topics, "topics");
+            querySubjects = sortedStrings(querySubjects, "querySubjects");
+            origin = Objects.requireNonNull(origin, "origin");
+        }
+    }
+
+    public record Workflow(
+            String id,
+            String version,
+            List<String> participantComponentIds,
+            String topic,
+            List<String> effectTypes,
+            Origin origin
+    ) {
+        public Workflow {
+            id = AppCapabilityManifest.id(id, "workflow id");
+            version = text(version, "workflow version");
+            participantComponentIds = sortedStrings(
+                    participantComponentIds, "participantComponentIds");
+            topic = text(topic, "workflow topic");
+            effectTypes = sortedStrings(effectTypes, "effectTypes");
+            origin = Objects.requireNonNull(origin, "origin");
+        }
+    }
+
+    public record CrossCutting(
+            String capabilityId,
+            String version,
+            boolean enabled,
+            String configurationDigest,
+            Map<String, String> attributes,
+            Origin origin
+    ) {
+        public CrossCutting {
+            capabilityId = AppCapabilityManifest.id(capabilityId, "capability id");
+            version = text(version, "capability version");
+            configurationDigest = text(configurationDigest, "configurationDigest");
+            attributes = Collections.unmodifiableMap(
+                    new TreeMap<>(Objects.requireNonNull(attributes, "attributes")));
+            attributes.forEach((key, value) -> {
+                text(key, "attribute key");
+                text(value, "attribute value");
+            });
+            origin = Objects.requireNonNull(origin, "origin");
+        }
+    }
+
+    public record ProofSubject(
+            String subjectId,
+            String componentId,
+            String keyNamespace,
+            String verificationTarget
+    ) {
+        public ProofSubject {
+            subjectId = AppCapabilityManifest.id(subjectId, "proof subject id");
+            componentId = componentId == null || componentId.isEmpty()
+                    ? "" : AppCapabilityManifest.id(componentId, "proof component id");
+            keyNamespace = text(keyNamespace, "keyNamespace");
+            verificationTarget = text(verificationTarget, "verificationTarget");
+        }
+    }
+
+    public static final class Builder {
+        private final String applicationId;
+        private final String applicationVersion;
+        private final List<Component> components = new ArrayList<>();
+        private final List<Workflow> workflows = new ArrayList<>();
+        private final List<CrossCutting> crossCutting = new ArrayList<>();
+        private final List<ProofSubject> proofSubjects = new ArrayList<>();
+
+        private Builder(String applicationId, String applicationVersion) {
+            this.applicationId = applicationId;
+            this.applicationVersion = applicationVersion;
+        }
+
+        public Builder component(Component value) { components.add(value); return this; }
+        public Builder workflow(Workflow value) { workflows.add(value); return this; }
+        public Builder crossCutting(CrossCutting value) { crossCutting.add(value); return this; }
+        public Builder proofSubject(ProofSubject value) { proofSubjects.add(value); return this; }
+
+        public AppCapabilityManifest build() {
+            return new AppCapabilityManifest(SCHEMA_VERSION, applicationId,
+                    applicationVersion, "", components, workflows, crossCutting, proofSubjects);
+        }
+    }
+
+    private static String digest(
+            int schemaVersion, String applicationId, String applicationVersion,
+            List<Component> components, List<Workflow> workflows,
+            List<CrossCutting> capabilities, List<ProofSubject> proofSubjects
+    ) {
+        try {
+            ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+            DataOutputStream out = new DataOutputStream(bytes);
+            out.writeInt(schemaVersion);
+            write(out, applicationId);
+            write(out, applicationVersion);
+            out.writeInt(components.size());
+            for (Component value : components) {
+                write(out, value.id()); write(out, value.version());
+                write(out, value.configurationId()); write(out, value.stateNamespace());
+                writes(out, value.topics()); writes(out, value.querySubjects());
+                write(out, value.origin().name());
+            }
+            out.writeInt(workflows.size());
+            for (Workflow value : workflows) {
+                write(out, value.id()); write(out, value.version());
+                writes(out, value.participantComponentIds()); write(out, value.topic());
+                writes(out, value.effectTypes()); write(out, value.origin().name());
+            }
+            out.writeInt(capabilities.size());
+            for (CrossCutting value : capabilities) {
+                write(out, value.capabilityId()); write(out, value.version());
+                out.writeBoolean(value.enabled()); write(out, value.configurationDigest());
+                out.writeInt(value.attributes().size());
+                for (Map.Entry<String, String> entry : value.attributes().entrySet()) {
+                    write(out, entry.getKey()); write(out, entry.getValue());
+                }
+                write(out, value.origin().name());
+            }
+            out.writeInt(proofSubjects.size());
+            for (ProofSubject value : proofSubjects) {
+                write(out, value.subjectId()); write(out, value.componentId());
+                write(out, value.keyNamespace()); write(out, value.verificationTarget());
+            }
+            out.flush();
+            return HexFormat.of().formatHex(Blake2bUtil.blake2bHash256(bytes.toByteArray()));
+        } catch (IOException impossible) {
+            throw new IllegalStateException(impossible);
+        }
+    }
+
+    private static void writes(DataOutputStream out, List<String> values) throws IOException {
+        out.writeInt(values.size());
+        for (String value : values) write(out, value);
+    }
+
+    private static void write(DataOutputStream out, String value) throws IOException {
+        byte[] encoded = value.getBytes(StandardCharsets.UTF_8);
+        out.writeInt(encoded.length);
+        out.write(encoded);
+    }
+
+    private static <T> List<T> sortedUnique(
+            List<T> values,
+            java.util.function.Function<T, String> key,
+            String kind
+    ) {
+        List<T> sorted = new ArrayList<>(Objects.requireNonNull(values, kind));
+        sorted.sort(Comparator.comparing(key));
+        Set<String> ids = new HashSet<>();
+        for (T value : sorted) {
+            if (value == null || !ids.add(key.apply(value))) {
+                throw new IllegalArgumentException("duplicate " + kind + " id");
+            }
+        }
+        return List.copyOf(sorted);
+    }
+
+    private static List<String> sortedStrings(List<String> values, String field) {
+        List<String> sorted = Objects.requireNonNull(values, field).stream()
+                .map(value -> text(value, field + " entry")).sorted().toList();
+        if (sorted.stream().distinct().count() != sorted.size()) {
+            throw new IllegalArgumentException(field + " contains duplicates");
+        }
+        return sorted;
+    }
+
+    private static String id(String value, String field) {
+        value = text(value, field);
+        if (!value.matches("[a-z0-9][a-z0-9:._-]{0,127}")) {
+            throw new IllegalArgumentException("invalid " + field);
+        }
+        return value;
+    }
+
+    private static String text(String value, String field) {
+        value = Objects.requireNonNull(value, field);
+        if (value.isBlank() || value.indexOf('\0') >= 0
+                || value.getBytes(StandardCharsets.UTF_8).length > 1024) {
+            throw new IllegalArgumentException("invalid " + field);
+        }
+        return value;
+    }
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/AppStateMachine.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/AppStateMachine.java
@@ -76,6 +76,11 @@ public interface AppStateMachine {
         return java.util.Map.of();
     }
 
+    /** Immutable application/composition discovery data; never used as mutable health state. */
+    default AppCapabilityManifest capabilityManifest() {
+        return AppCapabilityManifest.application(id());
+    }
+
     /**
      * Deterministic transition with block-scoped, replayable inputs and effect
      * emission (ADR-031). This is the only execution entry point.

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/state/StateCommitmentIdentity.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/state/StateCommitmentIdentity.java
@@ -29,6 +29,8 @@ public record StateCommitmentIdentity(
 
     private static final byte[] DIGEST_DOMAIN =
             "yano-state-commitment-identity-v1\0".getBytes(StandardCharsets.US_ASCII);
+    private static final byte[] APPLICATION_PROFILE_DOMAIN =
+            "yano-state-application-profile-v1\0".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] MARKER_KEY =
             "~yano/state-commitment/v1".getBytes(StandardCharsets.US_ASCII);
 
@@ -128,6 +130,18 @@ public record StateCommitmentIdentity(
         System.arraycopy(DIGEST_DOMAIN, 0, input, 0, DIGEST_DOMAIN.length);
         System.arraycopy(canonical, 0, input, DIGEST_DOMAIN.length, canonical.length);
         return Blake2bUtil.blake2bHash256(input);
+    }
+
+    /** Derive a fresh state generation for a committed application wrapper/profile. */
+    public StateCommitmentIdentity withApplicationProfile(byte[] profileDigest) {
+        byte[] profile = Objects.requireNonNull(profileDigest, "profileDigest").clone();
+        if (profile.length != 32) {
+            throw new IllegalArgumentException("application profile digest must contain 32 bytes");
+        }
+        byte[] input = ByteBuffer.allocate(
+                        APPLICATION_PROFILE_DOMAIN.length + genesisId.length + profile.length)
+                .put(APPLICATION_PROFILE_DOMAIN).put(genesisId).put(profile).array();
+        return explicit(this.profile, Blake2bUtil.blake2bHash256(input));
     }
 
     public static byte[] markerKey() {

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/transition/FinalizedMessageIndex.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/transition/FinalizedMessageIndex.java
@@ -14,6 +14,8 @@ import com.bloxbean.cardano.client.crypto.Blake2bUtil;
 
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -21,7 +23,11 @@ import java.util.Objects;
 /** Reusable authenticated index proving that finalized messages occupied block positions. */
 public final class FinalizedMessageIndex {
     public static final int SCHEMA_VERSION = 1;
-    public static final byte[] TIP_KEY = "~tip".getBytes(StandardCharsets.US_ASCII);
+    public static final String LOGICAL_NAMESPACE = "~yano/finalized-message/v1/";
+    public static final byte[] NAMESPACE =
+            LOGICAL_NAMESPACE.getBytes(StandardCharsets.US_ASCII);
+    public static final byte[] CONFIG_KEY = key("config".getBytes(StandardCharsets.US_ASCII));
+    public static final byte[] TIP_KEY = key("tip".getBytes(StandardCharsets.US_ASCII));
 
     public enum InclusionPolicy {
         ALL,
@@ -46,6 +52,10 @@ public final class FinalizedMessageIndex {
 
         public static Config allMessages() {
             return new Config(InclusionPolicy.ALL, AppChainConfig.MAX_BLOCK_MESSAGES);
+        }
+
+        public static Config applicationOnly(int maxMessagesPerBlock) {
+            return new Config(InclusionPolicy.APPLICATION_ONLY, maxMessagesPerBlock);
         }
 
         /** Stable bytes suitable for a component or application genesis profile. */
@@ -112,6 +122,14 @@ public final class FinalizedMessageIndex {
                 ((ByteString) fields.get(4)).getBytes());
     }
 
+    /** Physical reserved state key for the public finalized-message-v1 subject. */
+    public static byte[] messageKey(byte[] messageId) {
+        if (messageId == null || messageId.length != 32) {
+            throw new IllegalArgumentException("messageId must contain 32 bytes");
+        }
+        return key(messageId);
+    }
+
     private static StateMutation messageMutation(TransitionContext context) {
         MessageRecord record = new MessageRecord(context.height(), context.originalMessageIndex(),
                 context.topic(), context.sender());
@@ -121,12 +139,23 @@ public final class FinalizedMessageIndex {
         value.add(new UnsignedInteger(record.originalMessageIndex()));
         value.add(new UnicodeString(record.topic()));
         value.add(new ByteString(record.sender()));
-        return StateMutation.put(context.messageId(), CborSerializationUtil.serialize(value));
+        return StateMutation.put(messageKey(context.messageId()),
+                CborSerializationUtil.serialize(value));
     }
 
     private static StateMutation tipMutation(long height) {
         return StateMutation.put(TIP_KEY,
                 CborSerializationUtil.serialize(new UnsignedInteger(height)));
+    }
+
+    private static byte[] key(byte[] suffix) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            digest.update(NAMESPACE);
+            return digest.digest(suffix);
+        } catch (NoSuchAlgorithmException impossible) {
+            throw new IllegalStateException("SHA-256 is unavailable", impossible);
+        }
     }
 
     public record MessageRecord(

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/transition/FinalizedMessageIndexedStateMachine.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/transition/FinalizedMessageIndexedStateMachine.java
@@ -1,0 +1,134 @@
+package com.bloxbean.cardano.yano.api.appchain.transition;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityIds;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
+import com.bloxbean.cardano.yano.api.appchain.AppChainInfo;
+import com.bloxbean.cardano.yano.api.appchain.AppQueryContext;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
+import com.bloxbean.cardano.yano.api.appchain.AppStateReader;
+import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
+import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
+import com.bloxbean.cardano.yano.api.appchain.effects.EffectResult;
+
+import java.security.MessageDigest;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Generic same-transaction decorator for the optional finalized-message state index. */
+public final class FinalizedMessageIndexedStateMachine implements AppStateMachine {
+    public static final String ENABLED_SETTING = "machines.finalized-message-index.enabled";
+    public static final String POLICY_SETTING = "machines.finalized-message-index.policy";
+    public static final String MAX_MESSAGES_SETTING =
+            "machines.finalized-message-index.max-messages-per-block";
+
+    private final AppStateMachine delegate;
+    private final FinalizedMessageIndex.Config config;
+
+    public FinalizedMessageIndexedStateMachine(
+            AppStateMachine delegate,
+            FinalizedMessageIndex.Config config
+    ) {
+        this.delegate = Objects.requireNonNull(delegate, "delegate");
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    /** Resolve the canonical wrapper configuration shared by identity and execution. */
+    public static Optional<FinalizedMessageIndex.Config> configuration(
+            Map<String, String> settings, int frameworkMaxMessages
+    ) {
+        Map<String, String> source = settings == null ? Map.of() : settings;
+        String enabled = source.getOrDefault(ENABLED_SETTING, "false");
+        if (!"true".equals(enabled) && !"false".equals(enabled)) {
+            throw new IllegalArgumentException(ENABLED_SETTING + " must be true or false");
+        }
+        if (!Boolean.parseBoolean(enabled)) return Optional.empty();
+        String policy = source.getOrDefault(POLICY_SETTING, "APPLICATION_ONLY");
+        if (!FinalizedMessageIndex.InclusionPolicy.APPLICATION_ONLY.name().equals(policy)) {
+            throw new IllegalArgumentException(POLICY_SETTING + " must be APPLICATION_ONLY");
+        }
+        String configuredLimit = source.getOrDefault(
+                MAX_MESSAGES_SETTING, Integer.toString(frameworkMaxMessages));
+        int maximum;
+        try {
+            maximum = Integer.parseInt(configuredLimit);
+        } catch (NumberFormatException malformed) {
+            throw new IllegalArgumentException(
+                    MAX_MESSAGES_SETTING + " must be a positive integer", malformed);
+        }
+        if (maximum > frameworkMaxMessages) {
+            throw new IllegalArgumentException(
+                    "finalized-message index block limit exceeds committed framework limit");
+        }
+        return Optional.of(FinalizedMessageIndex.Config.applicationOnly(maximum));
+    }
+
+    @Override public String id() { return delegate.id(); }
+    @Override public void init(AppStateReader state, AppChainInfo info) {
+        delegate.init(state, info);
+        if (state.committedHeight() > 0) verifyConfig(state);
+    }
+    @Override public AdmissionResult validate(AppMessage message) { return delegate.validate(message); }
+    @Override public AdmissionResult validateForBlock(
+            AppMessage message, long candidateHeight, AppStateReader committedState) {
+        return delegate.validateForBlock(message, candidateHeight, committedState);
+    }
+    @Override public AdmissionResult validatePrivilegedSystemSubmission(String topic, byte[] body) {
+        return delegate.validatePrivilegedSystemSubmission(topic, body);
+    }
+    @Override public Map<String, Object> operationalStatus() { return delegate.operationalStatus(); }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        AppCapabilityManifest manifest = delegate.capabilityManifest();
+        return manifest.withCrossCutting(new AppCapabilityManifest.CrossCutting(
+                AppCapabilityIds.FINALIZED_MESSAGE, "1.0.0", true,
+                HexFormat.of().formatHex(config.digest()),
+                Map.of("policy", config.policy().name(),
+                        "maxMessagesPerBlock", Integer.toString(config.maxMessagesPerBlock()),
+                        "maximumWritesPerBlock", Integer.toString(config.maximumWritesPerBlock()),
+                        "keyNamespace", FinalizedMessageIndex.LOGICAL_NAMESPACE,
+                        "keyDerivation", "sha256(namespace || logical-key)"),
+                AppCapabilityManifest.Origin.LAUNCHER_ENABLED))
+                .withProofSubject(new AppCapabilityManifest.ProofSubject(
+                        "finalized-message-v1", "", FinalizedMessageIndex.LOGICAL_NAMESPACE,
+                        "state-proof"));
+    }
+
+    @Override
+    public void apply(AppBlockExecutionContext context, AppStateWriter writer,
+                      AppEffectEmitter effects) {
+        delegate.apply(context, writer, effects);
+        if (context.block().height() == 1) {
+            if (writer.get(FinalizedMessageIndex.CONFIG_KEY).isPresent()) {
+                throw new IllegalStateException("finalized-message index config already exists");
+            }
+            writer.put(FinalizedMessageIndex.CONFIG_KEY, config.canonicalBytes());
+        } else {
+            verifyConfig(writer);
+        }
+        TransitionPlans.commit(FinalizedMessageIndex.plan(context, config), writer, effects);
+    }
+
+    @Override
+    public void onEffectResult(AppBlockExecutionContext context, EffectResult result,
+                               AppStateWriter writer, AppEffectEmitter effects) {
+        delegate.onEffectResult(context, result, writer, effects);
+    }
+
+    @Override
+    public byte[] query(String path, byte[] params, AppQueryContext state) {
+        return delegate.query(path, params, state);
+    }
+
+    private void verifyConfig(AppStateReader state) {
+        byte[] retained = state.get(FinalizedMessageIndex.CONFIG_KEY).orElseThrow(() ->
+                new IllegalStateException("finalized-message index config is absent"));
+        if (!MessageDigest.isEqual(retained, config.canonicalBytes())) {
+            throw new IllegalStateException("finalized-message index config is incompatible");
+        }
+    }
+}

--- a/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/AppCapabilityManifestTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/AppCapabilityManifestTest.java
@@ -1,0 +1,67 @@
+package com.bloxbean.cardano.yano.api.appchain;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppCapabilityManifestTest {
+    @Test
+    void orderingIsCanonicalAndDigestIsStable() {
+        var first = AppCapabilityManifest.builder("demo", "1.0.0")
+                .crossCutting(capability("z:test"))
+                .crossCutting(capability("a:test"))
+                .build();
+        var second = AppCapabilityManifest.builder("demo", "1.0.0")
+                .crossCutting(capability("a:test"))
+                .crossCutting(capability("z:test"))
+                .build();
+
+        assertThat(first.crossCutting()).extracting(value -> value.capabilityId())
+                .containsExactly("a:test", "z:test");
+        assertThat(first.manifestDigest()).isEqualTo(second.manifestDigest())
+                .matches("[0-9a-f]{64}");
+    }
+
+    @Test
+    void duplicateStableIdsFailClosed() {
+        assertThatThrownBy(() -> AppCapabilityManifest.builder("demo", "1.0.0")
+                .crossCutting(capability("a:test"))
+                .crossCutting(capability("a:test"))
+                .build()).isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("duplicate capability");
+    }
+
+    @Test
+    void attributeInsertionOrderCannotChangeTheDigest() {
+        Map<String, String> forward = new LinkedHashMap<>();
+        forward.put("a", "1");
+        forward.put("z", "2");
+        Map<String, String> reverse = new LinkedHashMap<>();
+        reverse.put("z", "2");
+        reverse.put("a", "1");
+
+        var first = AppCapabilityManifest.builder("demo", "1.0.0")
+                .crossCutting(new AppCapabilityManifest.CrossCutting(
+                        "a:test", "1", true, "config", forward,
+                        AppCapabilityManifest.Origin.INTRINSIC)).build();
+        var second = AppCapabilityManifest.builder("demo", "1.0.0")
+                .crossCutting(new AppCapabilityManifest.CrossCutting(
+                        "a:test", "1", true, "config", reverse,
+                        AppCapabilityManifest.Origin.INTRINSIC)).build();
+
+        assertThat(first.manifestDigest()).isEqualTo(second.manifestDigest());
+        assertThat(first.crossCutting().getFirst().attributes().keySet())
+                .containsExactly("a", "z");
+    }
+
+    private static AppCapabilityManifest.CrossCutting capability(String id) {
+        return new AppCapabilityManifest.CrossCutting(id, "1.0.0", true,
+                "intrinsic-v1", Map.of("mode", "test"),
+                AppCapabilityManifest.Origin.INTRINSIC);
+    }
+}

--- a/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/state/StateCommitmentApplicationProfileTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/state/StateCommitmentApplicationProfileTest.java
@@ -1,0 +1,32 @@
+package com.bloxbean.cardano.yano.api.appchain.state;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class StateCommitmentApplicationProfileTest {
+    @Test
+    void committedApplicationProfileDerivesAStableFreshGeneration() {
+        byte[] genesis = new byte[32];
+        byte[] profileA = new byte[32];
+        byte[] profileB = new byte[32];
+        Arrays.fill(genesis, (byte) 1);
+        Arrays.fill(profileA, (byte) 2);
+        Arrays.fill(profileB, (byte) 3);
+        StateCommitmentIdentity base = StateCommitmentIdentity.explicit(
+                StateCommitmentProfiles.MPF, genesis);
+
+        StateCommitmentIdentity first = base.withApplicationProfile(profileA);
+
+        assertThat(first).isEqualTo(base.withApplicationProfile(profileA));
+        assertThat(first.genesisId()).isNotEqualTo(base.genesisId());
+        assertThat(first.genesisId())
+                .isNotEqualTo(base.withApplicationProfile(profileB).genesisId());
+        assertThat(first.profile()).isEqualTo(base.profile());
+        assertThatThrownBy(() -> base.withApplicationProfile(new byte[31]))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/transition/FinalizedMessageIndexedStateMachineTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/transition/FinalizedMessageIndexedStateMachineTest.java
@@ -1,0 +1,127 @@
+package com.bloxbean.cardano.yano.api.appchain.transition;
+
+import com.bloxbean.cardano.yaci.core.protocol.appmsg.model.AppMessage;
+import com.bloxbean.cardano.yano.api.appchain.AppBlock;
+import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
+import com.bloxbean.cardano.yano.api.appchain.AppChainInfo;
+import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
+import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
+import com.bloxbean.cardano.yano.api.appchain.FinalityCert;
+import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class FinalizedMessageIndexedStateMachineTest {
+    @Test
+    void resolvesOnlyCanonicalBoundedLauncherConfiguration() {
+        assertThat(FinalizedMessageIndexedStateMachine.configuration(Map.of(), 10)).isEmpty();
+        assertThat(FinalizedMessageIndexedStateMachine.configuration(Map.of(
+                FinalizedMessageIndexedStateMachine.ENABLED_SETTING, "true",
+                FinalizedMessageIndexedStateMachine.POLICY_SETTING, "APPLICATION_ONLY",
+                FinalizedMessageIndexedStateMachine.MAX_MESSAGES_SETTING, "7"), 10))
+                .hasValue(FinalizedMessageIndex.Config.applicationOnly(7));
+        assertThatThrownBy(() -> FinalizedMessageIndexedStateMachine.configuration(Map.of(
+                FinalizedMessageIndexedStateMachine.ENABLED_SETTING, "true",
+                FinalizedMessageIndexedStateMachine.MAX_MESSAGES_SETTING, "11"), 10))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void decoratesAStandaloneApplicationInTheSameStateTransaction() {
+        AppStateMachine application = new AppStateMachine() {
+            @Override public String id() { return "documents"; }
+            @Override public void apply(AppBlockExecutionContext context, AppStateWriter writer,
+                                        AppEffectEmitter effects) {
+                writer.put(new byte[]{1}, new byte[]{2});
+            }
+        };
+        var config = FinalizedMessageIndex.Config.applicationOnly(10);
+        var indexed = new FinalizedMessageIndexedStateMachine(application, config);
+        MapWriter writer = new MapWriter(0);
+        AppMessage app = message(1, "documents.command.v1");
+        AppMessage system = message(2, "~system");
+
+        indexed.apply(context(1, List.of(app, system)), writer,
+                AppEffectEmitter.rejecting("no effects"));
+
+        assertThat(writer.get(new byte[]{1})).contains(new byte[]{2});
+        assertThat(writer.get(FinalizedMessageIndex.CONFIG_KEY))
+                .contains(config.canonicalBytes());
+        assertThat(writer.get(FinalizedMessageIndex.messageKey(app.getMessageId()))).isPresent();
+        assertThat(writer.get(FinalizedMessageIndex.messageKey(system.getMessageId()))).isEmpty();
+        assertThat(indexed.capabilityManifest().crossCutting())
+                .extracting(value -> value.capabilityId())
+                .containsExactly("state-index:finalized-message-v1");
+        assertThat(indexed.capabilityManifest().proofSubjects())
+                .extracting(value -> value.subjectId())
+                .containsExactly("finalized-message-v1");
+        assertThat(indexed.capabilityManifest().proofSubjects().getFirst().keyNamespace())
+                .isEqualTo(FinalizedMessageIndex.LOGICAL_NAMESPACE);
+    }
+
+    @Test
+    void restartFailsClosedWhenCommittedConfigurationDiffers() {
+        MapWriter retained = new MapWriter(4);
+        retained.put(FinalizedMessageIndex.CONFIG_KEY,
+                FinalizedMessageIndex.Config.applicationOnly(4).canonicalBytes());
+        var indexed = new FinalizedMessageIndexedStateMachine(noop(),
+                FinalizedMessageIndex.Config.applicationOnly(5));
+
+        assertThatThrownBy(() -> indexed.init(retained,
+                new AppChainInfo("chain", "00".repeat(32), 1)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("incompatible");
+    }
+
+    private static AppStateMachine noop() {
+        return new AppStateMachine() {
+            @Override public String id() { return "noop"; }
+            @Override public void apply(AppBlockExecutionContext context, AppStateWriter writer,
+                                        AppEffectEmitter effects) { }
+        };
+    }
+
+    private static AppBlockExecutionContext context(long height, List<AppMessage> messages) {
+        return AppBlockExecutionContext.fromValidatedBlock(new AppBlock(
+                AppBlock.BLOCK_VERSION, "chain", height, new byte[32], 0,
+                new byte[0], 10, new byte[32], new byte[32], messages,
+                new byte[32], FinalityCert.empty()));
+    }
+
+    private static AppMessage message(int marker, String topic) {
+        byte[] id = new byte[32]; id[0] = (byte) marker;
+        return AppMessage.builder().version(1).messageId(id).chainId("chain")
+                .topic(topic).sender(new byte[32]).body(new byte[]{1})
+                .authProof(new byte[0]).build();
+    }
+
+    private static final class MapWriter implements AppStateWriter {
+        private final Map<Key, byte[]> values = new LinkedHashMap<>();
+        private final long height;
+        private MapWriter(long height) { this.height = height; }
+        @Override public void put(byte[] key, byte[] value) { values.put(new Key(key), value.clone()); }
+        @Override public void delete(byte[] key) { values.remove(new Key(key)); }
+        @Override public Optional<byte[]> get(byte[] key) {
+            byte[] value = values.get(new Key(key));
+            return value == null ? Optional.empty() : Optional.of(value.clone());
+        }
+        @Override public byte[] stateRoot() { return new byte[32]; }
+        @Override public long committedHeight() { return height; }
+    }
+
+    private record Key(byte[] value) {
+        private Key { value = value.clone(); }
+        @Override public boolean equals(Object other) {
+            return other instanceof Key that && Arrays.equals(value, that.value);
+        }
+        @Override public int hashCode() { return Arrays.hashCode(value); }
+    }
+}

--- a/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/transition/TransitionPlanTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/yano/api/appchain/transition/TransitionPlanTest.java
@@ -66,11 +66,11 @@ class TransitionPlanTest {
                 writer, AppEffectEmitter.rejecting("effects forbidden"));
 
         FinalizedMessageIndex.MessageRecord record = FinalizedMessageIndex.decode(
-                writer.get(selected.getMessageId()).orElseThrow());
+                writer.get(FinalizedMessageIndex.messageKey(selected.getMessageId())).orElseThrow());
         assertThat(record.height()).isEqualTo(8);
         assertThat(record.originalMessageIndex()).isEqualTo(1);
         assertThat(record.topic()).isEqualTo("orders");
-        assertThat(writer.get(hidden.getMessageId())).isEmpty();
+        assertThat(writer.get(FinalizedMessageIndex.messageKey(hidden.getMessageId()))).isEmpty();
         assertThat(writer.get(FinalizedMessageIndex.TIP_KEY)).isPresent();
     }
 

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/AppChainSubsystem.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/AppChainSubsystem.java
@@ -22,6 +22,8 @@ import com.bloxbean.cardano.yano.api.appchain.sequencer.SequencerModeProvider;
 import com.bloxbean.cardano.yano.api.appchain.sink.FinalizedStreamSinkFactory;
 import com.bloxbean.cardano.yano.api.appchain.state.StateCommitmentIdentity;
 import com.bloxbean.cardano.yano.api.appchain.state.StateSnapshot;
+import com.bloxbean.cardano.yano.api.appchain.transition.FinalizedMessageIndex;
+import com.bloxbean.cardano.yano.api.appchain.transition.FinalizedMessageIndexedStateMachine;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.api.events.AppBlockFinalizedEvent;
 import com.bloxbean.cardano.yano.api.events.AppMessageReceivedEvent;
@@ -472,8 +474,17 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
             Set<String> normalizedMembers = AppChainConfigSemantics.validate(config);
             this.effectsSettings = EffectsSettings.from(config);
             this.consensusProfile = effectsSettings.consensusProfile(config);
-            this.stateCommitmentIdentity = StateCommitmentIdentity.fromSettings(
+            String effectiveStateMachineId = stateMachine == null
+                    ? config.stateMachineId()
+                    : Objects.requireNonNull(stateMachine.id(), "AppStateMachine.id returned null");
+            StateCommitmentIdentity baseStateIdentity = StateCommitmentIdentity.fromSettings(
                     config.pluginSettings());
+            this.stateCommitmentIdentity = OrderedLogStateMachine.ID.equals(
+                    effectiveStateMachineId) ? baseStateIdentity
+                    : FinalizedMessageIndexedStateMachine.configuration(
+                                    config.pluginSettings(), consensusProfile.maxBlockMessages())
+                            .map(index -> baseStateIdentity.withApplicationProfile(index.digest()))
+                            .orElse(baseStateIdentity);
             this.protocolMagic = protocolMagic;
             this.eventBus = eventBus;
             this.log = Objects.requireNonNull(log, "log");
@@ -482,10 +493,8 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
             this.group = new MemberGroup(normalizedMembers, config.threshold());
             this.seenMessageIds = new SeenMessageIds(SEEN_IDS_HARD_CAP);
             this.pool = new AppMsgPool(config.poolMaxMessages());
-            this.stateMachine = stateMachine != null
-                    ? stateMachine
-                    : resolveStateMachine(config.stateMachineId(), pluginProviders,
-                            new com.bloxbean.cardano.yano.api.appchain.AppStateMachineContext() {
+            AppStateMachineContext stateMachineContext =
+                    new com.bloxbean.cardano.yano.api.appchain.AppStateMachineContext() {
                                 @Override public String chainId() { return config.chainId(); }
                                 @Override public java.util.Map<String, String> settings() {
                                     return config.pluginSettings();
@@ -515,7 +524,14 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
                                                 epoch.threshold());
                                     });
                                 }
-                            }, log);
+                            };
+            AppStateMachine resolvedStateMachine = stateMachine != null
+                    ? stateMachine
+                    : resolveStateMachine(config.stateMachineId(), pluginProviders,
+                            stateMachineContext, log);
+            this.stateMachine = OrderedLogStateMachine.ID.equals(effectiveStateMachineId)
+                    ? resolvedStateMachine
+                    : maybeFinalizedMessageIndexed(resolvedStateMachine, stateMachineContext);
             this.ledgerPath = (ledgerPath != null
                     ? ledgerPath : YanoConfig.DEFAULT_APP_CHAIN_STORAGE_PATH)
                     + "/" + config.chainId();
@@ -781,6 +797,11 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
             }
 
             @Override
+            public AppCapabilityManifest capabilityManifest() {
+                return delegate.capabilityManifest();
+            }
+
+            @Override
             public void apply(
                     AppBlockExecutionContext context,
                     AppStateWriter writer,
@@ -804,6 +825,21 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
                 return delegate.query(path, params, state);
             }
         };
+    }
+
+    private static AppStateMachine maybeFinalizedMessageIndexed(
+            AppStateMachine machine,
+            AppStateMachineContext context
+    ) {
+        int frameworkLimit = context.consensusProfile().orElseThrow(() ->
+                new IllegalArgumentException(
+                        "finalized-message index requires normalized consensus profile"))
+                .maxBlockMessages();
+        return FinalizedMessageIndexedStateMachine.configuration(
+                        context.settings(), frameworkLimit)
+                .<AppStateMachine>map(index ->
+                        new FinalizedMessageIndexedStateMachine(machine, index))
+                .orElse(machine);
     }
 
     private static com.bloxbean.cardano.yano.api.appchain.sequencer.SequencerMode
@@ -2824,6 +2860,7 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
             status.put("tipHeight", tipHeight());
             status.put("stateRoot", HexUtil.encodeHexString(stateRoot()));
             status.put("stateMachine", stateMachine.id());
+            status.put("capabilityManifest", capabilityManifest());
             Map<String, Object> machineStatus = stateMachine.operationalStatus();
             if (machineStatus != null && !machineStatus.isEmpty()) {
                 status.put("stateMachineStatus", Map.copyOf(machineStatus));
@@ -2973,6 +3010,7 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
         status.put("tipHeight", 0L);
         status.put("stateRoot", HexUtil.encodeHexString(new byte[32]));
         status.put("stateMachine", stateMachine.id());
+        status.put("capabilityManifest", capabilityManifest());
         Map<String, Object> machineStatus = stateMachine.operationalStatus();
         if (machineStatus != null && !machineStatus.isEmpty()) {
             status.put("stateMachineStatus", Map.copyOf(machineStatus));
@@ -3044,6 +3082,58 @@ public final class AppChainSubsystem implements Subsystem, AppChainGateway {
             status.put("oldestProvableHeight", currentLedger.stateBackend().oldestProvableHeight());
         }
         return Map.copyOf(status);
+    }
+
+    private AppCapabilityManifest capabilityManifest() {
+        AppCapabilityManifest manifest = Objects.requireNonNull(
+                stateMachine.capabilityManifest(), "state-machine capability manifest");
+        String profile = stateCommitmentIdentity.profile().id();
+        String capabilityId = profile.startsWith("jmt-")
+                ? AppCapabilityIds.JMT : AppCapabilityIds.MPF;
+        manifest = appendCapability(manifest, new AppCapabilityManifest.CrossCutting(
+                capabilityId, "1.0.0", true,
+                HexUtil.encodeHexString(stateCommitmentIdentity.profile().formatFingerprint()),
+                Map.of("backend", stateCommitmentIdentity.profile().backendFamily().name()
+                                .toLowerCase(Locale.ROOT),
+                        "verificationTarget", profile.startsWith("jmt-")
+                                ? "off-chain" : "off-chain,on-chain"),
+                AppCapabilityManifest.Origin.RUNTIME_CONFIGURED));
+        if (effectsSettings.enabled()) {
+            manifest = appendCapability(manifest, new AppCapabilityManifest.CrossCutting(
+                    AppCapabilityIds.OUTBOX_EFFECTS, "1.0.0", true,
+                    HexUtil.encodeHexString(
+                            AppChainConsensusProfileCommitment.digest(consensusProfile)),
+                    Map.of("maxPerBlock", Integer.toString(effectsSettings.maxPerBlock())),
+                    AppCapabilityManifest.Origin.RUNTIME_CONFIGURED));
+        }
+        Set<String> observerTypes = new TreeSet<>();
+        config.pluginSettings().forEach((key, value) -> {
+            if (key.startsWith("observers.") && key.endsWith(".type")) {
+                observerTypes.add(value);
+            }
+        });
+        for (String observerType : observerTypes) {
+            String id = switch (observerType) {
+                case "eutxo-vault-deposit-v1" -> AppCapabilityIds.L1_VAULT_DEPOSIT;
+                case "eutxo-batch-withdrawal-confirmation-v1" ->
+                        AppCapabilityIds.L1_WITHDRAWAL_CONFIRMATION;
+                default -> "l1-observer:" + observerType;
+            };
+            manifest = appendCapability(manifest, new AppCapabilityManifest.CrossCutting(
+                    id, "1.0.0", true, "observer-type:" + observerType,
+                    Map.of("observerType", observerType),
+                    AppCapabilityManifest.Origin.RUNTIME_CONFIGURED));
+        }
+        return manifest;
+    }
+
+    private static AppCapabilityManifest appendCapability(
+            AppCapabilityManifest manifest,
+            AppCapabilityManifest.CrossCutting capability
+    ) {
+        boolean present = manifest.crossCutting().stream().anyMatch(
+                value -> value.capabilityId().equals(capability.capabilityId()));
+        return present ? manifest : manifest.withCrossCutting(capability);
     }
 
     // ------------------------------------------------------------------

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/OrderedLogStateMachine.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/OrderedLogStateMachine.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.yano.runtime.appchain;
 
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityIds;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
 import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
 import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
@@ -10,7 +12,8 @@ import com.bloxbean.cardano.yano.api.appchain.transition.TransitionPlans;
 /**
  * Built-in default app: an append-only ordered log of opaque messages.
  * For every finalized message it writes
- * {@code key = message-id} → {@code cbor([height, index, topic, sender])}
+ * {@code key = sha256(namespace || message-id)} →
+ * {@code cbor([height, index, topic, sender])}
  * into the state trie — so any consumer can obtain an MPF inclusion proof
  * that a given message was finalized at a given position, verifiable against
  * an anchored state root without trusting the nodes (ADR app-layer/005 D10).
@@ -22,6 +25,25 @@ public final class OrderedLogStateMachine implements AppStateMachine {
     @Override
     public String id() {
         return ID;
+    }
+
+    @Override
+    public AppCapabilityManifest capabilityManifest() {
+        FinalizedMessageIndex.Config config = FinalizedMessageIndex.Config.allMessages();
+        return AppCapabilityManifest.builder(ID, "1.0.0")
+                .crossCutting(new AppCapabilityManifest.CrossCutting(
+                        AppCapabilityIds.FINALIZED_MESSAGE, "1.0.0", true,
+                        java.util.HexFormat.of().formatHex(config.digest()),
+                        java.util.Map.of("policy", config.policy().name(),
+                                "maxMessagesPerBlock",
+                                Integer.toString(config.maxMessagesPerBlock()),
+                                "keyNamespace", FinalizedMessageIndex.LOGICAL_NAMESPACE,
+                                "keyDerivation", "sha256(namespace || logical-key)"),
+                        AppCapabilityManifest.Origin.INTRINSIC))
+                .proofSubject(new AppCapabilityManifest.ProofSubject(
+                        "finalized-message-v1", "", FinalizedMessageIndex.LOGICAL_NAMESPACE,
+                        "state-proof"))
+                .build();
     }
 
     @Override

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/plugins/PluginSpiFacades.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/plugins/PluginSpiFacades.java
@@ -1278,6 +1278,11 @@ final class PluginSpiFacades {
         }
 
         @Override
+        public com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest capabilityManifest() {
+            return pluginCall(callbacks, loader, delegate::capabilityManifest);
+        }
+
+        @Override
         public void apply(
                 AppBlockExecutionContext context,
                 AppStateWriter writer,

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/AppChainAdminTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/AppChainAdminTest.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.yano.api.appchain.AppBlock;
 import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
 import com.bloxbean.cardano.yano.api.appchain.effects.AppEffectEmitter;
 import com.bloxbean.cardano.yano.api.appchain.AppStateMachine;
+import com.bloxbean.cardano.yano.api.appchain.AppCapabilityManifest;
 import com.bloxbean.cardano.yano.api.appchain.AppStateWriter;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -168,6 +169,74 @@ class AppChainAdminTest {
         assertThatThrownBy(node::resetMembers)
                 .isInstanceOf(IllegalStateException.class)
                 .hasMessageContaining("disabled while composite profile governance is active");
+    }
+
+    @Test
+    void governedMembershipDoesNotImplyBusinessAuthorizationOrApproval() {
+        String pubA = HexUtil.encodeHexString(KeyGenUtil.getPublicKeyFromPrivateKey(KEY_A));
+        AppChainConfig config = AppChainConfig.builder("membership-only-governed-chain")
+                .signingKeyHex(HexUtil.encodeHexString(KEY_A))
+                .memberKeysHex(Set.of(pubA)).proposerKeyHex(pubA).threshold(1)
+                .pluginSettings(Map.of("membership.mode", "governed"))
+                .blockIntervalMs(300)
+                .stateCommitmentIdentity(TestStateCommitments.MPF)
+                .build();
+        AppStateMachine machine = new AppStateMachine() {
+            @Override public String id() { return "document-only"; }
+            @Override public Map<String, Object> operationalStatus() {
+                return Map.of("businessAuthorization", "none", "businessApproval", "none");
+            }
+            @Override
+            public void apply(AppBlockExecutionContext context, AppStateWriter writer,
+                              AppEffectEmitter effects) { }
+        };
+        node = new AppChainSubsystem(config, 42, null, machine,
+                tempDir.resolve("membership-only-governed-ledger").toString(), null, log);
+        node.start();
+
+        assertThat(node.status())
+                .containsEntry("membershipMode", "governed")
+                .containsEntry("stateMachine", "document-only");
+        assertThat(node.status().get("stateMachineStatus")).isEqualTo(Map.of(
+                "businessAuthorization", "none", "businessApproval", "none"));
+        assertThat(node.status().get("capabilityManifest"))
+                .isInstanceOfSatisfying(AppCapabilityManifest.class, manifest -> {
+                    assertThat(manifest.applicationId()).isEqualTo("document-only");
+                    assertThat(manifest.crossCutting())
+                            .extracting(capability -> capability.capabilityId())
+                            .containsExactly("state-commitment:mpf-blake2b256-v1");
+                });
+    }
+
+    @Test
+    void finalizedMessageIndexWrapsLibrarySuppliedStateMachine() {
+        String pubA = HexUtil.encodeHexString(KeyGenUtil.getPublicKeyFromPrivateKey(KEY_A));
+        AppChainConfig config = AppChainConfig.builder("library-indexed-chain")
+                .signingKeyHex(HexUtil.encodeHexString(KEY_A))
+                .memberKeysHex(Set.of(pubA)).proposerKeyHex(pubA).threshold(1)
+                .pluginSettings(Map.of(
+                        "machines.finalized-message-index.enabled", "true",
+                        "machines.finalized-message-index.policy", "APPLICATION_ONLY"))
+                .blockIntervalMs(300)
+                .stateCommitmentIdentity(TestStateCommitments.MPF)
+                .build();
+        AppStateMachine machine = new AppStateMachine() {
+            @Override public String id() { return "library-custom"; }
+            @Override
+            public void apply(AppBlockExecutionContext context, AppStateWriter writer,
+                              AppEffectEmitter effects) { }
+        };
+        node = new AppChainSubsystem(config, 42, null, machine,
+                tempDir.resolve("library-indexed-ledger").toString(), null, log);
+        node.start();
+
+        assertThat(node.status().get("capabilityManifest"))
+                .isInstanceOfSatisfying(AppCapabilityManifest.class, manifest ->
+                        assertThat(manifest.crossCutting())
+                                .extracting(capability -> capability.capabilityId())
+                                .contains("state-index:finalized-message-v1"));
+        assertThat(node.stateCommitmentIdentity().orElseThrow().genesisId())
+                .isNotEqualTo(TestStateCommitments.MPF.genesisId());
     }
 
     private static void awaitTrue(String what, BooleanSupplier condition) throws InterruptedException {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginCatalogCollisionPolicyTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginCatalogCollisionPolicyTest.java
@@ -206,7 +206,7 @@ class PluginCatalogCollisionPolicyTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 id,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                currentApiRange(),
                 List.of(),
                 List.of(new BundleContribution(
                         ContributionKind.FINALIZED_SINK, SHARED_SCHEME, provider)));
@@ -221,7 +221,7 @@ class PluginCatalogCollisionPolicyTest {
                   "schemaVersion": 1,
                   "id": "%s",
                   "version": "1.0.0",
-                  "yanoApi": {"min": 1, "max": 1, "minLevel": 1},
+                  "yanoApi": {"min": %d, "max": %d, "minLevel": %d},
                   "dependencies": [],
                   "contributions": [{
                     "kind": "finalized-sink",
@@ -229,7 +229,18 @@ class PluginCatalogCollisionPolicyTest {
                     "provider": "%s"
                   }]
                 }
-                """.formatted(id, SHARED_SCHEME, provider).getBytes(StandardCharsets.UTF_8);
+                """.formatted(id,
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                PluginCatalogBuilder.PLUGIN_API_LEVEL,
+                SHARED_SCHEME, provider).getBytes(StandardCharsets.UTF_8);
+    }
+
+    private static YanoApiRange currentApiRange() {
+        return new YanoApiRange(
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                PluginCatalogBuilder.PLUGIN_API_LEVEL);
     }
 
     private static String manifestPath(String id) {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginCatalogProviderBudgetTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginCatalogProviderBudgetTest.java
@@ -51,7 +51,10 @@ class PluginCatalogProviderBudgetTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 id,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                new YanoApiRange(
+                        PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                        PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                        PluginCatalogBuilder.PLUGIN_API_LEVEL),
                 List.of(),
                 List.of(new BundleContribution(
                         ContributionKind.FINALIZED_SINK, name, provider)));

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginCatalogRuntimeTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginCatalogRuntimeTest.java
@@ -1935,7 +1935,7 @@ class PluginCatalogRuntimeTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 OpaqueVersionDependentSink.ID,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                currentApiRange(),
                 List.of(new BundleDependency(OpaqueVersionLegacyPlugin.ID,
                         SemVersion.parse("1.0.0"), null)),
                 List.of(new BundleContribution(ContributionKind.FINALIZED_SINK,
@@ -2780,7 +2780,7 @@ class PluginCatalogRuntimeTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 OpaqueVersionDependentSink.ID,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                currentApiRange(),
                 List.of(),
                 List.of(new BundleContribution(ContributionKind.FINALIZED_SINK,
                         OpaqueVersionDependentSink.SCHEME,
@@ -3085,7 +3085,7 @@ class PluginCatalogRuntimeTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 id,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                currentApiRange(),
                 List.of(),
                 List.of(new BundleContribution(
                         ContributionKind.NODE_PLUGIN, id, provider.getName())));
@@ -3102,7 +3102,7 @@ class PluginCatalogRuntimeTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 id,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                currentApiRange(),
                 List.of(),
                 List.of(new BundleContribution(
                         ContributionKind.FINALIZED_SINK, selector, provider)));
@@ -3756,13 +3756,16 @@ import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
                   "schemaVersion": 1,
                   "id": "%s",
                   "version": "1.0.0",
-                  "yanoApi": {"min": 1, "max": 1, "minLevel": %d},
+                  "yanoApi": {"min": %d, "max": %d, "minLevel": %d},
                   "dependencies": [%s],
                   "contributions": [
                     {"kind": "finalized-sink", "name": "%s", "provider": "%s"}
                   ]
                 }
-                """.formatted(id, minLevel, dependencyJson, name, provider))
+                """.formatted(id,
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                minLevel, dependencyJson, name, provider))
                 .getBytes(StandardCharsets.UTF_8);
     }
 
@@ -3790,7 +3793,7 @@ import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
                     BundleManifest.CURRENT_SCHEMA_VERSION,
                     deepCatalogBundleId(index),
                     SemVersion.parse("1.0.0"),
-                    new YanoApiRange(1, 1, 1),
+                    currentApiRange(),
                     dependencies,
                     List.of());
             bundles.add(new IndexedBundle(
@@ -3801,6 +3804,13 @@ import com.bloxbean.cardano.yano.api.appchain.AppBlockExecutionContext;
 
     private static String deepCatalogBundleId(int index) {
         return "com.example.deep.bundle%04d".formatted(index);
+    }
+
+    private static YanoApiRange currentApiRange() {
+        return new YanoApiRange(
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                PluginCatalogBuilder.PLUGIN_API_LEVEL);
     }
 
     private static byte[] emptyIndexBytes() {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginTcclBoundaryTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/plugins/PluginTcclBoundaryTest.java
@@ -1644,7 +1644,10 @@ class PluginTcclBoundaryTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 bundleId,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                new YanoApiRange(
+                        PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                        PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                        PluginCatalogBuilder.PLUGIN_API_LEVEL),
                 List.of(new BundleDependency(dependencyId, null, null)),
                 List.of());
         CatalogPluginProviderRegistry.Entry entry =
@@ -1715,7 +1718,10 @@ class PluginTcclBoundaryTest {
                 BundleManifest.CURRENT_SCHEMA_VERSION,
                 bundleId,
                 SemVersion.parse("1.0.0"),
-                new YanoApiRange(1, 1, 1),
+                new YanoApiRange(
+                        PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                        PluginCatalogBuilder.PLUGIN_API_MAJOR,
+                        PluginCatalogBuilder.PLUGIN_API_LEVEL),
                 List.of(),
                 List.of());
         CatalogPluginProviderRegistry.Entry entry =


### PR DESCRIPTION
## Summary

- make the default light showcase catalog-driven with twelve chains, including the L1 settlement boundary and reusable `document-review-chain` composition
- add deterministic application capability manifests across stock, composite, launcher, state-backend, effect, and observer capabilities
- add the generic finalized-message authenticated-state decorator with retained-identity binding and selected/all-chain launcher support
- add capability discovery, the dedicated console Capabilities tab, proof-lab integration, and receipt-backed reference workflow traces
- harden devnet/preprod deployment skills, separated app-chain/indexer storage, production settlement adoption, and resumable settlement bootstrap
- update ADR 033, showcase documentation, scripts, load aliases, distribution contracts, and operator runbooks

## Verification

- `./gradlew clean build` — passed (467 tasks)
- `:appchain-showcase:showcaseDistributionContract` — passed
- console UI: 68 tests, `svelte-check`, and production build — passed
- fresh three-node devnet qualification — twelve-chain root/profile/manifest agreement, all SCRIPT anchors bootstrapped, reference workflows passed
- fresh three-node preprod qualification — twelve-chain agreement, all SCRIPT anchors observed on L1, production settlement identity adopted, reference workflows passed
- finalized-message index disabled, selected-chain, and all-chain modes — restart/root identity and MPF/JMT proof behavior verified

Latest staged showcase ZIP SHA-256:

`52dbfaf24768630cc35b83e08a5d6dc21fa730d46416b1f8a1281531133062a4`
