### PR TITLE
feat: support chained transactions with a mempool UTXO overlay

### DIFF
--- a/adr/network/009-mempool-utxo-overlay-for-chained-transactions.md
+++ b/adr/network/009-mempool-utxo-overlay-for-chained-transactions.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -401,12 +401,27 @@ yano:
       max-txs: 10000
       max-bytes: 134217728
       ttl-seconds: 10800
-      max-utxo-index-entries: 250000
+      max-utxo-index-entries: 100000
 ```
 
 `max-utxo-index-entries` counts physical records across produced, spent, parent,
-and child indexes. The default of 250,000 is an initial operational limit and
-must be validated with heap profiling before this ADR is accepted.
+child, and reference-script indexes. The default is 100,000. Operators with a
+larger measured heap envelope can raise it explicitly.
+
+The acceptance profile on 2026-08-16 filled an adversarial mempool with 9,615
+transactions containing 25 outputs and one regular input each. The index stopped
+at 249,990 physical records under a temporary 250,000-record limit. After forced
+GC, used heap increased from 31.9 MiB with an empty mempool to 567 MiB at the
+limit: approximately 535 MiB retained, or 2.2 KiB per physical record for that
+transaction shape. Raw transaction CBOR was only 16.4 MiB.
+
+That result closes the profiling gate and makes 250,000 too costly as a general
+default. The 100,000-record default would retain approximately 214 MiB if the
+profiled workload scaled linearly; this is sizing guidance, not a JVM-independent
+guarantee. It still permits the 10,000-transaction limit for common independent
+payments (about three records per transaction) and simple parent-linked payments
+(about five records per transaction), while complex transactions encounter
+explicit `INDEX_CAPACITY` backpressure sooner.
 
 Before commit, admission calculates every record the candidate would add. If
 transaction count, raw bytes, or index cardinality would exceed a hard limit,
@@ -426,12 +441,17 @@ Expose at least:
 - admission-lane wait and hold duration;
 - ledger-validation duration;
 - slow validation-listener count;
-- estimated index bytes, explicitly labeled as an estimate.
+- estimated index bytes, explicitly labeled as a structural estimate rather
+  than a retained-heap forecast.
 
-Exact retained heap is JVM-dependent. Acceptance therefore requires profiling
-representative and adversarial full-mempool workloads. If 250,000 records exceed
-the agreed heap envelope, lower the default or use a more compact representation
-before enabling the feature by default.
+Exact retained heap is JVM- and workload-dependent. In the acceptance profile,
+the existing structural estimate reported about 62 MiB while the entire mempool
+overlay retained about 535 MiB. The values measure different things: the latter
+also includes transaction bodies, projections, decoded UTXOs, collection
+capacity, and object overhead. Operators must therefore use the hard cardinality
+limit and measured workload profiles for heap sizing, not treat the structural
+metric as a heap commitment. A calibrated whole-overlay retained-heap estimator
+is deferred until multiple representative transaction shapes have been profiled.
 
 ## Removal Semantics
 
@@ -559,9 +579,13 @@ Tradeoffs:
   contract.
 - A concurrently submitted child can be rejected if it reaches the lane before
   its parent.
-- The overlay consumes additional heap and needs retained-heap profiling.
+- The overlay consumes bounded but material heap; the profiled 100,000-record
+  default is expected to retain roughly 214 MiB under the adversarial acceptance
+  workload, with actual retention dependent on transaction shape and JVM.
 - Removing one non-confirmed parent can cascade through a large chain.
 - Correct confirmation cleanup requires ordering against canonical UTXO apply.
+- Transactions removed as confirmed are not automatically re-admitted if that
+  block is later rolled back; clients or peers must resubmit them.
 - Only UTXO chaining is supported; cross-transaction certificate and governance
   state dependencies remain unsupported.
 
@@ -586,7 +610,7 @@ Tradeoffs:
 9. Order confirmed removal after synchronous UTXO apply or async UTXO apply
    acknowledgement, and add rollback revalidation.
 10. Add metrics and heap-profile representative and adversarial full-mempool
-    workloads; validate or revise the 250,000-entry default.
+    workloads; use the measured result to set the accepted 100,000-entry default.
 
 ## Verification
 

--- a/adr/network/009-mempool-utxo-overlay-for-chained-transactions.md
+++ b/adr/network/009-mempool-utxo-overlay-for-chained-transactions.md
@@ -1,0 +1,634 @@
+# ADR-NET-009: Bounded Single-Writer Mempool UTXO Overlay for Chained Transactions
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-14
+
+## Context
+
+[Issue #66](https://github.com/bloxbean/yano/issues/66) identifies a gap in
+transaction admission when one unconfirmed transaction spends an output created
+by another transaction already in Yano's mempool.
+
+The original field report attached to the issue was withdrawn: that submission
+failed because its signature was calculated over re-encoded transaction bytes,
+not because a mempool output was missing. The source-level gap remains.
+
+Yano currently has two relevant validation paths:
+
+- Mempool admission calls `TransactionValidationService.validate(byte[])`,
+  which resolves regular, reference, and collateral inputs only from persistent
+  `UtxoState`.
+- Block selection calls `TransactionValidationService.validate(byte[],
+  resolver)` with `BlockBuildUtxoOverlay`. That overlay tracks inputs spent by
+  earlier selected transactions, but it does not expose outputs created by
+  those transactions.
+
+Consequently, when the built-in validator is enabled:
+
+1. transaction A can be accepted into the mempool;
+2. transaction B, which spends `A#n`, cannot find that output in persistent
+   `UtxoState` and is rejected with `UtxoNotFound`;
+3. adding an admission-only lookup would be insufficient, because block
+   selection could later reject B for the same reason.
+
+Scanning and deserializing every mempool transaction for every input lookup
+would avoid a new index, but admission would become proportional to total
+mempool size. With the existing defaults of 10,000 transactions and 128 MiB of
+transaction bodies, this is unsuitable for transaction diffusion and creates a
+CPU denial-of-service surface.
+
+ADR-NET-008B already establishes these relevant constraints:
+
+- one authoritative in-memory mempool;
+- one admission path for local and network transactions;
+- bounded transaction count, transaction-body bytes, and TTL;
+- transaction bodies stored once;
+- removal on confirmation and capacity/TTL eviction;
+- no durable mempool journal in the current design.
+
+The derived UTXO view must follow the same ownership and bounds. It must not
+become a second permanent UTXO store.
+
+The current admission flow is sequential for one transaction but not across
+transactions. `TransactionValidateEvent` listeners run synchronously and in
+order on each publisher thread, while `TxSubsystem.admitTransaction()` holds a
+shared read lock. REST, N2N, diffusion, and direct callers can therefore run
+different validation chains concurrently. `DefaultMemPool.addTransaction()`
+serializes individual map calls, but validation plus insertion is not an atomic
+state transition. Two conflicting transactions can validate against the same
+canonical UTXO and both enter the current mempool.
+
+The Haskell node, Dingo, and Dolos use different implementation mechanisms, but
+the applicable design principle is the same: there is one authoritative order
+of mempool state transitions, and a transaction is validated against the state
+produced by previously accepted transactions before that state advances.
+
+This ADR is intentionally limited to UTXO dependencies. It does not model
+tentative certificate, withdrawal, minting-policy, governance, or other ledger
+state transitions across mempool transactions. For example, transaction B is
+not made valid merely because transaction A in the mempool registers the stake
+credential that B delegates. Supporting those dependencies requires a broader
+mempool ledger-state transition model and is outside the scope of issue #66.
+The deferred evolution path is recorded in
+[ADR-NET-009-NEXT](009-next-generalized-mempool-ledger-state.md).
+
+## Decision
+
+Extend `DefaultMemPool` with a bounded, derived UTXO overlay and make it the
+single authority for stateful transaction admission.
+
+Admission is a serialized state transition. A transaction is validated against
+canonical `UtxoState` plus all previously accepted mempool effects, and the
+transaction entry and every derived index are committed atomically before the
+next admission can validate. The initial implementation deliberately does not
+use optimistic snapshots, resolution proofs, view versions, automatic retries,
+or parallel stateful validation.
+
+Work that cannot depend on mempool state may happen before the serialized
+transition, including transaction hashing, bounded CBOR decoding, transaction
+size checks, and other demonstrably stateless prechecks. UTXO resolution,
+ledger validation, conflict checks, capacity checks, and commit share the
+single admission order.
+
+The overlay supports arbitrary-depth UTXO chains in insertion order. It is an
+in-memory index, not canonical ledger state and not durable state. Its lifetime
+is the lifetime of the corresponding mempool entries.
+
+Admission and block selection resolve an outpoint in this order:
+
+1. If the outpoint is consumed by an accepted transaction in the relevant
+   mempool or block-local view, return missing.
+2. If the outpoint is produced by an accepted transaction in that view, return
+   its projected UTXO.
+3. Otherwise, fall back to persistent `UtxoState`.
+
+This decision covers regular, reference, and collateral input resolution. Only
+regular inputs of a transaction admitted as valid are added to the
+consumed-outpoint index. Reference inputs are read-only. Collateral inputs of a
+transaction that passed phase-2 validation are not consumed merely by entering
+the mempool.
+
+## Public Contract and Encapsulation
+
+Overlay maps, dependency maps, accounting, and locks remain internal to
+`DefaultMemPool`. `TxSubsystem` must not manipulate or rebuild those structures.
+A future mempool implementation can replace `DefaultMemPool` at its construction
+site without changing admission semantics; a factory may be introduced later if
+multiple implementations become an active requirement.
+
+Replace the raw `addTransaction(byte[])` mutation assumption with one semantic,
+typed admission operation on `MemPool`, conceptually:
+
+```text
+tryAdmit(txCbor, admissionValidator) -> MempoolAdmissionResult
+```
+
+The exact Java callback types are an implementation detail. The contract is
+that the implementation supplies an admission-scoped UTXO resolver to the
+validator and keeps validation plus commit in one serialized state transition.
+The result distinguishes at least:
+
+- accepted and newly inserted;
+- duplicate and already present;
+- malformed projection;
+- ledger-validation rejection;
+- conflicting spend;
+- transaction/byte/index capacity rejection.
+
+No public method exposes the produced, spent, parent, or child maps. Read-only
+status and block-selection snapshots remain semantic operations rather than
+access to mutable indexes.
+
+`MempoolAdmissionResult` replaces the current separate `contains(txHash)` and
+`addTransaction(txCbor)` calls. A duplicate returns the existing admission
+result without inserting, incrementing accounting, or republishing
+`MemPoolTransactionReceivedEvent`. This also removes the racy `alreadyPresent`
+rollback snapshot.
+
+All production ingress remains routed through `TxSubsystem`. Direct raw-byte
+insertion must not bypass projection, validation, conflict checks, or index
+accounting.
+
+## Serialized Admission
+
+`DefaultMemPool` owns a fair, single-writer admission/mutation lane. A lock is
+the preferred initial implementation; a dedicated actor or executor is not
+required. Every operation that can change transaction ownership or an overlay
+index participates in that same serialization domain.
+
+`TxSubsystem.admissionGate` remains a lifecycle gate. Admissions may continue
+to hold its read side so `stop`, `close`, and `clear` can take the write side and
+wait for in-flight work. It is not the mempool correctness lock. The fixed lock
+order is the `TxSubsystem` lifecycle gate followed by the internal mempool lane;
+code must never acquire them in reverse order.
+
+Admission proceeds as follows:
+
+1. Perform bounded stateless parsing and hashing outside the admission lane.
+2. Enter the single-writer admission lane.
+3. Return `DUPLICATE` if the transaction hash already exists.
+4. Calculate projected transaction, raw-byte, and index capacity and reject the
+   newcomer if any hard limit would be exceeded.
+5. Resolve regular, reference, and collateral inputs from the stable mempool
+   overlay followed by canonical `UtxoState`.
+6. Run the synchronous validation chain against that resolver.
+7. Reject any regular input already claimed in `spentByOutpoint` and verify
+   every discovered mempool parent is still live.
+8. Commit the transaction entry, outputs, consumed-input claims, dependency
+   edges, and accounting atomically.
+9. Publish the accepted-transaction event before releasing the admission lane.
+   If publication fails and remains admission-fatal, undo the new entry and all
+   of its derived records before another admission can observe it.
+10. Leave the admission lane and return the typed result.
+
+Because the resolver and indexes cannot change during steps 5 through 9, no
+resolution proof, mempool generation number, stale-view error, or automatic
+validation retry is needed. Concurrent conflicting transactions are ordered by
+the admission lane: the first valid commit claims the outpoint and the second
+is rejected with a stable mempool-conflict error.
+
+Clients that require parent/child ordering must await successful parent
+admission before submitting the child. If parent and child are submitted
+concurrently, whichever enters the admission lane first is processed first. A
+child processed before its parent is rejected with `UtxoNotFound`; the node does
+not queue or automatically retry unresolved children. If the parent is
+processed first, the child resolves its output and can be admitted immediately.
+
+Serialization intentionally includes stateful phase-1 and phase-2 validation.
+This can reduce admission throughput for script-heavy workloads, but it is the
+smallest correctness model and matches the current requirement. Hashing,
+bounded deserialization, and stateless checks may be parallelized. Parallel
+stateful validation is a later optimization that requires profiling and a
+separate decision.
+
+### Validation listener contract
+
+The existing built-in validator is a synchronous
+`TransactionValidateEvent` listener. Keeping the current event contract means
+the listener chain runs on the serialized admission lane in the initial
+implementation. The repository currently has only the built-in production
+listener, but external plugins can register additional listeners.
+
+Validation listeners therefore must:
+
+- complete synchronously;
+- not submit another transaction and wait for that admission;
+- not wait for another thread that requires a mempool mutation;
+- not mutate the mempool directly;
+- keep non-validation side effects idempotent or defer them to accepted-event
+  handling.
+
+Recursive admission from the admission thread must fail immediately with a
+stable error rather than block. Slow-listener duration must be observable. This
+is an explicit initial constraint, not a claim that arbitrary plugin code is
+safe under a lock. If stateful validation plugins become a real extension
+requirement, Yano should split stateless policy hooks from the internal
+serialized ledger validator in a follow-up ADR.
+
+`MemPoolTransactionReceivedEvent` is published only for a newly committed
+transaction. If the event remains part of the admission transaction, failure
+rollback occurs before releasing the lane, when no child can yet depend on the
+new entry. A later reliable-notification/outbox design may move this event
+outside admission without changing the overlay model.
+
+### Validator-disabled admission
+
+`yano.validation.default-validator-enabled=false` disables built-in ledger-rule
+validation; it does not disable mempool data-structure invariants.
+
+Every admission path still deserializes and projects the transaction under the
+same single-writer ordering. `DefaultMemPool` enforces duplicate handling,
+regular-input conflict checks, dependency consistency, and every capacity limit
+even when no built-in validator listener is registered. Full UTXO existence and
+phase-1/phase-2 validation remain disabled, so this mode is unsafe for untrusted
+submissions.
+
+Projection records a parent edge when an input names an output already produced
+by the mempool. An unresolved input may remain admissible in this explicitly
+unsafe mode, but its regular outpoint is still claimed in
+`spentByOutpoint`. If an unresolved child commits before its parent later
+arrives, the dependency edge is not backfilled. Later removal of that parent
+therefore cannot cascade through the missing edge. This accepted limitation is
+confined to validator-disabled mode; edge backfill is out of scope.
+
+## Ownership and Lifetime
+
+The indexes do not retain entries forever. Every index record has an owning
+mempool transaction or a dependency between live entries. Transaction storage
+and every derived index change atomically under the mempool mutation lane.
+
+| Mempool transition | Required behavior |
+|---|---|
+| New transaction accepted | Add its projected outputs, consumed regular inputs, and dependency edges atomically. |
+| Admission fails | Add nothing; no partial index records remain. |
+| Duplicate submission | Return the existing result without duplicating records, accounting, or accepted events. |
+| Transaction expires | Remove it and recursively remove descendants that can no longer resolve their parent. |
+| Count/byte/index limit reached during admission | Reject the newcomer without evicting existing entries. |
+| Configured count/byte limit reduced below current usage | Evict oldest roots as background reconciliation and cascade to newly orphaned descendants. |
+| Transaction included in a block candidate | Keep it and every index entry in the mempool until canonical application. |
+| Transaction confirmed in an applied block | Remove it without cascading to descendants; its outputs are now supplied by canonical `UtxoState`. This applies regardless of how or by whom the block was produced. |
+| Block forging fails | Change nothing in the mempool. |
+| Rollback | Revalidate the remaining derived view against restored `UtxoState`; remove transactions whose inputs no longer resolve and cascade to descendants. |
+| Clear/close | Clear transaction entries and every derived index in the same serialized transition. |
+| Process restart | Restore nothing; the mempool and indexes are in-memory only. |
+
+Canonical UTXO application must precede confirmed-entry removal. In synchronous
+UTXO mode this is event ordering. An asynchronous UTXO implementation must
+delay mempool confirmation cleanup until its apply acknowledgement. The initial
+design does not add an output-only confirmation bridge: retaining the bounded
+mempool entry until canonical visibility is simpler and prevents the
+forge-to-apply resolution gap.
+
+## Index Model
+
+The initial implementation maintains these logical indexes:
+
+```text
+transactionsByHash
+    txHash -> MempoolEntry
+
+producedByOutpoint
+    outpoint -> ProducedOutput(ownerTxHash, outputProjection)
+
+spentByOutpoint
+    regularInputOutpoint -> spendingTxHash
+
+parentsByTransaction
+    childTxHash -> parentTxHashes
+
+childrenByTransaction
+    parentTxHash -> childTxHashes
+```
+
+`parentsByTransaction` includes dependencies discovered through regular,
+reference, and collateral inputs. Reference inputs do not consume an outpoint,
+but removal of their unconfirmed producer still invalidates the child.
+
+`MempoolEntry` may hold a transaction's extracted UTXO projection so the body is
+parsed once. It must not copy the raw transaction body. The existing
+`MemPoolTransaction.txBytes` remains the single CBOR owner.
+
+The physical representation should minimize heap amplification:
+
+- use compact immutable binary transaction-id/outpoint keys instead of repeated
+  hex `String` values;
+- never use raw `byte[]` directly as a map key; implement value equality with an
+  immutable wrapper and defensive copying;
+- share a transaction-id object within an entry and its indexes;
+- reference an output projection rather than copying it between indexes;
+- do not retain a complete CCL `Transaction` after extracting required fields;
+- do not duplicate datum or reference-script bytes when immutable entry-owned
+  data can be referenced safely;
+- remove empty parent/child sets immediately.
+
+The output projection preserves the validation-relevant information exposed by
+persistent `UtxoState`: address, lovelace, native assets, datum hash, inline
+datum, and reference-script information.
+
+Only normal outputs of a transaction admitted as valid enter
+`producedByOutpoint`. A collateral-return output materializes only on phase-2
+failure and is not indexed as a produced output for an admitted valid
+transaction (`isValid=true`). Validator-disabled mode also does not treat the
+collateral-return field as a normal output.
+
+## Ordering and Block Selection
+
+A child can only resolve a mempool output after its parent commits. Insertion
+order is therefore a topological order for UTXO dependencies:
+
+```text
+A accepted -> B accepted -> C accepted
+```
+
+Block selection iterates an insertion-ordered snapshot and applies each
+accepted candidate to a block-local overlay. Applying a selected transaction:
+
+1. marks its regular inputs consumed;
+2. adds each normal output under `(txHash, outputIndex)`;
+3. leaves reference inputs unconsumed;
+4. makes its outputs available to later candidates.
+
+The snapshot is captured under the mempool lane, then validated and forged from
+its immutable transaction-body references after releasing the lane. It cannot
+observe a partially committed admission or partially removed chain.
+
+Yano initially enforces one in-flight block-selection/forge attempt per block
+producer. The selector does not remove or reserve individual mempool entries.
+Selected entries remain ordinary live entries and remain visible to admission
+while the block is forged and applied. A child submitted in that window can
+therefore resolve a selected parent's output. A failed forge leaves the
+mempool unchanged.
+
+A subsequent selection attempt cannot start until the previous attempt has
+either failed or reached local block-apply handling. This single-producer
+invariant replaces per-entry `PENDING`/`RESERVED` states, reservation ids,
+cancellation transitions, and leases. If Yano later supports concurrent block
+builders, that requires a separate reservation design.
+
+Transactions omitted because of block size or execution budget remain in the
+mempool. If a parent is selected but its child is omitted, canonical application
+removes the parent without cascading to the child; the child then resolves the
+parent output from `UtxoState`.
+
+A parent rejected during block selection is not applied to the block-local
+overlay. Remove it with reason `INVALIDATED` and cascade to its descendants
+rather than silently retaining a chain that cannot be selected.
+
+TTL reconciliation can race a forge snapshot without making the candidate
+block invalid because the snapshot owns the selected transaction bodies and
+uses its own UTXO overlay. It may reduce availability by removing an unconfirmed
+chain while a block is being forged. This is accepted for the initial design;
+the normal TTL is far longer than forge-to-apply latency. Selection does not
+extend transaction lifetime or create unbounded protected entries.
+
+## Memory Bounds and Pressure Control
+
+The existing limits make the overlay finite, but serialized CBOR byte size is
+not a sufficient heap guarantee. Maps, sets, keys, assets, and UTXO projections
+can amplify retained heap.
+
+The overlay therefore has an independent hard cardinality budget:
+
+```yaml
+yano:
+  tx:
+    mempool:
+      max-txs: 10000
+      max-bytes: 134217728
+      ttl-seconds: 10800
+      max-utxo-index-entries: 250000
+```
+
+`max-utxo-index-entries` counts physical records across produced, spent, parent,
+and child indexes. The default of 250,000 is an initial operational limit and
+must be validated with heap profiling before this ADR is accepted.
+
+Before commit, admission calculates every record the candidate would add. If
+transaction count, raw bytes, or index cardinality would exceed a hard limit,
+it rejects the newcomer without mutating or evicting existing entries. This
+reject-newcomer policy avoids allowing a small submission stream to repeatedly
+evict an old chain and all descendants. TTL, confirmation, operator clear, or
+background reconciliation after a configured limit reduction frees capacity.
+
+Expose at least:
+
+- current and configured transaction count and raw bytes;
+- current and configured UTXO-index record count;
+- produced-output, consumed-outpoint, and dependency-edge counts;
+- cascaded-removal count by reason;
+- duplicate, conflict, and capacity rejection counts;
+- current admission queue/wait count;
+- admission-lane wait and hold duration;
+- ledger-validation duration;
+- slow validation-listener count;
+- estimated index bytes, explicitly labeled as an estimate.
+
+Exact retained heap is JVM-dependent. Acceptance therefore requires profiling
+representative and adversarial full-mempool workloads. If 250,000 records exceed
+the agreed heap envelope, lower the default or use a more compact representation
+before enabling the feature by default.
+
+## Removal Semantics
+
+Removal APIs use an explicit reason. A generic
+`removeByTxHashes(Set<String>)` cannot express dependency behavior.
+
+Initial reasons are:
+
+- `CONFIRMED`
+- `EXPIRED`
+- `CONFIG_RECONCILIATION`
+- `INVALIDATED`
+- `EVENT_ROLLBACK`
+- `CLEAR`
+
+`CONFIRMED` applies to any mempool entry included in an applied block, regardless
+of whether Yano produced that block. It removes the transaction body,
+regular-input claims, produced-output records, and obsolete dependency edges
+without cascading to descendants. Canonical `UtxoState` now supplies the
+confirmed outputs.
+
+`EXPIRED`, `CONFIG_RECONCILIATION`, `INVALIDATED`, and `EVENT_ROLLBACK` removal
+of a parent cascade transitively to descendants that depend on it. `CLEAR`
+removes the complete mempool and all indexes in one transition.
+
+Background reconciliation may remove more transactions than the original
+count/byte excess when the oldest entry is a chain root. Logs and metrics must
+distinguish directly selected removals from cascaded removals.
+
+## Canonical-State Concurrency
+
+The single-writer lane serializes mempool mutations; it does not by itself stop
+canonical ledger application on another subsystem thread. For the initial
+implementation, Yano requires the following event order:
+
+1. apply the block to canonical `UtxoState`;
+2. acknowledge UTXO visibility;
+3. process confirmed mempool removal under the mempool lane.
+
+This prevents removing a confirmed parent's overlay outputs before its children
+can resolve them canonically. It also prevents releasing mempool spent claims
+before canonical removal is visible. Async UTXO mode must use its completion
+acknowledgement rather than raw `BlockAppliedEvent` publication for step 3.
+
+A chain-state change can still begin while a long admission validation is in
+progress. The initial implementation accepts this narrow existing race and
+revalidates candidates during block selection against the latest block-local
+view. Closing it requires a canonical ledger snapshot/version protocol and is
+outside the issue #66 fix.
+
+## Failure Handling
+
+Failure to deserialize, project, resolve, or validate a transaction is an
+admission failure and leaves the mempool unchanged.
+
+An invariant failure during index mutation fails closed:
+
+1. stop accepting new transactions;
+2. rebuild indexes from authoritative insertion-ordered transaction entries;
+3. resume only if the rebuilt view passes consistency checks;
+4. clear the in-memory mempool if safe rebuild is impossible.
+
+The node must not continue admission with transaction entries and indexes known
+to disagree.
+
+## Alternatives Considered
+
+### Scan and deserialize the full mempool for every admission
+
+Rejected. Admission cost becomes proportional to mempool size and transaction
+complexity, creating avoidable CPU and latency risk under diffusion.
+
+### Keep only a produced-output index
+
+Rejected. It supports simple chaining but does not prevent conflicting spends
+or support correct descendant removal.
+
+### Optimistic parallel validation with resolution proofs
+
+Deferred. It keeps phase-2 evaluation outside the commit lock but requires
+immutable admission snapshots, UTXO fingerprints, proof rechecks, transient
+stale-view errors, plugin idempotency rules, and retry semantics. That
+complexity is not justified before serialized admission is measured.
+
+### Per-entry block reservations and leases
+
+Rejected for the initial single-producer design. Keeping selected entries until
+canonical application and enforcing one in-flight forge attempt closes the
+forge-to-apply gap without pending/reserved states or lease recovery.
+
+### Admit chains but defer conflict checking to block selection
+
+Rejected. It wastes validation and diffusion resources and lets incompatible
+transactions consume bounded capacity.
+
+### Persist the overlay in RocksDB
+
+Rejected. Mempool state is intentionally ephemeral. Persistence introduces
+recovery, migration, and canonical/tentative reconciliation without being
+required for issue #66.
+
+### Copy mempool outputs into persistent `UtxoState`
+
+Rejected. `UtxoState` represents canonical applied-chain state. Tentative
+outputs would contaminate queries, rollback, stake accounting, and other ledger
+consumers.
+
+## Consequences
+
+Positive:
+
+- Sequential parent/child submission works to arbitrary UTXO-chain depth.
+- Conflicting spends cannot both commit to the mempool.
+- Admission lookup cost depends on candidate inputs, not total mempool size.
+- Admission and block selection use equivalent UTXO overlay semantics.
+- Insertion order is dependency order for accepted chains.
+- Parent removal cannot leave silent orphan descendants.
+- Index ownership, lifetime, and memory bounds are explicit.
+- `DefaultMemPool` remains replaceable behind the `MemPool` semantic contract.
+
+Tradeoffs:
+
+- Stateful ledger validation, including Plutus phase-2, is serialized.
+- A slow validation plugin stalls later admissions and must obey the listener
+  contract.
+- A concurrently submitted child can be rejected if it reaches the lane before
+  its parent.
+- The overlay consumes additional heap and needs retained-heap profiling.
+- Removing one non-confirmed parent can cascade through a large chain.
+- Correct confirmation cleanup requires ordering against canonical UTXO apply.
+- Only UTXO chaining is supported; cross-transaction certificate and governance
+  state dependencies remain unsupported.
+
+## Implementation Plan
+
+1. Introduce compact immutable transaction-id/outpoint keys and an extracted
+   UTXO projection that does not duplicate transaction CBOR.
+2. Replace raw `addTransaction` with typed `tryAdmit` semantics and make
+   `DefaultMemPool` own the fair single-writer admission/mutation lane.
+3. Add produced, spent, parent, and child indexes plus exact cardinality
+   accounting under that lane.
+4. Pass the lane-stable UTXO resolver to the built-in validation listener and
+   enforce the validation-listener contract, including fail-fast recursive
+   admission.
+5. Commit transaction storage and every index atomically; publish the accepted
+   event only for a newly inserted entry and make event-failure rollback atomic.
+6. Add reject-newcomer transaction, byte, and index capacity enforcement.
+7. Replace generic removal internals with reason-aware atomic removal and
+   transitive descendant cleanup.
+8. Extend the block-local overlay to add outputs, retain selected entries until
+   apply, and enforce one in-flight block-selection/forge attempt.
+9. Order confirmed removal after synchronous UTXO apply or async UTXO apply
+   acknowledgement, and add rollback revalidation.
+10. Add metrics and heap-profile representative and adversarial full-mempool
+    workloads; validate or revise the 250,000-entry default.
+
+## Verification
+
+Unit and integration tests must cover:
+
+- parent/child and at least three-level chains;
+- chains using regular, reference, and collateral input resolution;
+- native assets, inline datum, datum hash, and reference-script outputs;
+- exclusion of collateral-return outputs for valid transactions;
+- child-before-parent rejection;
+- submit-await-submit parent/child success;
+- concurrently submitted parent/child ordering in both lock orders;
+- sequential and concurrent double-spend rejection;
+- duplicate submission without duplicate accounting or accepted events;
+- typed admission results and removal of the `alreadyPresent` race;
+- binary key value equality and defensive-copy behavior;
+- serialized stateful validation and atomic index commit;
+- fail-fast recursive admission from a validation listener;
+- slow-listener and admission-lane timing metrics;
+- validator-disabled malformed projection, conflict, duplicate, and capacity
+  behavior;
+- validator-disabled unresolved-child edges are not backfilled;
+- atomic rollback after accepted-event publication failure;
+- complete index cleanup for every removal reason;
+- transitive TTL and configuration-reconciliation removal;
+- transaction, byte, and index pressure rejects the newcomer without evicting
+  existing chains;
+- parent confirmation without child removal, including confirmation by another
+  producer;
+- canonical UTXO visibility before confirmed overlay cleanup in synchronous and
+  asynchronous apply modes;
+- rollback invalidation and index rebuild;
+- complete-chain block selection in insertion order;
+- child admission while its parent remains present during forge-to-apply;
+- child retention when its parent fits but it does not fit the block;
+- forge failure leaves the mempool unchanged;
+- a second selection cannot start while one forge attempt is in flight;
+- block-local revalidation after a canonical-state change during admission;
+- exact index-capacity rejection without temporary overshoot;
+- retained-heap measurements at configured capacity;
+- admission throughput and latency for script-free and script-heavy workloads.
+
+After automated tests, perform a deliberate signed back-to-back chained submit
+on devnet and preprod. Verify that both transactions are accepted before the
+parent is confirmed, diffuse normally, and can be selected in dependency order.

--- a/adr/network/009-next-generalized-mempool-ledger-state.md
+++ b/adr/network/009-next-generalized-mempool-ledger-state.md
@@ -1,0 +1,460 @@
+# ADR-NET-009-NEXT: Generalized Mempool Ledger State and Advanced Transaction Workflows
+
+## Status
+
+Deferred future design note. This is not part of the ADR-NET-009 implementation
+or acceptance gate.
+
+## Date
+
+2026-08-15
+
+## Parent Decision
+
+[ADR-NET-009: Bounded Single-Writer Mempool UTXO Overlay for Chained Transactions](009-mempool-utxo-overlay-for-chained-transactions.md)
+
+## Purpose
+
+ADR-NET-009 deliberately solves the immediate transaction-chaining problem with
+a bounded UTXO-only overlay. This companion records how that foundation may
+evolve after the initial implementation is stable and measured.
+
+The long-term direction is a generalized mempool ledger state similar in
+semantics to the Haskell node: each accepted transaction is applied to the
+state produced by all transactions before it, and the resulting state is used
+to validate the next transaction. This would permit dependencies through any
+transaction-driven ledger transition that Cardano rules make immediately
+visible, rather than only through created and consumed UTXOs.
+
+This note also records advanced capabilities enabled before and after that
+generalization. None of them expand the scope of issue #66.
+
+## Foundation Inherited from ADR-NET-009
+
+The following decisions are intentional foundations, not temporary limitations:
+
+- one authoritative admission path for local, N2N, and diffusion submissions;
+- one ordered, single-writer state transition for stateful validation and
+  commit;
+- a typed admission result instead of separate `contains` and raw `add` calls;
+- atomic transaction, conflict, dependency, and accounting mutation;
+- successful admission order as the deterministic transaction order;
+- bounded transaction bodies and derived state;
+- reason-aware removal and canonical-chain reconciliation;
+- a semantic `MemPool` contract that permits implementation replacement;
+- immutable block-selection snapshots and one in-flight forge attempt in the
+  initial producer design.
+
+These properties allow the state representation to grow from a UTXO overlay to
+a complete ledger transition without changing the fundamental admission model.
+
+## Concurrent Submission Semantics
+
+Clients may submit transactions concurrently. The single-writer lane orders
+stateful admission internally; it does not require all clients to serialize
+independent submissions.
+
+| Concurrent submissions | Expected result |
+|---|---|
+| Independent A and B | Both wait for their turn and normally succeed. |
+| Parent P and child C, P enters first | P commits; C resolves P's output and succeeds. |
+| Parent P and child C, C enters first | C is rejected with `UtxoNotFound`; the client retries after P succeeds. |
+| Conflicting A and B | The first valid commit claims the state; the second is rejected. |
+| Duplicate A and A | One insertion; the other receives a duplicate result without another accepted event. |
+
+The client retry limitation applies to unresolved dependencies, not to parallel
+submission generally. Package admission described below can remove this race
+for a caller that already knows the complete dependency set.
+
+## Validation Throughput Clarification
+
+Yano owns the built-in transaction-validation listener, so arbitrary third-party
+plugin behavior is not an immediate operational risk. The relevant initial
+tradeoff is that expensive stateful validation, especially Plutus phase-2
+execution, delays later admissions on the same lane.
+
+Listener restrictions remain an extension contract in case third-party
+stateful validators are supported later. Performance work should first measure
+the built-in validator rather than introducing optimistic concurrency in
+anticipation of unknown plugins.
+
+## Future-Proof Admission Contract
+
+The public mempool contract should not permanently expose a UTXO-specific
+resolver as its top-level abstraction. Prefer an opaque or extensible admission
+context, conceptually:
+
+```java
+interface MempoolAdmissionContext {
+    UtxoResolver utxos();
+
+    // Added only by a future generalized implementation:
+    // LedgerStateView ledgerState();
+}
+
+MempoolAdmissionResult tryAdmit(
+        byte[] txCbor,
+        AdmissionValidator validator);
+```
+
+Alternatively, keep the context completely internal to `MemPool` and expose
+only the semantic `tryAdmit` operation. The important constraint is that callers
+must not depend on the concrete produced/spent maps from ADR-NET-009.
+
+## Generalized Mempool Ledger State
+
+The future model is:
+
+```text
+canonical ledger snapshot
+        |
+        v
+apply accepted transaction A
+        |
+        v
+mempool ledger state after A
+        |
+        v
+apply accepted transaction B
+        |
+        v
+mempool ledger state after A, B
+```
+
+Validation should return evidence of the transition rather than only a boolean:
+
+```text
+ValidatedTransition
+    validated transaction
+    ledger delta
+    validation/execution measurements
+    optional state read/write keys
+```
+
+The implementation must not retain a complete deep copy of ledger state per
+transaction. Candidate representations include:
+
+- an immutable base snapshot plus ordered deltas;
+- periodic checkpoints plus deltas between checkpoints;
+- copy-on-write/persistent state structures;
+- ledger tables and transaction-local diffs similar in principle to the
+  Haskell consensus implementation.
+
+UTXO indexes from ADR-NET-009 may remain as fast derived indexes. They cease to
+be the complete tentative state once generalized ledger deltas are introduced.
+
+## Ledger-State Domains
+
+A generalized transition may include transaction-driven changes to:
+
+- UTXOs, native assets, datums, and reference scripts;
+- stake credential registration and deregistration;
+- delegation state;
+- reward withdrawals and balances;
+- pool registration and retirement state;
+- deposits and refunds;
+- DRep registration and delegation;
+- governance proposals, votes, and committee-related state;
+- other ledger state required by the active era's transaction rules.
+
+This does not imply that every earlier transaction effect is immediately usable.
+Some effects become active only at an epoch boundary or another protocol-defined
+transition. The actual Cardano ledger rules, not a custom mempool shortcut,
+determine whether a later transaction is valid.
+
+## Removal, Rebase, and Revalidation
+
+Full ledger state makes removal more general than UTXO descendant cascading.
+Removing transaction A may invalidate any later transaction whose validation
+observed A's state transition, even without a UTXO edge.
+
+Two implementation strategies should be evaluated:
+
+1. **Ordered suffix reapplication:** remove A and reapply every later
+   transaction in admission order, dropping those that no longer validate.
+   This is simple and matches the ordered virtual-ledger model.
+2. **State-key dependencies:** record ledger keys read and written by every
+   transaction and revalidate only the affected closure. This can be faster but
+   is significantly more complex and requires complete read-set reporting from
+   ledger validation.
+
+The initial generalized implementation should prefer suffix reapplication
+unless profiling proves it inadequate.
+
+When the canonical chain advances or rolls back:
+
+1. obtain a coherent canonical ledger snapshot at the new point;
+2. replay accepted mempool transactions in order;
+3. retain transactions that still validate;
+4. drop invalid transactions and any later transactions invalidated by their
+   absence;
+5. atomically publish the rebuilt mempool state.
+
+Reapplication may skip cryptographic work already proven invariant, but it must
+repeat all checks that can change with ledger state, slot, or preceding
+transactions.
+
+## Future Capabilities
+
+### Transaction package admission
+
+Accept an ordered parent/child package as one operation:
+
+```text
+tryAdmitPackage([P, C1, C2])
+```
+
+The package is validated against one admission context and committed atomically:
+all transactions enter in dependency order or none enter. This removes the
+parent/child lock-order race for callers that possess the whole chain.
+
+Package limits must bound transaction count, bytes, execution units, index
+growth, and validation time. Package admission is a local mempool guarantee,
+not a protocol guarantee that another producer will include the package
+atomically.
+
+### Mempool-aware construction and evaluation
+
+Expose an opt-in API that resolves and evaluates against tentative mempool
+state. It can support:
+
+- constructing a child before its parent confirms;
+- evaluating a complete package;
+- reporting the transaction that invalidates a package;
+- predicting UTXOs, deposits, refunds, and immediately visible ledger state;
+- reporting bytes, fees, execution units, and reference-script costs;
+- checking whether a package can fit in a candidate block.
+
+Responses must identify the mempool generation or snapshot used so clients can
+recognize that the result is tentative.
+
+### Dependency-aware diffusion
+
+Use dependency data to:
+
+- announce parents before children;
+- avoid offering a child before its required ancestors;
+- request missing ancestors;
+- diffuse bounded packages;
+- suppress repeated dissemination of invalid orphan chains.
+
+This requires capability negotiation if package transfer extends the existing
+TxSubmission protocol. Parent-first ordering can be improved without a protocol
+extension.
+
+### Dependency-aware block packing
+
+Evaluate a transaction together with required ancestors using:
+
+- package fee and fee density;
+- total serialized bytes;
+- execution-unit memory and steps;
+- reference-script cost;
+- dependency depth;
+- validity interval and expiry risk.
+
+Selection must remain deterministic, topological, and constrained by Cardano
+block limits. A policy may prefer a valuable child-plus-parent package without
+ever placing the child before the parent.
+
+### Package-aware eviction and admission control
+
+Future policy may consider:
+
+- descendant count and total descendant bytes;
+- total validation/execution cost;
+- cost of removing a chain root;
+- package age and origin;
+- conflict-set size;
+- capacity reserved for local versus remote admission.
+
+Any replacement or fee-priority policy requires a separate ADR. The initial
+reject-newcomer policy remains authoritative until then.
+
+### Conflict sets and replacement policy
+
+Generalized state read/write information can identify transactions that cannot
+coexist. A future explicit replacement policy could consider fee improvement,
+execution cost, origin, age, and descendant impact. Replacement must never be
+an accidental consequence of ordinary admission.
+
+### Parallel validation of independent branches
+
+After serialized admission is profiled, transactions with disjoint state access
+may perform expensive validation concurrently:
+
+```text
+reads/writes(A) does not conflict with reads/writes(B)
+```
+
+Their final commits must still enter one deterministic order and recheck every
+state-dependent precondition. UTXO disjointness alone is insufficient once
+certificate and governance state is supported.
+
+Parallel validation is a performance optimization, not a prerequisite for
+concurrent client submission. It should be introduced only with evidence that
+serialized phase-2 validation is a material bottleneck.
+
+### Incremental revalidation
+
+State-key dependencies may allow a block or rollback to revalidate only the
+affected transaction closure. This follows, rather than precedes, a correct
+full-state replay implementation.
+
+### Persistence and recovery
+
+A future implementation may persist transaction bodies, admission order, and
+transition metadata using a journal or embedded store. Recovery must revalidate
+against the current canonical ledger; persisted validation success is not
+permanent evidence of validity.
+
+Persistence is independent of full ledger-state chaining and requires its own
+failure, schema, migration, and durability decision.
+
+### Intent and workflow processing
+
+On top of package validation, applications could submit an ordered intent or
+workflow and request:
+
+- all-or-nothing local admission;
+- deterministic dependency diagnostics;
+- candidate-block simulation;
+- status across parent, child, and rollback transitions;
+- certificate or governance workflows where ledger rules permit immediate
+  state visibility.
+
+This is a local node service, not a new Cardano atomic-transaction primitive.
+
+## Comparison Target
+
+The semantic reference for generalized state is the Haskell consensus mempool,
+which validates transactions strictly in list order against the ledger state
+produced by earlier entries and reapplies the ordered list after ledger changes:
+
+- [Ouroboros mempool API](https://ouroboros-consensus.cardano.intersectmbo.org/haddocks/ouroboros-consensus/Ouroboros-Consensus-Mempool-API.html)
+- [LedgerSupportsMempool](https://ouroboros-consensus.cardano.intersectmbo.org/haddocks/ouroboros-consensus/Ouroboros-Consensus-Ledger-SupportsMempool.html)
+
+Dingo is a useful near-term structural reference for serialized UTXO-overlay
+validation, dependency indexing, confirmed versus cascading removal, and
+background revalidation:
+
+- [Dingo mempool admission](https://github.com/blinklabs-io/dingo/blob/main/mempool/mempool.go#L1438-L1531)
+- [Dingo dependency DAG](https://github.com/blinklabs-io/dingo/blob/main/mempool/dag.go#L31-L159)
+
+Dolos demonstrates the simpler serialized-submission model and a durable
+pending-to-finalized transaction lifecycle:
+
+- [Dolos submission path](https://github.com/txpipe/dolos/blob/main/crates/core/src/submit.rs#L13-L79)
+- [Dolos mempool contract and UTXO view](https://github.com/txpipe/dolos/blob/main/crates/core/src/mempool.rs#L138-L433)
+
+Yano should use these as comparison points, not copy their storage, concurrency,
+or lifecycle mechanisms without local measurements and requirements.
+
+## Phased Roadmap
+
+### Phase 0: Preserve the extension seam during ADR-NET-009
+
+- Keep `MemPool` admission semantic and avoid exposing mutable UTXO indexes.
+- Use an opaque/extensible admission context rather than a permanent public
+  UTXO-only contract.
+- Record validation time, lane wait/hold time, chain depth, and revalidation
+  cost.
+
+### Phase 1: UTXO-based advanced capabilities
+
+- package admission;
+- mempool-aware evaluation;
+- parent-first diffusion;
+- dependency-aware block packing;
+- package-aware diagnostics and observability.
+
+These features can use the bounded indexes from ADR-NET-009 without full ledger
+state.
+
+### Phase 2: Generalized ledger transitions
+
+- define `MempoolLedgerState` and `ValidatedTransition`;
+- integrate the active-era ledger transition engine;
+- store bounded deltas/checkpoints;
+- implement canonical rebase and ordered suffix replay;
+- extend block selection to use the same transition semantics.
+
+### Phase 3: Selective and parallel processing
+
+- expose complete state read/write sets from validation;
+- introduce affected-closure revalidation;
+- validate independent branches concurrently;
+- retain deterministic serialized commit.
+
+### Phase 4: Optional durable and policy extensions
+
+- journal/snapshot recovery;
+- explicit conflict replacement;
+- richer fairness and local/remote capacity policy;
+- durable transaction-workflow status.
+
+Each phase after Phase 0 requires a new accepted ADR or an explicit revision of
+this deferred note.
+
+## Activation Criteria
+
+Begin a generalized-ledger-state ADR only when at least one of these is true:
+
+- a real application requires certificate, delegation, withdrawal, pool, DRep,
+  or governance dependencies across unconfirmed transactions;
+- profiling shows repeated full revalidation or UTXO-only modeling is the
+  dominant limitation;
+- package admission or mempool-aware evaluation has demonstrated product value;
+- Yano's ledger engine can return deterministic, bounded transaction deltas and
+  reapply previously validated transactions safely.
+
+Parallel validation additionally requires evidence that serialized validation
+is a material throughput bottleneck under representative script workloads.
+
+## Risks and Constraints
+
+- Full ledger state increases heap use and revalidation complexity.
+- Removing one transaction can invalidate a large ordered suffix.
+- Epoch and slot transitions make tentative validity time-dependent.
+- A custom approximation of ledger state can diverge from Cardano rules; the
+  actual ledger transition engine must remain authoritative.
+- State read/write sets are difficult to make complete and safe.
+- Parallel execution must not make admission order nondeterministic.
+- Mempool-aware APIs expose tentative results and require clear snapshot
+  identity and invalidation semantics.
+- Package, replacement, and prioritization policies can affect fairness and
+  diffusion behavior and therefore require explicit decisions.
+
+## Verification Gates for a Future Full-State Implementation
+
+- certificate registration followed by a dependent transaction, where ledger
+  rules make the transition immediately visible;
+- delegation, withdrawal, pool, DRep, and governance sequences covering both
+  valid and protocol-delayed effects;
+- identical results between mempool replay and applying the same ordered prefix
+  as block transactions;
+- removal from the beginning, middle, and end of an ordered dependency chain;
+- canonical roll-forward and rollback followed by deterministic replay;
+- transaction package atomic admission and failure rollback;
+- block selection preserving exactly the validated order;
+- retained-heap and replay-time measurements at configured capacity;
+- serialized-versus-parallel validation equivalence for independent branches;
+- restart recovery revalidating rather than trusting stale persisted success;
+- differential tests against the Haskell node for representative ledger-state
+  transitions.
+
+## Non-Decisions
+
+This note does not choose:
+
+- the concrete full ledger-state representation;
+- checkpoint frequency;
+- a persistence backend;
+- a transaction replacement policy;
+- fee-priority or fairness rules;
+- a package wire protocol;
+- a parallel validation scheduler;
+- public intent/workflow API shapes.
+
+Those choices remain deferred until measurements and concrete product use cases
+justify them.

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
@@ -8,6 +8,7 @@ import com.bloxbean.cardano.yano.api.LedgerQuery;
 import com.bloxbean.cardano.yano.api.NodeLifecycle;
 import com.bloxbean.cardano.yano.api.ProducerControl;
 import com.bloxbean.cardano.yano.api.TxEvaluationGateway;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.TxGateway;
 import com.bloxbean.cardano.yano.api.config.PluginsOptions;
 import com.bloxbean.cardano.yano.api.config.RuntimeOptions;
@@ -830,6 +831,12 @@ public class YanoProducer {
     @ApplicationScoped
     public TxEvaluationGateway createTxEvaluationGateway() {
         return ensureYano().txEvaluationGateway();
+    }
+
+    @Produces
+    @ApplicationScoped
+    public MempoolQueryGateway createMempoolQueryGateway() {
+        return ensureYano().mempoolQueryGateway();
     }
 
     @Produces

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/api/scripts/ScriptResource.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/api/scripts/ScriptResource.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.client.api.util.ReferenceScriptUtil;
 import com.bloxbean.cardano.client.exception.CborSerializationException;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.app.api.scripts.dto.ScriptCborDto;
 import jakarta.inject.Inject;
@@ -11,6 +12,8 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.PathParam;
 import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.DefaultValue;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -21,9 +24,14 @@ public class ScriptResource {
     @Inject
     LedgerQuery ledgerQuery;
 
+    @Inject
+    MempoolQueryGateway mempoolQueryGateway;
+
     @GET
     @Path("/{script_hash}/cbor")
-    public Response getScriptCbor(@PathParam("script_hash") String scriptHash) {
+    public Response getScriptCbor(@PathParam("script_hash") String scriptHash,
+                                  @QueryParam("include_mempool")
+                                  @DefaultValue("false") boolean includeMempool) {
         UtxoState u = ledgerQuery.getUtxoState();
         if (u == null || !u.isEnabled()) {
             return Response.status(Response.Status.SERVICE_UNAVAILABLE)
@@ -31,7 +39,10 @@ public class ScriptResource {
                     .build();
         }
 
-        return u.getScriptRefBytesByHash(scriptHash)
+        var scriptRef = includeMempool
+                ? mempoolQueryGateway.getScriptRefBytesByHash(scriptHash)
+                : u.getScriptRefBytesByHash(scriptHash);
+        return scriptRef
                 .map(ReferenceScriptUtil::deserializeScriptRef)
                 .map(script -> {
                     try {

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/api/status/NodeMetrics.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/api/status/NodeMetrics.java
@@ -36,6 +36,15 @@ public class NodeMetrics {
             "yano.node.mempool.bytes",
             "yano.node.mempool.capacity.transactions",
             "yano.node.mempool.capacity.bytes",
+            "yano.node.mempool.index.entries",
+            "yano.node.mempool.dependency.edges",
+            "yano.node.mempool.capacity.index.entries",
+            "yano.node.mempool.index.estimated.bytes",
+            "yano.node.mempool.rejections.total",
+            "yano.node.mempool.cascaded.removals.total",
+            "yano.node.mempool.admission.queue",
+            "yano.node.mempool.admission.duration.seconds",
+            "yano.node.mempool.validation.slow.total",
             "yano.node.tx.diffusion.total",
             "yano.node.tx.diffusion.inflight.transactions",
             "yano.node.tx.diffusion.inflight.bytes",
@@ -98,6 +107,40 @@ public class NodeMetrics {
                 "Configured mempool transaction capacity");
         gauge("yano.node.mempool.capacity.bytes", Snapshot::mempoolMaxBytes,
                 "Configured mempool byte capacity");
+        taggedGauge("yano.node.mempool.index.entries", "type", "total",
+                Snapshot::mempoolUtxoIndexEntries, "Current mempool index records by bounded type");
+        taggedGauge("yano.node.mempool.index.entries", "type", "produced",
+                Snapshot::mempoolProducedOutputs, "Current mempool index records by bounded type");
+        taggedGauge("yano.node.mempool.index.entries", "type", "spent",
+                Snapshot::mempoolSpentOutpoints, "Current mempool index records by bounded type");
+        taggedGauge("yano.node.mempool.index.entries", "type", "reference_script",
+                Snapshot::mempoolReferenceScripts, "Current mempool index records by bounded type");
+        gauge("yano.node.mempool.dependency.edges", Snapshot::mempoolDependencyEdges,
+                "Current parent-to-child mempool dependency edges");
+        gauge("yano.node.mempool.capacity.index.entries", Snapshot::mempoolMaxUtxoIndexEntries,
+                "Configured mempool UTXO and dependency index capacity");
+        gauge("yano.node.mempool.index.estimated.bytes", Snapshot::mempoolEstimatedIndexBytes,
+                "Estimated retained bytes for mempool indexes");
+
+        taggedFunctionCounter("yano.node.mempool.rejections.total", "reason", "duplicate",
+                Snapshot::mempoolDuplicateRejections, "Process-lifetime mempool rejections by bounded reason");
+        taggedFunctionCounter("yano.node.mempool.rejections.total", "reason", "conflict",
+                Snapshot::mempoolConflictRejections, "Process-lifetime mempool rejections by bounded reason");
+        taggedFunctionCounter("yano.node.mempool.rejections.total", "reason", "capacity",
+                Snapshot::mempoolCapacityRejections, "Process-lifetime mempool rejections by bounded reason");
+        taggedFunctionCounter("yano.node.mempool.rejections.total", "reason", "malformed",
+                Snapshot::mempoolMalformedRejections, "Process-lifetime mempool rejections by bounded reason");
+        taggedFunctionCounter("yano.node.mempool.rejections.total", "reason", "ledger",
+                Snapshot::mempoolLedgerRejections, "Process-lifetime mempool rejections by bounded reason");
+        functionCounter("yano.node.mempool.cascaded.removals.total", Snapshot::mempoolCascadedRemovals,
+                "Process-lifetime descendant removals caused by cascading eviction");
+        gauge("yano.node.mempool.admission.queue", Snapshot::mempoolAdmissionQueueLength,
+                "Current threads queued for the serialized mempool admission lane");
+        taggedDurationCounter("wait", Snapshot::mempoolAdmissionWaitNanos);
+        taggedDurationCounter("hold", Snapshot::mempoolAdmissionHoldNanos);
+        taggedDurationCounter("validation", Snapshot::mempoolValidationNanos);
+        functionCounter("yano.node.mempool.validation.slow.total", Snapshot::mempoolSlowValidations,
+                "Process-lifetime slow mempool validation listener dispatches");
 
         functionCounter("outbound_forwarded", Snapshot::outboundForwarded);
         functionCounter("outbound_suppressed", Snapshot::outboundSuppressed);
@@ -137,6 +180,29 @@ public class NodeMetrics {
                         metrics -> value.applyAsDouble(metrics.current()))
                 .tag("outcome", outcome)
                 .description("Process-lifetime transaction diffusion outcomes")
+                .register(registry);
+    }
+
+    private void functionCounter(String name, ToDoubleFunction<Snapshot> value, String description) {
+        FunctionCounter.builder(name, this, metrics -> value.applyAsDouble(metrics.current()))
+                .description(description)
+                .register(registry);
+    }
+
+    private void taggedFunctionCounter(String name, String tagName, String tagValue,
+                                       ToDoubleFunction<Snapshot> value, String description) {
+        FunctionCounter.builder(name, this, metrics -> value.applyAsDouble(metrics.current()))
+                .tag(tagName, tagValue)
+                .description(description)
+                .register(registry);
+    }
+
+    private void taggedDurationCounter(String phase, ToDoubleFunction<Snapshot> nanos) {
+        FunctionCounter.builder("yano.node.mempool.admission.duration.seconds", this,
+                        metrics -> nanos.applyAsDouble(metrics.current()) / 1_000_000_000d)
+                .tag("phase", phase)
+                .description("Process-lifetime mempool admission duration by bounded phase")
+                .baseUnit("seconds")
                 .register(registry);
     }
 
@@ -184,6 +250,24 @@ public class NodeMetrics {
                 number(status.getMempoolBytes()),
                 number(status.getMempoolMaxTxs()),
                 number(status.getMempoolMaxBytes()),
+                number(status.getMempoolUtxoIndexEntries()),
+                number(status.getMempoolMaxUtxoIndexEntries()),
+                number(status.getMempoolProducedOutputs()),
+                number(status.getMempoolSpentOutpoints()),
+                number(status.getMempoolReferenceScripts()),
+                number(status.getMempoolDependencyEdges()),
+                number(status.getMempoolEstimatedIndexBytes()),
+                number(status.getMempoolDuplicateRejections()),
+                number(status.getMempoolConflictRejections()),
+                number(status.getMempoolCapacityRejections()),
+                number(status.getMempoolMalformedRejections()),
+                number(status.getMempoolLedgerRejections()),
+                number(status.getMempoolCascadedRemovals()),
+                number(status.getMempoolAdmissionQueueLength()),
+                number(status.getMempoolAdmissionWaitNanos()),
+                number(status.getMempoolAdmissionHoldNanos()),
+                number(status.getMempoolValidationNanos()),
+                number(status.getMempoolSlowValidations()),
                 number(status.getTxDiffusionOutboundForwarded()),
                 number(status.getTxDiffusionOutboundSuppressed()),
                 number(status.getTxDiffusionInboundTxBodiesAccepted()),
@@ -218,6 +302,24 @@ public class NodeMetrics {
             double mempoolBytes,
             double mempoolMaxTransactions,
             double mempoolMaxBytes,
+            double mempoolUtxoIndexEntries,
+            double mempoolMaxUtxoIndexEntries,
+            double mempoolProducedOutputs,
+            double mempoolSpentOutpoints,
+            double mempoolReferenceScripts,
+            double mempoolDependencyEdges,
+            double mempoolEstimatedIndexBytes,
+            double mempoolDuplicateRejections,
+            double mempoolConflictRejections,
+            double mempoolCapacityRejections,
+            double mempoolMalformedRejections,
+            double mempoolLedgerRejections,
+            double mempoolCascadedRemovals,
+            double mempoolAdmissionQueueLength,
+            double mempoolAdmissionWaitNanos,
+            double mempoolAdmissionHoldNanos,
+            double mempoolValidationNanos,
+            double mempoolSlowValidations,
             double outboundForwarded,
             double outboundSuppressed,
             double inboundAccepted,

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/api/status/NodeMetrics.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/api/status/NodeMetrics.java
@@ -120,7 +120,7 @@ public class NodeMetrics {
         gauge("yano.node.mempool.capacity.index.entries", Snapshot::mempoolMaxUtxoIndexEntries,
                 "Configured mempool UTXO and dependency index capacity");
         gauge("yano.node.mempool.index.estimated.bytes", Snapshot::mempoolEstimatedIndexBytes,
-                "Estimated retained bytes for mempool indexes");
+                "Structural byte estimate for mempool indexes, not a retained-heap forecast");
 
         taggedFunctionCounter("yano.node.mempool.rejections.total", "reason", "duplicate",
                 Snapshot::mempoolDuplicateRejections, "Process-lifetime mempool rejections by bounded reason");

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/api/utxos/UtxoResource.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/api/utxos/UtxoResource.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yano.app.api.utxos;
 
 import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.app.api.utxos.dto.UtxoDto;
@@ -20,6 +21,9 @@ public class UtxoResource {
 
     @Inject
     LedgerQuery ledgerQuery;
+
+    @Inject
+    MempoolQueryGateway mempoolQueryGateway;
 
     private UtxoState utxo() {
         return ledgerQuery.getUtxoState();
@@ -81,14 +85,20 @@ public class UtxoResource {
     @GET
     @Path("/utxos/{txHash}/{index}")
     public Response getUtxo(@PathParam("txHash") String txHash,
-                            @PathParam("index") int index) {
+                            @PathParam("index") int index,
+                            @QueryParam("include_mempool")
+                            @DefaultValue("false") boolean includeMempool) {
         UtxoState u = utxo();
         if (u == null || !u.isEnabled()) {
             return Response.status(Response.Status.SERVICE_UNAVAILABLE)
                     .entity("{\"error\":\"UTXO state disabled\"}")
                     .build();
         }
-        return u.getUtxo(new Outpoint(txHash, index))
+        Outpoint outpoint = new Outpoint(txHash, index);
+        var result = includeMempool
+                ? mempoolQueryGateway.resolveUtxo(outpoint)
+                : u.getUtxo(outpoint);
+        return result
                 .map(utxo -> Response.ok(UtxoDtoMapper.toDto(utxo, ledgerQuery::slotToUnixTime)).build())
                 .orElse(Response.status(Response.Status.NOT_FOUND).build());
     }

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -320,6 +320,8 @@ yano:
       tracking-enabled: true          # Protocol param tracking from blocks
     governance:
       enabled: true                   # Governance state tracking
+    utxo:
+      enabled: true                   # Required by devnet faucet, queries, and transaction validation
     block-producer:
       enabled: true
       block-time-millis: 0
@@ -359,6 +361,8 @@ yano:
       tracking-enabled: true          # Protocol param tracking from blocks
     governance:
       enabled: true                   # Governance state tracking
+    utxo:
+      enabled: true                   # Required by devnet faucet, queries, and transaction validation
     block-producer:
       enabled: true
       slot-leader-mode: true

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -125,6 +125,7 @@ yano:
     mempool:
       max-txs: 10000
       max-bytes: 134217728
+      max-utxo-index-entries: 250000
       ttl-seconds: 10800
     diffusion:
       # Simple relay MVP switch. true maps to all-hot transaction diffusion.

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -125,7 +125,7 @@ yano:
     mempool:
       max-txs: 10000
       max-bytes: 134217728
-      max-utxo-index-entries: 250000
+      max-utxo-index-entries: 100000
       ttl-seconds: 10800
     diffusion:
       # Simple relay MVP switch. true maps to all-hot transaction diffusion.

--- a/app/src/test/java/com/bloxbean/cardano/yano/app/api/scripts/ScriptResourceMempoolQueryTest.java
+++ b/app/src/test/java/com/bloxbean/cardano/yano/app/api/scripts/ScriptResourceMempoolQueryTest.java
@@ -1,0 +1,50 @@
+package com.bloxbean.cardano.yano.app.api.scripts;
+
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
+import com.bloxbean.cardano.client.transaction.spec.Value;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
+import com.bloxbean.cardano.yano.api.utxo.UtxoState;
+import com.bloxbean.cardano.yano.app.api.scripts.dto.ScriptCborDto;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class ScriptResourceMempoolQueryTest {
+    @Test
+    void referenceScriptLookupUsesTransientViewOnlyWhenRequested() throws Exception {
+        PlutusV2Script script = PlutusV2Script.builder()
+                .cborHex("49480100002221200101")
+                .build();
+        TransactionOutput output = TransactionOutput.builder()
+                .address("addr_test1")
+                .value(new Value(BigInteger.ONE, null))
+                .scriptRef(script)
+                .build();
+        String scriptHash = HexUtil.encodeHexString(script.getScriptHash());
+        UtxoState state = mock(UtxoState.class);
+        when(state.isEnabled()).thenReturn(true);
+        when(state.getScriptRefBytesByHash(scriptHash)).thenReturn(Optional.empty());
+        LedgerQuery ledger = mock(LedgerQuery.class);
+        when(ledger.getUtxoState()).thenReturn(state);
+        MempoolQueryGateway mempool = mock(MempoolQueryGateway.class);
+        when(mempool.getScriptRefBytesByHash(scriptHash))
+                .thenReturn(Optional.of(output.getScriptRef()));
+        ScriptResource resource = new ScriptResource();
+        resource.ledgerQuery = ledger;
+        resource.mempoolQueryGateway = mempool;
+
+        assertThat(resource.getScriptCbor(scriptHash, false).getStatus()).isEqualTo(404);
+        var response = resource.getScriptCbor(scriptHash, true);
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(((ScriptCborDto) response.getEntity()).cbor())
+                .isEqualTo(HexUtil.encodeHexString(script.serializeScriptBody()));
+    }
+}

--- a/app/src/test/java/com/bloxbean/cardano/yano/app/api/status/NodeMetricsTest.java
+++ b/app/src/test/java/com/bloxbean/cardano/yano/app/api/status/NodeMetricsTest.java
@@ -37,6 +37,23 @@ class NodeMetricsTest {
                 .mempoolBytes(11L)
                 .mempoolMaxTxs(12)
                 .mempoolMaxBytes(13L)
+                .mempoolUtxoIndexEntries(22)
+                .mempoolMaxUtxoIndexEntries(23)
+                .mempoolProducedOutputs(24)
+                .mempoolSpentOutpoints(25)
+                .mempoolDependencyEdges(26)
+                .mempoolEstimatedIndexBytes(27L)
+                .mempoolDuplicateRejections(28L)
+                .mempoolConflictRejections(29L)
+                .mempoolCapacityRejections(30L)
+                .mempoolMalformedRejections(31L)
+                .mempoolLedgerRejections(32L)
+                .mempoolCascadedRemovals(33L)
+                .mempoolAdmissionQueueLength(34)
+                .mempoolAdmissionWaitNanos(1_500_000_000L)
+                .mempoolAdmissionHoldNanos(2_500_000_000L)
+                .mempoolValidationNanos(3_500_000_000L)
+                .mempoolSlowValidations(35L)
                 .txDiffusionOutboundForwarded(14L)
                 .txDiffusionOutboundSuppressed(15L)
                 .txDiffusionInboundTxBodiesAccepted(16L)
@@ -61,6 +78,16 @@ class NodeMetricsTest {
         assertThat(registry.get("yano.node.sync.gap.blocks").gauge().value()).isZero();
         assertThat(registry.get("yano.node.utxo.enabled").gauge().value()).isZero();
         assertThat(registry.get("yano.node.utxo.lag.blocks").gauge().value()).isZero();
+        assertThat(registry.get("yano.node.mempool.index.entries").tag("type", "total")
+                .gauge().value()).isEqualTo(22);
+        assertThat(registry.get("yano.node.mempool.dependency.edges")
+                .gauge().value()).isEqualTo(26);
+        assertThat(registry.get("yano.node.mempool.rejections.total").tag("reason", "capacity")
+                .functionCounter().count()).isEqualTo(30);
+        assertThat(registry.get("yano.node.mempool.admission.duration.seconds").tag("phase", "wait")
+                .functionCounter().count()).isEqualTo(1.5);
+        assertThat(registry.get("yano.node.mempool.admission.duration.seconds").tag("phase", "hold")
+                .functionCounter().count()).isEqualTo(2.5);
 
         assertThat(registry.get("yano.node.peers.connections").gauges())
                 .extracting(gauge -> gauge.getId().getTag("type"))

--- a/app/src/test/java/com/bloxbean/cardano/yano/app/api/status/NodeMetricsTest.java
+++ b/app/src/test/java/com/bloxbean/cardano/yano/app/api/status/NodeMetricsTest.java
@@ -82,6 +82,9 @@ class NodeMetricsTest {
                 .gauge().value()).isEqualTo(22);
         assertThat(registry.get("yano.node.mempool.dependency.edges")
                 .gauge().value()).isEqualTo(26);
+        assertThat(registry.get("yano.node.mempool.index.estimated.bytes")
+                .gauge().getId().getDescription())
+                .isEqualTo("Structural byte estimate for mempool indexes, not a retained-heap forecast");
         assertThat(registry.get("yano.node.mempool.rejections.total").tag("reason", "capacity")
                 .functionCounter().count()).isEqualTo(30);
         assertThat(registry.get("yano.node.mempool.admission.duration.seconds").tag("phase", "wait")

--- a/app/src/test/java/com/bloxbean/cardano/yano/app/api/utxos/UtxoResourceMempoolQueryTest.java
+++ b/app/src/test/java/com/bloxbean/cardano/yano/app/api/utxos/UtxoResourceMempoolQueryTest.java
@@ -1,0 +1,47 @@
+package com.bloxbean.cardano.yano.app.api.utxos;
+
+import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
+import com.bloxbean.cardano.yano.api.utxo.UtxoState;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+import com.bloxbean.cardano.yano.app.api.utxos.dto.UtxoDto;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class UtxoResourceMempoolQueryTest {
+    @Test
+    void pointLookupUsesTransientViewOnlyWhenRequested() {
+        Outpoint outpoint = new Outpoint("11".repeat(32), 0);
+        Utxo canonical = utxo(outpoint, 1_000_000);
+        Utxo transientView = utxo(outpoint, 2_000_000);
+        UtxoState state = mock(UtxoState.class);
+        when(state.isEnabled()).thenReturn(true);
+        when(state.getUtxo(outpoint)).thenReturn(Optional.of(canonical));
+        LedgerQuery ledger = mock(LedgerQuery.class);
+        when(ledger.getUtxoState()).thenReturn(state);
+        MempoolQueryGateway mempool = mock(MempoolQueryGateway.class);
+        when(mempool.resolveUtxo(outpoint)).thenReturn(Optional.of(transientView));
+        UtxoResource resource = new UtxoResource();
+        resource.ledgerQuery = ledger;
+        resource.mempoolQueryGateway = mempool;
+
+        UtxoDto defaultBody = (UtxoDto) resource.getUtxo(outpoint.txHash(), 0, false).getEntity();
+        UtxoDto transientBody = (UtxoDto) resource.getUtxo(outpoint.txHash(), 0, true).getEntity();
+
+        assertThat(defaultBody.amount().getFirst().quantity()).isEqualTo(BigInteger.valueOf(1_000_000));
+        assertThat(transientBody.amount().getFirst().quantity()).isEqualTo(BigInteger.valueOf(2_000_000));
+    }
+
+    private static Utxo utxo(Outpoint outpoint, long lovelace) {
+        return new Utxo(outpoint, "addr_test1", BigInteger.valueOf(lovelace),
+                List.of(), null, null, null, null, false, 1, 1, "block");
+    }
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/MempoolQueryGateway.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/MempoolQueryGateway.java
@@ -1,0 +1,26 @@
+package com.bloxbean.cardano.yano.api;
+
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+
+import java.util.Optional;
+
+/**
+ * Optional, node-local query surface for a mempool-inclusive UTXO view.
+ *
+ * <p>This is deliberately separate from {@link LedgerQuery}: canonical ledger
+ * queries remain stable by default, while clients that are deliberately
+ * constructing transaction chains can opt into the node's transient view.</p>
+ */
+public interface MempoolQueryGateway {
+    MempoolQueryGateway UNAVAILABLE = new MempoolQueryGateway() { };
+
+    default Optional<Utxo> resolveUtxo(Outpoint outpoint) {
+        return Optional.empty();
+    }
+
+    /** Return the encoded reference-script bytes, including mempool outputs. */
+    default Optional<byte[]> getScriptRefBytesByHash(String scriptHash) {
+        return Optional.empty();
+    }
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
@@ -235,6 +235,8 @@ public final class YanoPropertyKeys {
         public static final String MEMPOOL_MAX_TXS = "yano.tx.mempool.max-txs";
         public static final String MEMPOOL_MAX_BYTES = "yano.tx.mempool.max-bytes";
         public static final String MEMPOOL_TTL_SECONDS = "yano.tx.mempool.ttl-seconds";
+        public static final String MEMPOOL_MAX_UTXO_INDEX_ENTRIES =
+                "yano.tx.mempool.max-utxo-index-entries";
         public static final String DIFFUSION_ENABLED = "yano.tx.diffusion.enabled";
         public static final String DIFFUSION_MODE = "yano.tx.diffusion.mode";
         public static final String DIFFUSION_MAX_IN_FLIGHT_TXS_PER_PEER =

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/TransactionValidateEvent.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/TransactionValidateEvent.java
@@ -5,6 +5,10 @@ import com.bloxbean.cardano.yaci.events.api.VetoableEvent;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Function;
+
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 
 /**
  * Published before a transaction is admitted to the mempool.
@@ -29,6 +33,7 @@ public final class TransactionValidateEvent implements VetoableEvent {
     private final byte[] txCbor;
     private final String txHash;
     private final String origin;
+    private final Function<Outpoint, Utxo> utxoResolver;
     private final List<Rejection> rejections = new ArrayList<>();
 
     /**
@@ -37,14 +42,27 @@ public final class TransactionValidateEvent implements VetoableEvent {
      * @param origin submission path identifier ("rest-api", "txsubmission", etc.)
      */
     public TransactionValidateEvent(byte[] txCbor, String txHash, String origin) {
+        this(txCbor, txHash, origin, null);
+    }
+
+    /**
+     * Creates an admission-scoped validation event.
+     *
+     * @param utxoResolver resolver for the stable mempool-plus-canonical UTXO
+     *                     view, or {@code null} for callers outside admission
+     */
+    public TransactionValidateEvent(byte[] txCbor, String txHash, String origin,
+                                    Function<Outpoint, Utxo> utxoResolver) {
         this.txCbor = txCbor;
         this.txHash = txHash;
         this.origin = origin;
+        this.utxoResolver = utxoResolver;
     }
 
     public byte[] txCbor() { return txCbor; }
     public String txHash() { return txHash; }
     public String origin() { return origin; }
+    public Function<Outpoint, Utxo> utxoResolver() { return utxoResolver; }
 
     @Override
     public void reject(String source, String reason) {

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/UtxoStateAppliedEvent.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/UtxoStateAppliedEvent.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.yano.api.events;
+
+import com.bloxbean.cardano.yaci.events.api.Event;
+
+import java.util.Objects;
+
+/**
+ * Published after a {@link BlockAppliedEvent} is visible through canonical
+ * UTXO state. This is an acknowledgement event, not a second block event.
+ */
+public record UtxoStateAppliedEvent(BlockAppliedEvent blockAppliedEvent) implements Event {
+    public UtxoStateAppliedEvent {
+        Objects.requireNonNull(blockAppliedEvent, "blockAppliedEvent");
+    }
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/UtxoStateRolledBackEvent.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/UtxoStateRolledBackEvent.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yano.api.events;
+
+import com.bloxbean.cardano.yaci.events.api.Event;
+
+import java.util.Objects;
+
+/** Published after a rollback is visible through canonical UTXO state. */
+public record UtxoStateRolledBackEvent(RollbackEvent rollbackEvent) implements Event {
+    public UtxoStateRolledBackEvent {
+        Objects.requireNonNull(rollbackEvent, "rollbackEvent");
+    }
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/model/NodeStatus.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/model/NodeStatus.java
@@ -332,6 +332,60 @@ public class NodeStatus {
      */
     private final Long mempoolTtlSeconds;
 
+    /** Current physical records across the mempool UTXO and dependency indexes. */
+    private final Integer mempoolUtxoIndexEntries;
+
+    /** Configured maximum records across the mempool UTXO and dependency indexes. */
+    private final Integer mempoolMaxUtxoIndexEntries;
+
+    /** Current outputs projected by unconfirmed mempool transactions. */
+    private final Integer mempoolProducedOutputs;
+
+    /** Current regular-input claims held by mempool transactions. */
+    private final Integer mempoolSpentOutpoints;
+
+    /** Current unique reference scripts indexed from mempool outputs. */
+    private final Integer mempoolReferenceScripts;
+
+    /** Current parent-to-child dependency edge count. */
+    private final Integer mempoolDependencyEdges;
+
+    /** Estimated retained bytes for mempool indexes. */
+    private final Long mempoolEstimatedIndexBytes;
+
+    /** Process-lifetime mempool duplicate rejections. */
+    private final Long mempoolDuplicateRejections;
+
+    /** Process-lifetime mempool input-conflict rejections. */
+    private final Long mempoolConflictRejections;
+
+    /** Process-lifetime mempool capacity rejections. */
+    private final Long mempoolCapacityRejections;
+
+    /** Process-lifetime malformed transaction rejections. */
+    private final Long mempoolMalformedRejections;
+
+    /** Process-lifetime ledger validation rejections. */
+    private final Long mempoolLedgerRejections;
+
+    /** Process-lifetime descendant removals caused by cascading eviction. */
+    private final Long mempoolCascadedRemovals;
+
+    /** Current number of threads queued for the serialized admission lane. */
+    private final Integer mempoolAdmissionQueueLength;
+
+    /** Process-lifetime nanoseconds spent waiting for the admission lane. */
+    private final Long mempoolAdmissionWaitNanos;
+
+    /** Process-lifetime nanoseconds holding the admission lane. */
+    private final Long mempoolAdmissionHoldNanos;
+
+    /** Process-lifetime nanoseconds spent validating admitted candidates. */
+    private final Long mempoolValidationNanos;
+
+    /** Process-lifetime count of slow validation listener dispatches. */
+    private final Long mempoolSlowValidations;
+
     /**
      * Whether transaction admission is currently accepting new transactions.
      */

--- a/devnet-toolkit/src/main/java/com/bloxbean/cardano/yano/devnet/YanoDevnetAssembly.java
+++ b/devnet-toolkit/src/main/java/com/bloxbean/cardano/yano/devnet/YanoDevnetAssembly.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yano.devnet;
 import com.bloxbean.cardano.yano.api.ChainQuery;
 import com.bloxbean.cardano.yano.api.DevnetControl;
 import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.NodeLifecycle;
 import com.bloxbean.cardano.yano.api.ProducerControl;
 import com.bloxbean.cardano.yano.api.TxEvaluationGateway;
@@ -203,6 +204,11 @@ public final class YanoDevnetAssembly {
         @Override
         public TxEvaluationGateway txEvaluationGateway() {
             return delegate.txEvaluationGateway();
+        }
+
+        @Override
+        public MempoolQueryGateway mempoolQueryGateway() {
+            return delegate.mempoolQueryGateway();
         }
 
         @Override

--- a/devnet-toolkit/src/test/java/com/bloxbean/cardano/yano/devnet/YanoDevnetAssemblyTest.java
+++ b/devnet-toolkit/src/test/java/com/bloxbean/cardano/yano/devnet/YanoDevnetAssemblyTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yano.devnet;
 
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.api.plugin.domain.DomainApiGateway;
 import com.bloxbean.cardano.yano.runtime.assembly.YanoAssembly;
@@ -11,6 +12,7 @@ import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 
 class YanoDevnetAssemblyTest {
     @TempDir
@@ -38,6 +40,8 @@ class YanoDevnetAssemblyTest {
             assertTrue(node.pluginCatalog().isPresent());
             assertTrue(node.pluginOperations().isPresent());
             assertNotSame(DomainApiGateway.empty(), node.domainApis());
+            assertNotSame(MempoolQueryGateway.UNAVAILABLE, node.mempoolQueryGateway());
+            assertSame(node.txEvaluationGateway(), node.mempoolQueryGateway());
         } finally {
             node.close();
         }

--- a/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/ScriptReferenceResolverScope.java
+++ b/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/ScriptReferenceResolverScope.java
@@ -1,0 +1,64 @@
+package com.bloxbean.cardano.yano.ledgerrules;
+
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Thread-scoped reference-script view used while validating one transaction.
+ *
+ * <p>The ledger validator's {@code ScriptSupplier} is constructed once, while
+ * mempool and block-local UTXOs vary per validation. This scope bridges those
+ * lifetimes without exposing mempool indexes or retaining transaction data.</p>
+ */
+public final class ScriptReferenceResolverScope {
+    private static final ThreadLocal<Map<String, byte[]>> CURRENT = new ThreadLocal<>();
+
+    private ScriptReferenceResolverScope() {
+    }
+
+    public static Scope open(Iterable<Utxo> resolvedInputs) {
+        Map<String, byte[]> scripts = new HashMap<>();
+        if (resolvedInputs != null) {
+            for (Utxo utxo : resolvedInputs) {
+                if (utxo == null || utxo.referenceScriptHash() == null
+                        || utxo.scriptRef() == null) continue;
+                try {
+                    scripts.put(normalize(utxo.referenceScriptHash()),
+                            java.util.HexFormat.of().parseHex(utxo.scriptRef()));
+                } catch (IllegalArgumentException ignored) {
+                    // Malformed script bytes are handled by normal validation;
+                    // do not let scope construction mask its typed result.
+                }
+            }
+        }
+        Map<String, byte[]> previous = CURRENT.get();
+        CURRENT.set(Map.copyOf(scripts));
+        return () -> {
+            if (previous == null) CURRENT.remove();
+            else CURRENT.set(previous);
+        };
+    }
+
+    public static Optional<byte[]> resolve(String scriptHash) {
+        if (scriptHash == null) return Optional.empty();
+        Map<String, byte[]> scripts = CURRENT.get();
+        if (scripts == null) return Optional.empty();
+        byte[] bytes = scripts.get(normalize(scriptHash));
+        return bytes != null ? Optional.of(Arrays.copyOf(bytes, bytes.length)) : Optional.empty();
+    }
+
+    private static String normalize(String scriptHash) {
+        return scriptHash.toLowerCase(Locale.ROOT);
+    }
+
+    @FunctionalInterface
+    public interface Scope extends AutoCloseable {
+        @Override
+        void close();
+    }
+}

--- a/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/impl/YaciScriptSupplier.java
+++ b/ledger-rules/src/main/java/com/bloxbean/cardano/yano/ledgerrules/impl/YaciScriptSupplier.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.client.api.ScriptSupplier;
 import com.bloxbean.cardano.client.api.util.ReferenceScriptUtil;
 import com.bloxbean.cardano.client.plutus.spec.PlutusScript;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
+import com.bloxbean.cardano.yano.ledgerrules.ScriptReferenceResolverScope;
 
 import java.util.Optional;
 
@@ -15,7 +16,8 @@ public class YaciScriptSupplier implements ScriptSupplier {
 
     @Override
     public Optional<PlutusScript> getScript(String scriptHash) {
-        return utxoState.getScriptRefBytesByHash(scriptHash)
+        return ScriptReferenceResolverScope.resolve(scriptHash)
+                .or(() -> utxoState.getScriptRefBytesByHash(scriptHash))
                 .map(bytes -> ReferenceScriptUtil.deserializeScriptRef(bytes))
                 .filter(script -> script instanceof PlutusScript)
                 .map(PlutusScript.class::cast);

--- a/ledger-rules/src/test/java/com/bloxbean/cardano/yano/ledgerrules/impl/YaciScriptSupplierTest.java
+++ b/ledger-rules/src/test/java/com/bloxbean/cardano/yano/ledgerrules/impl/YaciScriptSupplierTest.java
@@ -1,0 +1,54 @@
+package com.bloxbean.cardano.yano.ledgerrules.impl;
+
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
+import com.bloxbean.cardano.client.transaction.spec.Value;
+import com.bloxbean.cardano.yano.api.utxo.UtxoState;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+import com.bloxbean.cardano.yano.ledgerrules.ScriptReferenceResolverScope;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class YaciScriptSupplierTest {
+    @Test
+    void resolvesAdmissionScopedReferenceScriptBeforeCanonicalState() throws Exception {
+        PlutusV2Script script = PlutusV2Script.builder()
+                .cborHex("49480100002221200101")
+                .build();
+        String hash = java.util.HexFormat.of().formatHex(script.getScriptHash());
+        TransactionOutput output = TransactionOutput.builder()
+                .address("00").value(new Value(BigInteger.ONE, null)).scriptRef(script).build();
+        String scriptRef = java.util.HexFormat.of().formatHex(output.getScriptRef());
+        Utxo overlayUtxo = new Utxo(new Outpoint("ab".repeat(32), 0), "00",
+                BigInteger.ONE, List.of(), null, null, scriptRef, hash,
+                false, 0, 0, null);
+        UtxoState canonical = new EmptyUtxoState();
+        YaciScriptSupplier supplier = new YaciScriptSupplier(canonical);
+
+        assertThat(supplier.getScript(hash)).isEmpty();
+        try (var ignored = ScriptReferenceResolverScope.open(List.of(overlayUtxo))) {
+            assertThat(supplier.getScript(hash)).containsInstanceOf(PlutusV2Script.class);
+        }
+        assertThat(supplier.getScript(hash)).isEmpty();
+    }
+
+    private static final class EmptyUtxoState implements UtxoState {
+        @Override public List<Utxo> getUtxosByAddress(String address, int page, int pageSize) {
+            return List.of();
+        }
+        @Override public List<Utxo> getUtxosByPaymentCredential(
+                String credential, int page, int pageSize) {
+            return List.of();
+        }
+        @Override public Optional<Utxo> getUtxo(Outpoint outpoint) {
+            return Optional.empty();
+        }
+        @Override public boolean isEnabled() { return true; }
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/RuntimeYano.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/RuntimeYano.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yano.runtime.assembly;
 import com.bloxbean.cardano.yano.api.ChainQuery;
 import com.bloxbean.cardano.yano.api.DevnetControl;
 import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.NodeLifecycle;
 import com.bloxbean.cardano.yano.api.ProducerControl;
 import com.bloxbean.cardano.yano.api.TxEvaluationGateway;
@@ -135,6 +136,12 @@ final class RuntimeYano implements Yano, DevnetRuntimeProvider {
     @Override
     public TxEvaluationGateway txEvaluationGateway() {
         return txEvaluationGateway;
+    }
+
+    @Override
+    public MempoolQueryGateway mempoolQueryGateway() {
+        return txEvaluationGateway instanceof MempoolQueryGateway gateway
+                ? gateway : MempoolQueryGateway.UNAVAILABLE;
     }
 
     @Override

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/Yano.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/Yano.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yano.runtime.assembly;
 import com.bloxbean.cardano.yano.api.ChainQuery;
 import com.bloxbean.cardano.yano.api.DevnetControl;
 import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.NodeLifecycle;
 import com.bloxbean.cardano.yano.api.ProducerControl;
 import com.bloxbean.cardano.yano.api.TxEvaluationGateway;
@@ -26,6 +27,10 @@ public interface Yano extends AutoCloseable {
     TxGateway txGateway();
 
     TxEvaluationGateway txEvaluationGateway();
+
+    default MempoolQueryGateway mempoolQueryGateway() {
+        return MempoolQueryGateway.UNAVAILABLE;
+    }
 
     Optional<ProducerControl> producerControl();
 

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBodySizeLimitSupplier.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBodySizeLimitSupplier.java
@@ -1,0 +1,60 @@
+package com.bloxbean.cardano.yano.runtime.blockproducer;
+
+import com.bloxbean.cardano.yano.api.EpochParamProvider;
+
+import java.math.BigInteger;
+import java.util.Objects;
+import java.util.function.Supplier;
+
+/**
+ * Supplies the effective maximum block-body size for the epoch containing a block slot.
+ */
+@FunctionalInterface
+public interface BlockBodySizeLimitSupplier {
+
+    long getMaxBlockBodySize(long slot);
+
+    /**
+     * Resolve every resource limit from one epoch-parameter view. Legacy lambda
+     * implementations constrain body bytes only and leave execution units unbounded.
+     */
+    default BlockProductionLimits getLimits(long slot) {
+        return new BlockProductionLimits(getMaxBlockBodySize(slot), null, null);
+    }
+
+    static BlockBodySizeLimitSupplier unbounded() {
+        return slot -> Long.MAX_VALUE;
+    }
+
+    static BlockBodySizeLimitSupplier fromEpochParams(Supplier<EpochParamProvider> providerSupplier) {
+        Objects.requireNonNull(providerSupplier, "providerSupplier must not be null");
+        return new BlockBodySizeLimitSupplier() {
+            @Override
+            public long getMaxBlockBodySize(long slot) {
+                return getLimits(slot).maxBodyBytes();
+            }
+
+            @Override
+            public BlockProductionLimits getLimits(long slot) {
+                if (slot < 0) {
+                    throw new IllegalStateException(
+                            "Effective block limits require a non-negative slot; got " + slot);
+                }
+                EpochParamProvider provider = Objects.requireNonNull(providerSupplier.get(),
+                        "effective epoch parameter provider must not be null");
+                int epoch = provider.getEpochSlotCalc().slotToEpoch(slot);
+                Integer maxBlockSize = provider.getMaxBlockSize(epoch);
+                BigInteger maxBlockExMem = provider.getMaxBlockExMem(epoch);
+                BigInteger maxBlockExSteps = provider.getMaxBlockExSteps(epoch);
+                if (maxBlockSize == null || maxBlockSize <= 0
+                        || maxBlockExMem == null || maxBlockExMem.signum() <= 0
+                        || maxBlockExSteps == null || maxBlockExSteps.signum() <= 0) {
+                    throw new IllegalStateException(
+                            "Effective block limits are unavailable or invalid for epoch " + epoch);
+                }
+                return new BlockProductionLimits(
+                        maxBlockSize.longValue(), maxBlockExMem, maxBlockExSteps);
+            }
+        };
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBuildUtxoOverlay.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBuildUtxoOverlay.java
@@ -5,8 +5,12 @@ import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
+import com.bloxbean.cardano.yano.runtime.chain.TransactionOutputProjector;
 
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -18,6 +22,7 @@ public class BlockBuildUtxoOverlay {
 
     private final UtxoState utxoState;
     private final Set<Outpoint> spent = new HashSet<>();
+    private final Map<Outpoint, Utxo> produced = new HashMap<>();
 
     public BlockBuildUtxoOverlay(UtxoState utxoState) {
         this.utxoState = utxoState;
@@ -32,6 +37,10 @@ public class BlockBuildUtxoOverlay {
             if (spent.contains(outpoint)) {
                 return null; // Already consumed in this block
             }
+            Utxo projected = produced.get(outpoint);
+            if (projected != null) {
+                return projected;
+            }
             return utxoState.getUtxo(outpoint).orElse(null);
         };
     }
@@ -41,15 +50,36 @@ public class BlockBuildUtxoOverlay {
      */
     public void markSpent(byte[] txCbor) {
         try {
+            applyTransaction(txCbor);
+        } catch (Exception e) {
+            // If deserialization fails here, the tx already passed validation,
+            // so this shouldn't happen. Log and continue.
+        }
+    }
+
+    /**
+     * Apply a selected valid transaction to the block-local view. Regular
+     * inputs are consumed and normal outputs become visible to later
+     * candidates. Collateral-return outputs are deliberately excluded.
+     */
+    public void applyTransaction(byte[] txCbor) {
+        try {
             Transaction tx = Transaction.deserialize(txCbor);
             if (tx.getBody().getInputs() != null) {
                 for (TransactionInput input : tx.getBody().getInputs()) {
                     spent.add(new Outpoint(input.getTransactionId(), input.getIndex()));
                 }
             }
+            String txHash = TransactionUtil.getTxHash(txCbor);
+            if (tx.getBody().getOutputs() != null) {
+                for (int index = 0; index < tx.getBody().getOutputs().size(); index++) {
+                    Utxo utxo = TransactionOutputProjector.project(
+                            txHash, index, tx.getBody().getOutputs().get(index));
+                    produced.put(utxo.outpoint(), utxo);
+                }
+            }
         } catch (Exception e) {
-            // If deserialization fails here, the tx already passed validation,
-            // so this shouldn't happen. Log and continue.
+            throw new IllegalArgumentException("failed to apply transaction to block UTXO overlay", e);
         }
     }
 
@@ -58,5 +88,6 @@ public class BlockBuildUtxoOverlay {
      */
     public void reset() {
         spent.clear();
+        produced.clear();
     }
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProducerHelper.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProducerHelper.java
@@ -200,7 +200,10 @@ public final class BlockProducerHelper {
     public static List<byte[]> drainMempool(MemPool memPool,
                                       TransactionValidationService validatorService,
                                       UtxoState utxoState) {
-        return transactionSelector(memPool, validatorService, utxoState).drainForBlock();
+        BlockTransactionSelector selector = transactionSelector(memPool, validatorService, utxoState);
+        List<byte[]> selected = selector.drainForBlock();
+        selector.blockCandidatePublished();
+        return selected;
     }
 
     public static void prepareEpochTransitionBeforeBlock(EventBus eventBus, long slot, long blockNumber,

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProductionLimits.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProductionLimits.java
@@ -1,0 +1,26 @@
+package com.bloxbean.cardano.yano.runtime.blockproducer;
+
+import java.math.BigInteger;
+
+/** Epoch-effective resource limits for one produced block. */
+public record BlockProductionLimits(
+        long maxBodyBytes,
+        BigInteger maxExecutionMemory,
+        BigInteger maxExecutionSteps) {
+
+    public BlockProductionLimits {
+        if (maxBodyBytes <= 0) {
+            throw new IllegalArgumentException("maxBodyBytes must be positive");
+        }
+        if (maxExecutionMemory != null && maxExecutionMemory.signum() <= 0) {
+            throw new IllegalArgumentException("maxExecutionMemory must be positive when set");
+        }
+        if (maxExecutionSteps != null && maxExecutionSteps.signum() <= 0) {
+            throw new IllegalArgumentException("maxExecutionSteps must be positive when set");
+        }
+    }
+
+    public static BlockProductionLimits unbounded() {
+        return new BlockProductionLimits(Long.MAX_VALUE, null, null);
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockBuilder.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockBuilder.java
@@ -2,10 +2,15 @@ package com.bloxbean.cardano.yano.runtime.blockproducer;
 
 import co.nstant.in.cbor.model.*;
 import com.bloxbean.cardano.client.crypto.Blake2bUtil;
+import com.bloxbean.cardano.client.plutus.spec.ExUnits;
+import com.bloxbean.cardano.client.plutus.spec.Redeemer;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 import com.bloxbean.cardano.yaci.core.util.CborSerializationUtil;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import lombok.extern.slf4j.Slf4j;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.Objects;
 
@@ -46,6 +51,7 @@ public class DevnetBlockBuilder {
     private static final long DEFAULT_PROTOCOL_MINOR = 2;
 
     private final ProtocolVersionSupplier protocolVersionSupplier;
+    private final BlockBodySizeLimitSupplier blockBodySizeLimitSupplier;
 
     public DevnetBlockBuilder() {
         this(DEFAULT_PROTOCOL_MAJOR, DEFAULT_PROTOCOL_MINOR);
@@ -56,8 +62,15 @@ public class DevnetBlockBuilder {
     }
 
     public DevnetBlockBuilder(ProtocolVersionSupplier protocolVersionSupplier) {
+        this(protocolVersionSupplier, BlockBodySizeLimitSupplier.unbounded());
+    }
+
+    public DevnetBlockBuilder(ProtocolVersionSupplier protocolVersionSupplier,
+                              BlockBodySizeLimitSupplier blockBodySizeLimitSupplier) {
         this.protocolVersionSupplier = Objects.requireNonNull(protocolVersionSupplier,
                 "protocolVersionSupplier must not be null");
+        this.blockBodySizeLimitSupplier = Objects.requireNonNull(blockBodySizeLimitSupplier,
+                "blockBodySizeLimitSupplier must not be null");
     }
 
     /**
@@ -85,12 +98,56 @@ public class DevnetBlockBuilder {
                                        List<byte[]> transactions) {
         // 1. Compute block body
         BlockBodyResult body = computeBlockBody(transactions);
+        enforceBlockLimits(slot, body.bodySize(), transactions);
 
         // 2. Build header array: [[header_body], signature]
         Array headerArray = buildHeaderArray(blockNumber, slot, prevHash, body.bodySize(), body.bodyHash());
 
         // 3-5. Compute block hash, assemble full block and wrapped header
         return assembleBlock(headerArray, body, blockNumber, slot, transactions != null ? transactions.size() : 0);
+    }
+
+    /**
+     * Return the largest insertion-ordered transaction prefix whose exact encoded block body
+     * fits the epoch-effective protocol limit. Transactions outside the prefix remain in the
+     * mempool and are eligible for the next block.
+     */
+    public List<byte[]> fitTransactions(long slot, List<byte[]> transactions) {
+        if (transactions == null || transactions.isEmpty()) {
+            return List.of();
+        }
+
+        BlockProductionLimits limits = resolveBlockProductionLimits(slot);
+        if (limits.maxBodyBytes() == Long.MAX_VALUE
+                && limits.maxExecutionMemory() == null
+                && limits.maxExecutionSteps() == null) {
+            return List.copyOf(transactions);
+        }
+
+        BodySizeAccumulator size = new BodySizeAccumulator();
+        int accepted = 0;
+        for (byte[] transaction : transactions) {
+            TransactionComponentSize componentSize = measureTransaction(transaction, accepted);
+            if (!size.canAdd(componentSize, limits)) {
+                break;
+            }
+            size.add(componentSize);
+            accepted++;
+        }
+
+        if (accepted == transactions.size()) {
+            return List.copyOf(transactions);
+        }
+        if (accepted == 0) {
+            throw new UnfitBlockTransactionException(
+                    TransactionUtil.getTxHash(transactions.getFirst()));
+        }
+
+        log.info("Block resource limits selected {} of {} mempool transactions "
+                        + "(maxBlockSize={} bytes, maxBlockExMem={}, maxBlockExSteps={})",
+                accepted, transactions.size(), limits.maxBodyBytes(),
+                limits.maxExecutionMemory(), limits.maxExecutionSteps());
+        return List.copyOf(transactions.subList(0, accepted));
     }
 
     /**
@@ -193,6 +250,167 @@ public class DevnetBlockBuilder {
         long bodySize = txBodiesBytes.length + txWitnessesBytes.length + auxDataBytes.length + invalidTxsBytes.length;
 
         return new BlockBodyResult(txBodiesArray, txWitnessesArray, auxDataMap, invalidTxsArray, bodySize, bodyHash);
+    }
+
+    protected long resolveMaxBlockBodySize(long slot) {
+        return resolveBlockProductionLimits(slot).maxBodyBytes();
+    }
+
+    protected void enforceBlockBodySize(long slot, long bodySize) {
+        BlockProductionLimits limits = resolveBlockProductionLimits(slot);
+        if (bodySize > limits.maxBodyBytes()) {
+            throw new IllegalStateException("Encoded block body size " + bodySize
+                    + " exceeds effective maxBlockSize " + limits.maxBodyBytes() + " at slot " + slot);
+        }
+    }
+
+    protected BlockProductionLimits resolveBlockProductionLimits(long slot) {
+        return blockBodySizeLimitSupplier.getLimits(slot);
+    }
+
+    protected void enforceBlockLimits(long slot, long bodySize, List<byte[]> transactions) {
+        BlockProductionLimits limits = resolveBlockProductionLimits(slot);
+        if (bodySize > limits.maxBodyBytes()) {
+            throw new IllegalStateException("Encoded block body size " + bodySize
+                    + " exceeds effective maxBlockSize " + limits.maxBodyBytes() + " at slot " + slot);
+        }
+
+        ExecutionUnitTotal total = measureExecutionUnits(transactions);
+        if (exceeds(total.memory(), limits.maxExecutionMemory())) {
+            throw new IllegalStateException("Block execution memory " + total.memory()
+                    + " exceeds effective maxBlockExMem " + limits.maxExecutionMemory()
+                    + " at slot " + slot);
+        }
+        if (exceeds(total.steps(), limits.maxExecutionSteps())) {
+            throw new IllegalStateException("Block execution steps " + total.steps()
+                    + " exceeds effective maxBlockExSteps " + limits.maxExecutionSteps()
+                    + " at slot " + slot);
+        }
+    }
+
+    private TransactionComponentSize measureTransaction(byte[] txCbor, int index) {
+        try {
+            DataItem txDI = CborSerializationUtil.deserializeOne(txCbor);
+            Array txArray = (Array) txDI;
+            List<DataItem> items = txArray.getDataItems();
+            int bodyBytes = CborSerializationUtil.serialize(items.get(0)).length;
+            int witnessBytes = CborSerializationUtil.serialize(items.get(1)).length;
+            int auxiliaryEntries = 0;
+            int auxiliaryBytes = 0;
+            if (items.size() > 3 && items.get(3).getMajorType() != MajorType.SPECIAL) {
+                auxiliaryEntries = 1;
+                auxiliaryBytes = CborSerializationUtil.serialize(new UnsignedInteger(index)).length
+                        + CborSerializationUtil.serialize(items.get(3)).length;
+            }
+            ExecutionUnitTotal executionUnits = measureExecutionUnits(txCbor);
+            return new TransactionComponentSize(
+                    bodyBytes, witnessBytes, auxiliaryEntries, auxiliaryBytes,
+                    executionUnits.memory(), executionUnits.steps());
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to size selected transaction at index " + index, e);
+        }
+    }
+
+    private record TransactionComponentSize(
+            int bodyBytes,
+            int witnessBytes,
+            int auxiliaryEntries,
+            int auxiliaryBytes,
+            BigInteger executionMemory,
+            BigInteger executionSteps) {
+    }
+
+    private static final class BodySizeAccumulator {
+        private int transactions;
+        private int auxiliaryEntries;
+        private long bodyBytes;
+        private long witnessBytes;
+        private long auxiliaryBytes;
+        private BigInteger executionMemory = BigInteger.ZERO;
+        private BigInteger executionSteps = BigInteger.ZERO;
+
+        boolean canAdd(TransactionComponentSize addition, BlockProductionLimits limits) {
+            int projectedTransactions = transactions + 1;
+            int projectedAuxiliaryEntries = auxiliaryEntries + addition.auxiliaryEntries();
+            long projected = cborCollectionHeaderSize(projectedTransactions) * 2L
+                    + bodyBytes + addition.bodyBytes()
+                    + witnessBytes + addition.witnessBytes()
+                    + cborCollectionHeaderSize(projectedAuxiliaryEntries)
+                    + auxiliaryBytes + addition.auxiliaryBytes()
+                    + cborCollectionHeaderSize(0); // invalid transaction index array
+            return projected <= limits.maxBodyBytes()
+                    && !exceeds(executionMemory.add(addition.executionMemory()),
+                    limits.maxExecutionMemory())
+                    && !exceeds(executionSteps.add(addition.executionSteps()),
+                    limits.maxExecutionSteps());
+        }
+
+        void add(TransactionComponentSize addition) {
+            transactions++;
+            auxiliaryEntries += addition.auxiliaryEntries();
+            bodyBytes += addition.bodyBytes();
+            witnessBytes += addition.witnessBytes();
+            auxiliaryBytes += addition.auxiliaryBytes();
+            executionMemory = executionMemory.add(addition.executionMemory());
+            executionSteps = executionSteps.add(addition.executionSteps());
+        }
+
+        private static int cborCollectionHeaderSize(long entries) {
+            if (entries <= 23) return 1;
+            if (entries <= 0xffL) return 2;
+            if (entries <= 0xffffL) return 3;
+            if (entries <= 0xffff_ffffL) return 5;
+            return 9;
+        }
+    }
+
+    private static ExecutionUnitTotal measureExecutionUnits(List<byte[]> transactions) {
+        if (transactions == null || transactions.isEmpty()) {
+            return ExecutionUnitTotal.ZERO;
+        }
+        BigInteger memory = BigInteger.ZERO;
+        BigInteger steps = BigInteger.ZERO;
+        for (byte[] transaction : transactions) {
+            ExecutionUnitTotal total = measureExecutionUnits(transaction);
+            memory = memory.add(total.memory());
+            steps = steps.add(total.steps());
+        }
+        return new ExecutionUnitTotal(memory, steps);
+    }
+
+    private static ExecutionUnitTotal measureExecutionUnits(byte[] txCbor) {
+        try {
+            Transaction transaction = Transaction.deserialize(txCbor);
+            if (transaction.getWitnessSet() == null
+                    || transaction.getWitnessSet().getRedeemers() == null) {
+                return ExecutionUnitTotal.ZERO;
+            }
+            BigInteger memory = BigInteger.ZERO;
+            BigInteger steps = BigInteger.ZERO;
+            for (Redeemer redeemer : transaction.getWitnessSet().getRedeemers()) {
+                ExUnits exUnits = redeemer != null ? redeemer.getExUnits() : null;
+                if (exUnits == null) continue;
+                if (exUnits.getMem() != null) memory = memory.add(exUnits.getMem());
+                if (exUnits.getSteps() != null) steps = steps.add(exUnits.getSteps());
+            }
+            if (memory.signum() < 0 || steps.signum() < 0) {
+                throw new IllegalArgumentException("negative execution units");
+            }
+            return new ExecutionUnitTotal(memory, steps);
+        } catch (RuntimeException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Failed to read selected transaction execution units", e);
+        }
+    }
+
+    private static boolean exceeds(BigInteger value, BigInteger limit) {
+        return limit != null && value.compareTo(limit) > 0;
+    }
+
+    private record ExecutionUnitTotal(BigInteger memory, BigInteger steps) {
+        private static final ExecutionUnitTotal ZERO =
+                new ExecutionUnitTotal(BigInteger.ZERO, BigInteger.ZERO);
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
@@ -292,19 +292,24 @@ public class DevnetBlockProducer implements BlockProducerService {
         if (lazy && txList.isEmpty()) {
             return;
         }
+        try {
+            var result = blockBuilder.buildBlock(nextBlockNumber, slot, prevBlockHash, txList);
+            storeBlock(result);
 
-        var result = blockBuilder.buildBlock(nextBlockNumber, slot, prevBlockHash, txList);
-        storeBlock(result);
+            long producedBlockNumber = nextBlockNumber;
+            nextBlockNumber++;
+            prevBlockHash = result.blockHash();
 
-        long producedBlockNumber = nextBlockNumber;
-        nextBlockNumber++;
-        prevBlockHash = result.blockHash();
+            log.info("Block #{} produced: slot={}, txs={}",
+                    producedBlockNumber, slot, txList.size());
 
-        log.info("Block #{} produced: slot={}, txs={}",
-                producedBlockNumber, slot, txList.size());
-
-        publishEvent(result, txList.size());
-        notifyServer();
+            publishEvent(result, txList.size());
+            transactions.blockCandidatePublished();
+            notifyServer();
+        } catch (RuntimeException | Error e) {
+            transactions.blockSelectionFailed();
+            throw e;
+        }
     }
 
     private List<byte[]> drainMempool() {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
@@ -288,11 +288,12 @@ public class DevnetBlockProducer implements BlockProducerService {
         BlockProducerHelper.prepareEpochTransitionBeforeBlock(
                 eventBus, slot, nextBlockNumber, "devnet-block-producer");
 
-        List<byte[]> txList = drainMempool();
-        if (lazy && txList.isEmpty()) {
-            return;
-        }
         try {
+            List<byte[]> txList = blockBuilder.fitTransactions(slot, drainMempool());
+            if (lazy && txList.isEmpty()) {
+                transactions.blockSelectionFailed();
+                return;
+            }
             var result = blockBuilder.buildBlock(nextBlockNumber, slot, prevBlockHash, txList);
             storeBlock(result);
 
@@ -306,6 +307,15 @@ public class DevnetBlockProducer implements BlockProducerService {
             publishEvent(result, txList.size());
             transactions.blockCandidatePublished();
             notifyServer();
+        } catch (UnfitBlockTransactionException e) {
+            int removed;
+            try {
+                removed = transactions.invalidateSelectedTransaction(e.transactionHash());
+            } finally {
+                transactions.blockSelectionFailed();
+            }
+            log.warn("Discarded {} mempool transaction(s) after block resource rejection: {}",
+                    removed, e.getMessage());
         } catch (RuntimeException | Error e) {
             transactions.blockSelectionFailed();
             throw e;

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SignedBlockBuilder.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SignedBlockBuilder.java
@@ -57,7 +57,15 @@ public class SignedBlockBuilder extends DevnetBlockBuilder {
     public SignedBlockBuilder(BlockProducerKeys keys, long slotsPerKESPeriod, long maxKESEvolutions,
                               EpochNonceState epochNonceState, NonceStateStore nonceStore,
                               ProtocolVersionSupplier protocolVersionSupplier) {
-        super(protocolVersionSupplier);
+        this(keys, slotsPerKESPeriod, maxKESEvolutions, epochNonceState, nonceStore,
+                protocolVersionSupplier, BlockBodySizeLimitSupplier.unbounded());
+    }
+
+    public SignedBlockBuilder(BlockProducerKeys keys, long slotsPerKESPeriod, long maxKESEvolutions,
+                              EpochNonceState epochNonceState, NonceStateStore nonceStore,
+                              ProtocolVersionSupplier protocolVersionSupplier,
+                              BlockBodySizeLimitSupplier blockBodySizeLimitSupplier) {
+        super(protocolVersionSupplier, blockBodySizeLimitSupplier);
         this.keys = keys;
         this.blockSigner = new BlockSigner();
         this.epochNonceState = epochNonceState;
@@ -110,6 +118,7 @@ public class SignedBlockBuilder extends DevnetBlockBuilder {
                                                  BlockSigner.VrfSignResult vrfResult) {
         // 1. Compute block body
         BlockBodyResult body = computeBlockBody(transactions);
+        enforceBlockBodySize(slot, body.bodySize());
 
         // 2. Build header body CBOR array
         Array headerBody = buildSignedHeaderBody(blockNumber, slot, prevHash,

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderBlockProducer.java
@@ -278,8 +278,8 @@ public class SlotLeaderBlockProducer implements BlockProducerService {
         BlockProducerHelper.prepareEpochTransitionBeforeBlock(
                 eventBus, slot, blockNumber, "slot-leader-block-producer");
 
-        List<byte[]> txList = transactions.drainForBlock();
         try {
+            List<byte[]> txList = blockBuilder.fitTransactions(slot, transactions.drainForBlock());
             var result = blockBuilder.buildBlock(blockNumber, slot, prevHash, txList, vrfResult);
 
             BlockProducerHelper.storeProducedBlock(chainState, blockBuilder, result);
@@ -290,6 +290,15 @@ public class SlotLeaderBlockProducer implements BlockProducerService {
             BlockProducerHelper.publishEvent(eventBus, result, txList.size(), "slot-leader-block-producer");
             transactions.blockCandidatePublished();
             BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+        } catch (UnfitBlockTransactionException e) {
+            int removed;
+            try {
+                removed = transactions.invalidateSelectedTransaction(e.transactionHash());
+            } finally {
+                transactions.blockSelectionFailed();
+            }
+            log.warn("Discarded {} mempool transaction(s) after block resource rejection: {}",
+                    removed, e.getMessage());
         } catch (RuntimeException | Error e) {
             transactions.blockSelectionFailed();
             throw e;

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderBlockProducer.java
@@ -279,16 +279,21 @@ public class SlotLeaderBlockProducer implements BlockProducerService {
                 eventBus, slot, blockNumber, "slot-leader-block-producer");
 
         List<byte[]> txList = transactions.drainForBlock();
+        try {
+            var result = blockBuilder.buildBlock(blockNumber, slot, prevHash, txList, vrfResult);
 
-        var result = blockBuilder.buildBlock(blockNumber, slot, prevHash, txList, vrfResult);
+            BlockProducerHelper.storeProducedBlock(chainState, blockBuilder, result);
 
-        BlockProducerHelper.storeProducedBlock(chainState, blockBuilder, result);
+            log.info("Block #{} produced: slot={}, txs={}, hash={}",
+                    blockNumber, slot, txList.size(), HexUtil.encodeHexString(result.blockHash()));
 
-        log.info("Block #{} produced: slot={}, txs={}, hash={}",
-                blockNumber, slot, txList.size(), HexUtil.encodeHexString(result.blockHash()));
-
-        BlockProducerHelper.publishEvent(eventBus, result, txList.size(), "slot-leader-block-producer");
-        BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+            BlockProducerHelper.publishEvent(eventBus, result, txList.size(), "slot-leader-block-producer");
+            transactions.blockCandidatePublished();
+            BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+        } catch (RuntimeException | Error e) {
+            transactions.blockSelectionFailed();
+            throw e;
+        }
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -281,8 +281,8 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         BlockProducerHelper.prepareEpochTransitionBeforeBlock(
                 eventBus, slot, blockNumber, "slot-leader-time-travel");
 
-        List<byte[]> txList = transactions.drainForBlock();
         try {
+            List<byte[]> txList = blockBuilder.fitTransactions(slot, transactions.drainForBlock());
             var result = blockBuilder.buildBlock(blockNumber, slot, prevHash, txList, vrfResult);
             BlockProducerHelper.storeProducedBlock(chainState, blockBuilder, result);
 
@@ -292,6 +292,15 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
             BlockProducerHelper.publishEvent(eventBus, result, txList.size(), "slot-leader-time-travel");
             transactions.blockCandidatePublished();
             BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+        } catch (UnfitBlockTransactionException e) {
+            int removed;
+            try {
+                removed = transactions.invalidateSelectedTransaction(e.transactionHash());
+            } finally {
+                transactions.blockSelectionFailed();
+            }
+            log.warn("Discarded {} mempool transaction(s) after block resource rejection: {}",
+                    removed, e.getMessage());
         } catch (RuntimeException | Error e) {
             transactions.blockSelectionFailed();
             throw e;

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -282,15 +282,20 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
                 eventBus, slot, blockNumber, "slot-leader-time-travel");
 
         List<byte[]> txList = transactions.drainForBlock();
+        try {
+            var result = blockBuilder.buildBlock(blockNumber, slot, prevHash, txList, vrfResult);
+            BlockProducerHelper.storeProducedBlock(chainState, blockBuilder, result);
 
-        var result = blockBuilder.buildBlock(blockNumber, slot, prevHash, txList, vrfResult);
-        BlockProducerHelper.storeProducedBlock(chainState, blockBuilder, result);
+            log.info("Slot-leader time-travel block #{} produced: slot={}, txs={}, hash={}",
+                    blockNumber, slot, txList.size(), HexUtil.encodeHexString(result.blockHash()));
 
-        log.info("Slot-leader time-travel block #{} produced: slot={}, txs={}, hash={}",
-                blockNumber, slot, txList.size(), HexUtil.encodeHexString(result.blockHash()));
-
-        BlockProducerHelper.publishEvent(eventBus, result, txList.size(), "slot-leader-time-travel");
-        BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+            BlockProducerHelper.publishEvent(eventBus, result, txList.size(), "slot-leader-time-travel");
+            transactions.blockCandidatePublished();
+            BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+        } catch (RuntimeException | Error e) {
+            transactions.blockSelectionFailed();
+            throw e;
+        }
     }
 
     private long calculateWallClockSlot() {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/TransactionEvaluationService.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/TransactionEvaluationService.java
@@ -5,6 +5,7 @@ import com.bloxbean.cardano.client.transaction.spec.Transaction;
 import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.ledgerrules.ScriptReferenceResolverScope;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 import lombok.extern.slf4j.Slf4j;
 
@@ -16,6 +17,12 @@ import java.util.*;
  */
 @Slf4j
 public class TransactionEvaluationService {
+
+    @FunctionalInterface
+    public interface UtxoView {
+        Map<Outpoint, com.bloxbean.cardano.yano.api.utxo.model.Utxo> resolve(
+                Collection<Outpoint> outpoints);
+    }
 
     private final TransactionEvaluator evaluator;
     private final UtxoState utxoState;
@@ -34,10 +41,29 @@ public class TransactionEvaluationService {
      * @throws Exception on deserialization, UTxO resolution, or evaluation failure
      */
     public List<TransactionEvaluator.EvaluationResult> evaluate(byte[] txCbor) throws Exception {
+        return evaluate(txCbor, outpoints -> {
+            Map<Outpoint, com.bloxbean.cardano.yano.api.utxo.model.Utxo> resolved =
+                    new LinkedHashMap<>();
+            for (Outpoint outpoint : outpoints) {
+                utxoState.getUtxo(outpoint).ifPresent(utxo -> resolved.put(outpoint, utxo));
+            }
+            return resolved;
+        });
+    }
+
+    /**
+     * Evaluate against a caller-provided stable UTXO view. The view is resolved
+     * before phase-2 evaluation so its synchronization does not span evaluator
+     * execution.
+     */
+    public List<TransactionEvaluator.EvaluationResult> evaluate(
+            byte[] txCbor, UtxoView utxoView) throws Exception {
         Transaction transaction = Transaction.deserialize(txCbor);
 
         // Collect all inputs: regular + reference + collateral
         Set<Utxo> inputUtxos = new HashSet<>();
+        List<com.bloxbean.cardano.yano.api.utxo.model.Utxo> resolvedInputUtxos =
+                new ArrayList<>();
         List<TransactionInput> allInputs = new ArrayList<>();
 
         if (transaction.getBody().getInputs() != null) {
@@ -50,16 +76,27 @@ public class TransactionEvaluationService {
             allInputs.addAll(transaction.getBody().getCollateral());
         }
 
+        Set<Outpoint> requiredOutpoints = new LinkedHashSet<>();
         for (TransactionInput input : allInputs) {
-            Outpoint op = new Outpoint(input.getTransactionId(), input.getIndex());
-            var yaciUtxo = utxoState.getUtxo(op).orElse(null);
+            requiredOutpoints.add(new Outpoint(input.getTransactionId(), input.getIndex()));
+        }
+
+        Map<Outpoint, com.bloxbean.cardano.yano.api.utxo.model.Utxo> resolved =
+                Objects.requireNonNull(utxoView, "utxoView").resolve(requiredOutpoints);
+        if (resolved == null) resolved = Map.of();
+
+        for (Outpoint op : requiredOutpoints) {
+            var yaciUtxo = resolved.get(op);
             if (yaciUtxo == null) {
                 throw new IllegalArgumentException("UTXO not found: " + op.txHash() + "#" + op.index());
             }
 
+            resolvedInputUtxos.add(yaciUtxo);
             inputUtxos.add(UtxoMapper.toCclUtxo(yaciUtxo));
         }
 
-        return evaluator.evaluate(txCbor, inputUtxos);
+        try (var ignored = ScriptReferenceResolverScope.open(resolvedInputUtxos)) {
+            return evaluator.evaluate(txCbor, inputUtxos);
+        }
     }
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/TransactionValidationService.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/TransactionValidationService.java
@@ -6,6 +6,7 @@ import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionValidator;
+import com.bloxbean.cardano.yano.ledgerrules.ScriptReferenceResolverScope;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationError;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationResult;
 import lombok.extern.slf4j.Slf4j;
@@ -54,6 +55,7 @@ public class TransactionValidationService {
 
         // Collect all inputs that need resolution: regular + reference + collateral
         Set<Utxo> inputUtxos = new HashSet<>();
+        List<com.bloxbean.cardano.yano.api.utxo.model.Utxo> resolvedInputUtxos = new ArrayList<>();
         List<TransactionInput> allInputs = new ArrayList<>();
 
         if (transaction.getBody().getInputs() != null) {
@@ -76,10 +78,11 @@ public class TransactionValidationService {
                         ValidationError.Phase.PHASE_1));
             }
 
+            resolvedInputUtxos.add(yaciUtxo);
             inputUtxos.add(UtxoMapper.toCclUtxo(yaciUtxo));
         }
 
-        try {
+        try (var ignored = ScriptReferenceResolverScope.open(resolvedInputUtxos)) {
             return validator.validate(txCbor, inputUtxos);
         } catch (Exception e) {
             log.debug("Validation threw exception: {}", e.getMessage());

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/UnfitBlockTransactionException.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/UnfitBlockTransactionException.java
@@ -1,0 +1,19 @@
+package com.bloxbean.cardano.yano.runtime.blockproducer;
+
+/**
+ * A selected transaction cannot fit an otherwise empty block under the
+ * effective protocol limits, so retrying the same selection cannot progress.
+ */
+public final class UnfitBlockTransactionException extends IllegalStateException {
+    private final String transactionHash;
+
+    public UnfitBlockTransactionException(String transactionHash) {
+        super("Selected transaction " + transactionHash
+                + " cannot fit an empty block under the effective protocol resource limits");
+        this.transactionHash = transactionHash;
+    }
+
+    public String transactionHash() {
+        return transactionHash;
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPool.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPool.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.locks.ReentrantLock;
@@ -38,6 +39,7 @@ public class DefaultMemPool implements MemPool {
     private final LinkedHashMap<TxId, Entry> transactionsByHash = new LinkedHashMap<>();
     private final Map<IndexedOutpoint, ProducedOutput> producedByOutpoint = new HashMap<>();
     private final Map<IndexedOutpoint, TxId> spentByOutpoint = new HashMap<>();
+    private final Map<String, ReferenceScriptEntry> referenceScriptsByHash = new HashMap<>();
     private final Map<TxId, Set<TxId>> parentsByTransaction = new HashMap<>();
     private final Map<TxId, Set<TxId>> childrenByTransaction = new HashMap<>();
     private final AtomicLong cursor = new AtomicLong();
@@ -126,6 +128,7 @@ public class DefaultMemPool implements MemPool {
             Set<TxId> parents = discoverParents(projection.allInputs());
             int addedIndexEntries = projection.outputs().size()
                     + projection.regularInputs().size()
+                    + newReferenceScriptHashes(projection).size()
                     + (parents.size() * 2);
 
             if (effectiveLimits.maxTransactions() > 0
@@ -197,6 +200,92 @@ public class DefaultMemPool implements MemPool {
                     projection.txHash(), externalCopy(transaction), List.of(), "accepted");
         } finally {
             totalAdmissionHoldNanos += System.nanoTime() - holdStarted;
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public Map<Outpoint, Utxo> resolveUtxos(Collection<Outpoint> outpoints,
+                                            Function<Outpoint, Utxo> canonicalResolver) {
+        Objects.requireNonNull(outpoints, "outpoints");
+        Function<Outpoint, Utxo> canonical = canonicalResolver != null
+                ? canonicalResolver : ignored -> null;
+
+        Set<Outpoint> ordered = new LinkedHashSet<>();
+        for (Outpoint outpoint : outpoints) {
+            ordered.add(Objects.requireNonNull(outpoint,
+                    "outpoints must not contain null"));
+        }
+        Map<Outpoint, Utxo> resolved = new HashMap<>();
+        Set<Outpoint> canonicalCandidates = new LinkedHashSet<>();
+
+        lane.lock();
+        try {
+            for (Outpoint outpoint : ordered) {
+                IndexedOutpoint indexed = tryIndexedOutpoint(outpoint);
+                if (indexed == null || spentByOutpoint.containsKey(indexed)) continue;
+                ProducedOutput produced = producedByOutpoint.get(indexed);
+                if (produced != null) {
+                    resolved.put(outpoint, externalCopy(produced.utxo()));
+                } else {
+                    canonicalCandidates.add(outpoint);
+                }
+            }
+        } finally {
+            lane.unlock();
+        }
+
+        // Persistent-state reads may block on storage and must not hold the
+        // single-writer admission lane.
+        Map<Outpoint, Utxo> canonicalResults = new HashMap<>();
+        for (Outpoint outpoint : canonicalCandidates) {
+            Utxo utxo = canonical.apply(outpoint);
+            if (utxo != null) canonicalResults.put(outpoint, externalCopy(utxo));
+        }
+
+        // Reconcile every requested outpoint after persistent-state reads. A
+        // produced overlay hit can itself be claimed or removed while another
+        // outpoint is read from storage, so limiting this pass to canonical
+        // misses would return a stale transient output.
+        lane.lock();
+        try {
+            for (Outpoint outpoint : ordered) {
+                IndexedOutpoint indexed = tryIndexedOutpoint(outpoint);
+                if (indexed == null || spentByOutpoint.containsKey(indexed)) {
+                    resolved.remove(outpoint);
+                    continue;
+                }
+                ProducedOutput produced = producedByOutpoint.get(indexed);
+                if (produced != null) {
+                    resolved.put(outpoint, externalCopy(produced.utxo()));
+                } else {
+                    Utxo canonicalUtxo = canonicalResults.get(outpoint);
+                    if (canonicalUtxo != null) resolved.put(outpoint, canonicalUtxo);
+                }
+            }
+        } finally {
+            lane.unlock();
+        }
+
+        Map<Outpoint, Utxo> snapshot = new LinkedHashMap<>();
+        for (Outpoint outpoint : ordered) {
+            Utxo utxo = resolved.get(outpoint);
+            if (utxo != null) snapshot.put(outpoint, utxo);
+        }
+        return Collections.unmodifiableMap(snapshot);
+    }
+
+    @Override
+    public Optional<byte[]> getScriptRefBytesByHash(String scriptHash) {
+        String normalized = normalizeScriptHash(scriptHash);
+        if (normalized == null) return Optional.empty();
+        lane.lock();
+        try {
+            ReferenceScriptEntry entry = referenceScriptsByHash.get(normalized);
+            return entry != null
+                    ? Optional.of(Arrays.copyOf(entry.scriptRefBytes, entry.scriptRefBytes.length))
+                    : Optional.empty();
+        } finally {
             lane.unlock();
         }
     }
@@ -311,6 +400,7 @@ public class DefaultMemPool implements MemPool {
             transactionsByHash.clear();
             producedByOutpoint.clear();
             spentByOutpoint.clear();
+            referenceScriptsByHash.clear();
             parentsByTransaction.clear();
             childrenByTransaction.clear();
             byteSize = 0;
@@ -468,14 +558,18 @@ public class DefaultMemPool implements MemPool {
         lane.lock();
         try {
             int dependencyIndexRecords = indexEntryCount
-                    - producedByOutpoint.size() - spentByOutpoint.size();
+                    - producedByOutpoint.size() - spentByOutpoint.size()
+                    - referenceScriptsByHash.size();
             int dependencyEdges = dependencyIndexRecords / 2;
             long estimatedIndexBytes = (producedByOutpoint.size() * 256L)
                     + (spentByOutpoint.size() * 96L)
+                    + referenceScriptsByHash.values().stream()
+                    .mapToLong(entry -> 96L + entry.scriptRefBytes.length).sum()
                     + (dependencyEdges * 256L);
             return new MempoolStats(
                     transactionsByHash.size(), byteSize, indexEntryCount,
-                    producedByOutpoint.size(), spentByOutpoint.size(), dependencyEdges,
+                    producedByOutpoint.size(), spentByOutpoint.size(),
+                    referenceScriptsByHash.size(), dependencyEdges,
                     estimatedIndexBytes,
                     duplicateRejections, conflictRejections, capacityRejections,
                     malformedRejections, ledgerRejections, cascadedRemovals,
@@ -492,6 +586,7 @@ public class DefaultMemPool implements MemPool {
         byteSize += entry.transaction().size();
         entry.projection().outputs().forEach((outpoint, utxo) ->
                 producedByOutpoint.put(outpoint, new ProducedOutput(id, utxo)));
+        int newReferenceScripts = addReferenceScripts(entry.projection());
         entry.projection().regularInputs().forEach(outpoint -> spentByOutpoint.put(outpoint, id));
         if (!parents.isEmpty()) {
             parentsByTransaction.put(id, new HashSet<>(parents));
@@ -500,6 +595,7 @@ public class DefaultMemPool implements MemPool {
         }
         indexEntryCount += entry.projection().outputs().size()
                 + entry.projection().regularInputs().size()
+                + newReferenceScripts
                 + (parents.size() * 2);
     }
 
@@ -512,6 +608,7 @@ public class DefaultMemPool implements MemPool {
             transactionsByHash.clear();
             producedByOutpoint.clear();
             spentByOutpoint.clear();
+            referenceScriptsByHash.clear();
             parentsByTransaction.clear();
             childrenByTransaction.clear();
             byteSize = 0;
@@ -522,6 +619,7 @@ public class DefaultMemPool implements MemPool {
     private void rebuildIndexesFromEntries() {
         producedByOutpoint.clear();
         spentByOutpoint.clear();
+        referenceScriptsByHash.clear();
         parentsByTransaction.clear();
         childrenByTransaction.clear();
         byteSize = 0;
@@ -540,6 +638,7 @@ public class DefaultMemPool implements MemPool {
             }
             projection.outputs().forEach((outpoint, utxo) ->
                     producedByOutpoint.put(outpoint, new ProducedOutput(id, utxo)));
+            addReferenceScripts(projection);
             if (!parents.isEmpty()) {
                 parentsByTransaction.put(id, new HashSet<>(parents));
                 parents.forEach(parent -> childrenByTransaction
@@ -577,6 +676,7 @@ public class DefaultMemPool implements MemPool {
             for (IndexedOutpoint outpoint : entry.projection().outputs().keySet()) {
                 if (producedByOutpoint.remove(outpoint) != null) removedIndexEntries++;
             }
+            removedIndexEntries += removeReferenceScripts(entry.projection());
             for (IndexedOutpoint outpoint : entry.projection().regularInputs()) {
                 if (spentByOutpoint.remove(outpoint, id)) removedIndexEntries++;
             }
@@ -615,8 +715,67 @@ public class DefaultMemPool implements MemPool {
     private int calculateIndexEntryCount() {
         return producedByOutpoint.size()
                 + spentByOutpoint.size()
+                + referenceScriptsByHash.size()
                 + parentsByTransaction.values().stream().mapToInt(Set::size).sum()
                 + childrenByTransaction.values().stream().mapToInt(Set::size).sum();
+    }
+
+    private Set<String> newReferenceScriptHashes(Projection projection) {
+        Set<String> additions = new HashSet<>();
+        for (Utxo utxo : projection.outputs().values()) {
+            String hash = normalizeScriptHash(utxo.referenceScriptHash());
+            if (hash != null && utxo.scriptRef() != null
+                    && !referenceScriptsByHash.containsKey(hash)) {
+                additions.add(hash);
+            }
+        }
+        return additions;
+    }
+
+    private int addReferenceScripts(Projection projection) {
+        int additions = 0;
+        for (Utxo utxo : projection.outputs().values()) {
+            String hash = normalizeScriptHash(utxo.referenceScriptHash());
+            if (hash == null || utxo.scriptRef() == null) continue;
+            byte[] bytes = HexUtil.decodeHexString(utxo.scriptRef());
+            ReferenceScriptEntry existing = referenceScriptsByHash.get(hash);
+            if (existing == null) {
+                referenceScriptsByHash.put(hash, new ReferenceScriptEntry(bytes, 1));
+                additions++;
+            } else {
+                if (!Arrays.equals(existing.scriptRefBytes, bytes)) {
+                    throw new IllegalStateException(
+                            "different reference-script bytes share hash " + hash);
+                }
+                existing.references++;
+            }
+        }
+        return additions;
+    }
+
+    private int removeReferenceScripts(Projection projection) {
+        int removals = 0;
+        for (Utxo utxo : projection.outputs().values()) {
+            String hash = normalizeScriptHash(utxo.referenceScriptHash());
+            if (hash == null || utxo.scriptRef() == null) continue;
+            ReferenceScriptEntry existing = referenceScriptsByHash.get(hash);
+            if (existing == null) continue;
+            if (--existing.references == 0) {
+                referenceScriptsByHash.remove(hash);
+                removals++;
+            }
+        }
+        return removals;
+    }
+
+    private static String normalizeScriptHash(String scriptHash) {
+        if (scriptHash == null || scriptHash.isBlank()) return null;
+        try {
+            byte[] decoded = HexUtil.decodeHexString(scriptHash);
+            return decoded.length > 0 ? HexUtil.encodeHexString(decoded) : null;
+        } catch (RuntimeException e) {
+            return null;
+        }
     }
 
     private Set<TxId> discoverParents(Set<IndexedOutpoint> inputs) {
@@ -755,6 +914,22 @@ public class DefaultMemPool implements MemPool {
                 transaction.insertedAt());
     }
 
+    private static Utxo externalCopy(Utxo utxo) {
+        return new Utxo(
+                utxo.outpoint(),
+                utxo.address(),
+                utxo.lovelace(),
+                utxo.assets() != null ? List.copyOf(utxo.assets()) : List.of(),
+                utxo.datumHash(),
+                utxo.inlineDatum() != null ? utxo.inlineDatum().clone() : null,
+                utxo.scriptRef(),
+                utxo.referenceScriptHash(),
+                utxo.collateralReturn(),
+                utxo.slot(),
+                utxo.blockNumber(),
+                utxo.blockHash());
+    }
+
     private static MempoolAdmissionResult result(MempoolAdmissionResult.Status status,
                                                   String txHash,
                                                   MemPoolTransaction transaction,
@@ -773,6 +948,16 @@ public class DefaultMemPool implements MemPool {
     }
 
     private record ProducedOutput(TxId owner, Utxo utxo) {
+    }
+
+    private static final class ReferenceScriptEntry {
+        private final byte[] scriptRefBytes;
+        private int references;
+
+        private ReferenceScriptEntry(byte[] scriptRefBytes, int references) {
+            this.scriptRefBytes = Arrays.copyOf(scriptRefBytes, scriptRefBytes.length);
+            this.references = references;
+        }
     }
 
     private record IndexedOutpoint(TxId txId, int index) {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPool.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPool.java
@@ -1,158 +1,825 @@
 package com.bloxbean.cardano.yano.runtime.chain;
+
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
 import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 import com.bloxbean.cardano.yaci.core.common.TxBodyType;
 import com.bloxbean.cardano.yaci.core.util.HexUtil;
 import com.bloxbean.cardano.yano.api.model.MemPoolTransaction;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
+/**
+ * In-memory FIFO mempool with one fair mutation lane and a derived, bounded UTXO
+ * overlay. Transaction bodies and every index transition share that lane.
+ */
 public class DefaultMemPool implements MemPool {
-    // LinkedHashMap preserves insertion order for efficient oldest-first iteration
-    private final LinkedHashMap<String, MemPoolTransaction> txIndex;
-    private final AtomicLong cursor = new AtomicLong(0);
+    private static final long SLOW_VALIDATION_NANOS = 1_000_000_000L;
+
+    private final ReentrantLock lane = new ReentrantLock(true);
+    private final LinkedHashMap<TxId, Entry> transactionsByHash = new LinkedHashMap<>();
+    private final Map<IndexedOutpoint, ProducedOutput> producedByOutpoint = new HashMap<>();
+    private final Map<IndexedOutpoint, TxId> spentByOutpoint = new HashMap<>();
+    private final Map<TxId, Set<TxId>> parentsByTransaction = new HashMap<>();
+    private final Map<TxId, Set<TxId>> childrenByTransaction = new HashMap<>();
+    private final AtomicLong cursor = new AtomicLong();
+
     private long byteSize;
-
-    public DefaultMemPool() {
-        this.txIndex = new LinkedHashMap<>();
-    }
+    private int indexEntryCount;
+    private long duplicateRejections;
+    private long conflictRejections;
+    private long capacityRejections;
+    private long malformedRejections;
+    private long ledgerRejections;
+    private long cascadedRemovals;
+    private long totalAdmissionWaitNanos;
+    private long totalAdmissionHoldNanos;
+    private long totalValidationNanos;
+    private long slowValidations;
 
     @Override
-    public synchronized MemPoolTransaction addTransaction(byte[] txBytes) {
-        var txHash = TransactionUtil.getTxHash(txBytes);
-        // Deduplicate: skip if already present
-        if (txIndex.containsKey(txHash)) {
-            return txIndex.get(txHash);
+    public MempoolAdmissionResult tryAdmit(byte[] txBytes,
+                                           Function<Outpoint, Utxo> canonicalResolver,
+                                           AdmissionValidator validator,
+                                           MempoolAdmissionLimits limits,
+                                           Consumer<MemPoolTransaction> acceptedListener) {
+        Objects.requireNonNull(txBytes, "txBytes");
+        if (lane.isHeldByCurrentThread()) {
+            return result(MempoolAdmissionResult.Status.REENTRANT_ADMISSION, null, null,
+                    "recursive admission from the mempool mutation lane is not allowed");
         }
-        long txSeqId = cursor.incrementAndGet();
-        var memPoolTransaction = new MemPoolTransaction(txSeqId, HexUtil.decodeHexString(txHash), txBytes, TxBodyType.CONWAY);
-        txIndex.put(txHash, memPoolTransaction);
-        byteSize += memPoolTransaction.size();
-        return memPoolTransaction;
-    }
-
-    @Override
-    public synchronized MemPoolTransaction getNextTransaction() {
-        var it = txIndex.entrySet().iterator();
-        if (!it.hasNext()) return null;
-        var entry = it.next();
-        it.remove();
-        byteSize -= entry.getValue().size();
-        return entry.getValue();
-    }
-
-    @Override
-    public synchronized boolean isEmpty() {
-        return txIndex.isEmpty();
-    }
-
-    @Override
-    public synchronized int size() {
-        return txIndex.size();
-    }
-
-    @Override
-    public synchronized long byteSize() {
-        return byteSize;
-    }
-
-    @Override
-    public synchronized boolean contains(String txHash) {
-        return txIndex.containsKey(txHash);
-    }
-
-    @Override
-    public synchronized MemPoolTransaction getTransaction(String txHash) {
-        return txIndex.get(txHash);
-    }
-
-    @Override
-    public synchronized List<MemPoolTransaction> snapshotTransactions(int maxCount, long maxBytes) {
-        if (maxCount <= 0 || maxBytes < 0) {
-            return List.of();
+        MempoolAdmissionLimits effectiveLimits = limits != null
+                ? limits : MempoolAdmissionLimits.unbounded();
+        if (effectiveLimits.maxBytes() > 0 && txBytes.length > effectiveLimits.maxBytes()) {
+            lane.lock();
+            try {
+                capacityRejections++;
+            } finally {
+                lane.unlock();
+            }
+            return result(MempoolAdmissionResult.Status.BYTE_CAPACITY, null, null,
+                    "transaction body exceeds the mempool byte limit");
         }
-        List<MemPoolTransaction> snapshot = new ArrayList<>(Math.min(maxCount, txIndex.size()));
-        long selectedBytes = 0;
-        for (MemPoolTransaction transaction : txIndex.values()) {
-            int size = transaction.size();
-            if (!snapshot.isEmpty() && selectedBytes + size > maxBytes) {
-                break;
+
+        // The mempool owns one immutable-by-convention body copy. Without this,
+        // caller mutation could make the body disagree with its hash and indexes.
+        byte[] ownedTxBytes = Arrays.copyOf(txBytes, txBytes.length);
+
+        final Projection projection;
+        try {
+            projection = project(ownedTxBytes);
+        } catch (Exception e) {
+            lane.lock();
+            try {
+                malformedRejections++;
+            } finally {
+                lane.unlock();
             }
-            if (size > maxBytes && snapshot.isEmpty()) {
-                break;
-            }
-            snapshot.add(transaction);
-            selectedBytes += size;
-            if (snapshot.size() >= maxCount) {
-                break;
-            }
+            return result(MempoolAdmissionResult.Status.MALFORMED, safeHash(ownedTxBytes), null,
+                    "transaction projection failed: " + stableMessage(e));
         }
-        return List.copyOf(snapshot);
+
+        Function<Outpoint, Utxo> canonical = canonicalResolver != null
+                ? canonicalResolver : ignored -> null;
+        AdmissionValidator effectiveValidator = validator != null
+                ? validator : (ignoredBytes, ignoredHash, ignoredResolver) -> List.of();
+
+        long waitStarted = System.nanoTime();
+        lane.lock();
+        long holdStarted = System.nanoTime();
+        totalAdmissionWaitNanos += holdStarted - waitStarted;
+        try {
+            Entry existing = transactionsByHash.get(projection.txId());
+            if (existing != null) {
+                duplicateRejections++;
+                return new MempoolAdmissionResult(MempoolAdmissionResult.Status.DUPLICATE,
+                        projection.txHash(), externalCopy(existing.transaction()), List.of(), "already present");
+            }
+
+            for (IndexedOutpoint input : projection.regularInputs()) {
+                TxId spender = spentByOutpoint.get(input);
+                if (spender != null) {
+                    conflictRejections++;
+                    return result(MempoolAdmissionResult.Status.CONFLICT, projection.txHash(), null,
+                            "regular input is already claimed by " + spender.hex() + ": " + input);
+                }
+            }
+
+            Set<TxId> parents = discoverParents(projection.allInputs());
+            int addedIndexEntries = projection.outputs().size()
+                    + projection.regularInputs().size()
+                    + (parents.size() * 2);
+
+            if (effectiveLimits.maxTransactions() > 0
+                    && transactionsByHash.size() + 1 > effectiveLimits.maxTransactions()) {
+                capacityRejections++;
+                return result(MempoolAdmissionResult.Status.TRANSACTION_CAPACITY,
+                        projection.txHash(), null, "transaction-count limit reached");
+            }
+            if (effectiveLimits.maxBytes() > 0
+                    && byteSize + ownedTxBytes.length > effectiveLimits.maxBytes()) {
+                capacityRejections++;
+                return result(MempoolAdmissionResult.Status.BYTE_CAPACITY,
+                        projection.txHash(), null, "transaction-byte limit reached");
+            }
+            if (effectiveLimits.maxUtxoIndexEntries() > 0
+                    && indexEntryCount + addedIndexEntries > effectiveLimits.maxUtxoIndexEntries()) {
+                capacityRejections++;
+                return result(MempoolAdmissionResult.Status.INDEX_CAPACITY,
+                        projection.txHash(), null, "UTXO-index limit reached");
+            }
+
+            ScopedResolver resolver = new ScopedResolver(canonical);
+            long validationStarted = System.nanoTime();
+            List<com.bloxbean.cardano.yaci.events.api.VetoableEvent.Rejection> rejections;
+            try {
+                rejections = effectiveValidator.validate(ownedTxBytes, projection.txHash(), resolver);
+            } finally {
+                resolver.close();
+                long duration = System.nanoTime() - validationStarted;
+                totalValidationNanos += duration;
+                if (duration >= SLOW_VALIDATION_NANOS) slowValidations++;
+            }
+            if (rejections != null && !rejections.isEmpty()) {
+                ledgerRejections++;
+                return new MempoolAdmissionResult(MempoolAdmissionResult.Status.LEDGER_REJECTED,
+                        projection.txHash(), null, rejections, "ledger validation rejected transaction");
+            }
+
+            // Validation callbacks cannot mutate the mempool, but recheck the
+            // claims explicitly so this invariant remains local to commit.
+            for (IndexedOutpoint input : projection.regularInputs()) {
+                if (spentByOutpoint.containsKey(input)) {
+                    conflictRejections++;
+                    return result(MempoolAdmissionResult.Status.CONFLICT, projection.txHash(), null,
+                            "regular input was claimed before commit: " + input);
+                }
+            }
+            if (!allParentsLive(parents)) {
+                return result(MempoolAdmissionResult.Status.CONFLICT, projection.txHash(), null,
+                        "a mempool parent disappeared before commit");
+            }
+
+            MemPoolTransaction transaction = new MemPoolTransaction(
+                    cursor.incrementAndGet(), projection.txId().bytes(), ownedTxBytes, TxBodyType.CONWAY);
+            Entry entry = new Entry(transaction, projection);
+            try {
+                commit(entry, parents);
+            } catch (RuntimeException | Error commitFailure) {
+                recoverFailedCommit(projection.txId(), commitFailure);
+                throw commitFailure;
+            }
+            try {
+                if (acceptedListener != null) acceptedListener.accept(externalCopy(transaction));
+            } catch (RuntimeException | Error e) {
+                removeInternal(Set.of(projection.txId()), true, false);
+                throw e;
+            }
+            return new MempoolAdmissionResult(MempoolAdmissionResult.Status.ACCEPTED,
+                    projection.txHash(), externalCopy(transaction), List.of(), "accepted");
+        } finally {
+            totalAdmissionHoldNanos += System.nanoTime() - holdStarted;
+            lane.unlock();
+        }
     }
 
     @Override
-    public synchronized void clear() {
-        txIndex.clear();
+    public MemPoolTransaction addTransaction(byte[] txBytes) {
+        MempoolAdmissionResult admission = tryAdmit(txBytes, ignored -> null,
+                (ignoredBytes, ignoredHash, ignoredResolver) -> List.of(),
+                MempoolAdmissionLimits.unbounded(), null);
+        if (admission.present()) return admission.transaction();
+        throw new MempoolAdmissionException(admission);
+    }
+
+    @Override
+    public MemPoolTransaction getNextTransaction() {
+        lane.lock();
+        try {
+            if (transactionsByHash.isEmpty()) return null;
+            TxId oldest = transactionsByHash.keySet().iterator().next();
+            MemPoolTransaction transaction = externalCopy(transactionsByHash.get(oldest).transaction());
+            removeInternal(Set.of(oldest), true, true);
+            return transaction;
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public boolean isEmpty() {
+        lane.lock();
+        try {
+            return transactionsByHash.isEmpty();
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public int size() {
+        lane.lock();
+        try {
+            return transactionsByHash.size();
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public long byteSize() {
+        lane.lock();
+        try {
+            return byteSize;
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public boolean contains(String txHash) {
+        TxId id = tryTxId(txHash);
+        if (id == null) return false;
+        lane.lock();
+        try {
+            return transactionsByHash.containsKey(id);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public MemPoolTransaction getTransaction(String txHash) {
+        TxId id = tryTxId(txHash);
+        if (id == null) return null;
+        lane.lock();
+        try {
+            Entry entry = transactionsByHash.get(id);
+            return entry != null ? externalCopy(entry.transaction()) : null;
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public List<MemPoolTransaction> snapshotTransactions(int maxCount, long maxBytes) {
+        if (maxCount <= 0 || maxBytes < 0) return List.of();
+        lane.lock();
+        try {
+            List<MemPoolTransaction> snapshot = new ArrayList<>(
+                    Math.min(maxCount, transactionsByHash.size()));
+            long selectedBytes = 0;
+            for (Entry entry : transactionsByHash.values()) {
+                // Snapshot consumers treat transaction records as immutable. The
+                // stable admission-owned body is shared here to avoid duplicating
+                // up to the full configured mempool byte budget.
+                MemPoolTransaction transaction = entry.transaction();
+                int size = transaction.size();
+                if (selectedBytes + size > maxBytes) break;
+                snapshot.add(transaction);
+                selectedBytes += size;
+                if (snapshot.size() >= maxCount) break;
+            }
+            return List.copyOf(snapshot);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public void clear() {
+        lane.lock();
+        try {
+            transactionsByHash.clear();
+            producedByOutpoint.clear();
+            spentByOutpoint.clear();
+            parentsByTransaction.clear();
+            childrenByTransaction.clear();
+            byteSize = 0;
+            indexEntryCount = 0;
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    /** Confirmation removal deliberately does not cascade to descendants. */
+    @Override
+    public int removeByTxHashes(Set<String> txHashes) {
+        lane.lock();
+        try {
+            return removeInternal(toIds(txHashes), false, false);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public int removeConflictingInputs(Set<Outpoint> consumedOutpoints) {
+        if (consumedOutpoints == null || consumedOutpoints.isEmpty()) return 0;
+        lane.lock();
+        try {
+            Set<TxId> roots = new LinkedHashSet<>();
+            for (Outpoint outpoint : consumedOutpoints) {
+                IndexedOutpoint indexed = tryIndexedOutpoint(outpoint);
+                if (indexed == null) continue;
+                TxId spender = spentByOutpoint.get(indexed);
+                if (spender != null) roots.add(spender);
+            }
+            return removeInternal(roots, true, true);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public int removeInvalidated(Set<String> txHashes) {
+        lane.lock();
+        try {
+            return removeInternal(toIds(txHashes), true, true);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public int evictOldest(int count) {
+        if (count <= 0) return 0;
+        lane.lock();
+        try {
+            Set<TxId> roots = new LinkedHashSet<>();
+            for (TxId id : transactionsByHash.keySet()) {
+                roots.add(id);
+                if (roots.size() >= count) break;
+            }
+            return removeInternal(roots, true, true);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public int evictOldestUntilBytesAtMost(long maxBytes) {
+        long target = Math.max(0, maxBytes);
+        lane.lock();
+        try {
+            Set<TxId> roots = new LinkedHashSet<>();
+            Set<TxId> plannedRemovals = new HashSet<>();
+            long projectedBytes = byteSize;
+            for (Map.Entry<TxId, Entry> entry : transactionsByHash.entrySet()) {
+                if (projectedBytes <= target) break;
+                if (plannedRemovals.contains(entry.getKey())) continue;
+                roots.add(entry.getKey());
+                ArrayDeque<TxId> queue = new ArrayDeque<>();
+                queue.add(entry.getKey());
+                while (!queue.isEmpty()) {
+                    TxId removal = queue.removeFirst();
+                    if (!plannedRemovals.add(removal)) continue;
+                    Entry removedEntry = transactionsByHash.get(removal);
+                    if (removedEntry != null) projectedBytes -= removedEntry.transaction().size();
+                    childrenByTransaction.getOrDefault(removal, Set.of()).forEach(queue::addLast);
+                }
+            }
+            return removeInternal(roots, true, true);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public int removeOlderThan(long beforeEpochMillis) {
+        lane.lock();
+        try {
+            Set<TxId> roots = new LinkedHashSet<>();
+            for (Map.Entry<TxId, Entry> entry : transactionsByHash.entrySet()) {
+                if (entry.getValue().transaction().insertedAt() >= beforeEpochMillis) break;
+                roots.add(entry.getKey());
+            }
+            return removeInternal(roots, true, true);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public int revalidate(Function<Outpoint, Utxo> canonicalResolver) {
+        Function<Outpoint, Utxo> canonical = canonicalResolver != null
+                ? canonicalResolver : ignored -> null;
+        lane.lock();
+        try {
+            Map<IndexedOutpoint, ProducedOutput> validProduced = new HashMap<>();
+            Set<IndexedOutpoint> validSpent = new HashSet<>();
+            Set<TxId> invalidRoots = new LinkedHashSet<>();
+            for (Map.Entry<TxId, Entry> mapEntry : transactionsByHash.entrySet()) {
+                Entry entry = mapEntry.getValue();
+                Projection projection = entry.projection();
+                boolean valid = true;
+                for (IndexedOutpoint input : projection.allInputs()) {
+                    if (validSpent.contains(input)) {
+                        valid = false;
+                        break;
+                    }
+                    if (!validProduced.containsKey(input)
+                            && safeCanonicalResolve(input, canonical) == null) {
+                        valid = false;
+                        break;
+                    }
+                }
+                if (valid) {
+                    for (IndexedOutpoint input : projection.regularInputs()) {
+                        if (!validSpent.add(input)) {
+                            valid = false;
+                            break;
+                        }
+                    }
+                }
+                if (!valid) {
+                    invalidRoots.add(mapEntry.getKey());
+                    continue;
+                }
+                projection.outputs().forEach((outpoint, utxo) ->
+                        validProduced.put(outpoint, new ProducedOutput(mapEntry.getKey(), utxo)));
+            }
+            return removeInternal(invalidRoots, true, true);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    @Override
+    public MempoolStats stats() {
+        lane.lock();
+        try {
+            int dependencyIndexRecords = indexEntryCount
+                    - producedByOutpoint.size() - spentByOutpoint.size();
+            int dependencyEdges = dependencyIndexRecords / 2;
+            long estimatedIndexBytes = (producedByOutpoint.size() * 256L)
+                    + (spentByOutpoint.size() * 96L)
+                    + (dependencyEdges * 256L);
+            return new MempoolStats(
+                    transactionsByHash.size(), byteSize, indexEntryCount,
+                    producedByOutpoint.size(), spentByOutpoint.size(), dependencyEdges,
+                    estimatedIndexBytes,
+                    duplicateRejections, conflictRejections, capacityRejections,
+                    malformedRejections, ledgerRejections, cascadedRemovals,
+                    lane.getQueueLength(), totalAdmissionWaitNanos, totalAdmissionHoldNanos,
+                    totalValidationNanos, slowValidations);
+        } finally {
+            lane.unlock();
+        }
+    }
+
+    private void commit(Entry entry, Set<TxId> parents) {
+        TxId id = entry.projection().txId();
+        transactionsByHash.put(id, entry);
+        byteSize += entry.transaction().size();
+        entry.projection().outputs().forEach((outpoint, utxo) ->
+                producedByOutpoint.put(outpoint, new ProducedOutput(id, utxo)));
+        entry.projection().regularInputs().forEach(outpoint -> spentByOutpoint.put(outpoint, id));
+        if (!parents.isEmpty()) {
+            parentsByTransaction.put(id, new HashSet<>(parents));
+            parents.forEach(parent -> childrenByTransaction
+                    .computeIfAbsent(parent, ignored -> new HashSet<>()).add(id));
+        }
+        indexEntryCount += entry.projection().outputs().size()
+                + entry.projection().regularInputs().size()
+                + (parents.size() * 2);
+    }
+
+    private void recoverFailedCommit(TxId failedId, Throwable commitFailure) {
+        transactionsByHash.remove(failedId);
+        try {
+            rebuildIndexesFromEntries();
+        } catch (RuntimeException | Error rebuildFailure) {
+            commitFailure.addSuppressed(rebuildFailure);
+            transactionsByHash.clear();
+            producedByOutpoint.clear();
+            spentByOutpoint.clear();
+            parentsByTransaction.clear();
+            childrenByTransaction.clear();
+            byteSize = 0;
+            indexEntryCount = 0;
+        }
+    }
+
+    private void rebuildIndexesFromEntries() {
+        producedByOutpoint.clear();
+        spentByOutpoint.clear();
+        parentsByTransaction.clear();
+        childrenByTransaction.clear();
         byteSize = 0;
+        indexEntryCount = 0;
+
+        for (Map.Entry<TxId, Entry> mapEntry : transactionsByHash.entrySet()) {
+            TxId id = mapEntry.getKey();
+            Entry entry = mapEntry.getValue();
+            Projection projection = entry.projection();
+            Set<TxId> parents = discoverParents(projection.allInputs());
+            for (IndexedOutpoint input : projection.regularInputs()) {
+                TxId previous = spentByOutpoint.putIfAbsent(input, id);
+                if (previous != null) {
+                    throw new IllegalStateException("conflicting spend while rebuilding mempool indexes");
+                }
+            }
+            projection.outputs().forEach((outpoint, utxo) ->
+                    producedByOutpoint.put(outpoint, new ProducedOutput(id, utxo)));
+            if (!parents.isEmpty()) {
+                parentsByTransaction.put(id, new HashSet<>(parents));
+                parents.forEach(parent -> childrenByTransaction
+                        .computeIfAbsent(parent, ignored -> new HashSet<>()).add(id));
+            }
+            byteSize += entry.transaction().size();
+        }
+        indexEntryCount = calculateIndexEntryCount();
     }
 
-    @Override
-    public synchronized int removeByTxHashes(Set<String> txHashes) {
-        int removed = 0;
-        for (String hash : txHashes) {
-            MemPoolTransaction transaction = txIndex.remove(hash);
-            if (transaction != null) {
-                byteSize -= transaction.size();
-                removed++;
+    private int removeInternal(Set<TxId> requested, boolean cascade, boolean countCascade) {
+        if (requested == null || requested.isEmpty()) return 0;
+        Set<TxId> direct = new LinkedHashSet<>();
+        requested.forEach(id -> {
+            if (transactionsByHash.containsKey(id)) direct.add(id);
+        });
+        if (direct.isEmpty()) return 0;
+
+        Set<TxId> removals = new LinkedHashSet<>(direct);
+        if (cascade) {
+            ArrayDeque<TxId> queue = new ArrayDeque<>(direct);
+            while (!queue.isEmpty()) {
+                TxId parent = queue.removeFirst();
+                for (TxId child : childrenByTransaction.getOrDefault(parent, Set.of())) {
+                    if (removals.add(child)) queue.addLast(child);
+                }
             }
         }
+
+        int removedIndexEntries = 0;
+        for (TxId id : removals) {
+            Entry entry = transactionsByHash.remove(id);
+            if (entry == null) continue;
+            byteSize -= entry.transaction().size();
+            for (IndexedOutpoint outpoint : entry.projection().outputs().keySet()) {
+                if (producedByOutpoint.remove(outpoint) != null) removedIndexEntries++;
+            }
+            for (IndexedOutpoint outpoint : entry.projection().regularInputs()) {
+                if (spentByOutpoint.remove(outpoint, id)) removedIndexEntries++;
+            }
+
+            Set<TxId> parents = parentsByTransaction.remove(id);
+            if (parents != null) {
+                removedIndexEntries += parents.size();
+                for (TxId parent : parents) {
+                    if (removeEdge(childrenByTransaction, parent, id)) removedIndexEntries++;
+                }
+            }
+            Set<TxId> children = childrenByTransaction.remove(id);
+            if (children != null) {
+                removedIndexEntries += children.size();
+                for (TxId child : children) {
+                    if (removeEdge(parentsByTransaction, child, id)) removedIndexEntries++;
+                }
+            }
+        }
+        indexEntryCount -= removedIndexEntries;
+        if (indexEntryCount < 0) {
+            throw new IllegalStateException("mempool UTXO index count became negative");
+        }
+        if (countCascade) cascadedRemovals += Math.max(0, removals.size() - direct.size());
+        return removals.size();
+    }
+
+    private static boolean removeEdge(Map<TxId, Set<TxId>> index, TxId key, TxId value) {
+        Set<TxId> values = index.get(key);
+        if (values == null) return false;
+        boolean removed = values.remove(value);
+        if (values.isEmpty()) index.remove(key);
         return removed;
     }
 
-    @Override
-    public synchronized int evictOldest(int count) {
-        int evicted = 0;
-        var it = txIndex.entrySet().iterator();
-        while (it.hasNext() && evicted < count) {
-            var entry = it.next();
-            it.remove();
-            byteSize -= entry.getValue().size();
-            evicted++;
-        }
-        return evicted;
+    private int calculateIndexEntryCount() {
+        return producedByOutpoint.size()
+                + spentByOutpoint.size()
+                + parentsByTransaction.values().stream().mapToInt(Set::size).sum()
+                + childrenByTransaction.values().stream().mapToInt(Set::size).sum();
     }
 
-    @Override
-    public synchronized int evictOldestUntilBytesAtMost(long maxBytes) {
-        if (maxBytes < 0) {
-            maxBytes = 0;
+    private Set<TxId> discoverParents(Set<IndexedOutpoint> inputs) {
+        Set<TxId> parents = new HashSet<>();
+        for (IndexedOutpoint input : inputs) {
+            ProducedOutput output = producedByOutpoint.get(input);
+            if (output != null) parents.add(output.owner());
         }
-        int evicted = 0;
-        var it = txIndex.entrySet().iterator();
-        while (it.hasNext() && byteSize > maxBytes) {
-            var entry = it.next();
-            it.remove();
-            byteSize -= entry.getValue().size();
-            evicted++;
-        }
-        return evicted;
+        return parents;
     }
 
-    @Override
-    public synchronized int removeOlderThan(long beforeEpochMillis) {
-        int removed = 0;
-        var it = txIndex.entrySet().iterator();
-        while (it.hasNext()) {
-            var entry = it.next();
-            if (entry.getValue().insertedAt() < beforeEpochMillis) {
-                it.remove();
-                byteSize -= entry.getValue().size();
-                removed++;
-            } else {
-                // LinkedHashMap is insertion-ordered, so once we hit a newer entry, stop
-                break;
+    private boolean allParentsLive(Set<TxId> parents) {
+        return parents.stream().allMatch(transactionsByHash::containsKey);
+    }
+
+    private Utxo resolve(Outpoint outpoint, Function<Outpoint, Utxo> canonicalResolver) {
+        IndexedOutpoint indexed = tryIndexedOutpoint(outpoint);
+        if (indexed == null) return null;
+        if (spentByOutpoint.containsKey(indexed)) return null;
+        ProducedOutput produced = producedByOutpoint.get(indexed);
+        if (produced != null) return produced.utxo();
+        return canonicalResolver.apply(outpoint);
+    }
+
+    /** Resolver capability that is valid only for the synchronous validation callback. */
+    private final class ScopedResolver implements Function<Outpoint, Utxo> {
+        private final Function<Outpoint, Utxo> canonicalResolver;
+        private boolean active = true;
+
+        private ScopedResolver(Function<Outpoint, Utxo> canonicalResolver) {
+            this.canonicalResolver = canonicalResolver;
+        }
+
+        @Override
+        public synchronized Utxo apply(Outpoint outpoint) {
+            if (!active) {
+                throw new IllegalStateException(
+                        "mempool admission UTXO resolver is no longer active");
+            }
+            return resolve(outpoint, canonicalResolver);
+        }
+
+        private synchronized void close() {
+            active = false;
+        }
+    }
+
+    private static Utxo safeCanonicalResolve(IndexedOutpoint outpoint,
+                                             Function<Outpoint, Utxo> canonicalResolver) {
+        try {
+            return canonicalResolver.apply(outpoint.external());
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static Projection project(byte[] txBytes) throws Exception {
+        String txHash = TransactionUtil.getTxHash(txBytes);
+        TxId txId = TxId.fromHex(txHash);
+        Transaction transaction = Transaction.deserialize(txBytes);
+        if (transaction.getBody() == null) {
+            throw new IllegalArgumentException("transaction body is null");
+        }
+
+        Set<IndexedOutpoint> regularInputs = projectInputs(transaction.getBody().getInputs());
+        Set<IndexedOutpoint> allInputs = new LinkedHashSet<>(regularInputs);
+        allInputs.addAll(projectInputs(transaction.getBody().getReferenceInputs()));
+        allInputs.addAll(projectInputs(transaction.getBody().getCollateral()));
+
+        Map<IndexedOutpoint, Utxo> outputs = new LinkedHashMap<>();
+        if (transaction.getBody().getOutputs() != null) {
+            for (int index = 0; index < transaction.getBody().getOutputs().size(); index++) {
+                IndexedOutpoint outpoint = new IndexedOutpoint(txId, index);
+                outputs.put(outpoint, TransactionOutputProjector.project(
+                        txHash, index, transaction.getBody().getOutputs().get(index)));
             }
         }
-        return removed;
+        return new Projection(txId, txHash, Set.copyOf(regularInputs),
+                Set.copyOf(allInputs), Collections.unmodifiableMap(outputs));
+    }
+
+    private static Set<IndexedOutpoint> projectInputs(Collection<TransactionInput> inputs) {
+        if (inputs == null || inputs.isEmpty()) return Set.of();
+        Set<IndexedOutpoint> projected = new LinkedHashSet<>();
+        for (TransactionInput input : inputs) {
+            projected.add(new IndexedOutpoint(TxId.fromHex(input.getTransactionId()), input.getIndex()));
+        }
+        return projected;
+    }
+
+    private static Set<TxId> toIds(Set<String> hashes) {
+        if (hashes == null || hashes.isEmpty()) return Set.of();
+        Set<TxId> ids = new LinkedHashSet<>();
+        hashes.forEach(hash -> {
+            TxId id = tryTxId(hash);
+            if (id != null) ids.add(id);
+        });
+        return ids;
+    }
+
+    private static TxId tryTxId(String hash) {
+        try {
+            return TxId.fromHex(hash);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static IndexedOutpoint tryIndexedOutpoint(Outpoint outpoint) {
+        if (outpoint == null) return null;
+        try {
+            return new IndexedOutpoint(TxId.fromHex(outpoint.txHash()), outpoint.index());
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static String safeHash(byte[] txBytes) {
+        try {
+            return TransactionUtil.getTxHash(txBytes);
+        } catch (RuntimeException e) {
+            return null;
+        }
+    }
+
+    private static String stableMessage(Exception e) {
+        return e.getMessage() != null ? e.getMessage() : e.getClass().getSimpleName();
+    }
+
+    private static MemPoolTransaction externalCopy(MemPoolTransaction transaction) {
+        return new MemPoolTransaction(
+                transaction.seqId(),
+                transaction.txHash().clone(),
+                transaction.txBytes().clone(),
+                transaction.txBodyType(),
+                transaction.insertedAt());
+    }
+
+    private static MempoolAdmissionResult result(MempoolAdmissionResult.Status status,
+                                                  String txHash,
+                                                  MemPoolTransaction transaction,
+                                                  String detail) {
+        return new MempoolAdmissionResult(status, txHash, transaction, List.of(), detail);
+    }
+
+    private record Entry(MemPoolTransaction transaction, Projection projection) {
+    }
+
+    private record Projection(TxId txId,
+                              String txHash,
+                              Set<IndexedOutpoint> regularInputs,
+                              Set<IndexedOutpoint> allInputs,
+                              Map<IndexedOutpoint, Utxo> outputs) {
+    }
+
+    private record ProducedOutput(TxId owner, Utxo utxo) {
+    }
+
+    private record IndexedOutpoint(TxId txId, int index) {
+        Outpoint external() {
+            return new Outpoint(txId.hex(), index);
+        }
+
+        @Override
+        public String toString() {
+            return txId.hex() + "#" + index;
+        }
+    }
+
+    /** Immutable value-equality wrapper. Raw byte arrays are never map keys. */
+    private static final class TxId {
+        private final byte[] bytes;
+        private final int hashCode;
+
+        private TxId(byte[] bytes) {
+            if (bytes == null || bytes.length != 32) {
+                throw new IllegalArgumentException("transaction id must be 32 bytes");
+            }
+            this.bytes = Arrays.copyOf(bytes, bytes.length);
+            this.hashCode = Arrays.hashCode(this.bytes);
+        }
+
+        static TxId fromHex(String hex) {
+            if (hex == null) throw new IllegalArgumentException("transaction id is null");
+            return new TxId(HexUtil.decodeHexString(hex));
+        }
+
+        byte[] bytes() {
+            return Arrays.copyOf(bytes, bytes.length);
+        }
+
+        String hex() {
+            return HexUtil.encodeHexString(bytes);
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return this == other || other instanceof TxId txId && Arrays.equals(bytes, txId.bytes);
+        }
+
+        @Override
+        public int hashCode() {
+            return hashCode;
+        }
     }
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMempoolEvictionPolicy.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMempoolEvictionPolicy.java
@@ -2,8 +2,12 @@ package com.bloxbean.cardano.yano.runtime.chain;
 
 import com.bloxbean.cardano.yaci.core.model.TransactionBody;
 import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.HashSet;
+import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -39,17 +43,35 @@ public class DefaultMempoolEvictionPolicy implements MempoolEvictionPolicy {
             return;
         }
 
-        Set<String> confirmedHashes = event.block().getTransactionBodies().stream()
+        List<TransactionBody> transactionBodies = event.block().getTransactionBodies();
+        Set<String> confirmedHashes = transactionBodies.stream()
                 .map(TransactionBody::getTxHash)
+                .filter(java.util.Objects::nonNull)
                 .collect(Collectors.toSet());
-
-        if (confirmedHashes.isEmpty()) {
-            return;
-        }
 
         int removed = memPool.removeByTxHashes(confirmedHashes);
         if (removed > 0) {
             log.info("Evicted {} confirmed txs from mempool (block #{})", removed, event.blockNumber());
+        }
+
+        // Remove other mempool transactions that conflict with what canonical
+        // apply actually consumed. Valid transactions consume regular inputs;
+        // phase-2-invalid transactions consume collateral inputs instead.
+        Set<Integer> invalidIndexes = event.block().getInvalidTransactions() != null
+                ? new HashSet<>(event.block().getInvalidTransactions()) : Set.of();
+        Set<Outpoint> consumed = new LinkedHashSet<>();
+        for (int index = 0; index < transactionBodies.size(); index++) {
+            TransactionBody body = transactionBodies.get(index);
+            var inputs = invalidIndexes.contains(index)
+                    ? body.getCollateralInputs() : body.getInputs();
+            if (inputs == null) continue;
+            inputs.forEach(input -> consumed.add(
+                    new Outpoint(input.getTransactionId(), input.getIndex())));
+        }
+        int invalidated = memPool.removeConflictingInputs(consumed);
+        if (invalidated > 0) {
+            log.info("Invalidated {} mempool txs conflicting with canonical block #{}",
+                    invalidated, event.blockNumber());
         }
     }
 

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MemPool.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MemPool.java
@@ -1,12 +1,35 @@
 package com.bloxbean.cardano.yano.runtime.chain;
 
 import com.bloxbean.cardano.yano.api.model.MemPoolTransaction;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+import com.bloxbean.cardano.yaci.events.api.VetoableEvent;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Function;
 
 public interface MemPool {
+    @FunctionalInterface
+    interface AdmissionValidator {
+        List<VetoableEvent.Rejection> validate(byte[] txBytes, String txHash,
+                                               Function<Outpoint, Utxo> resolver);
+    }
+
+    /**
+     * Validate and commit one transaction against a stable
+     * mempool-plus-canonical UTXO view.
+     */
+    MempoolAdmissionResult tryAdmit(byte[] txBytes,
+                                    Function<Outpoint, Utxo> canonicalResolver,
+                                    AdmissionValidator validator,
+                                    MempoolAdmissionLimits limits,
+                                    Consumer<MemPoolTransaction> acceptedListener);
+
     // Add a transaction to the mempool and return the created mempool transaction
+    // Compatibility path for trusted callers. Implementations must still project
+    // the transaction and preserve all index invariants.
     MemPoolTransaction addTransaction(byte[] txBytes);
 
     // Get the next transaction to process (FIFO)
@@ -36,6 +59,12 @@ public interface MemPool {
     /** Remove transactions confirmed in a block. Returns count removed. */
     int removeByTxHashes(Set<String> txHashes);
 
+    /** Remove transactions claiming canonically consumed outpoints, with descendants. */
+    int removeConflictingInputs(Set<Outpoint> consumedOutpoints);
+
+    /** Remove invalid transactions and all dependent descendants. */
+    int removeInvalidated(Set<String> txHashes);
+
     /** Evict the oldest N transactions. Returns actual count evicted. */
     int evictOldest(int count);
 
@@ -44,4 +73,10 @@ public interface MemPool {
 
     /** Remove transactions inserted before the given timestamp. Returns count removed. */
     int removeOlderThan(long beforeEpochMillis);
+
+    /** Reconcile the ordered overlay after canonical UTXO rollback. */
+    int revalidate(Function<Outpoint, Utxo> canonicalResolver);
+
+    /** Read-only semantic status; does not expose mutable indexes. */
+    MempoolStats stats();
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MemPool.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MemPool.java
@@ -5,7 +5,10 @@ import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 import com.bloxbean.cardano.yaci.events.api.VetoableEvent;
 
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -26,6 +29,21 @@ public interface MemPool {
                                     AdmissionValidator validator,
                                     MempoolAdmissionLimits limits,
                                     Consumer<MemPoolTransaction> acceptedListener);
+
+    /**
+     * Resolve a collection of outpoints against one stable mempool-plus-canonical
+     * UTXO view. Outpoints already claimed by a mempool transaction are absent
+     * from the returned snapshot.
+     *
+     * <p>The returned map and UTXOs are detached from implementation-owned
+     * indexes, so callers may perform expensive work after the mempool lane has
+     * been released.</p>
+     */
+    Map<Outpoint, Utxo> resolveUtxos(Collection<Outpoint> outpoints,
+                                     Function<Outpoint, Utxo> canonicalResolver);
+
+    /** Look up encoded reference-script bytes produced by a live mempool entry. */
+    Optional<byte[]> getScriptRefBytesByHash(String scriptHash);
 
     // Add a transaction to the mempool and return the created mempool transaction
     // Compatibility path for trusted callers. Implementations must still project

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolAdmissionException.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolAdmissionException.java
@@ -1,0 +1,15 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+/** Stable failure for a non-ledger mempool admission rejection. */
+public final class MempoolAdmissionException extends RuntimeException {
+    private final MempoolAdmissionResult result;
+
+    public MempoolAdmissionException(MempoolAdmissionResult result) {
+        super("Mempool admission failed (" + result.status() + "): " + result.detail());
+        this.result = result;
+    }
+
+    public MempoolAdmissionResult result() {
+        return result;
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolAdmissionLimits.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolAdmissionLimits.java
@@ -1,0 +1,8 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+/** Hard admission limits. A non-positive byte or index limit is unbounded. */
+public record MempoolAdmissionLimits(int maxTransactions, long maxBytes, int maxUtxoIndexEntries) {
+    public static MempoolAdmissionLimits unbounded() {
+        return new MempoolAdmissionLimits(Integer.MAX_VALUE, Long.MAX_VALUE, Integer.MAX_VALUE);
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolAdmissionResult.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolAdmissionResult.java
@@ -1,0 +1,39 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+import com.bloxbean.cardano.yaci.events.api.VetoableEvent;
+import com.bloxbean.cardano.yano.api.model.MemPoolTransaction;
+
+import java.util.List;
+
+/** Typed result of one atomic mempool admission attempt. */
+public record MempoolAdmissionResult(
+        Status status,
+        String txHash,
+        MemPoolTransaction transaction,
+        List<VetoableEvent.Rejection> rejections,
+        String detail) {
+
+    public enum Status {
+        ACCEPTED,
+        DUPLICATE,
+        MALFORMED,
+        LEDGER_REJECTED,
+        CONFLICT,
+        TRANSACTION_CAPACITY,
+        BYTE_CAPACITY,
+        INDEX_CAPACITY,
+        REENTRANT_ADMISSION
+    }
+
+    public MempoolAdmissionResult {
+        rejections = rejections == null ? List.of() : List.copyOf(rejections);
+    }
+
+    public boolean accepted() {
+        return status == Status.ACCEPTED;
+    }
+
+    public boolean present() {
+        return status == Status.ACCEPTED || status == Status.DUPLICATE;
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolStats.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolStats.java
@@ -1,0 +1,23 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+/** Immutable operational view of bounded mempool state. */
+public record MempoolStats(
+        int transactions,
+        long transactionBytes,
+        int utxoIndexEntries,
+        int producedOutputs,
+        int spentOutpoints,
+        int dependencyEdges,
+        long estimatedIndexBytes,
+        long duplicateRejections,
+        long conflictRejections,
+        long capacityRejections,
+        long malformedRejections,
+        long ledgerRejections,
+        long cascadedRemovals,
+        int admissionQueueLength,
+        long totalAdmissionWaitNanos,
+        long totalAdmissionHoldNanos,
+        long totalValidationNanos,
+        long slowValidations) {
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolStats.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/MempoolStats.java
@@ -7,6 +7,7 @@ public record MempoolStats(
         int utxoIndexEntries,
         int producedOutputs,
         int spentOutpoints,
+        int referenceScripts,
         int dependencyEdges,
         long estimatedIndexBytes,
         long duplicateRejections,

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/TransactionOutputProjector.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/TransactionOutputProjector.java
@@ -1,0 +1,71 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+import com.bloxbean.cardano.client.api.util.ReferenceScriptUtil;
+import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.utxo.model.AssetAmount;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+/** Shared projection used by mempool and block-local UTXO overlays. */
+public final class TransactionOutputProjector {
+    private TransactionOutputProjector() {
+    }
+
+    public static Utxo project(String txHash, int outputIndex, TransactionOutput output) {
+        if (output == null || output.getValue() == null) {
+            throw new IllegalArgumentException("transaction output or value is null");
+        }
+
+        BigInteger lovelace = output.getValue().getCoin() != null
+                ? output.getValue().getCoin() : BigInteger.ZERO;
+        List<AssetAmount> assets = new ArrayList<>();
+        if (output.getValue().getMultiAssets() != null) {
+            output.getValue().getMultiAssets().forEach(multiAsset -> {
+                if (multiAsset.getAssets() == null) return;
+                multiAsset.getAssets().forEach(asset -> {
+                    String assetName = asset.getNameAsHex();
+                    if (assetName != null && assetName.startsWith("0x")) {
+                        assetName = assetName.substring(2);
+                    }
+                    assets.add(new AssetAmount(
+                            multiAsset.getPolicyId(), assetName, asset.getValue()));
+                });
+            });
+        }
+
+        String datumHash = output.getDatumHash() != null
+                ? HexUtil.encodeHexString(output.getDatumHash()) : null;
+        byte[] inlineDatum = output.getInlineDatum() != null
+                ? output.getInlineDatum().serializeToBytes() : null;
+        String scriptRef = output.getScriptRef() != null
+                ? HexUtil.encodeHexString(output.getScriptRef()) : null;
+        String referenceScriptHash = null;
+        if (output.getScriptRef() != null) {
+            try {
+                var script = ReferenceScriptUtil.deserializeScriptRef(output.getScriptRef());
+                referenceScriptHash = HexUtil.encodeHexString(script.getScriptHash());
+            } catch (Exception e) {
+                throw new IllegalArgumentException("invalid reference script", e);
+            }
+        }
+
+        return new Utxo(
+                new Outpoint(txHash, outputIndex),
+                output.getAddress(),
+                lovelace,
+                List.copyOf(assets),
+                datumHash,
+                inlineDatum,
+                scriptRef,
+                referenceScriptHash,
+                false,
+                0,
+                0,
+                null);
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/events/PropagatingEventBus.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/events/PropagatingEventBus.java
@@ -9,6 +9,9 @@ import com.bloxbean.cardano.yaci.events.api.EventMetadata;
 import com.bloxbean.cardano.yaci.events.api.PublishOptions;
 import com.bloxbean.cardano.yaci.events.api.SubscriptionHandle;
 import com.bloxbean.cardano.yaci.events.api.SubscriptionOptions;
+import com.bloxbean.cardano.yano.api.events.TransactionValidateEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateRolledBackEvent;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.ArrayList;
@@ -65,8 +68,12 @@ public final class PropagatingEventBus implements EventBus {
         if (closed.get()) {
             throw new IllegalStateException("EventBus is closed");
         }
-        CopyOnWriteArrayList<Sub<?>> list = subs.computeIfAbsent(type, ignored -> new CopyOnWriteArrayList<>());
         SubscriptionOptions effective = options != null ? options : SubscriptionOptions.builder().build();
+        if (requiresSynchronousDelivery(type) && effective.executor() != null) {
+            throw new IllegalArgumentException(
+                    type.getSimpleName() + " listeners must be synchronous");
+        }
+        CopyOnWriteArrayList<Sub<?>> list = subs.computeIfAbsent(type, ignored -> new CopyOnWriteArrayList<>());
         Sub<E> sub = new Sub<>(listener, effective, sequence.incrementAndGet());
         int index = 0;
         for (; index < list.size(); index++) {
@@ -94,6 +101,12 @@ public final class PropagatingEventBus implements EventBus {
                 return sub.active.get();
             }
         };
+    }
+
+    private static boolean requiresSynchronousDelivery(Class<?> type) {
+        return type == TransactionValidateEvent.class
+                || type == UtxoStateAppliedEvent.class
+                || type == UtxoStateRolledBackEvent.class;
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -24,6 +24,7 @@ import com.bloxbean.cardano.yano.api.NodeLifecycle;
 import com.bloxbean.cardano.yano.api.ProducerControl;
 import com.bloxbean.cardano.yano.api.SyncPhase;
 import com.bloxbean.cardano.yano.api.TxEvaluationGateway;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.TxGateway;
 import com.bloxbean.cardano.yano.api.appchain.AppChainConfig;
 import com.bloxbean.cardano.yano.appchain.config.AppChainConfigParser;
@@ -46,6 +47,8 @@ import com.bloxbean.cardano.yano.api.model.SnapshotInfo;
 import com.bloxbean.cardano.yano.api.model.TimeAdvanceResult;
 import com.bloxbean.cardano.yano.api.model.TxEvaluationResult;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionValidator;
 import com.bloxbean.cardano.yano.api.bootstrap.BootstrapDataProvider;
@@ -173,6 +176,7 @@ import java.util.function.Supplier;
  */
 @Slf4j
 public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGateway, TxEvaluationGateway,
+        MempoolQueryGateway,
         ProducerControl, AutoCloseable, DebugLedgerStateAccess, RuntimeKernelProvider, DevnetRuntimeProvider {
     // Configuration
     private final YanoConfig config;
@@ -2388,6 +2392,7 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
                     epochNonceState,
                     nonceStore,
                     protocolVersionSupplier,
+                    BlockBodySizeLimitSupplier.fromEpochParams(this::effectiveEpochParamProvider),
                     activeSlotsCoeff);
             var signedBlockBuilder = signingComponents.signedBlockBuilder();
             var slotLeaderCheck = signingComponents.slotLeaderCheck();
@@ -2444,6 +2449,16 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
     @Override
     public List<TxEvaluationResult> evaluateTransaction(byte[] txCbor) throws Exception {
         return txSubsystem.evaluateTransaction(txCbor);
+    }
+
+    @Override
+    public Optional<Utxo> resolveUtxo(Outpoint outpoint) {
+        return txSubsystem.resolveUtxo(outpoint);
+    }
+
+    @Override
+    public Optional<byte[]> getScriptRefBytesByHash(String scriptHash) {
+        return txSubsystem.getScriptRefBytesByHash(scriptHash);
     }
 
     @Override
@@ -4054,6 +4069,7 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
         PeerRecoveryFailureTracker.Snapshot recoveryStatus = syncSubsystem.peerRecoverySnapshot();
         UpstreamStatus upstreamStatus = syncSubsystem.upstreamStatus();
         TxDiffusionStats txDiffusionStats = txSubsystem.txDiffusionStats();
+        var mempoolStats = txSubsystem.mempoolStats();
         RuntimeMaintenanceGate maintenanceGate = chainStorage.maintenanceGate();
         RuntimeMaintenanceGate.Degradation maintenanceDegradation = maintenanceGate.degradation();
 
@@ -4183,6 +4199,24 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
                 .mempoolMaxTxs(txSubsystem.mempoolMaxTxs())
                 .mempoolMaxBytes(txSubsystem.mempoolMaxBytes())
                 .mempoolTtlSeconds(txSubsystem.mempoolTtlSeconds())
+                .mempoolUtxoIndexEntries(mempoolStats.utxoIndexEntries())
+                .mempoolMaxUtxoIndexEntries(txSubsystem.mempoolMaxUtxoIndexEntries())
+                .mempoolProducedOutputs(mempoolStats.producedOutputs())
+                .mempoolSpentOutpoints(mempoolStats.spentOutpoints())
+                .mempoolReferenceScripts(mempoolStats.referenceScripts())
+                .mempoolDependencyEdges(mempoolStats.dependencyEdges())
+                .mempoolEstimatedIndexBytes(mempoolStats.estimatedIndexBytes())
+                .mempoolDuplicateRejections(mempoolStats.duplicateRejections())
+                .mempoolConflictRejections(mempoolStats.conflictRejections())
+                .mempoolCapacityRejections(mempoolStats.capacityRejections())
+                .mempoolMalformedRejections(mempoolStats.malformedRejections())
+                .mempoolLedgerRejections(mempoolStats.ledgerRejections())
+                .mempoolCascadedRemovals(mempoolStats.cascadedRemovals())
+                .mempoolAdmissionQueueLength(mempoolStats.admissionQueueLength())
+                .mempoolAdmissionWaitNanos(mempoolStats.totalAdmissionWaitNanos())
+                .mempoolAdmissionHoldNanos(mempoolStats.totalAdmissionHoldNanos())
+                .mempoolValidationNanos(mempoolStats.totalValidationNanos())
+                .mempoolSlowValidations(mempoolStats.slowValidations())
                 .mempoolAccepting(txSubsystem.isAccepting())
                 .mempoolValidationAvailable(txSubsystem.transactionValidationService() != null)
                 .mempoolEvaluationAvailable(txSubsystem.isTransactionEvaluationAvailable())

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetBlockBuilderFactory.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetBlockBuilderFactory.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.yano.api.EpochParamProvider;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.ledgerstate.EpochParamTracker;
 import com.bloxbean.cardano.yano.runtime.blockproducer.DevnetBlockBuilder;
+import com.bloxbean.cardano.yano.runtime.blockproducer.BlockBodySizeLimitSupplier;
 import com.bloxbean.cardano.yano.runtime.blockproducer.EpochNonceEvolver;
 import com.bloxbean.cardano.yano.runtime.blockproducer.EpochNonceState;
 import com.bloxbean.cardano.yano.runtime.blockproducer.GenesisConfig;
@@ -44,7 +45,9 @@ public final class DevnetBlockBuilderFactory {
         }
 
         log.info("Using DevnetBlockBuilder with dummy signatures (no key files configured)");
-        return new DevnetBlockBuilder(dependencies.protocolVersionSupplier().get());
+        return new DevnetBlockBuilder(
+                dependencies.protocolVersionSupplier().get(),
+                BlockBodySizeLimitSupplier.fromEpochParams(dependencies.effectiveEpochParamProvider()));
     }
 
     public static boolean hasConfiguredProducerKeys(YanoConfig config) {
@@ -102,7 +105,8 @@ public final class DevnetBlockBuilderFactory {
                     maxKESEvolutions,
                     nonceState,
                     nonceStore,
-                    dependencies.protocolVersionSupplier().get());
+                    dependencies.protocolVersionSupplier().get(),
+                    BlockBodySizeLimitSupplier.fromEpochParams(dependencies.effectiveEpochParamProvider()));
         } catch (Exception e) {
             throw new IllegalStateException("Failed to initialize SignedBlockBuilder with configured producer keys", e);
         }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/ProducerStartupCoordinator.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/ProducerStartupCoordinator.java
@@ -19,6 +19,7 @@ import com.bloxbean.cardano.yano.runtime.blockproducer.NonceEvolutionListener;
 import com.bloxbean.cardano.yano.runtime.blockproducer.NonceReplayService;
 import com.bloxbean.cardano.yano.runtime.blockproducer.NonceStateStore;
 import com.bloxbean.cardano.yano.runtime.blockproducer.ProtocolVersionSupplier;
+import com.bloxbean.cardano.yano.runtime.blockproducer.BlockBodySizeLimitSupplier;
 import lombok.extern.slf4j.Slf4j;
 
 import java.util.List;
@@ -174,6 +175,7 @@ public final class ProducerStartupCoordinator {
                     epochNonceState,
                     nonceStore,
                     protocolVersionSupplier,
+                    BlockBodySizeLimitSupplier.fromEpochParams(actions::effectiveEpochParamProvider),
                     activeSlotsCoeff);
             var signedBlockBuilder = signingComponents.signedBlockBuilder();
             var slotLeaderCheck = signingComponents.slotLeaderCheck();

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/SlotLeaderSigningComponents.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/SlotLeaderSigningComponents.java
@@ -1,6 +1,7 @@
 package com.bloxbean.cardano.yano.runtime.producer;
 
 import com.bloxbean.cardano.yano.runtime.blockproducer.EpochNonceState;
+import com.bloxbean.cardano.yano.runtime.blockproducer.BlockBodySizeLimitSupplier;
 import com.bloxbean.cardano.yano.runtime.blockproducer.NonceStateStore;
 import com.bloxbean.cardano.yano.runtime.blockproducer.ProtocolVersionSupplier;
 import com.bloxbean.cardano.yano.runtime.blockproducer.SignedBlockBuilder;
@@ -28,9 +29,22 @@ public record SlotLeaderSigningComponents(
                                                      NonceStateStore nonceStore,
                                                      ProtocolVersionSupplier protocolVersionSupplier,
                                                      double activeSlotsCoeff) {
+        return create(keyMaterial, slotsPerKESPeriod, maxKESEvolutions, epochNonceState, nonceStore,
+                protocolVersionSupplier, BlockBodySizeLimitSupplier.unbounded(), activeSlotsCoeff);
+    }
+
+    public static SlotLeaderSigningComponents create(SlotLeaderKeyMaterial keyMaterial,
+                                                     long slotsPerKESPeriod,
+                                                     long maxKESEvolutions,
+                                                     EpochNonceState epochNonceState,
+                                                     NonceStateStore nonceStore,
+                                                     ProtocolVersionSupplier protocolVersionSupplier,
+                                                     BlockBodySizeLimitSupplier blockBodySizeLimitSupplier,
+                                                     double activeSlotsCoeff) {
         Objects.requireNonNull(keyMaterial, "keyMaterial");
         Objects.requireNonNull(epochNonceState, "epochNonceState");
         Objects.requireNonNull(protocolVersionSupplier, "protocolVersionSupplier");
+        Objects.requireNonNull(blockBodySizeLimitSupplier, "blockBodySizeLimitSupplier");
 
         var signedBlockBuilder = new SignedBlockBuilder(
                 keyMaterial.keys(),
@@ -38,7 +52,8 @@ public record SlotLeaderSigningComponents(
                 maxKESEvolutions,
                 epochNonceState,
                 nonceStore,
-                protocolVersionSupplier);
+                protocolVersionSupplier,
+                blockBodySizeLimitSupplier);
         var slotLeaderCheck = new SlotLeaderCheck(
                 keyMaterial.keys().getVrfSkey(),
                 BigDecimal.valueOf(activeSlotsCoeff),

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelector.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelector.java
@@ -10,4 +10,20 @@ public interface BlockTransactionSelector {
     boolean hasPendingTransactions();
 
     List<byte[]> drainForBlock();
+
+    /** Release a successful selection after its block reaches canonical apply. */
+    default void blockSelectionCompleted() {
+    }
+
+    /** Release a selection when forging or storing its candidate fails. */
+    default void blockSelectionFailed() {
+    }
+
+    /**
+     * Compatibility hook for selectors used directly by a producer without a
+     * transaction subsystem. The authoritative TxSubsystem path waits for the
+     * canonical UTXO acknowledgement instead.
+     */
+    default void blockCandidatePublished() {
+    }
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelector.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelector.java
@@ -20,6 +20,15 @@ public interface BlockTransactionSelector {
     }
 
     /**
+     * Invalidate one selected transaction that can never fit an empty block
+     * under the current protocol limits. Implementations should also remove
+     * dependent descendants.
+     */
+    default int invalidateSelectedTransaction(String txHash) {
+        return 0;
+    }
+
+    /**
      * Compatibility hook for selectors used directly by a producer without a
      * transaction subsystem. The authoritative TxSubsystem path waits for the
      * canonical UTXO acknowledgement instead.

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelectors.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelectors.java
@@ -97,6 +97,11 @@ public final class BlockTransactionSelectors {
         }
 
         @Override
+        public int invalidateSelectedTransaction(String txHash) {
+            return memPool.removeInvalidated(Set.of(txHash));
+        }
+
+        @Override
         public void blockCandidatePublished() {
             Set<String> published = selectedHashes;
             if (!published.isEmpty()) memPool.removeByTxHashes(published);

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelectors.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/BlockTransactionSelectors.java
@@ -7,24 +7,26 @@ import com.bloxbean.cardano.yano.ledgerrules.ValidationResult;
 import com.bloxbean.cardano.yano.runtime.blockproducer.BlockBuildUtxoOverlay;
 import com.bloxbean.cardano.yano.runtime.blockproducer.TransactionValidationService;
 import com.bloxbean.cardano.yano.runtime.chain.MemPool;
+import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 import org.slf4j.Logger;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 
-/**
- * Factory methods for block transaction selection strategies.
- */
+/** Factory methods for block transaction selection strategies. */
 public final class BlockTransactionSelectors {
     private BlockTransactionSelectors() {
     }
 
-    public static BlockTransactionSelector fromMemPool(MemPool memPool,
-                                                       Supplier<TransactionValidationService> validatorServiceSupplier,
-                                                       Supplier<UtxoState> utxoStateSupplier,
-                                                       Logger log) {
+    public static BlockTransactionSelector fromMemPool(
+            MemPool memPool,
+            Supplier<TransactionValidationService> validatorServiceSupplier,
+            Supplier<UtxoState> utxoStateSupplier,
+            Logger log) {
         return new MempoolBlockTransactionSelector(
                 Objects.requireNonNull(memPool, "memPool"),
                 Objects.requireNonNull(validatorServiceSupplier, "validatorServiceSupplier"),
@@ -33,14 +35,29 @@ public final class BlockTransactionSelectors {
     }
 
     /**
-     * Mempool-backed selector that optionally validates transactions against a
-     * block-local UTXO overlay before inclusion.
+     * Selection uses an insertion-ordered immutable snapshot. It never removes
+     * selected transactions; confirmation cleanup happens after canonical UTXO
+     * apply. One selection may be in flight at a time.
      */
-    private record MempoolBlockTransactionSelector(MemPool memPool,
-                                                   Supplier<TransactionValidationService> validatorServiceSupplier,
-                                                   Supplier<UtxoState> utxoStateSupplier,
-                                                   Logger log)
-            implements BlockTransactionSelector {
+    private static final class MempoolBlockTransactionSelector implements BlockTransactionSelector {
+        private final MemPool memPool;
+        private final Supplier<TransactionValidationService> validatorServiceSupplier;
+        private final Supplier<UtxoState> utxoStateSupplier;
+        private final Logger log;
+        private final AtomicBoolean selectionInFlight = new AtomicBoolean();
+        private volatile Set<String> selectedHashes = Set.of();
+
+        private MempoolBlockTransactionSelector(
+                MemPool memPool,
+                Supplier<TransactionValidationService> validatorServiceSupplier,
+                Supplier<UtxoState> utxoStateSupplier,
+                Logger log) {
+            this.memPool = memPool;
+            this.validatorServiceSupplier = validatorServiceSupplier;
+            this.utxoStateSupplier = utxoStateSupplier;
+            this.log = log;
+        }
+
         @Override
         public boolean hasPendingTransactions() {
             return !memPool.isEmpty();
@@ -48,38 +65,69 @@ public final class BlockTransactionSelectors {
 
         @Override
         public List<byte[]> drainForBlock() {
-            return drainMempool(validatorServiceSupplier.get(), utxoStateSupplier.get());
+            if (!selectionInFlight.compareAndSet(false, true)) {
+                throw new IllegalStateException("a block transaction selection is already in flight");
+            }
+            try {
+                List<byte[]> selected = selectMempool(
+                        validatorServiceSupplier.get(), utxoStateSupplier.get());
+                if (selected.isEmpty()) {
+                    selectionInFlight.set(false);
+                } else {
+                    selectedHashes = selected.stream()
+                            .map(TransactionUtil::getTxHash).collect(java.util.stream.Collectors.toUnmodifiableSet());
+                }
+                return selected;
+            } catch (RuntimeException | Error e) {
+                selectionInFlight.set(false);
+                throw e;
+            }
         }
 
-        private List<byte[]> drainMempool(TransactionValidationService validatorService,
-                                          UtxoState utxoState) {
+        @Override
+        public void blockSelectionCompleted() {
+            selectedHashes = Set.of();
+            selectionInFlight.set(false);
+        }
+
+        @Override
+        public void blockSelectionFailed() {
+            selectedHashes = Set.of();
+            selectionInFlight.set(false);
+        }
+
+        @Override
+        public void blockCandidatePublished() {
+            Set<String> published = selectedHashes;
+            if (!published.isEmpty()) memPool.removeByTxHashes(published);
+            blockSelectionCompleted();
+        }
+
+        private List<byte[]> selectMempool(TransactionValidationService validatorService,
+                                           UtxoState utxoState) {
+            List<MemPoolTransaction> snapshot = memPool.snapshotTransactions(
+                    Integer.MAX_VALUE, Long.MAX_VALUE);
             if (validatorService == null || utxoState == null) {
-                List<byte[]> txList = new ArrayList<>();
-                while (!memPool.isEmpty()) {
-                    MemPoolTransaction mpt = memPool.getNextTransaction();
-                    if (mpt == null) break;
-                    txList.add(mpt.txBytes());
-                }
-                return txList;
+                return snapshot.stream().map(MemPoolTransaction::txBytes).toList();
             }
 
             BlockBuildUtxoOverlay overlay = new BlockBuildUtxoOverlay(utxoState);
-            List<byte[]> txList = new ArrayList<>();
-            while (!memPool.isEmpty()) {
-                MemPoolTransaction mpt = memPool.getNextTransaction();
-                if (mpt == null) break;
+            List<byte[]> selected = new ArrayList<>();
+            for (MemPoolTransaction candidate : snapshot) {
+                String txHash = HexUtil.encodeHexString(candidate.txHash());
+                if (!memPool.contains(txHash)) continue;
 
-                ValidationResult result = validatorService.validate(mpt.txBytes(), overlay.resolver());
+                ValidationResult result = validatorService.validate(candidate.txBytes(), overlay.resolver());
                 if (result.valid()) {
-                    txList.add(mpt.txBytes());
-                    overlay.markSpent(mpt.txBytes());
+                    selected.add(candidate.txBytes());
+                    overlay.applyTransaction(candidate.txBytes());
                 } else {
-                    String txHashHex = HexUtil.encodeHexString(mpt.txHash());
                     log.warn("Dropping invalid tx {} during block production: {}",
-                            txHashHex, result.firstErrorMessage("unknown error"));
+                            txHash, result.firstErrorMessage("unknown error"));
+                    memPool.removeInvalidated(Set.of(txHash));
                 }
             }
-            return txList;
+            return List.copyOf(selected);
         }
     }
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystem.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystem.java
@@ -64,7 +64,7 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
     private static final int DEFAULT_MEMPOOL_MAX_TXS = 10_000;
     private static final long DEFAULT_MEMPOOL_MAX_BYTES = 128L * 1024L * 1024L;
     private static final long DEFAULT_MEMPOOL_TTL_SECONDS = 10_800L;
-    private static final int DEFAULT_MEMPOOL_MAX_UTXO_INDEX_ENTRIES = 250_000;
+    private static final int DEFAULT_MEMPOOL_MAX_UTXO_INDEX_ENTRIES = 100_000;
     private static final boolean DEFAULT_TX_DIFFUSION_ENABLED = true;
     private static final String DEFAULT_TX_DIFFUSION_MODE = "all-hot";
     private static final int DEFAULT_MAX_IN_FLIGHT_TXS_PER_PEER = 100;

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystem.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystem.java
@@ -11,6 +11,9 @@ import com.bloxbean.cardano.yano.api.config.YanoPropertyKeys;
 import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
 import com.bloxbean.cardano.yano.api.events.MemPoolTransactionReceivedEvent;
 import com.bloxbean.cardano.yano.api.events.TransactionValidateEvent;
+import com.bloxbean.cardano.yano.api.events.RollbackEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateRolledBackEvent;
 import com.bloxbean.cardano.yano.api.model.MemPoolTransaction;
 import com.bloxbean.cardano.yano.api.model.TxEvaluationResult;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
@@ -23,6 +26,9 @@ import com.bloxbean.cardano.yano.runtime.chain.DefaultMemPool;
 import com.bloxbean.cardano.yano.runtime.chain.DefaultMempoolEvictionPolicy;
 import com.bloxbean.cardano.yano.runtime.chain.MemPool;
 import com.bloxbean.cardano.yano.runtime.chain.MempoolEvictionPolicy;
+import com.bloxbean.cardano.yano.runtime.chain.MempoolAdmissionException;
+import com.bloxbean.cardano.yano.runtime.chain.MempoolAdmissionLimits;
+import com.bloxbean.cardano.yano.runtime.chain.MempoolAdmissionResult;
 import com.bloxbean.cardano.yano.runtime.kernel.Subsystem;
 import com.bloxbean.cardano.yano.runtime.kernel.SubsystemHealth;
 import com.bloxbean.cardano.yano.p2p.tx.diffusion.DefaultTxDiffusion;
@@ -36,7 +42,6 @@ import org.slf4j.Logger;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -44,6 +49,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BiConsumer;
 import java.util.function.Supplier;
+
+import static com.bloxbean.cardano.yano.runtime.util.LifecycleFailures.rethrowIfProcessFatalReachable;
 
 /**
  * Owns mempool state, transaction validation/evaluation services, and transaction
@@ -53,6 +60,7 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
     private static final int DEFAULT_MEMPOOL_MAX_TXS = 10_000;
     private static final long DEFAULT_MEMPOOL_MAX_BYTES = 128L * 1024L * 1024L;
     private static final long DEFAULT_MEMPOOL_TTL_SECONDS = 10_800L;
+    private static final int DEFAULT_MEMPOOL_MAX_UTXO_INDEX_ENTRIES = 250_000;
     private static final boolean DEFAULT_TX_DIFFUSION_ENABLED = true;
     private static final String DEFAULT_TX_DIFFUSION_MODE = "all-hot";
     private static final int DEFAULT_MAX_IN_FLIGHT_TXS_PER_PEER = 100;
@@ -72,6 +80,9 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
     private volatile TransactionEvaluationService transactionEvaluationService;
     private MempoolEvictionPolicy mempoolEvictionPolicy;
     private SubscriptionHandle mempoolEvictionSubscription;
+    private SubscriptionHandle mempoolUtxoAppliedSubscription;
+    private SubscriptionHandle mempoolRollbackSubscription;
+    private SubscriptionHandle mempoolUtxoRollbackSubscription;
     private SubscriptionHandle txDiffusionSubscription;
     private ScheduledFuture<?> mempoolEvictionTask;
     private List<SubscriptionHandle> validatorListenerSubscriptions = List.of();
@@ -81,6 +92,7 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
     private volatile int mempoolMaxTxs = DEFAULT_MEMPOOL_MAX_TXS;
     private volatile long mempoolMaxBytes = DEFAULT_MEMPOOL_MAX_BYTES;
     private volatile long mempoolTtlSeconds = DEFAULT_MEMPOOL_TTL_SECONDS;
+    private volatile int mempoolMaxUtxoIndexEntries = DEFAULT_MEMPOOL_MAX_UTXO_INDEX_ENTRIES;
     private volatile String txDiffusionMode = DEFAULT_TX_DIFFUSION_MODE;
     private volatile int txDiffusionMaxInFlightTxsPerPeer = DEFAULT_MAX_IN_FLIGHT_TXS_PER_PEER;
     private volatile long txDiffusionMaxInFlightBytesPerPeer = DEFAULT_MAX_IN_FLIGHT_BYTES_PER_PEER;
@@ -140,9 +152,23 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         mempoolEvictionPolicy = new DefaultMempoolEvictionPolicy(
                 memPool, maxAgeMillis, mempoolMaxTxs, mempoolMaxBytes);
 
-        mempoolEvictionSubscription = eventBus.subscribe(BlockAppliedEvent.class, ctx ->
-                        mempoolEvictionPolicy.onBlockApplied(ctx.event()),
+        mempoolEvictionSubscription = eventBus.subscribe(BlockAppliedEvent.class, ctx -> {
+                    UtxoState state = utxoStateSupplier.get();
+                    if (state == null || !state.isEnabled()) {
+                        onCanonicalBlockApplied(ctx.event());
+                    }
+                }, SubscriptionOptions.builder().priority(200).build());
+        mempoolUtxoAppliedSubscription = eventBus.subscribe(UtxoStateAppliedEvent.class,
+                ctx -> onCanonicalBlockApplied(ctx.event().blockAppliedEvent()),
                 SubscriptionOptions.builder().build());
+        mempoolRollbackSubscription = eventBus.subscribe(RollbackEvent.class, ctx -> {
+                    UtxoState state = utxoStateSupplier.get();
+                    if (state == null || !state.isEnabled()) {
+                        onCanonicalRollbackApplied();
+                    }
+                }, SubscriptionOptions.builder().priority(200).build());
+        mempoolUtxoRollbackSubscription = eventBus.subscribe(UtxoStateRolledBackEvent.class,
+                ctx -> onCanonicalRollbackApplied(), SubscriptionOptions.builder().build());
         txDiffusionSubscription = eventBus.subscribe(MemPoolTransactionReceivedEvent.class,
                 ctx -> txDiffusion.onTransactionAccepted(ctx.event().transaction()),
                 SubscriptionOptions.builder().build());
@@ -156,8 +182,9 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         }, 30, 30, TimeUnit.SECONDS);
 
         enableAdmission();
-        log.info("Mempool eviction policy initialized (ttl={}s, maxTxs={}, maxBytes={}, txDiffusionMode={})",
-                mempoolTtlSeconds, mempoolMaxTxs, mempoolMaxBytes, txDiffusionMode);
+        log.info("Mempool initialized (ttl={}s, maxTxs={}, maxBytes={}, maxUtxoIndexEntries={}, txDiffusionMode={})",
+                mempoolTtlSeconds, mempoolMaxTxs, mempoolMaxBytes,
+                mempoolMaxUtxoIndexEntries, txDiffusionMode);
     }
 
     @Override
@@ -191,6 +218,18 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         if (mempoolEvictionSubscription != null) {
             mempoolEvictionSubscription.close();
             mempoolEvictionSubscription = null;
+        }
+        if (mempoolUtxoAppliedSubscription != null) {
+            mempoolUtxoAppliedSubscription.close();
+            mempoolUtxoAppliedSubscription = null;
+        }
+        if (mempoolRollbackSubscription != null) {
+            mempoolRollbackSubscription.close();
+            mempoolRollbackSubscription = null;
+        }
+        if (mempoolUtxoRollbackSubscription != null) {
+            mempoolUtxoRollbackSubscription.close();
+            mempoolUtxoRollbackSubscription = null;
         }
         if (txDiffusionSubscription != null) {
             txDiffusionSubscription.close();
@@ -273,35 +312,34 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         readLock.lock();
         try {
             ensureAccepting();
-            String txHash = TransactionUtil.getTxHash(txCbor);
             String eventOrigin = normalizeOrigin(origin);
-
-            var validateEvent = new TransactionValidateEvent(txCbor, txHash, eventOrigin);
-            eventBus.publish(validateEvent,
-                    EventMetadata.builder().origin(eventOrigin).build(),
-                    PublishOptions.builder().build());
-
-            if (validateEvent.isRejected()) {
-                throw new TransactionValidationException(validateEvent.rejections());
-            }
-
-            ensureAccepting();
-            boolean alreadyPresent = memPool.contains(txHash);
-            var memPoolTransaction = memPool.addTransaction(txCbor);
-            if (memPoolTransaction != null) {
-                try {
-                    eventBus.publish(new MemPoolTransactionReceivedEvent(memPoolTransaction),
+            UtxoState canonicalState = utxoStateSupplier.get();
+            var admission = memPool.tryAdmit(
+                    txCbor,
+                    outpoint -> canonicalState != null
+                            ? canonicalState.getUtxo(outpoint).orElse(null) : null,
+                    (admissionBytes, txHash, resolver) -> {
+                        var validateEvent = new TransactionValidateEvent(
+                                admissionBytes, txHash, eventOrigin, resolver);
+                        eventBus.publish(validateEvent,
+                                EventMetadata.builder().origin(eventOrigin).build(),
+                                PublishOptions.builder().build());
+                        return validateEvent.rejections();
+                    },
+                    new MempoolAdmissionLimits(
+                            mempoolMaxTxs, mempoolMaxBytes, mempoolMaxUtxoIndexEntries),
+                    memPoolTransaction -> eventBus.publish(
+                            new MemPoolTransactionReceivedEvent(memPoolTransaction),
                             EventMetadata.builder().origin(eventOrigin).build(),
-                            PublishOptions.builder().build());
-                } catch (RuntimeException | Error e) {
-                    if (!alreadyPresent) {
-                        memPool.removeByTxHashes(Set.of(txHash));
-                    }
-                    throw e;
-                }
-            }
+                            PublishOptions.builder().build()));
 
-            return txHash;
+            if (admission.status() == MempoolAdmissionResult.Status.LEDGER_REJECTED) {
+                throw new TransactionValidationException(admission.rejections());
+            }
+            if (!admission.present()) {
+                throw new MempoolAdmissionException(admission);
+            }
+            return admission.txHash();
         } finally {
             readLock.unlock();
         }
@@ -326,6 +364,10 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
 
     public long mempoolTtlSeconds() {
         return mempoolTtlSeconds;
+    }
+
+    public int mempoolMaxUtxoIndexEntries() {
+        return mempoolMaxUtxoIndexEntries;
     }
 
     public String txDiffusionMode() {
@@ -380,6 +422,23 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         return blockTransactionSelector.drainForBlock();
     }
 
+    @Override
+    public void blockSelectionCompleted() {
+        blockTransactionSelector.blockSelectionCompleted();
+    }
+
+    @Override
+    public void blockSelectionFailed() {
+        blockTransactionSelector.blockSelectionFailed();
+    }
+
+    /** Canonical acknowledgement, not publication, completes TxSubsystem selection. */
+    @Override
+    public void blockCandidatePublished() {
+        // Intentionally no-op. Selected entries remain visible until
+        // UtxoStateAppliedEvent drives onCanonicalBlockApplied().
+    }
+
     public void clearPendingTransactions() {
         var writeLock = admissionGate.writeLock();
         writeLock.lock();
@@ -396,11 +455,29 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
 
     @Override
     public synchronized SubsystemHealth health() {
+        var mempoolStats = memPool.stats();
         return new SubsystemHealth(name(), SubsystemHealth.Status.UP, null, Map.ofEntries(
                 Map.entry("mempoolSize", memPool.size()),
                 Map.entry("mempoolBytes", memPool.byteSize()),
                 Map.entry("mempoolMaxTxs", mempoolMaxTxs),
                 Map.entry("mempoolMaxBytes", mempoolMaxBytes),
+                Map.entry("mempoolUtxoIndexEntries", mempoolStats.utxoIndexEntries()),
+                Map.entry("mempoolProducedOutputs", mempoolStats.producedOutputs()),
+                Map.entry("mempoolSpentOutpoints", mempoolStats.spentOutpoints()),
+                Map.entry("mempoolDependencyEdges", mempoolStats.dependencyEdges()),
+                Map.entry("mempoolEstimatedIndexBytes", mempoolStats.estimatedIndexBytes()),
+                Map.entry("mempoolMaxUtxoIndexEntries", mempoolMaxUtxoIndexEntries),
+                Map.entry("mempoolDuplicateRejections", mempoolStats.duplicateRejections()),
+                Map.entry("mempoolConflictRejections", mempoolStats.conflictRejections()),
+                Map.entry("mempoolCapacityRejections", mempoolStats.capacityRejections()),
+                Map.entry("mempoolMalformedRejections", mempoolStats.malformedRejections()),
+                Map.entry("mempoolLedgerRejections", mempoolStats.ledgerRejections()),
+                Map.entry("mempoolCascadedRemovals", mempoolStats.cascadedRemovals()),
+                Map.entry("mempoolAdmissionQueueLength", mempoolStats.admissionQueueLength()),
+                Map.entry("mempoolAdmissionWaitNanos", mempoolStats.totalAdmissionWaitNanos()),
+                Map.entry("mempoolAdmissionHoldNanos", mempoolStats.totalAdmissionHoldNanos()),
+                Map.entry("mempoolValidationNanos", mempoolStats.totalValidationNanos()),
+                Map.entry("mempoolSlowValidations", mempoolStats.slowValidations()),
                 Map.entry("mempoolTtlSeconds", mempoolTtlSeconds),
                 Map.entry("accepting", accepting),
                 Map.entry("validationAvailable", transactionValidationService != null),
@@ -420,6 +497,9 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
                 globals, YanoPropertyKeys.Tx.MEMPOOL_MAX_BYTES, DEFAULT_MEMPOOL_MAX_BYTES));
         mempoolTtlSeconds = Math.max(0L, resolveLong(
                 globals, YanoPropertyKeys.Tx.MEMPOOL_TTL_SECONDS, DEFAULT_MEMPOOL_TTL_SECONDS));
+        mempoolMaxUtxoIndexEntries = Math.max(1, resolveInt(
+                globals, YanoPropertyKeys.Tx.MEMPOOL_MAX_UTXO_INDEX_ENTRIES,
+                DEFAULT_MEMPOOL_MAX_UTXO_INDEX_ENTRIES));
         txDiffusionMode = resolveTxDiffusionMode(globals);
         txDiffusionMaxInFlightTxsPerPeer = Math.max(1, resolveInt(
                 globals,
@@ -497,6 +577,35 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
 
     private static String normalizeOrigin(String origin) {
         return origin != null && !origin.isBlank() ? origin : "unknown";
+    }
+
+    private void onCanonicalBlockApplied(BlockAppliedEvent event) {
+        try {
+            MempoolEvictionPolicy policy = mempoolEvictionPolicy;
+            if (policy != null) policy.onBlockApplied(event);
+        } catch (Throwable e) {
+            rethrowIfProcessFatalReachable(e);
+            // Canonical UTXO state is already durable. Mempool reconciliation is
+            // derived bookkeeping and cannot be allowed to fail ledger apply.
+            log.error("Mempool cleanup failed after canonical block #{} apply: {}",
+                    event.blockNumber(), e.toString(), e);
+        } finally {
+            blockTransactionSelector.blockSelectionCompleted();
+        }
+    }
+
+    private void onCanonicalRollbackApplied() {
+        try {
+            UtxoState state = utxoStateSupplier.get();
+            memPool.revalidate(outpoint -> state != null
+                    ? state.getUtxo(outpoint).orElse(null) : null);
+        } catch (Throwable e) {
+            rethrowIfProcessFatalReachable(e);
+            log.error("Mempool reconciliation failed after canonical rollback: {}",
+                    e.toString(), e);
+        } finally {
+            blockTransactionSelector.blockSelectionCompleted();
+        }
     }
 
     private void ensureAccepting() {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystem.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystem.java
@@ -17,6 +17,8 @@ import com.bloxbean.cardano.yano.api.events.UtxoStateRolledBackEvent;
 import com.bloxbean.cardano.yano.api.model.MemPoolTransaction;
 import com.bloxbean.cardano.yano.api.model.TxEvaluationResult;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionValidator;
 import com.bloxbean.cardano.yano.runtime.blockproducer.TransactionEvaluationService;
@@ -29,6 +31,7 @@ import com.bloxbean.cardano.yano.runtime.chain.MempoolEvictionPolicy;
 import com.bloxbean.cardano.yano.runtime.chain.MempoolAdmissionException;
 import com.bloxbean.cardano.yano.runtime.chain.MempoolAdmissionLimits;
 import com.bloxbean.cardano.yano.runtime.chain.MempoolAdmissionResult;
+import com.bloxbean.cardano.yano.runtime.chain.MempoolStats;
 import com.bloxbean.cardano.yano.runtime.kernel.Subsystem;
 import com.bloxbean.cardano.yano.runtime.kernel.SubsystemHealth;
 import com.bloxbean.cardano.yano.p2p.tx.diffusion.DefaultTxDiffusion;
@@ -43,6 +46,7 @@ import org.slf4j.Logger;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -290,10 +294,32 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         if (transactionEvaluationService == null) {
             throw new UnsupportedOperationException("Transaction evaluation is not available");
         }
-        return transactionEvaluationService.evaluate(txCbor).stream()
+        UtxoState canonicalState = utxoStateSupplier.get();
+        return transactionEvaluationService.evaluate(txCbor,
+                        outpoints -> memPool.resolveUtxos(outpoints,
+                                outpoint -> canonicalState != null
+                                        ? canonicalState.getUtxo(outpoint).orElse(null) : null))
+                .stream()
                 .map(result -> new TxEvaluationResult(
                         result.tag(), result.index(), result.memory(), result.steps()))
                 .toList();
+    }
+
+    public Optional<Utxo> resolveUtxo(Outpoint outpoint) {
+        Objects.requireNonNull(outpoint, "outpoint");
+        UtxoState canonicalState = utxoStateSupplier.get();
+        return Optional.ofNullable(memPool.resolveUtxos(List.of(outpoint),
+                candidate -> canonicalState != null
+                        ? canonicalState.getUtxo(candidate).orElse(null) : null).get(outpoint));
+    }
+
+    public Optional<byte[]> getScriptRefBytesByHash(String scriptHash) {
+        Objects.requireNonNull(scriptHash, "scriptHash");
+        Optional<byte[]> mempoolScript = memPool.getScriptRefBytesByHash(scriptHash);
+        if (mempoolScript.isPresent()) return mempoolScript;
+        UtxoState canonicalState = utxoStateSupplier.get();
+        return canonicalState != null
+                ? canonicalState.getScriptRefBytesByHash(scriptHash) : Optional.empty();
     }
 
     public String submitTransaction(byte[] txCbor, BiConsumer<String, byte[]> acceptedSubmitter) {
@@ -370,6 +396,10 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         return mempoolMaxUtxoIndexEntries;
     }
 
+    public MempoolStats mempoolStats() {
+        return memPool.stats();
+    }
+
     public String txDiffusionMode() {
         return txDiffusionMode;
     }
@@ -432,6 +462,11 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
         blockTransactionSelector.blockSelectionFailed();
     }
 
+    @Override
+    public int invalidateSelectedTransaction(String txHash) {
+        return blockTransactionSelector.invalidateSelectedTransaction(txHash);
+    }
+
     /** Canonical acknowledgement, not publication, completes TxSubsystem selection. */
     @Override
     public void blockCandidatePublished() {
@@ -464,6 +499,7 @@ public final class TxSubsystem implements Subsystem, TransactionAdmission, Block
                 Map.entry("mempoolUtxoIndexEntries", mempoolStats.utxoIndexEntries()),
                 Map.entry("mempoolProducedOutputs", mempoolStats.producedOutputs()),
                 Map.entry("mempoolSpentOutpoints", mempoolStats.spentOutpoints()),
+                Map.entry("mempoolReferenceScripts", mempoolStats.referenceScripts()),
                 Map.entry("mempoolDependencyEdges", mempoolStats.dependencyEdges()),
                 Map.entry("mempoolEstimatedIndexBytes", mempoolStats.estimatedIndexBytes()),
                 Map.entry("mempoolMaxUtxoIndexEntries", mempoolMaxUtxoIndexEntries),

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoEventHandler.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoEventHandler.java
@@ -7,6 +7,13 @@ import com.bloxbean.cardano.yaci.events.api.DomainEventListener;
 import com.bloxbean.cardano.yaci.events.api.EventBus;
 import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
 import com.bloxbean.cardano.yano.api.events.RollbackEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateRolledBackEvent;
+import com.bloxbean.cardano.yaci.events.api.EventMetadata;
+import com.bloxbean.cardano.yaci.events.api.PublishOptions;
+import lombok.extern.slf4j.Slf4j;
+
+import static com.bloxbean.cardano.yano.runtime.util.LifecycleFailures.rethrowIfProcessFatalReachable;
 
 import java.util.List;
 
@@ -14,11 +21,14 @@ import java.util.List;
  * Synchronous event handler that delegates to a UtxoStoreWriter.
  * Keeps ordering and atomicity identical to current behavior.
  */
+@Slf4j
 public final class UtxoEventHandler implements AutoCloseable {
+    private final EventBus bus;
     private final UtxoStoreWriter writer;
     private final List<SubscriptionHandle> handles;
 
     public UtxoEventHandler(EventBus bus, UtxoStoreWriter writer) {
+        this.bus = bus;
         this.writer = writer;
         SubscriptionOptions defaults = SubscriptionOptions.builder().build();
         this.handles = AnnotationListenerRegistrar.register(bus, this, defaults);
@@ -26,12 +36,32 @@ public final class UtxoEventHandler implements AutoCloseable {
 
     @DomainEventListener(order = 100)
     public void onBlockApplied(BlockAppliedEvent e) {
-        if (writer != null && writer.isEnabled()) writer.applyBlock(e);
+        if (writer != null && writer.isEnabled()) {
+            writer.applyBlock(e);
+            publishAcknowledgement(new UtxoStateAppliedEvent(e), "UTXO apply");
+        }
     }
 
     @DomainEventListener(order = 100)
     public void onRollback(RollbackEvent e) {
-        if (writer != null && writer.isEnabled()) writer.rollbackTo(e);
+        if (writer != null && writer.isEnabled()) {
+            writer.rollbackTo(e);
+            publishAcknowledgement(new UtxoStateRolledBackEvent(e), "UTXO rollback");
+        }
+    }
+
+    private void publishAcknowledgement(com.bloxbean.cardano.yaci.events.api.Event acknowledgement,
+                                        String operation) {
+        try {
+            bus.publish(acknowledgement, EventMetadata.builder().build(),
+                    PublishOptions.builder().build());
+        } catch (Throwable e) {
+            rethrowIfProcessFatalReachable(e);
+            // The canonical write has already committed. A derived-state listener
+            // must not make that durable write appear to have failed.
+            log.error("Listener failed after {}; canonical state remains applied: {}",
+                    operation, e.toString(), e);
+        }
     }
 
     @Override
@@ -39,4 +69,3 @@ public final class UtxoEventHandler implements AutoCloseable {
         if (handles != null) handles.forEach(h -> { try { h.close(); } catch (Exception ignored) {} });
     }
 }
-

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoEventHandlerAsync.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoEventHandlerAsync.java
@@ -8,6 +8,10 @@ import com.bloxbean.cardano.yaci.events.api.SubscriptionOptions;
 import com.bloxbean.cardano.yaci.events.api.support.AnnotationListenerRegistrar;
 import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
 import com.bloxbean.cardano.yano.api.events.RollbackEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateRolledBackEvent;
+import com.bloxbean.cardano.yaci.events.api.EventMetadata;
+import com.bloxbean.cardano.yaci.events.api.PublishOptions;
 import com.bloxbean.cardano.yano.runtime.events.PropagatingEventBus;
 
 import java.util.List;
@@ -20,6 +24,8 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static com.bloxbean.cardano.yano.runtime.util.LifecycleFailures.rethrowIfProcessFatalReachable;
+
 /**
  * Optional async UTXO event handler that preserves ordering using a single-thread executor.
  * Apply/rollback are offloaded off the publisher thread but executed sequentially.
@@ -28,12 +34,14 @@ public final class UtxoEventHandlerAsync implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(UtxoEventHandlerAsync.class);
 
     private final UtxoStoreWriter writer;
+    private final EventBus bus;
     private final PropagatingEventBus propagatingEventBus;
     private final ExecutorService single;
     private final List<SubscriptionHandle> handles;
     private final AtomicReference<RuntimeException> failure = new AtomicReference<>();
 
     public UtxoEventHandlerAsync(EventBus bus, UtxoStoreWriter writer) {
+        this.bus = bus;
         this.writer = writer;
         this.propagatingEventBus = bus instanceof PropagatingEventBus propagating ? propagating : null;
         this.single = Executors.newSingleThreadExecutor(r -> {
@@ -50,7 +58,10 @@ public final class UtxoEventHandlerAsync implements AutoCloseable {
         throwIfFailed();
         if (writer == null || !writer.isEnabled()) return;
         try {
-            single.execute(() -> runAsync(BlockAppliedEvent.class, "BlockAppliedEvent", () -> writer.applyBlock(e)));
+            single.execute(() -> runAsync(BlockAppliedEvent.class, "BlockAppliedEvent", () -> {
+                writer.applyBlock(e);
+                publishAcknowledgement(new UtxoStateAppliedEvent(e), "UTXO apply");
+            }));
         } catch (RejectedExecutionException ex) {
             throw recordFailure(BlockAppliedEvent.class, "BlockAppliedEvent enqueue", ex);
         }
@@ -61,7 +72,10 @@ public final class UtxoEventHandlerAsync implements AutoCloseable {
         throwIfFailed();
         if (writer == null || !writer.isEnabled()) return;
         try {
-            single.execute(() -> runAsync(RollbackEvent.class, "RollbackEvent", () -> writer.rollbackTo(e)));
+            single.execute(() -> runAsync(RollbackEvent.class, "RollbackEvent", () -> {
+                writer.rollbackTo(e);
+                publishAcknowledgement(new UtxoStateRolledBackEvent(e), "UTXO rollback");
+            }));
         } catch (RejectedExecutionException ex) {
             throw recordFailure(RollbackEvent.class, "RollbackEvent enqueue", ex);
         }
@@ -86,6 +100,19 @@ public final class UtxoEventHandlerAsync implements AutoCloseable {
             work.run();
         } catch (Throwable t) {
             recordFailure(eventType, description, t);
+        }
+    }
+
+    private void publishAcknowledgement(Event acknowledgement, String operation) {
+        try {
+            bus.publish(acknowledgement, EventMetadata.builder().build(),
+                    PublishOptions.builder().build());
+        } catch (Throwable e) {
+            rethrowIfProcessFatalReachable(e);
+            // Keep acknowledgement listeners outside the writer failure domain.
+            // The canonical mutation succeeded and must remain authoritative.
+            log.error("Listener failed after {}; canonical state remains applied: {}",
+                    operation, e.toString(), e);
         }
     }
 

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/validation/DefaultTransactionValidatorListener.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/validation/DefaultTransactionValidatorListener.java
@@ -46,7 +46,9 @@ public class DefaultTransactionValidatorListener {
             return;
         }
 
-        ValidationResult result = validationService.validate(event.txCbor());
+        ValidationResult result = event.utxoResolver() != null
+                ? validationService.validate(event.txCbor(), event.utxoResolver())
+                : validationService.validate(event.txCbor());
         if (!result.valid()) {
             for (ValidationError err : result.errors()) {
                 event.reject(err.rule(), err.message());

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/AppChainSnapshotTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/AppChainSnapshotTest.java
@@ -287,11 +287,17 @@ class AppChainSnapshotTest {
         Path ledgerDir = restoreBase.resolve("snap-chain");
         copyDir(snapshotDir, ledgerDir);
 
-        // Flip one byte in the first sst/log file covered by the manifest
-        Path victim = java.nio.file.Files.walk(ledgerDir)
-                .filter(java.nio.file.Files::isRegularFile)
-                .filter(p -> !p.getFileName().toString().startsWith("snapshot-manifest"))
-                .findFirst().orElseThrow();
+        // Flip one byte in a non-empty snapshot data file covered by the manifest.
+        // RocksDB checkpoints may contain zero-byte files, and Files.walk() does
+        // not guarantee an order across filesystems.
+        Path victim;
+        try (var files = java.nio.file.Files.walk(ledgerDir)) {
+            victim = files
+                    .filter(java.nio.file.Files::isRegularFile)
+                    .filter(p -> !p.getFileName().toString().startsWith("snapshot-manifest"))
+                    .filter(AppChainSnapshotTest::isNonEmptyFile)
+                    .findFirst().orElseThrow();
+        }
         byte[] bytes = java.nio.file.Files.readAllBytes(victim);
         bytes[bytes.length / 2] ^= 0x01;
         java.nio.file.Files.write(victim, bytes);
@@ -366,6 +372,14 @@ class AppChainSnapshotTest {
                 throw new RuntimeException(e);
             }
         });
+    }
+
+    private static boolean isNonEmptyFile(Path path) {
+        try {
+            return java.nio.file.Files.size(path) > 0;
+        } catch (java.io.IOException e) {
+            throw new java.io.UncheckedIOException(e);
+        }
     }
 
     private static AppStateMachine snapshotEffectEmitter() {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/assembly/YanoAssemblyTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/assembly/YanoAssemblyTest.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.yaci.core.model.Block;
 import com.bloxbean.cardano.yaci.core.model.Era;
 import com.bloxbean.cardano.yano.api.ChainQuery;
 import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.MempoolQueryGateway;
 import com.bloxbean.cardano.yano.api.NodeLifecycle;
 import com.bloxbean.cardano.yano.api.ProducerControl;
 import com.bloxbean.cardano.yano.api.TxEvaluationGateway;
@@ -40,6 +41,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -130,6 +132,7 @@ class YanoAssemblyTest {
             assertNotNull(node.ledger());
             assertNotNull(node.txGateway());
             assertNotNull(node.txEvaluationGateway());
+            assertNotSame(MempoolQueryGateway.UNAVAILABLE, node.mempoolQueryGateway());
             assertTrue(node.maintenanceGate().isPresent());
             assertTrue(node.debugLedgerStateAccess().isPresent());
             assertTrue(node.kernel().isPresent());

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBodySizeLimitSupplierTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBodySizeLimitSupplierTest.java
@@ -1,0 +1,71 @@
+package com.bloxbean.cardano.yano.runtime.blockproducer;
+
+import com.bloxbean.cardano.yano.api.EpochParamProvider;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BlockBodySizeLimitSupplierTest {
+
+    @Test
+    void resolvesMaxBlockSizeForEpochContainingTheProducedSlot() {
+        AtomicLong requestedEpoch = new AtomicLong(-1);
+        EpochParamProvider params = params(requestedEpoch, 91_000);
+        BlockBodySizeLimitSupplier supplier = BlockBodySizeLimitSupplier.fromEpochParams(() -> params);
+
+        BlockProductionLimits limits = supplier.getLimits(250);
+        assertThat(limits.maxBodyBytes()).isEqualTo(91_000);
+        assertThat(limits.maxExecutionMemory()).isEqualTo(BigInteger.valueOf(72_000_000));
+        assertThat(limits.maxExecutionSteps()).isEqualTo(BigInteger.valueOf(20_000_000_000L));
+        assertThat(requestedEpoch).hasValue(2);
+    }
+
+    @Test
+    void failsClosedWhenEffectiveMaxBlockSizeIsUnavailable() {
+        EpochParamProvider params = params(new AtomicLong(), null);
+        BlockBodySizeLimitSupplier supplier = BlockBodySizeLimitSupplier.fromEpochParams(() -> params);
+
+        assertThatThrownBy(() -> supplier.getMaxBlockBodySize(10))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("unavailable or invalid for epoch 0");
+    }
+
+    private static EpochParamProvider params(AtomicLong requestedEpoch, Integer maxBlockSize) {
+        return new EpochParamProvider() {
+            @Override
+            public BigInteger getKeyDeposit(long epoch) {
+                return BigInteger.ZERO;
+            }
+
+            @Override
+            public BigInteger getPoolDeposit(long epoch) {
+                return BigInteger.ZERO;
+            }
+
+            @Override
+            public Integer getMaxBlockSize(long epoch) {
+                requestedEpoch.set(epoch);
+                return maxBlockSize;
+            }
+
+            @Override
+            public BigInteger getMaxBlockExMem(long epoch) {
+                return BigInteger.valueOf(72_000_000);
+            }
+
+            @Override
+            public BigInteger getMaxBlockExSteps(long epoch) {
+                return BigInteger.valueOf(20_000_000_000L);
+            }
+
+            @Override
+            public long getEpochLength() {
+                return 100;
+            }
+        };
+    }
+}

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBuildUtxoOverlayTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockBuildUtxoOverlayTest.java
@@ -11,6 +11,7 @@ import java.util.*;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 
 class BlockBuildUtxoOverlayTest {
 
@@ -82,6 +83,24 @@ class BlockBuildUtxoOverlayTest {
 
         overlay.reset();
         assertThat(resolver.apply(op)).isNotNull();
+    }
+
+    @Test
+    void applyTransactionMakesNormalOutputsVisibleToLaterCandidates() {
+        String seedHash = "ab".repeat(32);
+        Outpoint seed = new Outpoint(seedHash, 0);
+        utxoState.put(seed, new Utxo(
+                seed, "addr_test1...", BigInteger.valueOf(5_000_000),
+                List.of(), null, null, null, null, false, 10, 1, "bh"));
+        byte[] parent = buildTxSpending(seedHash, 0);
+        Outpoint parentOutput = new Outpoint(TransactionUtil.getTxHash(parent), 0);
+
+        overlay.applyTransaction(parent);
+
+        assertThat(overlay.resolver().apply(seed)).isNull();
+        assertThat(overlay.resolver().apply(parentOutput)).isNotNull();
+        assertThat(overlay.resolver().apply(parentOutput).lovelace())
+                .isEqualTo(BigInteger.valueOf(1_000_000));
     }
 
     /**

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockBuilderFactoryTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockBuilderFactoryTest.java
@@ -3,12 +3,14 @@ package com.bloxbean.cardano.yano.runtime.blockproducer;
 import com.bloxbean.cardano.client.crypto.Blake2bUtil;
 import com.bloxbean.cardano.yaci.core.storage.ChainState;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
+import com.bloxbean.cardano.yano.api.EpochParamProvider;
 import com.bloxbean.cardano.yano.runtime.chain.InMemoryChainState;
 import com.bloxbean.cardano.yano.runtime.producer.DevnetBlockBuilderFactory;
 import org.junit.jupiter.api.Test;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.math.BigInteger;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
@@ -116,7 +118,7 @@ class DevnetBlockBuilderFactoryTest {
                 genesisConfig,
                 new DevnetBlockBuilderFactory.Dependencies(
                         new InMemoryChainState(),
-                        () -> null,
+                        DevnetBlockBuilderFactoryTest::epochParams,
                         DevnetBlockBuilderFactoryTest::genesisHash,
                         nonceState -> nonceState.setShelleyStartSlot(0),
                         (nonceState, nonceStore, replay, repairReason, modeDescription) -> {
@@ -145,7 +147,7 @@ class DevnetBlockBuilderFactoryTest {
                 genesisConfig,
                 new DevnetBlockBuilderFactory.Dependencies(
                         chainState,
-                        () -> null,
+                        DevnetBlockBuilderFactoryTest::epochParams,
                         DevnetBlockBuilderFactoryTest::genesisHash,
                         nonceState -> nonceState.setShelleyStartSlot(0),
                         (nonceState, nonceStore, replay, repairReason, modeDescription) -> {
@@ -172,6 +174,35 @@ class DevnetBlockBuilderFactoryTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static EpochParamProvider epochParams() {
+        return new EpochParamProvider() {
+            @Override
+            public BigInteger getKeyDeposit(long epoch) {
+                return BigInteger.ZERO;
+            }
+
+            @Override
+            public BigInteger getPoolDeposit(long epoch) {
+                return BigInteger.ZERO;
+            }
+
+            @Override
+            public Integer getMaxBlockSize(long epoch) {
+                return 90_112;
+            }
+
+            @Override
+            public BigInteger getMaxBlockExMem(long epoch) {
+                return BigInteger.valueOf(72_000_000L);
+            }
+
+            @Override
+            public BigInteger getMaxBlockExSteps(long epoch) {
+                return BigInteger.valueOf(20_000_000_000L);
+            }
+        };
     }
 
     private static YanoConfig signedProducerConfig() {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockBuilderTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockBuilderTest.java
@@ -5,6 +5,12 @@ import co.nstant.in.cbor.model.ByteString;
 import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import com.bloxbean.cardano.client.plutus.spec.BigIntPlutusData;
+import com.bloxbean.cardano.client.plutus.spec.ExUnits;
+import com.bloxbean.cardano.client.plutus.spec.Redeemer;
+import com.bloxbean.cardano.client.plutus.spec.RedeemerTag;
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionWitnessSet;
 import com.bloxbean.cardano.yaci.core.model.Block;
 import com.bloxbean.cardano.yaci.core.model.BlockHeader;
 import com.bloxbean.cardano.yaci.core.model.serializers.BlockHeaderSerializer;
@@ -16,9 +22,12 @@ import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
 import java.util.List;
+import java.math.BigInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.*;
 
 class DevnetBlockBuilderTest {
@@ -159,6 +168,101 @@ class DevnetBlockBuilderTest {
                 .isEqualTo(new ProtocolVersion(11, 0));
     }
 
+    @Test
+    void fitTransactionsUsesExactEncodedBodySizeAndKeepsInsertionOrderedPrefix() throws Exception {
+        byte[] tx = buildSampleTxCbor();
+        List<byte[]> candidates = IntStream.range(0, 30).mapToObj(ignored -> tx).toList();
+        long exactLimit = builder.computeBlockBody(candidates.subList(0, 24)).bodySize();
+        AtomicLong requestedSlot = new AtomicLong(-1);
+        var limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2),
+                slot -> {
+                    requestedSlot.set(slot);
+                    return exactLimit;
+                });
+
+        List<byte[]> selected = limitedBuilder.fitTransactions(321, candidates);
+
+        assertThat(requestedSlot).hasValue(321);
+        assertThat(selected).hasSize(24).containsExactlyElementsOf(candidates.subList(0, 24));
+        assertThat(limitedBuilder.computeBlockBody(selected).bodySize()).isEqualTo(exactLimit);
+        assertThat(limitedBuilder.buildBlock(1, 321, new byte[32], selected).blockCbor()).isNotEmpty();
+    }
+
+    @Test
+    void buildBlockRejectsBodyAboveEffectiveProtocolLimit() throws Exception {
+        byte[] tx = buildSampleTxCbor();
+        long oneTransactionSize = builder.computeBlockBody(List.of(tx)).bodySize();
+        var limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2), slot -> oneTransactionSize);
+
+        assertThatThrownBy(() -> limitedBuilder.buildBlock(1, 10, new byte[32], List.of(tx, tx)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("exceeds effective maxBlockSize");
+    }
+
+    @Test
+    void fitTransactionsAppliesMemoryAndStepLimitsToInsertionOrderedPrefix() throws Exception {
+        byte[] first = buildTransactionWithExUnits(30, 40);
+        byte[] second = buildTransactionWithExUnits(20, 30);
+        byte[] third = buildTransactionWithExUnits(1, 1);
+        long bodyLimit = builder.computeBlockBody(List.of(first, second, third)).bodySize();
+        var limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2),
+                limits(bodyLimit, 50, 70));
+
+        List<byte[]> selected = limitedBuilder.fitTransactions(
+                42, List.of(first, second, third));
+
+        assertThat(selected).containsExactly(first, second);
+        assertThat(limitedBuilder.buildBlock(1, 42, new byte[32], selected).blockCbor())
+                .isNotEmpty();
+    }
+
+    @Test
+    void buildBlockRejectsAggregateExecutionUnitsWhenFitIsBypassed() throws Exception {
+        byte[] first = buildTransactionWithExUnits(30, 40);
+        byte[] second = buildTransactionWithExUnits(21, 31);
+        long bodyLimit = builder.computeBlockBody(List.of(first, second)).bodySize();
+        var limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2),
+                limits(bodyLimit, 50, 70));
+
+        assertThatThrownBy(() -> limitedBuilder.buildBlock(
+                1, 42, new byte[32], List.of(first, second)))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("execution memory")
+                .hasMessageContaining("maxBlockExMem");
+    }
+
+    @Test
+    void fitTransactionsAcceptsExactExecutionUnitBoundary() throws Exception {
+        byte[] first = buildTransactionWithExUnits(30, 40);
+        byte[] second = buildTransactionWithExUnits(20, 30);
+        long bodyLimit = builder.computeBlockBody(List.of(first, second)).bodySize();
+        var limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2),
+                limits(bodyLimit, 50, 70));
+
+        assertThat(limitedBuilder.fitTransactions(42, List.of(first, second)))
+                .containsExactly(first, second);
+    }
+
+    @Test
+    void fitTransactionsIdentifiesFirstTransactionThatCannotFitEmptyBlock() throws Exception {
+        byte[] transaction = buildTransactionWithExUnits(51, 1);
+        long bodyLimit = builder.computeBlockBody(List.of(transaction)).bodySize();
+        var limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2),
+                limits(bodyLimit, 50, 70));
+
+        assertThatThrownBy(() -> limitedBuilder.fitTransactions(42, List.of(transaction)))
+                .isInstanceOf(UnfitBlockTransactionException.class)
+                .extracting(failure -> ((UnfitBlockTransactionException) failure).transactionHash())
+                .isEqualTo(com.bloxbean.cardano.client.transaction.util.TransactionUtil
+                        .getTxHash(transaction));
+    }
+
     /**
      * Same as extractRawBytesAndCompare but uses a non-canonically encoded transaction
      * (map keys in descending order, which canonical mode will re-sort).
@@ -268,6 +372,37 @@ class DevnetBlockBuilderTest {
         tx.add(co.nstant.in.cbor.model.SimpleValue.NULL);
 
         return CborSerializationUtil.serialize(tx);
+    }
+
+    private byte[] buildTransactionWithExUnits(long memory, long steps) throws Exception {
+        Transaction transaction = Transaction.deserialize(buildSampleTxCbor());
+        transaction.setWitnessSet(TransactionWitnessSet.builder()
+                .redeemers(List.of(Redeemer.builder()
+                        .tag(RedeemerTag.Spend)
+                        .index(0)
+                        .data(BigIntPlutusData.of(1))
+                        .exUnits(ExUnits.builder()
+                                .mem(BigInteger.valueOf(memory))
+                                .steps(BigInteger.valueOf(steps))
+                                .build())
+                        .build()))
+                .build());
+        return transaction.serialize();
+    }
+
+    private static BlockBodySizeLimitSupplier limits(long bodyBytes, long memory, long steps) {
+        return new BlockBodySizeLimitSupplier() {
+            @Override
+            public long getMaxBlockBodySize(long slot) {
+                return bodyBytes;
+            }
+
+            @Override
+            public BlockProductionLimits getLimits(long slot) {
+                return new BlockProductionLimits(
+                        bodyBytes, BigInteger.valueOf(memory), BigInteger.valueOf(steps));
+            }
+        };
     }
 
     @Test

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducerTest.java
@@ -39,6 +39,8 @@ import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -164,6 +166,83 @@ class DevnetBlockProducerTest {
 
         assertThat(drained).isTrue();
         assertThat(chainState.getTip().getBlockNumber()).isGreaterThanOrEqualTo(1);
+    }
+
+    @Test
+    void producerLimitsSelectedTransactionsToEffectiveMaxBlockSize() {
+        byte[] tx = buildSampleTxCbor();
+        DevnetBlockBuilder sizingBuilder = new DevnetBlockBuilder();
+        long oneTransactionBodySize = sizingBuilder.computeBlockBody(List.of(tx)).bodySize();
+        DevnetBlockBuilder limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2), slot -> oneTransactionBodySize);
+        BlockTransactionSelector selector = new BlockTransactionSelector() {
+            @Override
+            public boolean hasPendingTransactions() {
+                return true;
+            }
+
+            @Override
+            public List<byte[]> drainForBlock() {
+                return List.of(tx, tx);
+            }
+        };
+        blockProducer = DevnetBlockProducer.withTransactionSelector(
+                chainState, selector, () -> null, new NoopEventBus(), scheduler, limitedBuilder,
+                2_000, false, System.currentTimeMillis(), 1_000, null);
+        blockProducer.start();
+        blockProducer.setForceSequentialSlots(true);
+
+        blockProducer.produceBlock();
+
+        ChainTip tip = chainState.getTip();
+        var block = com.bloxbean.cardano.yaci.core.model.serializers.BlockSerializer.INSTANCE
+                .deserialize(chainState.getBlock(tip.getBlockHash()));
+        assertThat(block.getTransactionBodies()).hasSize(1);
+    }
+
+    @Test
+    void producerInvalidatesFirstTransactionThatCannotFitEmptyBlock() {
+        byte[] tx = buildSampleTxCbor();
+        String txHash = com.bloxbean.cardano.client.transaction.util.TransactionUtil.getTxHash(tx);
+        AtomicReference<String> invalidated = new AtomicReference<>();
+        AtomicInteger failedSelections = new AtomicInteger();
+        BlockTransactionSelector selector = new BlockTransactionSelector() {
+            @Override
+            public boolean hasPendingTransactions() {
+                return true;
+            }
+
+            @Override
+            public List<byte[]> drainForBlock() {
+                return List.of(tx);
+            }
+
+            @Override
+            public int invalidateSelectedTransaction(String candidateHash) {
+                invalidated.set(candidateHash);
+                return 1;
+            }
+
+            @Override
+            public void blockSelectionFailed() {
+                failedSelections.incrementAndGet();
+            }
+        };
+        DevnetBlockBuilder sizingBuilder = new DevnetBlockBuilder();
+        long emptyBlockBodySize = sizingBuilder.computeBlockBody(List.of()).bodySize();
+        DevnetBlockBuilder limitedBuilder = new DevnetBlockBuilder(
+                ProtocolVersionSupplier.fixed(10, 2), slot -> emptyBlockBodySize);
+        blockProducer = DevnetBlockProducer.withTransactionSelector(
+                chainState, selector, () -> null, new NoopEventBus(), scheduler, limitedBuilder,
+                2_000, false, System.currentTimeMillis(), 1_000, null);
+        blockProducer.start();
+        blockProducer.setForceSequentialSlots(true);
+
+        blockProducer.produceBlock();
+
+        assertThat(invalidated).hasValue(txHash);
+        assertThat(failedSelections).hasValue(1);
+        assertThat(chainState.getTip().getBlockNumber()).isZero();
     }
 
     @Test

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/TransactionValidationServiceTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/TransactionValidationServiceTest.java
@@ -4,6 +4,8 @@ import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.ledgerrules.TransactionValidator;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationResult;
+import com.bloxbean.cardano.yano.ledgerrules.impl.YaciScriptSupplier;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -94,6 +96,44 @@ class TransactionValidationServiceTest {
 
         assertThat(result.valid()).isFalse();
         assertThat(result.errors().get(0).rule()).isEqualTo("UtxoNotFound");
+    }
+
+    @Test
+    void validate_exposesReferenceScriptsFromCustomResolverToScriptSupplier() throws Exception {
+        String inputHash = "cc".repeat(32);
+        var input = com.bloxbean.cardano.client.transaction.spec.TransactionInput.builder()
+                .transactionId(inputHash).index(0).build();
+        var output = com.bloxbean.cardano.client.transaction.spec.TransactionOutput.builder()
+                .address("addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp")
+                .value(new com.bloxbean.cardano.client.transaction.spec.Value(
+                        BigInteger.valueOf(1_000_000), null)).build();
+        byte[] txCbor = com.bloxbean.cardano.client.transaction.spec.Transaction.builder()
+                .body(com.bloxbean.cardano.client.transaction.spec.TransactionBody.builder()
+                        .inputs(List.of(input)).outputs(List.of(output))
+                        .fee(BigInteger.valueOf(200_000)).build())
+                .build().serialize();
+        PlutusV2Script script = PlutusV2Script.builder()
+                .cborHex("49480100002221200101").build();
+        String scriptHash = java.util.HexFormat.of().formatHex(script.getScriptHash());
+        var scriptOutput = com.bloxbean.cardano.client.transaction.spec.TransactionOutput.builder()
+                .address("00")
+                .value(new com.bloxbean.cardano.client.transaction.spec.Value(BigInteger.ONE, null))
+                .scriptRef(script).build();
+        var resolved = new com.bloxbean.cardano.yano.api.utxo.model.Utxo(
+                new Outpoint(inputHash, 0), "00", BigInteger.ONE, List.of(),
+                null, null, java.util.HexFormat.of().formatHex(scriptOutput.getScriptRef()),
+                scriptHash, false, 0, 0, null);
+        YaciScriptSupplier supplier = new YaciScriptSupplier(utxoState);
+        TransactionValidationService overlayService = new TransactionValidationService(
+                (bytes, inputs) -> supplier.getScript(scriptHash).isPresent()
+                        ? ValidationResult.success()
+                        : ValidationResult.failure(new com.bloxbean.cardano.yano.ledgerrules.ValidationError(
+                                "ReferenceScript", "not found",
+                                com.bloxbean.cardano.yano.ledgerrules.ValidationError.Phase.PHASE_2)),
+                utxoState);
+
+        assertThat(overlayService.validate(txCbor, ignored -> resolved).valid()).isTrue();
+        assertThat(supplier.getScript(scriptHash)).isEmpty();
     }
 
     /**

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPoolTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPoolTest.java
@@ -1,0 +1,444 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+import com.bloxbean.cardano.client.transaction.spec.Transaction;
+import com.bloxbean.cardano.client.transaction.spec.TransactionBody;
+import com.bloxbean.cardano.client.transaction.spec.TransactionInput;
+import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
+import com.bloxbean.cardano.client.transaction.spec.Value;
+import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
+import com.bloxbean.cardano.yaci.events.api.VetoableEvent;
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
+import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DefaultMemPoolTest {
+    private static final String ADDRESS =
+            "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp";
+    private static final MempoolAdmissionLimits LIMITS =
+            new MempoolAdmissionLimits(100, 1_000_000, 1_000);
+
+    @Test
+    void admitsArbitraryDepthChainAgainstOrderedOverlay() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 1);
+
+        byte[] parent = transaction(seed, 200_001, List.of(), List.of());
+        Outpoint parentOutput = new Outpoint(TransactionUtil.getTxHash(parent), 0);
+        byte[] child = transaction(parentOutput, 200_002, List.of(), List.of());
+        Outpoint childOutput = new Outpoint(TransactionUtil.getTxHash(child), 0);
+        byte[] grandchild = transaction(childOutput, 200_003, List.of(), List.of());
+
+        assertThat(admit(pool, parent, canonical).status())
+                .isEqualTo(MempoolAdmissionResult.Status.ACCEPTED);
+        assertThat(admit(pool, child, canonical).status())
+                .isEqualTo(MempoolAdmissionResult.Status.ACCEPTED);
+        assertThat(admit(pool, grandchild, canonical).status())
+                .isEqualTo(MempoolAdmissionResult.Status.ACCEPTED);
+
+        MempoolStats stats = pool.stats();
+        assertThat(stats.transactions()).isEqualTo(3);
+        assertThat(stats.producedOutputs()).isEqualTo(3);
+        assertThat(stats.spentOutpoints()).isEqualTo(3);
+        assertThat(stats.dependencyEdges()).isEqualTo(2);
+        assertThat(stats.utxoIndexEntries()).isEqualTo(10);
+    }
+
+    @Test
+    void duplicateIsIdempotentAndConflictingSpendIsRejected() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 2);
+        byte[] first = transaction(seed, 200_001, List.of(), List.of());
+        byte[] conflict = transaction(seed, 200_002, List.of(), List.of());
+        AtomicInteger acceptedEvents = new AtomicInteger();
+
+        MempoolAdmissionResult accepted = pool.tryAdmit(first, canonical::get,
+                resolvingValidator(), LIMITS, ignored -> acceptedEvents.incrementAndGet());
+        MempoolAdmissionResult duplicate = pool.tryAdmit(first, canonical::get,
+                resolvingValidator(), LIMITS, ignored -> acceptedEvents.incrementAndGet());
+        MempoolAdmissionResult rejected = admit(pool, conflict, canonical);
+
+        assertThat(accepted.status()).isEqualTo(MempoolAdmissionResult.Status.ACCEPTED);
+        assertThat(duplicate.status()).isEqualTo(MempoolAdmissionResult.Status.DUPLICATE);
+        assertThat(rejected.status()).isEqualTo(MempoolAdmissionResult.Status.CONFLICT);
+        assertThat(acceptedEvents).hasValue(1);
+        assertThat(pool.size()).isEqualTo(1);
+        assertThat(pool.stats().conflictRejections()).isEqualTo(1);
+    }
+
+    @Test
+    void confirmingParentKeepsChildAndConvertsDependencyToCanonical() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 3);
+        byte[] parent = transaction(seed, 200_001, List.of(), List.of());
+        String parentHash = TransactionUtil.getTxHash(parent);
+        Outpoint parentOutput = new Outpoint(parentHash, 0);
+        byte[] child = transaction(parentOutput, 200_002, List.of(), List.of());
+
+        assertThat(admit(pool, parent, canonical).accepted()).isTrue();
+        assertThat(admit(pool, child, canonical).accepted()).isTrue();
+        canonical.put(parentOutput, utxo(parentOutput));
+
+        assertThat(pool.removeByTxHashes(java.util.Set.of(parentHash))).isEqualTo(1);
+        assertThat(pool.size()).isEqualTo(1);
+        assertThat(pool.contains(TransactionUtil.getTxHash(child))).isTrue();
+        assertThat(pool.stats().dependencyEdges()).isZero();
+        assertThat(pool.revalidate(canonical::get)).isZero();
+    }
+
+    @Test
+    void invalidatingParentCascadesThroughDescendants() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 4);
+        byte[] parent = transaction(seed, 200_001, List.of(), List.of());
+        String parentHash = TransactionUtil.getTxHash(parent);
+        byte[] child = transaction(new Outpoint(parentHash, 0), 200_002, List.of(), List.of());
+
+        assertThat(admit(pool, parent, canonical).accepted()).isTrue();
+        assertThat(admit(pool, child, canonical).accepted()).isTrue();
+
+        assertThat(pool.removeInvalidated(java.util.Set.of(parentHash))).isEqualTo(2);
+        assertThat(pool.isEmpty()).isTrue();
+        assertThat(pool.stats().utxoIndexEntries()).isZero();
+        assertThat(pool.stats().cascadedRemovals()).isEqualTo(1);
+    }
+
+    @Test
+    void referenceAndCollateralInputsCreateDependenciesWithoutSpendClaims() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint parentSeed = seed(canonical, 5);
+        Outpoint referenceRegularSeed = seed(canonical, 6);
+        Outpoint collateralRegularSeed = seed(canonical, 7);
+        byte[] parent = transaction(parentSeed, 200_001, List.of(), List.of());
+        Outpoint parentOutput = new Outpoint(TransactionUtil.getTxHash(parent), 0);
+        byte[] referenceChild = transaction(
+                referenceRegularSeed, 200_002, List.of(parentOutput), List.of());
+        byte[] collateralChild = transaction(
+                collateralRegularSeed, 200_003, List.of(), List.of(parentOutput));
+
+        assertThat(admit(pool, parent, canonical).accepted()).isTrue();
+        assertThat(admit(pool, referenceChild, canonical).accepted()).isTrue();
+        assertThat(admit(pool, collateralChild, canonical).accepted()).isTrue();
+
+        assertThat(pool.stats().dependencyEdges()).isEqualTo(2);
+        assertThat(pool.stats().spentOutpoints()).isEqualTo(3);
+    }
+
+    @Test
+    void indexCapacityRejectsNewcomerWithoutPartialState() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 8);
+        byte[] transaction = transaction(seed, 200_001, List.of(), List.of());
+
+        MempoolAdmissionResult result = pool.tryAdmit(transaction, canonical::get,
+                resolvingValidator(), new MempoolAdmissionLimits(100, 1_000_000, 1), null);
+
+        assertThat(result.status()).isEqualTo(MempoolAdmissionResult.Status.INDEX_CAPACITY);
+        assertThat(pool.size()).isZero();
+        assertThat(pool.stats().utxoIndexEntries()).isZero();
+    }
+
+    @Test
+    void transactionAndByteCapacityRejectNewcomerWithoutEvictingExistingEntry() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint firstSeed = seed(canonical, 12);
+        Outpoint secondSeed = seed(canonical, 13);
+        byte[] first = transaction(firstSeed, 200_001, List.of(), List.of());
+        byte[] second = transaction(secondSeed, 200_002, List.of(), List.of());
+
+        assertThat(pool.tryAdmit(first, canonical::get, resolvingValidator(),
+                new MempoolAdmissionLimits(1, 1_000_000, 100), null).accepted()).isTrue();
+        MempoolAdmissionResult countRejected = pool.tryAdmit(second, canonical::get,
+                resolvingValidator(), new MempoolAdmissionLimits(1, 1_000_000, 100), null);
+
+        assertThat(countRejected.status())
+                .isEqualTo(MempoolAdmissionResult.Status.TRANSACTION_CAPACITY);
+        assertThat(pool.size()).isEqualTo(1);
+
+        DefaultMemPool byteLimited = new DefaultMemPool();
+        MempoolAdmissionResult byteRejected = byteLimited.tryAdmit(first, canonical::get,
+                resolvingValidator(), new MempoolAdmissionLimits(10, first.length - 1L, 100), null);
+        assertThat(byteRejected.status()).isEqualTo(MempoolAdmissionResult.Status.BYTE_CAPACITY);
+        assertThat(byteLimited.isEmpty()).isTrue();
+    }
+
+    @Test
+    void malformedAndLedgerRejectionAreTypedAndLeaveNoState() {
+        DefaultMemPool pool = new DefaultMemPool();
+
+        MempoolAdmissionResult malformed = pool.tryAdmit(new byte[] {1, 2, 3}, ignored -> null,
+                resolvingValidator(), LIMITS, null);
+        assertThat(malformed.status()).isEqualTo(MempoolAdmissionResult.Status.MALFORMED);
+
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 14);
+        byte[] transaction = transaction(seed, 200_001, List.of(), List.of());
+        MempoolAdmissionResult rejected = pool.tryAdmit(transaction, canonical::get,
+                (bytes, hash, resolver) -> List.of(
+                        new VetoableEvent.Rejection("test", "policy rejected")), LIMITS, null);
+
+        assertThat(rejected.status()).isEqualTo(MempoolAdmissionResult.Status.LEDGER_REJECTED);
+        assertThat(rejected.rejections()).extracting(VetoableEvent.Rejection::reason)
+                .containsExactly("policy rejected");
+        assertThat(pool.isEmpty()).isTrue();
+        assertThat(pool.stats().malformedRejections()).isEqualTo(1);
+        assertThat(pool.stats().ledgerRejections()).isEqualTo(1);
+    }
+
+    @Test
+    void ttlRemovalCascadesFromExpiredParent() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 15);
+        byte[] parent = transaction(seed, 200_001, List.of(), List.of());
+        byte[] child = transaction(
+                new Outpoint(TransactionUtil.getTxHash(parent), 0), 200_002, List.of(), List.of());
+        assertThat(admit(pool, parent, canonical).accepted()).isTrue();
+        assertThat(admit(pool, child, canonical).accepted()).isTrue();
+
+        assertThat(pool.removeOlderThan(Long.MAX_VALUE)).isEqualTo(2);
+        assertThat(pool.isEmpty()).isTrue();
+        assertThat(pool.stats().utxoIndexEntries()).isZero();
+    }
+
+    @Test
+    void acceptedEventFailureRollsBackBodyAndEveryIndex() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 9);
+        byte[] transaction = transaction(seed, 200_001, List.of(), List.of());
+
+        assertThatThrownBy(() -> pool.tryAdmit(transaction, canonical::get,
+                resolvingValidator(), LIMITS,
+                ignored -> { throw new IllegalStateException("publish failed"); }))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessage("publish failed");
+
+        assertThat(pool.size()).isZero();
+        assertThat(pool.byteSize()).isZero();
+        assertThat(pool.stats().utxoIndexEntries()).isZero();
+    }
+
+    @Test
+    void collateralReturnIsNotProjectedAsProducedOutput() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 10);
+        byte[] transaction = transactionWithCollateralReturn(seed);
+
+        assertThat(admit(pool, transaction, canonical).accepted()).isTrue();
+        assertThat(pool.stats().producedOutputs()).isEqualTo(1);
+    }
+
+    @Test
+    void callerArrayMutationCannotCorruptStoredBodyHashOrInternalKeys() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 11);
+        byte[] transaction = transaction(seed, 200_001, List.of(), List.of());
+        byte[] expectedBody = transaction.clone();
+        String expectedHash = TransactionUtil.getTxHash(transaction);
+
+        MempoolAdmissionResult result = admit(pool, transaction, canonical);
+        transaction[0] ^= 0x01;
+        result.transaction().txHash()[0] ^= 0x01;
+
+        assertThat(pool.contains(expectedHash)).isTrue();
+        assertThat(pool.getTransaction(expectedHash).txBytes()).containsExactly(expectedBody);
+        assertThat(pool.snapshotTransactions(1, Long.MAX_VALUE).getFirst().txBytes())
+                .containsExactly(expectedBody);
+    }
+
+    @Test
+    void admissionResolverExpiresWhenSynchronousValidationReturns() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 16);
+        byte[] transaction = transaction(seed, 200_001, List.of(), List.of());
+        AtomicReference<Function<Outpoint, Utxo>> captured = new AtomicReference<>();
+
+        MempoolAdmissionResult result = pool.tryAdmit(transaction, canonical::get,
+                (bytes, hash, resolver) -> {
+                    captured.set(resolver);
+                    assertThat(resolver.apply(seed)).isNotNull();
+                    return List.of();
+                }, LIMITS, null);
+
+        assertThat(result.accepted()).isTrue();
+        assertThatThrownBy(() -> captured.get().apply(seed))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no longer active");
+    }
+
+    @Test
+    void canonicalCompetingSpendInvalidatesMempoolChain() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint seed = seed(canonical, 17);
+        byte[] parent = transaction(seed, 200_001, List.of(), List.of());
+        String parentHash = TransactionUtil.getTxHash(parent);
+        byte[] child = transaction(new Outpoint(parentHash, 0), 200_002, List.of(), List.of());
+        assertThat(admit(pool, parent, canonical).accepted()).isTrue();
+        assertThat(admit(pool, child, canonical).accepted()).isTrue();
+
+        var competingBody = com.bloxbean.cardano.yaci.core.model.TransactionBody.builder()
+                .txHash("ab".repeat(32))
+                .inputs(java.util.Set.of(
+                        com.bloxbean.cardano.yaci.core.model.TransactionInput.builder()
+                                .transactionId(seed.txHash()).index(seed.index()).build()))
+                .outputs(List.of())
+                .build();
+        Block block = Block.builder().era(Era.Conway)
+                .transactionBodies(List.of(competingBody))
+                .invalidTransactions(List.of())
+                .build();
+
+        new DefaultMempoolEvictionPolicy(pool, 0, 100)
+                .onBlockApplied(new BlockAppliedEvent(
+                        Era.Conway, 1, 1, "cd".repeat(32), block));
+
+        assertThat(pool.isEmpty()).isTrue();
+        assertThat(pool.stats().utxoIndexEntries()).isZero();
+        assertThat(pool.stats().cascadedRemovals()).isEqualTo(1);
+    }
+
+    @Test
+    void phaseTwoInvalidCanonicalTransactionOnlyConflictsOnCollateral() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint regular = seed(canonical, 18);
+        Outpoint collateral = seed(canonical, 19);
+        byte[] regularSpender = transaction(regular, 200_001, List.of(), List.of());
+        byte[] collateralSpender = transaction(collateral, 200_002, List.of(), List.of());
+        assertThat(admit(pool, regularSpender, canonical).accepted()).isTrue();
+        assertThat(admit(pool, collateralSpender, canonical).accepted()).isTrue();
+
+        var invalidBody = com.bloxbean.cardano.yaci.core.model.TransactionBody.builder()
+                .txHash("ef".repeat(32))
+                .inputs(java.util.Set.of(
+                        com.bloxbean.cardano.yaci.core.model.TransactionInput.builder()
+                                .transactionId(regular.txHash()).index(regular.index()).build()))
+                .collateralInputs(java.util.Set.of(
+                        com.bloxbean.cardano.yaci.core.model.TransactionInput.builder()
+                                .transactionId(collateral.txHash()).index(collateral.index()).build()))
+                .outputs(List.of())
+                .build();
+        Block block = Block.builder().era(Era.Conway)
+                .transactionBodies(List.of(invalidBody))
+                .invalidTransactions(List.of(0))
+                .build();
+
+        new DefaultMempoolEvictionPolicy(pool, 0, 100)
+                .onBlockApplied(new BlockAppliedEvent(
+                        Era.Conway, 1, 1, "01".repeat(32), block));
+
+        assertThat(pool.contains(TransactionUtil.getTxHash(regularSpender))).isTrue();
+        assertThat(pool.contains(TransactionUtil.getTxHash(collateralSpender))).isFalse();
+    }
+
+    private static MempoolAdmissionResult admit(DefaultMemPool pool, byte[] tx,
+                                                 Map<Outpoint, Utxo> canonical) {
+        return pool.tryAdmit(tx, canonical::get, resolvingValidator(), LIMITS, null);
+    }
+
+    private static MemPool.AdmissionValidator resolvingValidator() {
+        return (txBytes, ignoredHash, resolver) -> {
+            try {
+                Transaction transaction = Transaction.deserialize(txBytes);
+                List<TransactionInput> inputs = new ArrayList<>();
+                if (transaction.getBody().getInputs() != null)
+                    inputs.addAll(transaction.getBody().getInputs());
+                if (transaction.getBody().getReferenceInputs() != null)
+                    inputs.addAll(transaction.getBody().getReferenceInputs());
+                if (transaction.getBody().getCollateral() != null)
+                    inputs.addAll(transaction.getBody().getCollateral());
+                for (TransactionInput input : inputs) {
+                    Outpoint outpoint = new Outpoint(input.getTransactionId(), input.getIndex());
+                    if (resolver.apply(outpoint) == null) {
+                        return List.of(new VetoableEvent.Rejection("test", "missing " + outpoint));
+                    }
+                }
+                return List.of();
+            } catch (Exception e) {
+                return List.of(new VetoableEvent.Rejection("test", e.getMessage()));
+            }
+        };
+    }
+
+    private static byte[] transaction(Outpoint regularInput, long fee,
+                                      List<Outpoint> referenceInputs,
+                                      List<Outpoint> collateralInputs) {
+        try {
+            TransactionBody.TransactionBodyBuilder body = TransactionBody.builder()
+                    .inputs(List.of(input(regularInput)))
+                    .outputs(List.of(TransactionOutput.builder()
+                            .address(ADDRESS)
+                            .value(new Value(BigInteger.valueOf(1_000_000), null))
+                            .build()))
+                    .fee(BigInteger.valueOf(fee));
+            if (!referenceInputs.isEmpty())
+                body.referenceInputs(referenceInputs.stream().map(DefaultMemPoolTest::input).toList());
+            if (!collateralInputs.isEmpty())
+                body.collateral(collateralInputs.stream().map(DefaultMemPoolTest::input).toList());
+            return Transaction.builder().body(body.build()).build().serialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static TransactionInput input(Outpoint outpoint) {
+        return TransactionInput.builder()
+                .transactionId(outpoint.txHash()).index(outpoint.index()).build();
+    }
+
+    private static byte[] transactionWithCollateralReturn(Outpoint regularInput) {
+        try {
+            TransactionOutput normal = TransactionOutput.builder()
+                    .address(ADDRESS).value(new Value(BigInteger.valueOf(1_000_000), null)).build();
+            TransactionOutput collateralReturn = TransactionOutput.builder()
+                    .address(ADDRESS).value(new Value(BigInteger.valueOf(500_000), null)).build();
+            TransactionBody body = TransactionBody.builder()
+                    .inputs(List.of(input(regularInput)))
+                    .outputs(List.of(normal))
+                    .fee(BigInteger.valueOf(200_000))
+                    .collateralReturn(collateralReturn)
+                    .totalCollateral(BigInteger.valueOf(500_000))
+                    .build();
+            return Transaction.builder().body(body).build().serialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Outpoint seed(Map<Outpoint, Utxo> canonical, int discriminator) {
+        Outpoint outpoint = new Outpoint(String.format("%064x", discriminator), 0);
+        canonical.put(outpoint, utxo(outpoint));
+        return outpoint;
+    }
+
+    private static Utxo utxo(Outpoint outpoint) {
+        return new Utxo(outpoint, ADDRESS, BigInteger.valueOf(2_000_000),
+                List.of(), null, null, null, null, false, 1, 1, "block");
+    }
+}

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPoolTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/DefaultMemPoolTest.java
@@ -19,6 +19,9 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
@@ -57,6 +60,169 @@ class DefaultMemPoolTest {
         assertThat(stats.spentOutpoints()).isEqualTo(3);
         assertThat(stats.dependencyEdges()).isEqualTo(2);
         assertThat(stats.utxoIndexEntries()).isEqualTo(10);
+    }
+
+    @Test
+    void resolvesBulkSnapshotFromOverlayAndCanonicalStateAndHidesClaims() {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint parentSeed = seed(canonical, 30);
+        Outpoint canonicalOnly = seed(canonical, 31);
+        byte[] parent = transaction(parentSeed, 200_001, List.of(), List.of());
+        Outpoint parentOutput = new Outpoint(TransactionUtil.getTxHash(parent), 0);
+
+        assertThat(admit(pool, parent, canonical).accepted()).isTrue();
+
+        Map<Outpoint, Utxo> resolved = pool.resolveUtxos(
+                List.of(parentOutput, canonicalOnly), canonical::get);
+        assertThat(resolved).containsOnlyKeys(parentOutput, canonicalOnly);
+        assertThat(resolved.get(parentOutput).lovelace()).isEqualTo(BigInteger.valueOf(1_000_000));
+        assertThatThrownBy(() -> resolved.clear())
+                .isInstanceOf(UnsupportedOperationException.class);
+
+        byte[] child = transaction(parentOutput, 200_002, List.of(), List.of());
+        assertThat(admit(pool, child, canonical).accepted()).isTrue();
+
+        assertThat(pool.resolveUtxos(List.of(parentOutput, canonicalOnly), canonical::get))
+                .containsOnlyKeys(canonicalOnly);
+    }
+
+    @Test
+    void referenceScriptHashIndexIsBoundedAndRemovedWithItsProducer() throws Exception {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint input = seed(canonical, 35);
+        var script = com.bloxbean.cardano.client.plutus.spec.PlutusV2Script.builder()
+                .cborHex("49480100002221200101")
+                .build();
+        var output = TransactionOutput.builder()
+                .address(ADDRESS)
+                .value(new Value(BigInteger.valueOf(1_000_000), null))
+                .scriptRef(script)
+                .build();
+        byte[] transaction = transaction(input, 200_001, output);
+        String transactionHash = TransactionUtil.getTxHash(transaction);
+        String scriptHash = com.bloxbean.cardano.yaci.core.util.HexUtil
+                .encodeHexString(script.getScriptHash());
+
+        assertThat(admit(pool, transaction, canonical).accepted()).isTrue();
+        assertThat(pool.stats().referenceScripts()).isEqualTo(1);
+        assertThat(pool.stats().utxoIndexEntries()).isEqualTo(3);
+
+        byte[] resolved = pool.getScriptRefBytesByHash(scriptHash).orElseThrow();
+        assertThat(resolved).containsExactly(output.getScriptRef());
+        resolved[0] ^= 1;
+        assertThat(pool.getScriptRefBytesByHash(scriptHash).orElseThrow())
+                .containsExactly(output.getScriptRef());
+
+        assertThat(pool.removeInvalidated(java.util.Set.of(transactionHash))).isEqualTo(1);
+        assertThat(pool.getScriptRefBytesByHash(scriptHash)).isEmpty();
+        assertThat(pool.stats().utxoIndexEntries()).isZero();
+    }
+
+    @Test
+    void canonicalSnapshotReadsDoNotHoldAdmissionLane() throws Exception {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint requested = seed(canonical, 32);
+        Outpoint concurrentSeed = seed(canonical, 33);
+        CountDownLatch storageReadStarted = new CountDownLatch(1);
+        CountDownLatch releaseStorageRead = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var resolution = executor.submit(() -> pool.resolveUtxos(List.of(requested), outpoint -> {
+                storageReadStarted.countDown();
+                try {
+                    if (!releaseStorageRead.await(5, TimeUnit.SECONDS))
+                        throw new IllegalStateException("timed out waiting to release storage read");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+                return canonical.get(outpoint);
+            }));
+
+            assertThat(storageReadStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            var admission = executor.submit(() -> admit(pool,
+                    transaction(concurrentSeed, 200_001, List.of(), List.of()), canonical));
+            assertThat(admission.get(1, TimeUnit.SECONDS).accepted()).isTrue();
+
+            releaseStorageRead.countDown();
+            assertThat(resolution.get(1, TimeUnit.SECONDS)).containsOnlyKeys(requested);
+        } finally {
+            releaseStorageRead.countDown();
+        }
+    }
+
+    @Test
+    void canonicalSnapshotRecheckHidesClaimCreatedDuringStorageRead() throws Exception {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint requested = seed(canonical, 34);
+        CountDownLatch storageReadStarted = new CountDownLatch(1);
+        CountDownLatch releaseStorageRead = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var resolution = executor.submit(() -> pool.resolveUtxos(List.of(requested), outpoint -> {
+                storageReadStarted.countDown();
+                try {
+                    if (!releaseStorageRead.await(5, TimeUnit.SECONDS))
+                        throw new IllegalStateException("timed out waiting to release storage read");
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new IllegalStateException(e);
+                }
+                return canonical.get(outpoint);
+            }));
+
+            assertThat(storageReadStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            var admission = executor.submit(() -> admit(pool,
+                    transaction(requested, 200_001, List.of(), List.of()), canonical));
+            assertThat(admission.get(1, TimeUnit.SECONDS).accepted()).isTrue();
+
+            releaseStorageRead.countDown();
+            assertThat(resolution.get(1, TimeUnit.SECONDS)).isEmpty();
+        } finally {
+            releaseStorageRead.countDown();
+        }
+    }
+
+    @Test
+    void canonicalSnapshotRecheckAlsoHidesOverlayHitClaimedDuringStorageRead() throws Exception {
+        DefaultMemPool pool = new DefaultMemPool();
+        Map<Outpoint, Utxo> canonical = new HashMap<>();
+        Outpoint parentSeed = seed(canonical, 36);
+        Outpoint canonicalRead = seed(canonical, 37);
+        byte[] parent = transaction(parentSeed, 200_001, List.of(), List.of());
+        Outpoint parentOutput = new Outpoint(TransactionUtil.getTxHash(parent), 0);
+        assertThat(admit(pool, parent, canonical).accepted()).isTrue();
+        CountDownLatch storageReadStarted = new CountDownLatch(1);
+        CountDownLatch releaseStorageRead = new CountDownLatch(1);
+
+        try (var executor = Executors.newVirtualThreadPerTaskExecutor()) {
+            var resolution = executor.submit(() -> pool.resolveUtxos(
+                    List.of(parentOutput, canonicalRead), outpoint -> {
+                        storageReadStarted.countDown();
+                        try {
+                            if (!releaseStorageRead.await(5, TimeUnit.SECONDS))
+                                throw new IllegalStateException("timed out waiting to release storage read");
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                            throw new IllegalStateException(e);
+                        }
+                        return canonical.get(outpoint);
+                    }));
+
+            assertThat(storageReadStarted.await(1, TimeUnit.SECONDS)).isTrue();
+            var admission = executor.submit(() -> admit(pool,
+                    transaction(parentOutput, 200_002, List.of(), List.of()), canonical));
+            assertThat(admission.get(1, TimeUnit.SECONDS).accepted()).isTrue();
+
+            releaseStorageRead.countDown();
+            assertThat(resolution.get(1, TimeUnit.SECONDS)).containsOnlyKeys(canonicalRead);
+        } finally {
+            releaseStorageRead.countDown();
+        }
     }
 
     @Test
@@ -402,6 +568,20 @@ class DefaultMemPoolTest {
             if (!collateralInputs.isEmpty())
                 body.collateral(collateralInputs.stream().map(DefaultMemPoolTest::input).toList());
             return Transaction.builder().body(body.build()).build().serialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] transaction(Outpoint regularInput, long fee,
+                                      TransactionOutput output) {
+        try {
+            TransactionBody body = TransactionBody.builder()
+                    .inputs(List.of(input(regularInput)))
+                    .outputs(List.of(output))
+                    .fee(BigInteger.valueOf(fee))
+                    .build();
+            return Transaction.builder().body(body).build().serialize();
         } catch (Exception e) {
             throw new RuntimeException(e);
         }

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/TransactionOutputProjectorTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/chain/TransactionOutputProjectorTest.java
@@ -1,0 +1,71 @@
+package com.bloxbean.cardano.yano.runtime.chain;
+
+import com.bloxbean.cardano.client.plutus.spec.PlutusData;
+import com.bloxbean.cardano.client.plutus.spec.PlutusV2Script;
+import com.bloxbean.cardano.client.transaction.spec.Asset;
+import com.bloxbean.cardano.client.transaction.spec.MultiAsset;
+import com.bloxbean.cardano.client.transaction.spec.TransactionOutput;
+import com.bloxbean.cardano.client.transaction.spec.Value;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TransactionOutputProjectorTest {
+    private static final String ADDRESS =
+            "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp";
+
+    @Test
+    void preservesAssetsInlineDatumAndReferenceScript() throws Exception {
+        String policyId = "ab".repeat(28);
+        MultiAsset multiAsset = MultiAsset.builder()
+                .policyId(policyId)
+                .assets(List.of(Asset.builder()
+                        .name("token")
+                        .value(BigInteger.valueOf(42))
+                        .build()))
+                .build();
+        PlutusData datum = PlutusData.unit();
+        PlutusV2Script script = PlutusV2Script.builder()
+                .cborHex("49480100002221200101")
+                .build();
+        TransactionOutput output = TransactionOutput.builder()
+                .address(ADDRESS)
+                .value(new Value(BigInteger.valueOf(3_000_000), List.of(multiAsset)))
+                .inlineDatum(datum)
+                .scriptRef(script)
+                .build();
+
+        var projected = TransactionOutputProjector.project("11".repeat(32), 3, output);
+
+        assertThat(projected.outpoint().index()).isEqualTo(3);
+        assertThat(projected.lovelace()).isEqualTo(BigInteger.valueOf(3_000_000));
+        assertThat(projected.assets()).containsExactly(
+                new com.bloxbean.cardano.yano.api.utxo.model.AssetAmount(
+                        policyId, "746f6b656e", BigInteger.valueOf(42)));
+        assertThat(projected.inlineDatum()).isEqualTo(datum.serializeToBytes());
+        assertThat(projected.scriptRef()).isEqualTo(HexUtil.encodeHexString(output.getScriptRef()));
+        assertThat(projected.referenceScriptHash())
+                .isEqualTo(HexUtil.encodeHexString(script.getScriptHash()));
+        assertThat(projected.collateralReturn()).isFalse();
+    }
+
+    @Test
+    void preservesDatumHash() {
+        byte[] datumHash = new byte[32];
+        datumHash[31] = 7;
+        TransactionOutput output = TransactionOutput.builder()
+                .address(ADDRESS)
+                .value(new Value(BigInteger.ONE, null))
+                .datumHash(datumHash)
+                .build();
+
+        var projected = TransactionOutputProjector.project("22".repeat(32), 0, output);
+
+        assertThat(projected.datumHash()).isEqualTo(HexUtil.encodeHexString(datumHash));
+        assertThat(projected.inlineDatum()).isNull();
+    }
+}

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/events/PropagatingEventBusTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/events/PropagatingEventBusTest.java
@@ -4,6 +4,8 @@ import com.bloxbean.cardano.yaci.events.api.Event;
 import com.bloxbean.cardano.yaci.events.api.EventMetadata;
 import com.bloxbean.cardano.yaci.events.api.PublishOptions;
 import com.bloxbean.cardano.yaci.events.api.SubscriptionOptions;
+import com.bloxbean.cardano.yano.api.events.TransactionValidateEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateAppliedEvent;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
@@ -81,6 +83,36 @@ class PropagatingEventBusTest {
                             EventMetadata.builder().build(),
                             PublishOptions.builder().build()));
             assertEquals("Event listener failed for TestEvent", failure.getMessage());
+        } finally {
+            bus.close();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void transactionValidationListenersCannotBeAsynchronous() {
+        PropagatingEventBus bus = new PropagatingEventBus();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            assertThrows(IllegalArgumentException.class,
+                    () -> bus.subscribe(TransactionValidateEvent.class,
+                            ignored -> { },
+                            SubscriptionOptions.builder().executor(executor).build()));
+        } finally {
+            bus.close();
+            executor.shutdownNow();
+        }
+    }
+
+    @Test
+    void canonicalUtxoAcknowledgementListenersCannotBeAsynchronous() {
+        PropagatingEventBus bus = new PropagatingEventBus();
+        ExecutorService executor = Executors.newSingleThreadExecutor();
+        try {
+            assertThrows(IllegalArgumentException.class,
+                    () -> bus.subscribe(UtxoStateAppliedEvent.class,
+                            ignored -> { },
+                            SubscriptionOptions.builder().executor(executor).build()));
         } finally {
             bus.close();
             executor.shutdownNow();

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystemTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystemTest.java
@@ -23,6 +23,8 @@ import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationError;
 import com.bloxbean.cardano.yano.ledgerrules.ValidationResult;
+import com.bloxbean.cardano.yano.ledgerrules.ScriptReferenceResolverScope;
+import com.bloxbean.cardano.yano.ledgerrules.TransactionEvaluator;
 import com.bloxbean.cardano.yano.runtime.blockproducer.TransactionValidationException;
 import com.bloxbean.cardano.yano.runtime.blockproducer.TransactionValidationService;
 import com.bloxbean.cardano.yano.runtime.chain.DefaultMemPool;
@@ -328,6 +330,90 @@ class TxSubsystemTest {
         assertThatThrownBy(() -> subsystem.evaluateTransaction(sampleTxCbor()))
                 .isInstanceOf(UnsupportedOperationException.class)
                 .hasMessage("Transaction evaluation is not available");
+    }
+
+    @Test
+    void evaluationResolvesUnconfirmedReferenceScriptOutputWithoutHoldingMempoolLane() throws Exception {
+        java.util.Map<Outpoint, Utxo> canonical = new java.util.HashMap<>();
+        Outpoint parentSeed = new Outpoint("61".repeat(32), 0);
+        Outpoint childSeed = new Outpoint("62".repeat(32), 0);
+        Outpoint concurrentSeed = new Outpoint("63".repeat(32), 0);
+        canonical.put(parentSeed, testUtxo(parentSeed));
+        canonical.put(childSeed, testUtxo(childSeed));
+        canonical.put(concurrentSeed, testUtxo(concurrentSeed));
+        UtxoState state = mapUtxoState(canonical);
+        TxSubsystem subsystem = new TxSubsystem(
+                eventBus, scheduler, RuntimeOptions.defaults(), () -> state,
+                LoggerFactory.getLogger(TxSubsystemTest.class));
+        subsystem.setTransactionEvaluator((txCbor, inputUtxos) -> ValidationResult.success());
+        subsystem.start();
+
+        var script = com.bloxbean.cardano.client.plutus.spec.PlutusV2Script.builder()
+                .cborHex("49480100002221200101")
+                .build();
+        String scriptHash = java.util.HexFormat.of().formatHex(script.getScriptHash());
+        var referenceOutput = com.bloxbean.cardano.client.transaction.spec.TransactionOutput.builder()
+                .address("addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp")
+                .value(new com.bloxbean.cardano.client.transaction.spec.Value(
+                        java.math.BigInteger.valueOf(1_000_000), null))
+                .scriptRef(script)
+                .build();
+        var spendOutput = com.bloxbean.cardano.client.transaction.spec.TransactionOutput.builder()
+                .address(referenceOutput.getAddress())
+                .value(referenceOutput.getValue())
+                .build();
+        var parentBody = com.bloxbean.cardano.client.transaction.spec.TransactionBody.builder()
+                .inputs(List.of(cclInput(parentSeed)))
+                .outputs(List.of(spendOutput, referenceOutput))
+                .fee(java.math.BigInteger.valueOf(200_001))
+                .build();
+        byte[] parent = com.bloxbean.cardano.client.transaction.spec.Transaction.builder()
+                .body(parentBody).build().serialize();
+        Outpoint parentSpendOutput = new Outpoint(TransactionUtil.getTxHash(parent), 0);
+        Outpoint parentReferenceOutput = new Outpoint(TransactionUtil.getTxHash(parent), 1);
+        subsystem.admitTransaction(parent, "test");
+        assertThat(subsystem.resolveUtxo(parentReferenceOutput)).isPresent();
+        assertThat(subsystem.getScriptRefBytesByHash(scriptHash).orElseThrow())
+                .containsExactly(referenceOutput.getScriptRef());
+
+        var childBody = com.bloxbean.cardano.client.transaction.spec.TransactionBody.builder()
+                .inputs(List.of(cclInput(parentSpendOutput)))
+                .referenceInputs(List.of(cclInput(parentReferenceOutput)))
+                .collateral(List.of(cclInput(childSeed)))
+                .outputs(List.of(spendOutput))
+                .fee(java.math.BigInteger.valueOf(200_002))
+                .build();
+        byte[] child = com.bloxbean.cardano.client.transaction.spec.Transaction.builder()
+                .body(childBody).build().serialize();
+        byte[] concurrent = cclTransaction(concurrentSeed, 200_003);
+        AtomicBoolean referenceScriptVisible = new AtomicBoolean();
+        AtomicBoolean concurrentAdmissionSucceeded = new AtomicBoolean();
+        AtomicReference<java.util.Set<com.bloxbean.cardano.client.api.model.Utxo>> evaluatedInputs =
+                new AtomicReference<>();
+
+        subsystem.setScriptEvaluator((txCbor, inputUtxos) -> {
+            evaluatedInputs.set(java.util.Set.copyOf(inputUtxos));
+            referenceScriptVisible.set(ScriptReferenceResolverScope.resolve(scriptHash).isPresent());
+            concurrentAdmissionSucceeded.set(
+                    subsystem.admitTransaction(concurrent, "evaluation-test") != null);
+            return List.of(new TransactionEvaluator.EvaluationResult("spend", 0, 10, 20));
+        });
+
+        var results = subsystem.evaluateTransaction(child);
+
+        assertThat(results).singleElement().satisfies(result -> {
+            assertThat(result.tag()).isEqualTo("spend");
+            assertThat(result.memory()).isEqualTo(10);
+            assertThat(result.steps()).isEqualTo(20);
+        });
+        assertThat(evaluatedInputs.get())
+                .extracting(com.bloxbean.cardano.client.api.model.Utxo::getTxHash)
+                .containsExactlyInAnyOrder(
+                        parentSpendOutput.txHash(), parentReferenceOutput.txHash(), childSeed.txHash());
+        assertThat(referenceScriptVisible).isTrue();
+        assertThat(ScriptReferenceResolverScope.resolve(scriptHash)).isEmpty();
+        assertThat(concurrentAdmissionSucceeded).isTrue();
+        assertThat(subsystem.memPool().size()).isEqualTo(2);
     }
 
     @Test
@@ -665,6 +751,12 @@ class TxSubsystemTest {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    private static com.bloxbean.cardano.client.transaction.spec.TransactionInput cclInput(
+            Outpoint input) {
+        return com.bloxbean.cardano.client.transaction.spec.TransactionInput.builder()
+                .transactionId(input.txHash()).index(input.index()).build();
     }
 
     private static Utxo testUtxo(Outpoint outpoint) {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystemTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystemTest.java
@@ -427,6 +427,7 @@ class TxSubsystemTest {
         subsystem.stop();
         subsystem.start();
 
+        assertThat(subsystem.mempoolMaxUtxoIndexEntries()).isEqualTo(100_000);
         assertThat(subsystem.health().details()).containsEntry("mempoolSize", 0);
         subsystem.close();
     }

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystemTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/tx/TxSubsystemTest.java
@@ -13,6 +13,11 @@ import com.bloxbean.cardano.yano.api.config.RuntimeOptions;
 import com.bloxbean.cardano.yano.api.config.YanoPropertyKeys;
 import com.bloxbean.cardano.yano.api.events.MemPoolTransactionReceivedEvent;
 import com.bloxbean.cardano.yano.api.events.TransactionValidateEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.serializers.BlockSerializer;
+import com.bloxbean.cardano.yano.runtime.blockproducer.DevnetBlockBuilder;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
@@ -22,6 +27,8 @@ import com.bloxbean.cardano.yano.runtime.blockproducer.TransactionValidationExce
 import com.bloxbean.cardano.yano.runtime.blockproducer.TransactionValidationService;
 import com.bloxbean.cardano.yano.runtime.chain.DefaultMemPool;
 import com.bloxbean.cardano.yano.runtime.chain.DefaultMempoolEvictionPolicy;
+import com.bloxbean.cardano.yano.runtime.chain.MempoolAdmissionException;
+import com.bloxbean.cardano.client.transaction.util.TransactionUtil;
 import com.bloxbean.cardano.yano.runtime.events.PropagatingEventBus;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
@@ -272,7 +279,7 @@ class TxSubsystemTest {
     }
 
     @Test
-    void mempoolEventFailureDoesNotRemovePreviouslyAcceptedDuplicate() {
+    void duplicateAdmissionDoesNotRepublishMempoolEvent() {
         TxSubsystem subsystem = new TxSubsystem(
                 eventBus, scheduler, RuntimeOptions.defaults(), () -> null,
                 LoggerFactory.getLogger(TxSubsystemTest.class));
@@ -284,8 +291,7 @@ class TxSubsystemTest {
                 ctx -> { throw new IllegalStateException("event failed"); },
                 SubscriptionOptions.builder().build());
 
-        assertThatThrownBy(() -> subsystem.admitTransaction(txCbor, "test"))
-                .isInstanceOf(RuntimeException.class);
+        assertThat(subsystem.admitTransaction(txCbor, "test")).isNotBlank();
 
         assertThat(subsystem.memPool().size()).isEqualTo(1);
     }
@@ -345,6 +351,7 @@ class TxSubsystemTest {
                 YanoPropertyKeys.Tx.MEMPOOL_MAX_TXS, 2,
                 YanoPropertyKeys.Tx.MEMPOOL_MAX_BYTES, 4096L,
                 YanoPropertyKeys.Tx.MEMPOOL_TTL_SECONDS, 45L,
+                YanoPropertyKeys.Tx.MEMPOOL_MAX_UTXO_INDEX_ENTRIES, 123,
                 YanoPropertyKeys.Tx.DIFFUSION_MODE, "local-submit-only",
                 YanoPropertyKeys.Tx.DIFFUSION_MAX_IN_FLIGHT_TXS_PER_PEER, 7,
                 YanoPropertyKeys.Tx.DIFFUSION_MAX_IN_FLIGHT_BYTES_PER_PEER, 8192L,
@@ -358,6 +365,7 @@ class TxSubsystemTest {
         assertThat(subsystem.mempoolMaxTxs()).isEqualTo(2);
         assertThat(subsystem.mempoolMaxBytes()).isEqualTo(4096L);
         assertThat(subsystem.mempoolTtlSeconds()).isEqualTo(45L);
+        assertThat(subsystem.mempoolMaxUtxoIndexEntries()).isEqualTo(123);
         assertThat(subsystem.txDiffusionMode()).isEqualTo("local-submit-only");
         assertThat(subsystem.txDiffusionEnabled()).isTrue();
         assertThat(subsystem.txDiffusionMaxInFlightTxsPerPeer()).isEqualTo(7);
@@ -366,6 +374,7 @@ class TxSubsystemTest {
         assertThat(subsystem.health().details())
                 .containsEntry("mempoolMaxTxs", 2)
                 .containsEntry("mempoolMaxBytes", 4096L)
+                .containsEntry("mempoolMaxUtxoIndexEntries", 123)
                 .containsEntry("txDiffusionMode", "local-submit-only")
                 .containsEntry("txDiffusionEnabled", true);
     }
@@ -400,8 +409,8 @@ class TxSubsystemTest {
     @Test
     void mempoolEvictsOldestTransactionsToByteCap() {
         var memPool = new DefaultMemPool();
-        byte[] firstTx = sampleTxCbor(200_000);
-        byte[] secondTx = sampleTxCbor(200_001);
+        byte[] firstTx = sampleTxCbor(200_000, (byte) 1);
+        byte[] secondTx = sampleTxCbor(200_001, (byte) 2);
         memPool.addTransaction(firstTx);
         memPool.addTransaction(secondTx);
 
@@ -410,14 +419,14 @@ class TxSubsystemTest {
         assertThat(evicted).isEqualTo(1);
         assertThat(memPool.size()).isEqualTo(1);
         assertThat(memPool.byteSize()).isEqualTo(secondTx.length);
-        assertThat(memPool.getNextTransaction().txBytes()).isSameAs(secondTx);
+        assertThat(memPool.getNextTransaction().txBytes()).containsExactly(secondTx);
     }
 
     @Test
     void evictionPolicyAppliesByteCap() {
         var memPool = new DefaultMemPool();
-        byte[] firstTx = sampleTxCbor(200_000);
-        byte[] secondTx = sampleTxCbor(200_001);
+        byte[] firstTx = sampleTxCbor(200_000, (byte) 1);
+        byte[] secondTx = sampleTxCbor(200_001, (byte) 2);
         memPool.addTransaction(firstTx);
         memPool.addTransaction(secondTx);
         var policy = new DefaultMempoolEvictionPolicy(memPool, 0, 100, secondTx.length);
@@ -426,11 +435,11 @@ class TxSubsystemTest {
 
         assertThat(memPool.size()).isEqualTo(1);
         assertThat(memPool.byteSize()).isEqualTo(secondTx.length);
-        assertThat(memPool.getNextTransaction().txBytes()).isSameAs(secondTx);
+        assertThat(memPool.getNextTransaction().txBytes()).containsExactly(secondTx);
     }
 
     @Test
-    void drainForBlockReturnsPendingTransactionsAndClearsMempool() {
+    void drainForBlockReturnsSnapshotAndRetainsMempoolUntilCanonicalApply() {
         TxSubsystem subsystem = new TxSubsystem(
                 eventBus, scheduler, RuntimeOptions.defaults(), () -> null,
                 LoggerFactory.getLogger(TxSubsystemTest.class));
@@ -441,8 +450,11 @@ class TxSubsystemTest {
 
         assertThat(subsystem.hasPendingTransactions()).isTrue();
         assertThat(subsystem.drainForBlock()).containsExactly(txCbor);
-        assertThat(subsystem.hasPendingTransactions()).isFalse();
-        assertThat(subsystem.memPool().size()).isZero();
+        assertThat(subsystem.hasPendingTransactions()).isTrue();
+        assertThat(subsystem.memPool().size()).isEqualTo(1);
+
+        subsystem.blockSelectionCompleted();
+        assertThat(subsystem.drainForBlock()).containsExactly(txCbor);
     }
 
     @Test
@@ -461,7 +473,7 @@ class TxSubsystemTest {
         validationService.set(validationService(ValidationResult.success()));
 
         assertThat(selector.drainForBlock()).containsExactly(txCbor);
-        assertThat(memPool.isEmpty()).isTrue();
+        assertThat(memPool.isEmpty()).isFalse();
     }
 
     @Test
@@ -478,15 +490,225 @@ class TxSubsystemTest {
         assertThat(memPool.isEmpty()).isTrue();
     }
 
+    @Test
+    void mempoolOverlaySupportsSequentialParentChildAdmissionAndBlockSelection() {
+        java.util.Map<Outpoint, Utxo> canonical = new java.util.HashMap<>();
+        Outpoint seed = new Outpoint("11".repeat(32), 0);
+        canonical.put(seed, testUtxo(seed));
+        UtxoState state = mapUtxoState(canonical);
+        TxSubsystem subsystem = new TxSubsystem(
+                eventBus, scheduler, RuntimeOptions.defaults(), () -> state,
+                LoggerFactory.getLogger(TxSubsystemTest.class));
+        subsystem.setTransactionEvaluator((txCbor, inputUtxos) -> ValidationResult.success());
+        subsystem.start();
+
+        byte[] parent = cclTransaction(seed, 200_001);
+        Outpoint parentOutput = new Outpoint(TransactionUtil.getTxHash(parent), 0);
+        byte[] child = cclTransaction(parentOutput, 200_002);
+
+        assertThat(subsystem.admitTransaction(parent, "test"))
+                .isEqualTo(parentOutput.txHash());
+        assertThat(subsystem.admitTransaction(child, "test")).isNotBlank();
+        assertThat(subsystem.memPool().stats().dependencyEdges()).isEqualTo(1);
+
+        assertThat(subsystem.drainForBlock()).containsExactly(parent, child);
+        assertThat(subsystem.memPool().size()).isEqualTo(2);
+        assertThatThrownBy(subsystem::drainForBlock)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("selection is already in flight");
+
+        subsystem.blockSelectionFailed();
+        assertThat(subsystem.drainForBlock()).containsExactly(parent, child);
+    }
+
+    @Test
+    void childSubmittedBeforeParentIsRejectedAndCanBeRetriedAfterParentCommits() {
+        java.util.Map<Outpoint, Utxo> canonical = new java.util.HashMap<>();
+        Outpoint seed = new Outpoint("22".repeat(32), 0);
+        canonical.put(seed, testUtxo(seed));
+        UtxoState state = mapUtxoState(canonical);
+        TxSubsystem subsystem = new TxSubsystem(
+                eventBus, scheduler, RuntimeOptions.defaults(), () -> state,
+                LoggerFactory.getLogger(TxSubsystemTest.class));
+        subsystem.setTransactionEvaluator((txCbor, inputUtxos) -> ValidationResult.success());
+        subsystem.start();
+
+        byte[] parent = cclTransaction(seed, 200_001);
+        byte[] child = cclTransaction(
+                new Outpoint(TransactionUtil.getTxHash(parent), 0), 200_002);
+
+        assertThatThrownBy(() -> subsystem.admitTransaction(child, "test"))
+                .isInstanceOf(TransactionValidationException.class)
+                .hasMessageContaining("UTXO not found");
+        subsystem.admitTransaction(parent, "test");
+        assertThat(subsystem.admitTransaction(child, "test")).isNotBlank();
+        assertThat(subsystem.memPool().size()).isEqualTo(2);
+    }
+
+    @Test
+    void concurrentDoubleSpendCommitsExactlyOneTransaction() throws Exception {
+        java.util.Map<Outpoint, Utxo> canonical = new java.util.HashMap<>();
+        Outpoint seed = new Outpoint("33".repeat(32), 0);
+        canonical.put(seed, testUtxo(seed));
+        UtxoState state = mapUtxoState(canonical);
+        TxSubsystem subsystem = new TxSubsystem(
+                eventBus, scheduler, RuntimeOptions.defaults(), () -> state,
+                LoggerFactory.getLogger(TxSubsystemTest.class));
+        subsystem.setTransactionEvaluator((txCbor, inputUtxos) -> ValidationResult.success());
+        subsystem.start();
+        byte[] first = cclTransaction(seed, 200_001);
+        byte[] second = cclTransaction(seed, 200_002);
+        CountDownLatch start = new CountDownLatch(1);
+        AtomicInteger accepted = new AtomicInteger();
+        AtomicInteger conflicted = new AtomicInteger();
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> firstResult = executor.submit(() -> admitAfterStart(
+                    subsystem, first, start, accepted, conflicted));
+            Future<?> secondResult = executor.submit(() -> admitAfterStart(
+                    subsystem, second, start, accepted, conflicted));
+            start.countDown();
+            firstResult.get(5, TimeUnit.SECONDS);
+            secondResult.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        assertThat(accepted).hasValue(1);
+        assertThat(conflicted).hasValue(1);
+        assertThat(subsystem.memPool().size()).isEqualTo(1);
+    }
+
+    @Test
+    void canonicalUtxoAcknowledgementRemovesConfirmedParentWithoutCascadingChild() throws Exception {
+        java.util.Map<Outpoint, Utxo> canonical = new java.util.HashMap<>();
+        Outpoint seed = new Outpoint("44".repeat(32), 0);
+        canonical.put(seed, testUtxo(seed));
+        UtxoState state = mapUtxoState(canonical);
+        TxSubsystem subsystem = new TxSubsystem(
+                eventBus, scheduler, RuntimeOptions.defaults(), () -> state,
+                LoggerFactory.getLogger(TxSubsystemTest.class));
+        subsystem.setTransactionEvaluator((txCbor, inputUtxos) -> ValidationResult.success());
+        subsystem.start();
+        byte[] parent = cclTransaction(seed, 200_001);
+        String parentHash = TransactionUtil.getTxHash(parent);
+        Outpoint parentOutput = new Outpoint(parentHash, 0);
+        byte[] child = cclTransaction(parentOutput, 200_002);
+        String childHash = TransactionUtil.getTxHash(child);
+        subsystem.admitTransaction(parent, "test");
+        subsystem.admitTransaction(child, "test");
+
+        canonical.put(parentOutput, testUtxo(parentOutput));
+        var built = new DevnetBlockBuilder().buildBlock(1, 1, null, List.of(parent));
+        var block = BlockSerializer.INSTANCE.deserialize(built.blockCbor());
+        var applied = new BlockAppliedEvent(Era.Conway, 1, 1, "block", block);
+        eventBus.publish(new UtxoStateAppliedEvent(applied),
+                EventMetadata.builder().origin("test").build(),
+                PublishOptions.builder().build());
+
+        assertThat(subsystem.memPool().contains(parentHash)).isFalse();
+        assertThat(subsystem.memPool().contains(childHash)).isTrue();
+        assertThat(subsystem.memPool().stats().dependencyEdges()).isZero();
+    }
+
+    @Test
+    void recursiveAdmissionFromValidationListenerFailsFastWithoutPartialCommit() {
+        TxSubsystem subsystem = new TxSubsystem(
+                eventBus, scheduler, RuntimeOptions.defaults(), () -> null,
+                LoggerFactory.getLogger(TxSubsystemTest.class));
+        subsystem.start();
+        byte[] nested = sampleTxCbor(200_002, (byte) 2);
+        AtomicBoolean recurse = new AtomicBoolean(true);
+        eventBus.subscribe(TransactionValidateEvent.class, ctx -> {
+                    if (recurse.getAndSet(false)) subsystem.admitTransaction(nested, "recursive");
+                }, SubscriptionOptions.builder().build());
+
+        assertThatThrownBy(() -> subsystem.admitTransaction(
+                sampleTxCbor(200_001, (byte) 1), "test"))
+                .isInstanceOf(RuntimeException.class);
+        assertThat(subsystem.memPool().isEmpty()).isTrue();
+    }
+
     private static byte[] sampleTxCbor() {
         return sampleTxCbor(200_000);
     }
 
+    private static void admitAfterStart(TxSubsystem subsystem, byte[] transaction,
+                                        CountDownLatch start, AtomicInteger accepted,
+                                        AtomicInteger conflicted) {
+        try {
+            start.await(5, TimeUnit.SECONDS);
+            subsystem.admitTransaction(transaction, "test");
+            accepted.incrementAndGet();
+        } catch (MempoolAdmissionException e) {
+            conflicted.incrementAndGet();
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static byte[] cclTransaction(Outpoint input, long fee) {
+        try {
+            var txInput = com.bloxbean.cardano.client.transaction.spec.TransactionInput.builder()
+                    .transactionId(input.txHash()).index(input.index()).build();
+            var output = com.bloxbean.cardano.client.transaction.spec.TransactionOutput.builder()
+                    .address("addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp")
+                    .value(new com.bloxbean.cardano.client.transaction.spec.Value(
+                            java.math.BigInteger.valueOf(1_000_000), null))
+                    .build();
+            var body = com.bloxbean.cardano.client.transaction.spec.TransactionBody.builder()
+                    .inputs(List.of(txInput)).outputs(List.of(output))
+                    .fee(java.math.BigInteger.valueOf(fee)).build();
+            return com.bloxbean.cardano.client.transaction.spec.Transaction.builder()
+                    .body(body).build().serialize();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static Utxo testUtxo(Outpoint outpoint) {
+        return new Utxo(outpoint,
+                "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp",
+                java.math.BigInteger.valueOf(2_000_000), List.of(), null, null,
+                null, null, false, 1, 1, "block");
+    }
+
+    private static UtxoState mapUtxoState(java.util.Map<Outpoint, Utxo> utxos) {
+        return new UtxoState() {
+            @Override
+            public List<Utxo> getUtxosByAddress(String address, int page, int pageSize) {
+                return List.of();
+            }
+
+            @Override
+            public List<Utxo> getUtxosByPaymentCredential(String credential, int page, int pageSize) {
+                return List.of();
+            }
+
+            @Override
+            public Optional<Utxo> getUtxo(Outpoint outpoint) {
+                return Optional.ofNullable(utxos.get(outpoint));
+            }
+
+            @Override
+            public boolean isEnabled() {
+                return true;
+            }
+        };
+    }
+
     private static byte[] sampleTxCbor(long fee) {
+        return sampleTxCbor(fee, (byte) 0);
+    }
+
+    private static byte[] sampleTxCbor(long fee, byte inputDiscriminator) {
         Map txBody = new Map();
         Array inputs = new Array();
         Array input = new Array();
-        input.add(new ByteString(new byte[32]));
+        byte[] inputHash = new byte[32];
+        inputHash[31] = inputDiscriminator;
+        input.add(new ByteString(inputHash));
         input.add(new UnsignedInteger(0));
         inputs.add(input);
         txBody.put(new UnsignedInteger(0), inputs);

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoAcknowledgementIsolationTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoAcknowledgementIsolationTest.java
@@ -1,0 +1,93 @@
+package com.bloxbean.cardano.yano.runtime.utxo;
+
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.storage.ChainState;
+import com.bloxbean.cardano.yaci.events.api.Event;
+import com.bloxbean.cardano.yaci.events.api.EventMetadata;
+import com.bloxbean.cardano.yaci.events.api.PublishOptions;
+import com.bloxbean.cardano.yaci.events.api.SubscriptionOptions;
+import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.RollbackEvent;
+import com.bloxbean.cardano.yano.api.events.UtxoStateAppliedEvent;
+import com.bloxbean.cardano.yano.runtime.events.PropagatingEventBus;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+class UtxoAcknowledgementIsolationTest {
+    private record UnrelatedEvent() implements Event { }
+
+    @Test
+    void synchronousAcknowledgementFailureDoesNotFailDurableApplyOrEventBus() {
+        PropagatingEventBus bus = new PropagatingEventBus();
+        CountingWriter writer = new CountingWriter();
+        bus.subscribe(UtxoStateAppliedEvent.class,
+                ignored -> { throw new IllegalStateException("bookkeeping failed"); },
+                SubscriptionOptions.builder().build());
+        try (UtxoEventHandler ignored = new UtxoEventHandler(bus, writer)) {
+            assertThatCode(() -> publish(bus, blockEvent())).doesNotThrowAnyException();
+            assertThat(writer.applied).hasValue(1);
+            assertThat(bus.hasAsyncFailure()).isFalse();
+            assertThatCode(() -> bus.publish(new UnrelatedEvent(), metadata(), options()))
+                    .doesNotThrowAnyException();
+        } finally {
+            bus.close();
+        }
+    }
+
+    @Test
+    void asynchronousAcknowledgementFailureDoesNotPoisonWriterOrEventBus() throws Exception {
+        PropagatingEventBus bus = new PropagatingEventBus();
+        CountingWriter writer = new CountingWriter();
+        bus.subscribe(UtxoStateAppliedEvent.class,
+                ignored -> { throw new IllegalStateException("bookkeeping failed"); },
+                SubscriptionOptions.builder().build());
+        try (UtxoEventHandlerAsync handler = new UtxoEventHandlerAsync(bus, writer)) {
+            publish(bus, blockEvent());
+            long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+            while (writer.applied.get() == 0 && System.nanoTime() < deadline) {
+                Thread.sleep(10);
+            }
+            assertThat(writer.applied).hasValue(1);
+            assertThat(handler.hasFailure()).isFalse();
+            assertThat(bus.hasAsyncFailure()).isFalse();
+            assertThatCode(() -> bus.publish(new UnrelatedEvent(), metadata(), options()))
+                    .doesNotThrowAnyException();
+        } finally {
+            bus.close();
+        }
+    }
+
+    private static BlockAppliedEvent blockEvent() {
+        Block block = Block.builder().era(Era.Babbage)
+                .transactionBodies(List.of()).invalidTransactions(List.of()).build();
+        return new BlockAppliedEvent(Era.Babbage, 1, 1, "ab".repeat(32), block);
+    }
+
+    private static void publish(PropagatingEventBus bus, BlockAppliedEvent event) {
+        bus.publish(event, metadata(), options());
+    }
+
+    private static EventMetadata metadata() {
+        return EventMetadata.builder().origin("test").build();
+    }
+
+    private static PublishOptions options() {
+        return PublishOptions.builder().build();
+    }
+
+    private static final class CountingWriter implements UtxoStoreWriter {
+        private final AtomicInteger applied = new AtomicInteger();
+
+        @Override public void applyBlock(BlockAppliedEvent event) { applied.incrementAndGet(); }
+        @Override public void rollbackTo(RollbackEvent event) { }
+        @Override public void reconcile(ChainState chainState) { }
+        @Override public boolean isEnabled() { return true; }
+    }
+}


### PR DESCRIPTION
## Summary

- add a bounded, single-writer mempool UTXO overlay for arbitrary-depth chained transactions
- atomically enforce duplicate, conflicting-spend, transaction-count, byte and UTXO-index admission rules
- resolve regular, reference and collateral inputs from consumed, produced and canonical UTXO state in order
- retain selected transactions through forge-to-apply and expose produced outputs in the block-local overlay
- reconcile confirmation, canonical competing spends, rollback and descendant invalidation without orphaning confirmed-parent children
- isolate canonical UTXO acknowledgements from derived-listener failures and require synchronous admission-critical listeners
- support reference scripts produced by unconfirmed parents during phase-2 validation
- add ADR-NET-009 and the deferred generalized-ledger-state ADR

## Design notes

- Overlay indexes, dependency maps and locking remain internal to `DefaultMemPool`.
- Stateful validation is deliberately serialized for the initial correctness model.
- Selected entries remain in the mempool until canonical UTXO apply acknowledgement.
- ADR-NET-009 remains `Proposed` pending its retained-heap profiling acceptance gate.
- Certificate, governance and other non-UTXO mempool dependencies remain future work.

## Verification

- `./gradlew :ledger-rules:test :runtime:test`
- focused admission, chaining, conflicting-canonical-spend, reference-script and acknowledgement-isolation regression tests
- `./gradlew compileJava compileTestJava`
- `git diff --check`

All completed successfully.

Closes #66

Deferred hardening and protocol-aware bounds are tracked in #68.
