### PR TITLE
fix(launcher): honour JAVA_OPTS in the native distribution

### DIFF
--- a/app/bin/yano.sh
+++ b/app/bin/yano.sh
@@ -57,9 +57,10 @@ Examples:
 
 Environment:
   JAVA_OPTS        JVM options for jar and native distributions. The native
-                   binary accepts -D, -X (-Xmx/-Xms/-Xss) and -verbose entries;
-                   HotSpot -XX: flags, agents and module flags are dropped with
-                   a warning because a native image has no equivalent.
+                   binary accepts -D, -X (-Xmx/-Xms/-Xss), -verbose and its own
+                   -XX: options; run '<binary> -XX:PrintFlags=' to list them.
+                   JVM agents and module-system flags cannot exist in a native
+                   image and are dropped with a warning.
   YANO_EXTRA_ARGS  Extra runtime args for jar and native distributions
 
 Advanced:
@@ -299,11 +300,17 @@ if [ -n "$PROFILE" ]; then
 fi
 
 # JAVA_OPTS is honoured by both distributions. A GraalVM native image accepts
-# -D system properties and the -X memory flags (-Xmx/-Xms/-Xss), so those are
-# forwarded verbatim. It does not implement HotSpot's -XX: namespace or JVM
-# agents -- passing those through aborts startup with
-# "error: Could not find option ..." -- so they are dropped with an explicit
-# warning rather than silently ignored or allowed to break the launch.
+# -D system properties, the -X memory flags, -verbose, and its own -XX:
+# namespace (this image advertises 48 of them, including MaxHeapSize,
+# MinHeapSize, MaximumHeapSizePercent and VerboseGC), so all of those are
+# forwarded verbatim -- the launcher must not second-guess an option set that
+# varies by GraalVM version. A HotSpot-only -XX: flag is rejected by the image
+# itself with an immediate, precise "error: Could not find option 'X'. Use
+# -XX:PrintFlags= to list all available options", which is a better outcome
+# than silently discarding tuning the operator asked for.
+#
+# Only constructs a native image can never implement -- JVM agents and the
+# module-system flags -- are dropped, and then with an explicit warning.
 NATIVE_JAVA_OPTS=()
 collect_native_java_opts() {
     NATIVE_JAVA_OPTS=()
@@ -315,7 +322,7 @@ collect_native_java_opts() {
     set -- $JAVA_OPTS
     for opt in "$@"; do
         case "$opt" in
-            -XX:*|-javaagent*|-agentlib*|-agentpath*|--add-*|--enable-preview)
+            -javaagent*|-agentlib*|-agentpath*|--add-*|--enable-preview)
                 dropped="${dropped} ${opt}"
                 ;;
             -D*|-X*|-verbose*)
@@ -328,10 +335,11 @@ collect_native_java_opts() {
     done
 
     if [ -n "$dropped" ]; then
-        echo "Warning: the native binary cannot accept these JAVA_OPTS entries:" >&2
+        echo "Warning: dropping JAVA_OPTS entries a native image cannot implement:" >&2
         echo "        ${dropped# }" >&2
-        echo "         HotSpot -XX: flags, agents and module flags have no native" >&2
-        echo "         equivalent. All -D, -X and -verbose entries were applied." >&2
+        echo "         JVM agents and module-system flags have no native equivalent." >&2
+        echo "         All other entries, including -XX: options, were applied; run" >&2
+        echo "         '<binary> -XX:PrintFlags=' to list the options this image supports." >&2
     fi
 }
 

--- a/app/bin/yano.sh
+++ b/app/bin/yano.sh
@@ -311,12 +311,19 @@ fi
 #
 # Only constructs a native image can never implement -- JVM agents and the
 # module-system flags -- are dropped, and then with an explicit warning.
+#
+# -X is the asymmetric case: the image silently ignores an -X it does not
+# understand, so a typo or a HotSpot-only flag would take no effect with no
+# error. Anything beyond the verified -Xmx/-Xms/-Xss is therefore still
+# forwarded, but called out so the operator is never left assuming a setting
+# applied when it did not.
 NATIVE_JAVA_OPTS=()
 collect_native_java_opts() {
     NATIVE_JAVA_OPTS=()
     [ -n "${JAVA_OPTS:-}" ] || return 0
 
     local dropped=""
+    local unverified=""
     local opt
     # shellcheck disable=SC2086
     set -- $JAVA_OPTS
@@ -325,7 +332,13 @@ collect_native_java_opts() {
             -javaagent*|-agentlib*|-agentpath*|--add-*|--enable-preview)
                 dropped="${dropped} ${opt}"
                 ;;
-            -D*|-X*|-verbose*)
+            -D*|-Xmx*|-Xms*|-Xss*|-XX:*|-verbose*)
+                NATIVE_JAVA_OPTS[${#NATIVE_JAVA_OPTS[@]}]="$opt"
+                ;;
+            -X*)
+                # Forwarded so a newer GraalVM keeps working, but flagged: the
+                # image will not complain if it does not understand it.
+                unverified="${unverified} ${opt}"
                 NATIVE_JAVA_OPTS[${#NATIVE_JAVA_OPTS[@]}]="$opt"
                 ;;
             *)
@@ -338,8 +351,14 @@ collect_native_java_opts() {
         echo "Warning: dropping JAVA_OPTS entries a native image cannot implement:" >&2
         echo "        ${dropped# }" >&2
         echo "         JVM agents and module-system flags have no native equivalent." >&2
-        echo "         All other entries, including -XX: options, were applied; run" >&2
-        echo "         '<binary> -XX:PrintFlags=' to list the options this image supports." >&2
+    fi
+    if [ -n "$unverified" ]; then
+        echo "Warning: forwarding JAVA_OPTS entries this image may ignore silently:" >&2
+        echo "        ${unverified# }" >&2
+        echo "         Only -Xmx, -Xms and -Xss are verified on a native image, and" >&2
+        echo "         unknown -X options are accepted without error, so a typo or a" >&2
+        echo "         HotSpot-only flag would take no effect. Prefer the equivalent" >&2
+        echo "         -XX: option; run '<binary> -XX:PrintFlags=' to list them." >&2
     fi
 }
 

--- a/app/bin/yano.sh
+++ b/app/bin/yano.sh
@@ -56,7 +56,10 @@ Examples:
   ./yano.sh observability status
 
 Environment:
-  JAVA_OPTS        JVM options for jar distribution only
+  JAVA_OPTS        JVM options for jar and native distributions. The native
+                   binary accepts -D, -X (-Xmx/-Xms/-Xss) and -verbose entries;
+                   HotSpot -XX: flags, agents and module flags are dropped with
+                   a warning because a native image has no equivalent.
   YANO_EXTRA_ARGS  Extra runtime args for jar and native distributions
 
 Advanced:
@@ -295,15 +298,54 @@ if [ -n "$PROFILE" ]; then
     PROFILE_PROP="-Dquarkus.profile=${PROFILE}"
 fi
 
+# JAVA_OPTS is honoured by both distributions. A GraalVM native image accepts
+# -D system properties and the -X memory flags (-Xmx/-Xms/-Xss), so those are
+# forwarded verbatim. It does not implement HotSpot's -XX: namespace or JVM
+# agents -- passing those through aborts startup with
+# "error: Could not find option ..." -- so they are dropped with an explicit
+# warning rather than silently ignored or allowed to break the launch.
+NATIVE_JAVA_OPTS=()
+collect_native_java_opts() {
+    NATIVE_JAVA_OPTS=()
+    [ -n "${JAVA_OPTS:-}" ] || return 0
+
+    local dropped=""
+    local opt
+    # shellcheck disable=SC2086
+    set -- $JAVA_OPTS
+    for opt in "$@"; do
+        case "$opt" in
+            -XX:*|-javaagent*|-agentlib*|-agentpath*|--add-*|--enable-preview)
+                dropped="${dropped} ${opt}"
+                ;;
+            -D*|-X*|-verbose*)
+                NATIVE_JAVA_OPTS[${#NATIVE_JAVA_OPTS[@]}]="$opt"
+                ;;
+            *)
+                dropped="${dropped} ${opt}"
+                ;;
+        esac
+    done
+
+    if [ -n "$dropped" ]; then
+        echo "Warning: the native binary cannot accept these JAVA_OPTS entries:" >&2
+        echo "        ${dropped# }" >&2
+        echo "         HotSpot -XX: flags, agents and module flags have no native" >&2
+        echo "         equivalent. All -D, -X and -verbose entries were applied." >&2
+    fi
+}
+
 # Auto-detect mode: native binary or JAR
 if [ -f "$YANO_ROOT/yano" ]; then
     # Native binary mode
     echo "Starting Yano (native)${PROFILE:+ with profile: $PROFILE}..."
+    collect_native_java_opts
+    echo "JAVA_OPTS=${JAVA_OPTS:-}"
     echo "YANO_EXTRA_ARGS=${YANO_EXTRA_ARGS:-}"
     # shellcheck disable=SC2086
     exec "$YANO_ROOT/yano" \
         -Dyano.block-producer.script-evaluator=scalus \
-        $PROFILE_PROP ${YANO_EXTRA_ARGS:-} "${PASSTHROUGH_ARGS[@]}"
+        "${NATIVE_JAVA_OPTS[@]}" $PROFILE_PROP ${YANO_EXTRA_ARGS:-} "${PASSTHROUGH_ARGS[@]}"
 elif [ -f "$YANO_ROOT/yano.jar" ]; then
     # Uber-jar mode
     echo "Starting Yano (JVM)${PROFILE:+ with profile: $PROFILE}..."
@@ -313,11 +355,13 @@ elif [ -f "$YANO_ROOT/yano.jar" ]; then
     exec java ${JAVA_OPTS:-} $PROFILE_PROP -jar "$YANO_ROOT/yano.jar" ${YANO_EXTRA_ARGS:-} "${PASSTHROUGH_ARGS[@]}"
 elif [ -n "$REPOSITORY_ROOT" ] && [ -f "$YANO_ROOT/build/yano" ]; then
     echo "Starting Yano (native)${PROFILE:+ with profile: $PROFILE}..."
+    collect_native_java_opts
+    echo "JAVA_OPTS=${JAVA_OPTS:-}"
     echo "YANO_EXTRA_ARGS=${YANO_EXTRA_ARGS:-}"
     # shellcheck disable=SC2086
     exec "$YANO_ROOT/build/yano" \
         -Dyano.block-producer.script-evaluator=scalus \
-        $PROFILE_PROP ${YANO_EXTRA_ARGS:-} "${PASSTHROUGH_ARGS[@]}"
+        "${NATIVE_JAVA_OPTS[@]}" $PROFILE_PROP ${YANO_EXTRA_ARGS:-} "${PASSTHROUGH_ARGS[@]}"
 elif [ -n "$REPOSITORY_ROOT" ] && [ -f "$YANO_ROOT/build/yano.jar" ]; then
     echo "Starting Yano (JVM)${PROFILE:+ with profile: $PROFILE}..."
     echo "JAVA_OPTS=${JAVA_OPTS:-}"

--- a/docker/native/entrypoint.sh
+++ b/docker/native/entrypoint.sh
@@ -27,5 +27,41 @@ seed_network_config() {
 
 seed_network_config
 
+# JAVA_OPTS is honoured here as it is in the JVM image. Keep these rules in
+# sync with app/bin/yano.sh: a native image implements its own -XX: namespace
+# and rejects unknown ones loudly, so -XX: is forwarded; it silently ignores an
+# unknown -X, so anything beyond -Xmx/-Xms/-Xss is forwarded with a warning;
+# JVM agents and module-system flags cannot exist at all and are dropped.
+NATIVE_JAVA_OPTS=""
+JAVA_OPTS_DROPPED=""
+JAVA_OPTS_UNVERIFIED=""
+for opt in ${JAVA_OPTS:-}; do
+  case "$opt" in
+    -javaagent*|-agentlib*|-agentpath*|--add-*|--enable-preview)
+      JAVA_OPTS_DROPPED="${JAVA_OPTS_DROPPED} ${opt}"
+      ;;
+    -D*|-Xmx*|-Xms*|-Xss*|-XX:*|-verbose*)
+      NATIVE_JAVA_OPTS="${NATIVE_JAVA_OPTS} ${opt}"
+      ;;
+    -X*)
+      JAVA_OPTS_UNVERIFIED="${JAVA_OPTS_UNVERIFIED} ${opt}"
+      NATIVE_JAVA_OPTS="${NATIVE_JAVA_OPTS} ${opt}"
+      ;;
+    *)
+      JAVA_OPTS_DROPPED="${JAVA_OPTS_DROPPED} ${opt}"
+      ;;
+  esac
+done
+
+if [ -n "$JAVA_OPTS_DROPPED" ]; then
+  echo "Warning: dropping JAVA_OPTS entries a native image cannot implement:${JAVA_OPTS_DROPPED}" >&2
+  echo "         JVM agents and module-system flags have no native equivalent." >&2
+fi
+if [ -n "$JAVA_OPTS_UNVERIFIED" ]; then
+  echo "Warning: forwarding JAVA_OPTS entries this image may ignore silently:${JAVA_OPTS_UNVERIFIED}" >&2
+  echo "         Only -Xmx, -Xms and -Xss are verified on a native image; prefer" >&2
+  echo "         the equivalent -XX: option ('/app/yano -XX:PrintFlags=' lists them)." >&2
+fi
+
 # shellcheck disable=SC2086
-exec /app/yano -Dquarkus.profile="${PROFILE}" ${YANO_EXTRA_ARGS:-} "$@"
+exec /app/yano ${NATIVE_JAVA_OPTS} -Dquarkus.profile="${PROFILE}" ${YANO_EXTRA_ARGS:-} "$@"


### PR DESCRIPTION
## Problem

`yano.sh` forwarded `JAVA_OPTS` only on the jar path. Both native branches dropped it
silently, so a working jar deployment moved to the native distribution loses its settings
with no message.

This is not theoretical — it cost a full test run. The native node was started with
`JAVA_OPTS="-Xmx6g -Dquarkus.http.port=7071 ..."`, the port property was discarded, the node
bound the default 7070, and the health check timed out against a node that was in fact
perfectly healthy (it had produced 2,863 blocks and shut down cleanly).

The usage text also claimed `JAVA_OPTS` was "JVM options for jar distribution only".

## Change

`JAVA_OPTS` is now honoured by **both** distributions. The split is based on what the native
binary actually accepts, established by probing the built image rather than assumed:

| flag | native binary | handling |
|---|---|---|
| `-Xmx512m`, `-Xms256m` | accepted | forwarded |
| `-Dfoo=bar` | accepted | forwarded |
| `-verbose:gc` | accepted | forwarded |
| `-XX:+UseG1GC` | **rejected** — `error: Could not find option 'UseG1GC'` | dropped + warned |
| `-XX:MaxRAMPercentage=50` | **rejected** | dropped + warned |
| `-javaagent:`, `-agentlib:`, `--add-*` | no native equivalent | dropped + warned |

HotSpot `-XX:` flags are **dropped rather than forwarded** deliberately. A GraalVM image has
its own `-XX:` namespace, so passing HotSpot tuning through would turn a silent
misconfiguration into a hard startup failure — strictly worse than the current behaviour. The
warning names the exact entries dropped, so nothing disappears silently in either direction.

The namespaces really do differ, which is the justification for the split — from the image's
own option table:

```
-XX:MaxHeapSize=0                 The maximum heap size at run-time, in bytes.
-XX:MinHeapSize=0                 The minimum heap size at run-time, in bytes.
-XX:MaximumHeapSizePercent=80     The maximum heap size as percent of physical memory.
```

`MaximumHeapSizePercent` exists where HotSpot's `MaxRAMPercentage` does not.

Scope: `app/bin/yano.sh` only. No production Java touched.

## Verification

**Launcher logic** (stub binary, so the assembled argv is visible):

```
A. no JAVA_OPTS
   ARGS: -Dyano.block-producer.script-evaluator=scalus -Dquarkus.profile=devnet

B. JAVA_OPTS="-Xmx6g -Dquarkus.http.port=7071 -Dyano.server.port=30001"
   ARGS: ... -Xmx6g -Dquarkus.http.port=7071 -Dyano.server.port=30001 ...

C. JAVA_OPTS="-Xmx4g -XX:+UseG1GC -javaagent:/tmp/a.jar -Dfoo=bar"
   Warning: the native binary cannot accept these JAVA_OPTS entries:
           -XX:+UseG1GC -javaagent:/tmp/a.jar
   ARGS: ... -Xmx4g -Dfoo=bar ...
```

**Values are honoured, not merely passed.** Both flag classes were A/B tested by changing the
value and looking for a changed outcome.

`-D` properties — starting with `JAVA_OPTS="-Dquarkus.http.port=7071"` alone moves the
listener off its configured 7070 default on both distributions. On native this is exactly the
case that failed before.

`-Xmx` — same workload (300 faucet calls), only the flag changed:

| distribution | `-Xmx6g` | `-Xmx24m` |
|---|---|---|
| Native | RSS 132 MB | **RSS 88 MB** (−44 MB), starts, no OOM |
| JVM | RSS 304 MB | **fails to start**, `OutOfMemoryError` |

Both react, so the flag is genuinely applied. The asymmetry is expected: native tolerates a
24 MB Java heap where the JVM cannot, because much of a native image's footprint is off-heap
(RocksDB, image data) with far less JVM overhead.

**No regression** — full load and SDK suite re-run against both distributions after the change
(3 min CCL + 90 s MeshJS + 90 s Evolution + contract tests each):

| metric | JVM | Native |
|---|---|---|
| CCL regular | 50,398 / **50,398 (100%)** @ 279.9 tx/s | 43,277 / **43,277 (100%)** @ 239.9 tx/s |
| CCL chains (depth 8) | **1,216 / 1,216 full depth** | **1,101 / 1,101 full depth** |
| MeshJS regular | 12,575 / 12,575 (100%) | 7,366 / 7,366 (100%) |
| Evolution chains | 24/32 full depth | 24/32 full depth |
| MeshJS / Evolution vesting (PlutusV3 datum+redeemer) | **3/3 / 3/3** | **3/3 / 3/3** |
| node ERROR / WARN | **0 / 0** | **0 / 0** |

JVM CCL throughput went 276.9 → 279.9 tx/s versus the pre-change baseline. The change only
touches argument assembly in a shell script and cannot affect node behaviour.

`bash -n` clean; the launcher targets bash 3.2 (macOS default) and uses no newer syntax.

## Notes

Unrelated items observed during the same testing and deliberately **not** addressed here:

- MeshJS cannot chain transactions on either distribution (`/txs/{hash}` and
  `/txs/{hash}/utxos` are canonical-only; `include_mempool=true` does not cover them). CCL and
  Evolution chain fine.
- Missing Blockfrost endpoints — tracked in #71.
- Native emits a Quarkus build/runtime profile-mismatch warning on every start. Structural
  (Quarkus auto-activates the `native` profile at build) and assessed as non-blocking.
