### PR TITLE
feat(archive): ADR-039 canonical projection outbox, Phases 0-4b

### DIFF
--- a/adr/in-progress/039-canonical-projection-outbox.md
+++ b/adr/in-progress/039-canonical-projection-outbox.md
@@ -1,0 +1,2343 @@
+# ADR-039: Canonical Projection Outbox for Fresh-Sync History
+
+## Status
+
+**Partially implemented — Phases 0–4b complete on `feat/adr-039-canonical-projection-outbox`
+and validated to preprod tip with all four shipped block datasets; Phase 5 next, Phases 6–7 to
+follow, Phase 8 deferred.** Reconciled with two source reviews.
+This ADR describes a replacement architecture and must not be treated as an implementation
+continuation of ADR-038.
+
+The six decisions in "Review decision requested" are treated as **recorded** by the
+instruction to implement this ADR end to end; the review closed with no open editorial
+items. Implementation reports live in `adr/reports/adr-039-*`.
+
+### Implementation state — 2026-08-20
+
+| Phase | State |
+|---|---|
+| 0 boundary proofs, recovery classification | complete |
+| 1 contracts, identity, fresh-sync guard | complete |
+| 2 durable block outbox | complete |
+| 3 transaction/UTXO slice + Byron carrier | complete (differential parity met) |
+| 4 DuckLake primary sink | **complete** — full preprod sync to tip (1h07m, 5,076,688 blocks), restart and `kill -9` verified, near-tip batch policy and sink-owned maintenance live |
+| 4b remaining shipped datasets | **complete, validated to preprod tip** on a fresh four-section sync (contributor lag 0, 0 drain failures, backlog pinned at the finality window). Archive logical size 4.50 GB against 3.16 GB with two sections — **1.42x** over the whole sync, which is the figure to size with; the `bytesPerBlock` status counter (4,637 vs 2,817) is backlog density at tip, not a sync average — all four datasets have contributors; account-event parity covered by seven certificate fixtures, address-transaction parity verified side by side against the live dataset on a real spend. Section cost measured at 234 B/participation, which materially increases outbox volume: the gate-4 bytes-per-block model was taken with two sections and must be re-derived before mainnet sizing |
+| 5 epoch artifacts | not started — next, as a stacked child PR |
+| 6 operational/API cutover | not started |
+| 7 remove superseded pipelines | not started; **must not begin until every API/read path is cut over and parity-validated in Phase 6** |
+| 8 standalone SQLite primary sink | **deferred — explicitly out of scope for this campaign.** The `ProjectionSink` / `ProjectionSinkProvider` boundary is retained so it stays buildable later; nothing in Phases 5-7 may remove the interfaces it needs |
+
+One acceptance gate remains open: **criterion 1, the core regression budget**. It is now
+*bounded* rather than inconclusive: attributing the projection's cost inside a single run — no
+second run, so no cross-run variance — puts it at **at most 6.3% of sync throughput** over
+2.27M blocks, against a 5% budget. The bound straddles the budget, so the gate is not yet met
+but the pre-optimisation −14% is not the current cost. Criterion 2 was withdrawn on direct
+measurement — see below.
+
+### Phase 0 outcome that changes the plan
+
+**Acceptance criterion 2 cannot be satisfied as written.** Measured uncontended on a
+fresh preprod sync, history-disabled core production runs at **1,500–3,600 blocks/s**
+depending on block density. The only measured sink rate is ADR-038's **59.84 blocks/s**.
+These are different workloads and must not be reduced to one ratio, but the gap is
+roughly 1.5 orders of magnitude, and ADR-038 attributes only ~82–86% of per-block worker
+cost to the decode this design removes. No decode-free sink closes that.
+
+**Withdrawn — measured false.** The ADR-039 DuckLake sink was subsequently measured directly
+on a fresh preprod sync: **1,292 blocks/s sink versus 1,193 blocks/s producer**, with the
+outbox backlog pinned at the finality window (4,319 blocks) from block 170,000 through 4.8M
+and zero drain failures. The sink keeps up with full-speed bootstrap; rollback-safety, not
+sink throughput, is the binding constraint.
+
+The original conclusion inferred the new sink's capability from ADR-038's 59.84 blocks/s,
+which is the *old replay-worker* rate — repeated decode, contended writer, synchronous
+locator, none of which the projection sink does. That inference was invalid.
+
+The superseded reasoning follows, retained because the reasoning error is instructive.
+
+**Superseded.** The conclusion drawn from this — that sink-paced core sync was the only
+live option — was wrong, and criterion 2 has since been replaced (see "Revised criteria"
+below). The comparison pitted the sink against *accelerated bootstrap* core production,
+which asynchrony exists to decouple. At steady state a sink at even 60 blocks/s outruns
+mainnet block arrival by three orders of magnitude. The bootstrap deficit is a disk-capacity
+question, governed by an aggregate retained-disk budget with visible pause and automatic
+resume, not a reason to pace core to sink speed.
+
+### Phase 3 outcome: acceptance criterion 1 also fails
+
+Measured cleanly — four legs alternating, each alone on an idle machine, fresh chainstate,
+wall clock to block 1,000,000 on preprod:
+
+```
+median history-disabled : 2,410 blocks/s
+median history-enabled  : 2,070 blocks/s
+delta                   : -14.1%  (plausible range -10% to -18%)
+criterion 1 threshold   :  -5.0%
+```
+
+Disk cost over the same range: +3.42 GB chainstate, i.e. **3,419 bytes/block on disk**
+against ~2,400 bytes/block of logical outbox — roughly **1.4x amplification**. That
+quantifies review finding D3.
+
+This ADR already prescribes the response: "the design must first remove avoidable
+copies/encoding work. It must not hide the overhead by making the canonical/outbox
+boundary best-effort." That optimisation pass has **not** been attempted, so the 14% is
+an unoptimised first measurement, not a floor.
+
+Criteria 1 and 2 fail independently. Cheaper encoding would not bring a sink within an
+order of magnitude of core production, and accepting sink-paced sync would not recover
+the 14%.
+
+### Open question 1 has a concrete, blocking answer
+
+"Which live subsystem is the authoritative contributor for datum/redeemer and
+pointer-address projection facts?" is not merely a design preference. The projection row
+builder uses `UtxoHistoryDataset`'s resolver-less constructor, which **throws** on a
+pre-Conway pointer address. Datum and redeemer facts are fine — they come from the block
+itself. Pointer addresses are not, and until this is answered a sink must not be enabled
+on a network whose pre-Conway range contains them.
+
+### Corrections to this ADR made during implementation
+
+- §4's illustrative `account-events:v1` is wrong for the shipped dataset: `ACCOUNT_EVENT`
+  is at projectionVersion 3, so its section is `account-events:v3`. Section versions are
+  now *derived* from `ArchiveSchemas`, so they cannot drift from dataset identity.
+- §11's crash-boundary case 9 has a concrete failure mode the text does not name:
+  acknowledging the outbox range deletes artifact *references*, so a crash before lease
+  release orphans the lease. Startup lease reconciliation is required with the first
+  artifact, not after.
+- Rollback of pending envelopes must be keyed on the rollback **slot**, not on a chain
+  tip read inside a listener; listener order relative to chain-state rollback is
+  unspecified.
+
+## Date
+
+2026-08-19
+
+## Source-review reconciliation — 2026-08-19
+
+The source reviews against `feat/adr-038-archive-throughput@5a3cebec` found four
+initial blocking omissions plus epoch-artifact durability and retention
+clarifications. This revision incorporates them:
+
+- Byron main blocks now require a typed already-decoded projection carrier;
+  EBBs produce empty envelopes so coverage remains contiguous.
+- One global chain/UTXO/ledger transaction is no longer an implementation
+  candidate. Existing per-contributor RocksDB batches, cursors, retained bodies,
+  reconciliation, and `BlockBodyRetentionBoundary` form the durability model.
+- Replay-worker removal is gated on all four shipped block datasets, not only
+  transaction and UTXO parity.
+- Core-only rate, concurrent sink rate, outbox bytes/block, and full-sync backlog
+  are Phase 0 decision gates.
+- The existing epoch staged-file source is retained as the logical-equivalence
+  baseline and hardened where it is the selected durable representation;
+  immutable live-generation references require per-artifact correctness and
+  performance evidence.
+- Required staged artifacts must be hardened beyond the current best-effort
+  failure isolation and process-restart durability before they satisfy the new
+  completeness contract.
+- Existing dataset/table/projection-version ownership is preserved initially.
+- The hot-RocksDB compaction consequence of a lagging outbox is explicit.
+- First-slice UTXO inputs do not require resolved consumed-output data;
+  Shelley+ address/credential history does, and Byron retains an archive-owned
+  resolver.
+- Epoch recoverability is classified per column. Persisted generations,
+  conditionally recomputable facts, and non-reconstructible boundary-time joins
+  have different capture/durability requirements.
+- One-epoch delayed eligibility is not treated as durability. Deferred
+  force/digest publication is safe only after an exact reconstruction source or
+  minimal immutable boundary evidence is already durable.
+- Artifact cleanup requires renewable, fenced reader leases; wall-clock expiry
+  alone cannot authorize deletion.
+- Persisted epoch-stake generations receive an explicit snapshot-pruning clamp;
+  their retained chainstate bytes participate in the aggregate backlog limits.
+- The runtime common `RollbackCapableStore` floor is reused as a
+  retention-health constraint and checked against the oldest active artifact or
+  reward-replay requirement; it is not an archive-finality cutoff.
+- `PREPARING` recovery is class-specific; its marker cannot substitute for
+  atomic evidence when boundary-time facts are otherwise irreconstructible.
+
+## Decision summary
+
+For a history-enabled node starting from genesis, canonical block application
+will produce one ordered, durable, versioned projection stream. A single
+configured primary archive sink — DuckLake or standalone SQLite — consumes that
+stream asynchronously. Blocks are decoded and stateful facts are resolved once,
+while the authoritative live stores already hold the required context.
+
+The stream is implemented as a transactional RocksDB outbox:
+
+```text
+canonical block and ledger application
+                  |
+                  | atomic state/projection boundary
+                  v
+       canonical projection outbox
+                  |
+                  | ordered, finality-gated batches
+                  v
+          one primary archive sink
+           DuckLake OR SQLite
+                  |
+                  v
+       optional derived projections
+  tx locator / search / alternate store / export
+```
+
+The initial release supports exactly one primary sink and only a fresh history
+sync. It does not migrate a partially synchronized archive, enable history on an
+already synchronized chainstate, or feed multiple primary sinks. Those
+restrictions are deliberate simplifications and are enforced at startup.
+
+Small block-level facts are stored inline or in bounded chunks under a logical
+block envelope. Large epoch data is not copied into that envelope. Its durable
+source is either a hardened immutable staged-file representation or, where a
+per-artifact review proves it safer and faster, an epoch-versioned immutable
+live-store generation protected by a durable pruning lease. The sink streams the
+source and acknowledgement permits its cleanup.
+
+The existing independent archive replay workers remain only as a temporary
+differential oracle during implementation. After parity and recovery gates pass,
+the block-replay history pipeline and the unused legacy synchronous history path
+are removed. The archive schemas, query contracts, DuckLake/SQLite storage
+implementations, receipts, and backend conformance tests are retained where
+they satisfy this ADR.
+
+## Architecture at a glance
+
+### Contributors complete one logical block envelope
+
+Canonical synchronization does **not** wait for every history contributor before
+accepting the next block. Each contributor processes blocks in canonical order
+and atomically commits its own state changes, envelope section, and contributor
+cursor. The archive sink sees only the completed logical envelope.
+
+```text
+                            CANONICAL BLOCK 100
+                                     |
+                   stored body is the durable replay intent
+                                     |
+       +-----------------------------+-----------------------------+
+       |                             |                             |
+       v                             v                             v
++------------------+       +--------------------+       +--------------------+
+| TRANSACTION      |       | UTXO_HISTORY       |       | ACCOUNT_EVENT      |
+| contributor      |       | contributor        |       | contributor        |
+|                  |       |                    |       |                    |
+| chain_transaction|       | outputs            |       | account_events     |
+|                  |       | output_assets      |       |                    |
+| atomic batch:    |       | inputs             |       | atomic batch:      |
+| section + cursor |       | datums/redeemers   |       | state + section    |
++---------+--------+       |                    |       | + cursor           |
+          |                | atomic batch:      |       +----------+---------+
+          |                | state + section    |                  |
+          |                | + cursor           |                  |
+          |                +----------+---------+                  |
+          |                           |                            |
+          |                +----------+----------------------------+
+          |                |
+          |                |       +------------------------+
+          |                |       | ADDRESS_TRANSACTION    |
+          |                |       | contributor            |
+          |                |       |                        |
+          |                |       | address_transactions   |
+          |                |       | resolver + section     |
+          |                |       | + cursor atomically    |
+          |                |       +-----------+------------+
+          |                |                   |
+          +----------------+-------------------+
+                                           |
+                                           v
+                         +----------------------------------+
+                         | BLOCK 100 LOGICAL ENVELOPE       |
+                         |                                  |
+                         | TRANSACTION          complete    |
+                         | UTXO_HISTORY         complete    |
+                         | ACCOUNT_EVENT        complete    |
+                         | ADDRESS_TRANSACTION  complete    |
+                         | epoch artifact refs  if required |
+                         +----------------+-----------------+
+                                          |
+                                    envelope complete
+```
+
+If a separately accepted product ADR retires a dataset such as
+`ADDRESS_TRANSACTION`, it is removed from the archive identity's required
+section set. It must not simply be omitted while still marked required.
+
+### Core, contributors, and archive advance independently
+
+```text
+time --------------------------------------------------------------->
+
+canonical core       [100] [101] [102] [103]
+TRANSACTION          [100] [101] [102]
+UTXO_HISTORY         [100] [101] [102]
+ACCOUNT_EVENT        [100] [101]
+ADDRESS_TRANSACTION  [100] [101]
+
+complete envelopes   [100] [101]
+rollback-safe         [100]
+primary archive      [100]
+```
+
+In this example, core is at block 103 while the primary archive is at block 100.
+That is valid. Bodies needed by incomplete contributors remain protected from
+pruning. A contributor that restarts resumes from its own cursor and reconstructs
+missing sections from those retained bodies.
+
+### Archive flow for each contiguous envelope range
+
+```text
+all required contributor sections present?
+                 |
+          +------+------+
+          |             |
+         no            yes
+          |             |
+ wait at this block     v
+                 ENVELOPE COMPLETE
+                         |
+                 rollback-safe yet?
+                         |
+                  +------+------+
+                  |             |
+                 no            yes
+                  |             |
+          wait for finality     v
+                   batch consecutive complete envelopes
+                                |
+                                v
+                    DuckLake OR SQLite commit
+                    rows + durable receipt atomically
+                                |
+                       commit/receipt verified?
+                                |
+                         +------+------+
+                         |             |
+                        no            yes
+                         |             |
+                  retry same job       v
+                                 acknowledge range
+                                         |
+                                         v
+                              delete outbox chunks and
+                              release artifact protection
+```
+
+The sink cannot skip an incomplete block. It may batch blocks 100–120 together
+only when every envelope in that range is complete, rollback-safe, contiguous,
+and compatible with the same sink transaction bounds.
+
+## Context
+
+The current archive architecture reconstructs history by running independent
+projections over durable block bodies and durable epoch sources. Block-derived
+datasets have separate cursors and worker lifecycles. In practice this means
+that transaction, address/account, and UTXO projections can reread and decode
+the same block independently, advance at different rates, contend for one
+archive writer, and require explicit catch-up-to-live handoff logic.
+
+ADR-038 demonstrated both the value and the limit of optimizing that model:
+
+- Appender-to-staging made archive row insertion fast without weakening logical
+  key verification.
+- Ordered UTXO prefetch improved the slowest dataset from 31.57 to 59.84
+  blocks/s in the accepted production window.
+- The remaining synchronous transaction locator later held shared archive
+  capacity for seconds to minutes despite being a derived query hint.
+- Much of the old UTXO cost was repeated CBOR decoding even though canonical
+  block application had already decoded the same transactions and resolved the
+  same spent outputs.
+
+The node already has the information required for history while applying a
+canonical block:
+
+- decoded transactions and witnesses;
+- transaction validity and collateral semantics;
+- new outputs, assets, datums, redeemers, and consumed outpoints;
+- consumed outpoint identity and, where a later address/credential projection
+  requires it, the original consumed output from the live UTXO set;
+- same-block transaction ordering;
+- resolved ledger transitions and rollback information;
+- immutable, epoch-keyed stake, reward, ADA-pot, DRep, and governance outputs.
+
+Re-reading old block bodies to reconstruct those facts duplicates work and
+creates a second state-resolution system whose correctness must track the live
+ledger implementation. A durable projection outbox captures the already-known
+result and lets storage remain asynchronous.
+
+This is not a generic event-bus decision. The outbox is a local durability and
+projection boundary for one node. It is not initially a permanent Kafka-like
+log, and acknowledged records may be deleted.
+
+## Goals
+
+1. Decode each canonical block once for new history.
+2. Reuse authoritative live-path UTXO and ledger resolution.
+3. Keep DuckLake and SQLite work outside the core synchronization hot path.
+4. Replace separate dataset catch-up/live lifecycles with one ordered backlog.
+5. Make rollback, crash replay, receipt verification, and pruning explicit.
+6. Support one primary DuckLake or SQLite sink through a common contract.
+7. Allow future versioned sections such as governance and epoch artifacts.
+8. Make point indexes and search stores optional downstream projections.
+9. Remove unused legacy history and, after parity, the current block-replay
+   archive workers.
+10. Keep the primary archive sufficiently complete to derive later stores and
+    query projections without involving the core sync path.
+
+## Non-goals
+
+The initial implementation does not:
+
+- enable history midway through an existing chainstate;
+- migrate existing partial archive coverage;
+- support two simultaneous primary archive sinks;
+- retain the outbox forever for arbitrary future consumers;
+- solve the `txHash -> block` point-index design;
+- promise complete historical support for a data type not captured by the
+  primary archive or retained block bodies;
+- archive mutable current-state CFs such as account state by reference;
+- make DuckLake, SQLite, or a locator authoritative ledger state;
+- support an ordinary rollback deeper than the configured retained rollback
+  boundary;
+- preserve the current per-dataset worker architecture for compatibility.
+
+## Terms
+
+**Canonical projection envelope** — the logical projection result associated
+with one canonical block. It has a header, zero or more versioned inline/chunked
+sections, and zero or more immutable artifact references.
+
+**Projection outbox** — the durable RocksDB records holding envelopes until the
+primary sink acknowledges them.
+
+**Primary archive sink** — the one configured authoritative historical store for
+this node: DuckLake or standalone SQLite.
+
+**Artifact** — a large immutable, generation-addressed source such as a durable
+staged epoch file or a proven immutable live-store generation that a sink streams
+by reference.
+
+**Artifact lease** — durable metadata preventing pruning of an artifact and any
+required recomputation-input closure until the primary sink acknowledges it or
+the projection is explicitly abandoned.
+
+**Derived projection** — a rebuildable downstream index or store populated from
+the primary archive, not directly acknowledged by the core outbox.
+
+**Projection coordinate** — the greatest contiguous canonical block envelope
+durably committed by the primary sink. Epoch-artifact coverage is reported
+separately by artifact type and semantic epoch.
+
+## Decision
+
+### 1. Fresh-sync history is an enforced identity invariant
+
+Projection-outbox history may be enabled only when all of the following hold:
+
+1. canonical chainstate is empty/genesis, or a coordinated snapshot explicitly
+   includes matching projection metadata;
+2. the outbox has no non-genesis projection identity;
+3. the selected primary archive is empty, or has the exact expected network,
+   genesis, archive, schema, and projection identity;
+4. no incompatible legacy/archive coverage is being adopted implicitly.
+
+Starting with history disabled and enabling it after synchronization has begun
+is rejected. Pointing an existing chainstate at an empty primary archive is
+rejected. Pointing a fresh chainstate at an unrelated archive is rejected.
+
+A future coordinated snapshot format may include chainstate, projection
+coordinate, pending outbox, artifact leases, and archive identity. Such a
+snapshot counts as a fresh coherent start; a chainstate snapshot alone does not.
+
+The operator choices for an existing node are therefore explicit:
+
+- continue using a release that supports its existing history layout;
+- start a fresh sync with projection-outbox history;
+- or use a separately designed and verified offline migration.
+
+### 2. One logical envelope per canonical block
+
+The envelope header contains at least:
+
+```text
+network/genesis identity
+block number, hash, and parent hash
+slot, epoch, and block time
+canonical projection version
+section manifest
+artifact-reference manifest
+deterministic envelope ID
+```
+
+The deterministic envelope ID is derived from canonical identity and projection
+version, not from a random retry ID. Replaying the same canonical block therefore
+addresses the same logical envelope.
+
+An envelope is logical, not necessarily one RocksDB value. Physical records may
+be:
+
+```text
+projection/header/<block>
+projection/section/<block>/<type>/<chunk>
+projection/artifact/<block>/<type>/<generation>
+```
+
+The header manifest records section versions, chunk counts, logical row counts,
+byte counts, and digests. The primary sink verifies the complete logical
+envelope before acknowledgement.
+
+No physical value is allowed to grow without a configured bound. Large
+block-level collections are chunked deterministically.
+
+### 3. Initial block-level sections
+
+The first complete vertical slice contains two logical sections and writes the
+existing six physical archive tables. Version one preserves the current
+dataset-to-table identity and projection versions; it does not silently move
+datum/redeemer coverage from `UTXO_HISTORY` to `TRANSACTION`:
+
+```text
+transaction:v2
+  -> chain_transaction
+
+utxo-history:v5
+  -> transaction_outputs
+  -> transaction_output_assets
+  -> transaction_inputs
+  -> transaction_datums
+  -> transaction_redeemers
+```
+
+Envelope section names are transport groupings, not permission to change
+archive dataset identity. Any future repartitioning of tables between logical
+datasets requires an explicit projection-version transition, coverage
+reconciliation rules, conformance-fixture updates, and query compatibility
+decision.
+
+`utxo-history:v5` records output creation when the output is created, even when it
+remains unspent indefinitely. A later consuming input is a separate immutable
+event. The output row is not moved or deleted from the archive.
+
+During canonical UTXO application, the processor already has the decoded
+transaction, validity, input role, new outputs, and consumed outpoint. The
+current `transaction_inputs` schema records the referenced outpoint rather than
+denormalizing the original consumed output, so the first transaction/UTXO slice
+does not require that output lookup for its archive rows. It materializes
+self-contained projection facts before mutating `cfUnspent`/`cfSpent`. The
+asynchronous sink never needs to reread the block.
+
+Original consumed-output resolution is required by later Shelley+ address and
+credential projections such as `address_transaction`; it is not the primary
+justification for the first slice. Decode-once during normal operation is the
+primary throughput benefit. Address/credential history also requires an
+archive-owned sequential resolver for Byron because the live UTXO subsystem
+does not apply Byron transactions.
+
+Shelley-and-later validity semantics remain explicit:
+
+- ordinary inputs consume outputs only for a valid transaction;
+- collateral inputs consume outputs for a failed transaction;
+- reference inputs never consume outputs;
+- ordinary outputs are created only for a valid transaction;
+- collateral-return output is created for the applicable failed transaction;
+- same-block parent/child transactions preserve canonical transaction order.
+
+Addresses, credentials, assets, datum/reference-script material, and witness
+facts required by the archive schema are captured while available. A sink does
+format translation and batching; it does not repeat ledger resolution.
+
+#### Byron and epoch-boundary blocks
+
+`BlockAppliedEvent.block()` is deliberately `null` for Byron main blocks and
+Byron epoch-boundary blocks (EBBs), and multiple existing consumers use that
+sentinel. The projection design must not overload or reinterpret it.
+
+When projection history is enabled, `BodyFetchManager` publishes a dedicated
+typed Byron projection event carrying the already-decoded raw `ByronMainBlock`
+or `ByronEbBlock` after canonical storage. The collector retains the current
+Byron normalizer that maps a main block into the projection model. It does not
+decode stored CBOR again during normal application. EBBs produce an empty
+logical envelope so the block projection coordinate remains contiguous.
+
+Byron projection semantics are an explicit strict subset:
+
+- `chain_transaction.fee` is `NULL` because the normalized Byron transaction
+  does not provide a fee and the schema permits null;
+- there are no invalid-transaction, collateral, reference-input, datum,
+  redeemer, multi-asset, or pointer-address facts;
+- Byron addresses use their raw base58 representation;
+- Byron address/account participation that needs input funding addresses uses
+  an archive-owned resolver seeded from Byron genesis and advanced in canonical
+  order.
+
+Crash recovery may decode a retained Byron body to rebuild a missing contributor
+section. This is recovery replay, not a second normal-operation decode.
+
+### 4. Extensible versioned sections
+
+Later releases may add sections such as:
+
+```text
+account-events:v1
+credential-filter:v1
+governance-events:v1
+certificate-events:v1
+withdrawal-events:v1
+```
+
+The names above are illustrative until Phase 1 maps them to existing dataset
+identity. In particular, the currently shipped `ACCOUNT_EVENT` and
+`ADDRESS_TRANSACTION` datasets must receive equivalent sections before their
+replay workers can be removed, unless a separately accepted product ADR
+explicitly retires those datasets and their public API behavior.
+
+Each section has an independent type and version. Unknown optional sections may
+be skipped only when the archive identity says they are not required. A required
+section unknown to the configured sink is a startup/processing error, not a
+silent omission.
+
+The envelope is not a dump of mutable internal objects. Section schemas are
+stable projection contracts with deterministic encoding and explicit evolution
+rules. A projection change increments the affected section version and the
+archive records the activation coordinate.
+
+### 5. Large epoch data uses a durable artifact source
+
+Suitable large artifacts include immutable epoch-keyed generations of:
+
+- epoch stake;
+- rewards and reward-rest data;
+- ADA pots;
+- DRep distribution;
+- governance proposal/status snapshots;
+- other finalized epoch/governance snapshots meeting the eligibility contract.
+
+Mutable CFs such as current account state are never referenced. Historical UTXO
+balances are derived from archived output creation and consumption. Historical
+stake/reward/account semantics are derived from the corresponding certificate,
+withdrawal, reward, pot, and immutable epoch artifacts.
+
+The codebase already has a restartable staged-artifact implementation:
+
+```text
+EpochArchiveStagingSink
+  -> EpochArchiveStagingService
+  -> DurableEpochFileSource
+```
+
+It streams epoch facts into immutable restartable files, writes a manifest with
+deterministic job identity, exposes bounded paged reads and leases, and deletes
+the staged source after acknowledgement. Retain this path in the storage
+foundation. It is the starting representation for ephemeral facts that exist
+only while a transition is evaluated, and it is the logical-equivalence
+baseline for all epoch artifacts. It is not yet a proven power-loss-durable
+source.
+
+The existing implementation is a baseline, not yet the required-source
+contract. `EpochArchiveStagingSink` currently isolates capture failures from the
+authoritative transition, and `EpochArchiveStagingService` may disable/discard a
+failed boundary. A required fresh-sync artifact cannot disappear that way. Phase
+0/5 must either make capture failure fail closed before the source becomes
+unreconstructible, or retain a durable replay source from which the exact staged
+artifact is regenerated. Required versus optional artifacts are fixed in the
+archive identity.
+
+The staged-file commit must also prove power-loss durability: rows, manifest,
+parent-directory rename state, completion marker, row count, codec/projection
+version, and digest are forced/published in an order where no completed artifact
+can reference missing or partial bytes. Process-restart tests alone are not
+sufficient. Acknowledgement cannot delete a source with an active read lease.
+
+Recoverability is classified per projected column, not merely per dataset. A
+single archive row may combine an immutable value with boundary-time joins from
+mutable state. Phase 0 must place every field into one of these classes:
+
+| recovery class | current examples | required source contract |
+|---|---|---|
+| Exact persisted generation | `EPOCH_STAKE`; `ADA_POT`; the stake-amount columns of `DREP_DISTRIBUTION` | Protect the immutable generation and stream it later. No staged-file force is required at the transition if replay from that generation is byte-for-byte or logically deterministic. |
+| Conditionally recomputable | `REWARD`, subject to proof | Retain the complete deterministic input closure and its versions until archive acknowledgement. For rewards this includes every required stake snapshot, pot/fee value, block-production count, protocol parameter, era/rule configuration, source identity, and calculation version; retaining only stake and pot data is not assumed sufficient. |
+| Not reconstructible from current persisted state | Boundary-time DRep-state joins such as `stored_expiry`, `dormant_epochs`, `effective_expiry`, and `active`; governance proposal observation/decision semantics not present in its persisted snapshot | Persist the minimal immutable source evidence atomically with the contributor transition, or make the completed staged artifact durable before the transition can make the evidence unreconstructible. |
+
+`DREP_DISTRIBUTION` therefore cannot receive one representation decision for
+the whole dataset without further work. Its persisted amount generation is a
+candidate live-generation source, while its joined boundary-state columns need
+an immutable boundary snapshot or a hardened staged capture. Its
+`source_state_version` and artifact manifest identify the representation and
+semantic/source version used to produce the row.
+
+`REWARD` remains in the conditional class until Phase 0 proves that replay
+retains all inputs and versioned calculation semantics. If that proof fails, it
+moves to the non-reconstructible class. The same classification is required for
+future `reward_rest` and other artifact types before they enter archive
+identity.
+
+An exact persisted generation is not equivalent to an indefinitely retained
+generation. `EPOCH_STAKE` currently shares the configured delegation-snapshot
+retention window, and epoch-boundary pruning deletes older snapshot keys. A
+reference to that generation therefore registers its retention requirement in
+the same contributor batch that makes the reference recoverable. Snapshot
+pruning clamps its oldest-to-keep boundary to the oldest active artifact or
+reward-replay requirement. The generation remains protected until the sink
+receipt is acknowledged; ordinary configured retention alone is not evidence
+that it will still exist when a lagging sink reads it.
+
+Staged files are not automatically the fastest representation. The current
+writer encodes and writes them synchronously while epoch processing is
+iterating the facts. For a generation already stored immutably in RocksDB, that
+duplicates bytes and may lengthen epoch-boundary latency. Phase 0 must measure
+staged-file boundary overhead, including required durability forcing, and
+compare it with streaming the retained generation later. The decision is made
+per artifact type, not globally.
+
+A live-store generation may be referenced instead of staged only when:
+
+1. keys identify an immutable epoch/generation;
+2. the generation is never updated in place after closure;
+3. its complete range is deterministic;
+4. a versioned reader can translate it into stable projection rows;
+5. pruning observes durable leases;
+6. it can be scanned without holding the core apply lock for the duration;
+7. rollback semantics for its producing boundary are defined;
+8. measured epoch-boundary and sink performance is better than or equal to the
+   staged representation without increasing recovery risk.
+
+An artifact reference records at least:
+
+```text
+artifact type
+semantic epoch
+producing transition
+effective coordinate
+source generation/key range
+source codec version
+source representation = staged-file | immutable-generation
+expected row/byte count when cheaply available
+content/state digest when available
+rollback-safe eligibility coordinate
+```
+
+The sink accesses artifacts through an `ArchiveArtifactReader`; DuckLake and
+SQLite code do not receive raw CF handles or depend directly on physical key
+encoding.
+
+Durability work may run after the authoritative transition only when the exact
+source generation or complete replay input closure is already durable and
+protected. For non-reconstructible facts, this sequence is unsafe:
+
+```text
+write unforced staged bytes
+commit authoritative transition
+power loss
+force/digest/publish staged artifact later
+```
+
+A one-epoch eligibility delay does not recover bytes lost between the second
+and fourth steps. The preferred low-latency solution is to commit the minimum
+immutable boundary evidence in the contributor's existing RocksDB batch and
+materialize/force the large staged representation asynchronously. If that is
+not possible, durable staged capture is on the transition's fail-closed path
+and its latency must pass the Phase 0 gate.
+
+### 6. Epoch artifacts publish one safe boundary later
+
+At transition `E-1 -> E`, the ledger produces immutable state whose semantic
+epoch is `E`. It is protected but not immediately eligible for archive
+publication. At transition `E -> E+1`, the first canonical block crossing the
+boundary may reference the artifact produced at `E-1 -> E`, provided its
+producing coordinate is also older than the configured rollback-safe cutoff.
+
+```text
+transition E-1 -> E
+  create immutable artifact E
+  register protection
+  keep pending
+
+transition E -> E+1
+  publish/reference artifact E if rollback-safe
+  create and protect artifact E+1
+```
+
+The first block in `E+1` carries the reference, but the row remains labelled by
+its semantic epoch `E`. The model distinguishes closing values for the prior
+epoch from opening values effective in the new epoch.
+
+One epoch is the normal delay, not the fundamental proof. The required check is:
+
+```text
+producing transition coordinate <= rollback-safe cutoff
+```
+
+This handles networks with short epochs or unusually large rollback retention.
+If a block crosses more than one epoch boundary, the envelope may carry an
+ordered list of transitions and newly eligible artifact references.
+
+The delay supplies ample scheduling slack for force, digest, and manifest
+publication when a durable reconstruction source or atomic boundary-evidence
+record already exists. It is not itself a durability barrier. An artifact is
+ineligible until both rollback safety and source durability are proven.
+
+Archive code does not invent a second finality calculation. The greatest
+normally eligible block remains:
+
+```text
+tip block - ArchiveSafetyWindows.archiveFinalityBlocks
+```
+
+`ArchiveSafetyWindows.resolve(...)` derives the security, rollback-retention,
+and archive-finality depths from genesis/configuration and enforces:
+
+```text
+archiveFinalityBlocks >= rollbackRetentionBlocks >= securityParam
+```
+
+Equivalently, combining the depths uses:
+
+```text
+tip - max(archiveFinalityBlocks, rollbackRetentionBlocks)
+```
+
+That reduces to the existing finality boundary. The resulting block identity is
+read consistently with the canonical tip.
+
+The runtime common rollback floor is a different quantity: the maximum of all
+`RollbackCapableStore.getRollbackFloorSlot()` values, where a lower slot means
+more history remains replayable and zero means unbounded retention. In the
+account store it incorporates the earliest retained per-block issuer/fee facts
+and the earliest delegation snapshot needed four epochs later by reward replay.
+Phase 0 verifies that this calculation covers every input needed to reproduce
+the archived reward schema; archive code reuses the result rather than copying
+the calculation.
+
+For every pending envelope, artifact, or recomputation closure, record the
+oldest rollback target/source slot it still requires. Retention is healthy only
+while:
+
+```text
+runtime common rollback floor <= oldest active required slot
+```
+
+The lease clamps source pruning so the floor cannot cross that requirement.
+Equality is an exhaustion warning; a greater floor means required replay data
+was lost and triggers the visible fail-closed/pause path. It does not silently
+move the finality boundary or skip the affected work. A restore or configuration
+change that invalidates this invariant likewise fails closed unless an explicit
+reconstruction or exceptional invalidation protocol repairs it.
+
+### 7. Artifact leases are durable pruning contracts
+
+Artifact production/protection and its transition marker use a protocol that
+cannot expose an eligible reference without a durable source. A filesystem
+artifact and a RocksDB marker do not pretend to share an atomic transaction:
+the file reaches forced, digest-verified completion first, then a RocksDB
+`READY` marker makes it referenceable; recovery removes orphaned pre-marker
+files and fails closed on a marker whose source cannot be verified. For staged
+files, acknowledgement is the only normal deletion path. For immutable
+live-store generations, source registration/protection is committed in the
+contributor batch and pruning uses:
+
+```text
+eligible for normal pruning
+AND no active projection artifact lease
+```
+
+The lease remains from artifact creation until durable primary-sink
+acknowledgement. It survives restart and software upgrade. A sink lag therefore
+causes visible retained-disk growth rather than silent data loss.
+
+A wall-clock expiry is a liveness signal, not authority to remove protection
+from a source that a reader may still use. Readers renew leases and carry a
+fenced process/session identity; abandonment cleanup proves that the owner is
+stale before releasing protection. Registration, renewal, acknowledgement, and
+cleanup are coordinated so acknowledgement cannot remove staged bytes or a
+generation while a live reader lease exists. The current staged-file expiry
+cleanup and acknowledgement behavior must be hardened to satisfy this contract.
+
+Recovery from `PREPARING` is class-specific:
+
+- for an exact persisted generation, re-derive the staged representation from
+  the protected generation;
+- for a conditionally recomputable artifact, recompute it only after verifying
+  the complete retained input and calculation-version closure;
+- for a non-reconstructible artifact, regenerate it from the immutable evidence
+  committed in the contributor batch, or fail closed if that evidence is not
+  present.
+
+The `PREPARING -> READY` marker is detection and orchestration, not the source of
+non-reconstructible-data safety. A design without atomic boundary evidence must
+instead force and verify its staged source before the authoritative transition
+becomes irreversible.
+
+Native RocksDB snapshots are not held for hours as the default mechanism because
+they can pin SST files and impede compaction. A staged immutable file or
+epoch-versioned immutable keys plus a logical pruning lease are preferred. An
+immutable checkpoint is allowed where the source store cannot provide versioned
+generations and its lifecycle is equally explicit.
+
+Staged files freeze a stable projection codec at capture time. Immutable live-CF
+references instead require readers for every source codec version still
+referenced by a pending artifact. Startup fails before processing if any pending
+artifact representation cannot be read.
+
+### 8. Canonical apply and outbox durability contract
+
+The design requires the following invariant:
+
+> An applied canonical block `B` cannot become unreconstructible until every
+> required contributor section for `B` is durable. Canonical progress may lead a
+> contributor, but the stored body plus contributor cursor remains a durable
+> replay intent and pruning protection until the logical envelope is complete.
+
+The current runtime deliberately has no one transaction spanning canonical
+chain storage, UTXO state, ledger/account state, and projections. Canonical
+`storeBlock` commits before `BlockAppliedEvent`; UTXO and ledger contributors
+have their own cursors, RocksDB batches, and replay-from-stored-body recovery.
+ADR-039 preserves that production recovery model rather than introducing a
+cross-subsystem transaction.
+
+Each required contributor writes its section chunks and contributor coordinate
+inside the same existing RocksDB `WriteBatch` as the state and rollback data from
+which that section was derived. All contributors use the node's shared RocksDB,
+but atomicity is per contributor. A logical envelope becomes complete and sink
+eligible only after every required contributor for its projection identity has
+durably reached that block with matching canonical identity.
+
+The stored canonical body and contributor cursors are the durable apply intent.
+Startup reconciliation replays any missing contributor range in canonical order
+before the envelope can be marked complete. Block-body pruning is clamped by the
+oldest incomplete required contributor through the existing
+`BlockBodyRetentionBoundary` mechanism. A body cannot be pruned merely because
+one faster contributor has produced its section.
+
+Phase 0 must still map and test each contributor boundary, required-section
+completion, pruning clamp, and replay order. It must not attempt a single batch
+across chain, UTXO, ledger, and projection unless source evidence later proves a
+specific correctness need that per-contributor replay cannot satisfy.
+
+A best-effort event-bus listener after block commit is rejected. A crash between
+canonical progress and an ephemeral listener would create an unrecoverable gap
+once block bodies are pruned. An event-driven contributor is acceptable only
+when its section and cursor commit atomically with its source state and the
+retention/reconciliation contract prevents that gap.
+
+Projection construction is allowed on the hot path; sink I/O is not. The hot
+path may perform deterministic encoding and a bounded RocksDB write. It must not
+open DuckDB/SQLite archive sessions, wait for an archive writer, or scan a large
+epoch artifact.
+
+“Decode once” means once during successful normal operation. Crash/startup
+reconciliation may decode a retained body again to reproduce the same
+deterministic contributor section. No field may depend on state that is
+unavailable or unreconstructible when that replay occurs.
+
+### 9. Finality-gated asynchronous consumption
+
+Envelopes are created immediately with canonical application so rollback can
+remove them exactly. The primary sink consumes only the greatest contiguous
+range whose blocks are older than the configured rollback-safe cutoff.
+
+There is no separate `CATCHING_UP -> LIVE` archive lifecycle:
+
+```text
+small outbox backlog = near-live archive
+large outbox backlog = archive catching up
+```
+
+The consumer is ordered by canonical block coordinate. It may batch several
+envelopes within configured row, byte, block, time, and memory bounds. It must
+not reorder stateful section semantics.
+
+Core sync normally continues while the sink is slow or unavailable. Soft limits
+degrade archive health and expose lag/disk metrics. A configured hard disk or
+outbox bound may pause canonical ingestion rather than discard projection data;
+the node must report that condition explicitly.
+
+### 10. Exactly-once effect through receipts and idempotency
+
+The delivery protocol is at-least-once. Deterministic jobs, logical keys,
+digests, counts, and durable sink receipts provide exactly-once effect.
+
+```text
+read contiguous eligible envelopes
+  -> begin deterministic sink job
+  -> write all required rows/artifacts
+  -> verify keys/counts/digest
+  -> commit sink data + durable receipt
+  -> acknowledge outbox range
+  -> delete acknowledged chunks and release artifact leases
+```
+
+On retry, an existing receipt is accepted only when identity, projection
+versions, envelope range, counts, and digest match. A differently shaped retry
+is rejected.
+
+Cleanup is scoped exactly to a verified receipt. It does not infer success from
+the sink's current maximum block or from partial row presence.
+
+### 11. Crash boundaries
+
+At minimum, tests cover:
+
+1. crash after canonical body commit but before one or more contributor sections;
+2. crash after a contributor state commit before logical-envelope completion;
+3. crash after complete durable outbox commit before sink start;
+4. failure after multiple sink staging flushes but before sink commit;
+5. crash during artifact streaming;
+6. sink commit failure;
+7. crash after sink data commit but before outbox acknowledgement;
+8. crash after acknowledgement but during chunk cleanup;
+9. crash after receipt verification but before artifact-lease release;
+10. restart with an old pending section/artifact codec;
+11. sink unavailability until soft and hard backlog thresholds;
+12. power loss after an epoch transition but before deferred artifact
+    force/digest/manifest publication;
+13. a live reader exceeds its lease deadline while acknowledgement or stale
+    cleanup races it.
+
+Every case must recover without missing facts, duplicate logical rows, cursor
+skips, premature pruning, or unbounded retry memory.
+
+### 12. Rollback and invalidation
+
+Before sink eligibility, rollback removes or replaces envelopes and artifact
+references atomically with live-state rollback. A replacement canonical block at
+the same height has a different deterministic envelope identity.
+
+The primary sink normally contains only data older than the supported rollback
+boundary. Ordinary rollback therefore never mutates the immutable archive.
+
+An explicitly supported exceptional deep rollback requires a separate
+group-atomic archive invalidation contract and downstream invalidation journal.
+It is not silently implemented as row deletion. If deep rollback beyond archive
+finality remains unsupported, the node fails closed and requires a coordinated
+restore/resync.
+
+### 13. One primary sink in version one
+
+Configuration selects exactly one:
+
+```text
+history.projection.sink=ducklake
+```
+
+or:
+
+```text
+history.projection.sink=sqlite
+```
+
+The archive identity records the selected sink and cannot be changed in place.
+The sink contract is conceptually:
+
+```java
+interface ProjectionSink {
+    ProjectionReceipt append(ProjectionBatch batch);
+    ProjectionCoordinate coordinate();
+    ProjectionCoverage coverage();
+}
+```
+
+The actual API must also carry identity, versions, receipts, artifact readers,
+capacity/backpressure, health, and close semantics. This sketch is not the full
+contract.
+
+If both sinks were direct outbox consumers, cleanup would require per-consumer
+offsets and the slowest consumer would retain every envelope. Version one avoids
+that complexity.
+
+### 14. Future sinks derive from the primary archive
+
+A later SQLite, DuckLake, search, or export store is built from the current
+primary archive through a separately designed projection/cutover process:
+
+```text
+primary archive snapshot at G
+  -> populate target through G
+  -> apply source changes G+1..H
+  -> final fenced drain
+  -> verify identity/counts/digests/coverage
+  -> optional active-sink switch
+```
+
+Because acknowledged outbox entries are deleted, a new sink cannot assume the
+old outbox remains available. It either derives from the primary archive, starts
+at an explicit activation coordinate, or requires a fresh sync.
+
+The primary archive must therefore retain stable provenance and all facts needed
+by promised downstream projections. A future projection requiring data never
+captured by the primary archive needs new section activation, retained-block
+replay, or a fresh sync.
+
+### 15. Transaction locator is deferred and downstream
+
+The projection outbox does not itself make a Parquet point lookup fast.
+`txHash -> block/job/partition` remains useful for `/txs/{hash}` and input-parent
+resolution because a hash predicate over many Parquet files can be slow.
+
+The locator is not part of the primary sink acknowledgement in this ADR. A
+future design may use:
+
+- a SQLite locator fed from a durable DuckLake delta journal;
+- a long-lived RocksDB transaction index;
+- another indexed store;
+- or a future native archive indexing capability.
+
+Until then, DuckLake queries may use a slower scan/fallback and APIs requiring a
+complete point index must report their limitation. In particular, the separate
+per-block credential-filter and `/scan` proposal currently relies on a complete
+transaction index for some `/txs/{hash}` and parent-input fallbacks. Those phases
+are not claimed complete by this ADR.
+
+Before API cutover, produce a per-endpoint decision table for at least
+`/txs/{hash}`, transaction UTXO/input-parent resolution, address history,
+account history, and wallet confirmation/status behavior. For each endpoint it
+must name the primary table, live fast path, no-locator fallback, completeness
+range, latency bound/timeout, and response when the fallback cannot provide the
+promised result. “The archive can scan” is not by itself an API contract.
+
+Standalone SQLite may provide indexed transaction lookup natively, but that does
+not change the cross-backend contract: point lookup is a query capability, not a
+condition for acknowledging canonical archive data.
+
+### 16. Coverage and query semantics
+
+The primary block projection exposes one greatest contiguous committed block
+coordinate. It does not expose independent transaction and UTXO cursors for the
+same envelope range.
+
+Epoch artifact coverage remains typed because semantic epochs and publication
+delay differ from block projection coverage:
+
+```text
+blockProjectionThrough: B
+epochStakeThrough: E
+rewardsThrough: E-1
+drepDistributionThrough: E
+```
+
+History APIs either:
+
+- serve only ranges covered by every required table/artifact;
+- return explicit partial-coverage metadata;
+- or return an unavailable/catching-up response.
+
+They never present an outbox row as archived before the primary sink receipt.
+Current live state may still answer explicitly current-state APIs, but it is not
+silently merged into immutable historical coverage.
+
+### 17. No mutable-CF archive references
+
+Mutable account/current-state CFs are excluded. Historical UTXO-based balances
+can be reconstructed at block `H` from outputs created through `H` minus inputs
+that consume them through `H`, including native-asset rows. Common expensive
+queries may later use derived snapshots plus deltas.
+
+Stake/reward/account semantics not represented by UTXOs are reconstructed from
+the archived certificate, withdrawal, reward, ADA-pot, and immutable epoch
+artifacts. The design preserves facts and events, not every mutable materialized
+view.
+
+## Correctness invariants
+
+The implementation must preserve all of the following:
+
+1. **No canonical gap:** every applied block in a history-enabled fresh sync has
+   exactly one required logical projection envelope or a retained canonical body
+   plus contributor coordinates that can deterministically complete it.
+2. **Canonical identity:** envelope block hash and parent match canonical state
+   at the atomic boundary.
+3. **Ordered state effects:** UTXO and other stateful facts preserve canonical
+   transaction and block order.
+4. **No unfinalized archive rows:** the sink consumes only rollback-safe blocks
+   and artifacts.
+5. **Atomic sink visibility:** all required tables for a projection batch and
+   its receipt become visible together.
+6. **Receipt-before-cleanup:** no outbox data or artifact protection is removed
+   before the matching durable receipt is verified.
+7. **Idempotent replay:** a matching retry has no duplicate logical effect; a
+   mismatching retry is rejected.
+8. **Lease-before-prune:** referenced artifact data and conditionally
+   recomputable input closure cannot be pruned while any unacknowledged
+   reference depends on them.
+9. **Version readability:** every pending required section/artifact has an
+   installed compatible reader.
+10. **Sink isolation:** archive or optional-index failure cannot corrupt
+    canonical state and does not normally block it before an explicit hard
+    resource limit.
+11. **Complete manifest:** a sink cannot acknowledge a logical envelope with a
+    missing chunk or required section.
+12. **Fresh identity:** incomplete mid-chain activation is rejected rather than
+    represented as genesis-complete coverage.
+13. **Contributor-before-prune:** no canonical body required by an incomplete
+    contributor may be pruned.
+14. **Retention floor below requirements:** the runtime common rollback floor
+    cannot advance above the oldest slot required by any pending envelope,
+    artifact, or recomputation-input closure. A violation pauses rather than
+    narrowing archive eligibility.
+
+## Operational model
+
+At minimum expose:
+
+- canonical tip and projection sink coordinate;
+- outbox lag in blocks, rows, and bytes;
+- oldest pending envelope age;
+- eligible versus finality-waiting envelopes;
+- active batch identity and stage;
+- sink commit latency and throughput;
+- receipt replay count;
+- outbox cleanup lag;
+- active artifact leases by type/epoch/representation/bytes;
+- oldest retained delegation snapshot and the configured versus lease-clamped
+  pruning boundary;
+- runtime common rollback floor, oldest active required slot, and remaining
+  retention margin;
+- outbox bytes, staged-file bytes, estimated bytes in pinned live generations,
+  total chainstate bytes, and filesystem free space;
+- oldest codec version still pending;
+- soft/hard backlog state;
+- archive and artifact coverage;
+- last failure with bounded/sanitized detail.
+
+Shutdown stops new sink batches, lets the active bounded batch finish or abort,
+preserves the outbox, and closes the sink. Core shutdown does not delete pending
+data. Startup reconciles identity, receipts, acknowledged-but-not-cleaned ranges,
+and artifact leases before accepting new projection work.
+
+Soft/hard resource limits cover the whole archive retention obligation, not only
+outbox CF values. They include staged files and generations kept in chainstate
+beyond normal retention. Because RocksDB SST sharing makes exact attribution
+impossible, the policy uses logical/estimated pinned-generation bytes together
+with measured total chainstate growth and free space. At the hard limit the node
+pauses canonical ingestion visibly; it never satisfies the limit by pruning an
+unacknowledged source.
+
+## Performance model and acceptance criteria
+
+The architecture moves deterministic fact encoding and an additional bounded
+RocksDB write into canonical processing, while removing repeated block reads,
+decodes, and resolver work from history workers. It is accepted only if the
+trade is measured.
+
+The outbox absorbs burst variance; it does not create sustainable throughput.
+Let:
+
+```text
+Rc = concurrent history-enabled canonical production rate in blocks/s
+Rs = concurrent primary-sink drain rate in equivalent blocks/s
+B  = measured outbox bytes produced per canonical block
+```
+
+If `Rs < Rc`, retained bytes grow approximately as
+`(Rc - Rs) * B * elapsedSeconds`. Over a genesis sync this can move a material
+fraction of the archive into the hot RocksDB, increase its compaction/write
+amplification, and eventually throttle core ingestion at the hard limit. That is
+a product mode, not a transient backlog, and cannot be accepted accidentally.
+This equation covers block-envelope growth only; capacity planning adds staged
+files and the logical/physical cost of live generations pinned beyond their
+normal retention window.
+
+### Revised criteria — 2026-08-20
+
+**Criterion 2 as originally written is withdrawn.** "Sink drain rate at least 20% greater
+than concurrent history-enabled canonical production" measured the sink against
+*accelerated bootstrap* core production and therefore asked the wrong question. Canonical
+sync is asynchronous: core does not wait for the sink, and the outbox exists precisely so
+it need not. Two regimes must be separated:
+
+```text
+bootstrap   core ~2,000+ blocks/s   sink drains behind    -> a capacity question
+steady tip  core ~0.05 blocks/s     sink far ahead        -> a margin question
+```
+
+At mainnet's 20-second slots a sink doing even 60 blocks/s outruns block arrival by three
+orders of magnitude. There is no steady-state throughput problem. The bootstrap deficit is
+a one-time backlog whose cost is **disk**, not throughput, and the correct control is a
+disk budget, not pacing core to sink speed.
+
+Replacement criteria:
+
+**Bootstrap**
+
+- Core may run ahead of the sink; this is the designed behaviour, not a degraded mode.
+- Measure the complete backlog and disk requirement for a full genesis sync.
+- The projected backlog must fit an explicitly accepted disk budget.
+- Measure time-for-core-to-reach-tip and time-for-history-to-catch-up **separately**.
+- Sink catch-up time must be measured and bounded.
+- Historical APIs report `catching_up` until their required coverage exists.
+
+**Steady state**
+
+- Sink capacity must exceed actual network block arrival with a safe margin.
+- The steady-state outbox must remain bounded.
+- Maintenance must not cause sustained backlog growth.
+
+**Disk backpressure**
+
+- Continue asynchronous canonical sync while aggregate archive-retained disk usage stays
+  below the configured hard limit.
+- Pause canonical ingestion visibly when aggregate usage reaches the hard limit, or
+  filesystem free space reaches the configured safety reserve.
+- Resume automatically once acknowledged cleanup returns usage below a low-water mark.
+  Hysteresis is required; resuming at the pause threshold oscillates.
+- Never discard envelopes, artifact evidence, receipts, or protected source generations to
+  recover space.
+- Expose pause reason, current usage, thresholds and required cleanup progress through
+  status, readiness and metrics.
+
+Aggregate archive-retained usage covers outbox column families, staged artifact files,
+chainstate generations pinned by artifact leases, and expected RocksDB write/compaction
+amplification — measured at roughly **1.4x** logical for the first slice.
+
+**In-memory bounds** on staging, batches, queues and chunks remain, but they are local
+flow control: a full queue may briefly block its immediate producer, must never lose
+projection data, and must never permanently pause core sync. Durable disk limits are the
+only authority over how far canonical sync may run ahead over time.
+
+**Readiness** — core readiness and archive readiness are independent. Core may be ready
+while historical endpoints report `catching_up`. Historical endpoints must never claim
+coverage beyond verified sink receipts.
+
+The first vertical slice must demonstrate:
+
+1. no more than 5% sustained core-sync throughput regression with history enabled versus
+   the same fresh-sync workload with history disabled;
+2. a bootstrap backlog and disk requirement that fit an accepted budget, a measured and
+   bounded sink catch-up time, and a steady-state sink margin over real block arrival;
+3. bounded envelope/chunk size and memory;
+4. measured average/p95/p99 outbox bytes per block, a full-mainnet-sync
+   wall-clock/backlog model, staged and pinned-generation retention, bounded
+   normal growth, and accurate total chainstate/disk growth under an
+   intentionally stopped sink;
+5. logical equivalence with the existing transaction/UTXO archive for the same
+   chain range, including rows, logical keys, counts, and digests;
+6. no missing/duplicate facts across every crash boundary;
+7. correct rollback across blocks, same-block dependencies, and an epoch
+   boundary before sink eligibility;
+8. no artifact pruning while protected and successful pruning after receipt;
+9. startup recovery without full archive scans in the normal case;
+10. API coverage/readiness that matches the committed primary archive exactly.
+
+#### Status of the ten, 2026-08-20
+
+| # | Criterion | State |
+|---|---|---|
+| 1 | <=5% core regression | **BOUNDED, budget straddled** — measured by attribution inside a single run over 2,267,163 blocks: per-block cycle 520,033 ns, apply 159,789 ns (30.7%), projection 32,711 ns (**6.3% of cycle**, 20.5% of apply); the run continued to 3,107,640 blocks with the apply share settling at 18.5%, so the ratio is stable across three million blocks. That 6.3% is an *upper bound* — it assumes apply sits wholly on the critical path — so the true cost is in (0, 6.3%] against a 5% budget. Round 1's −14.1% is not the current cost. Excludes the asynchronous sink drain and the separately-measured ~1.4x write amplification. |
+| 2 | bootstrap backlog/disk, catch-up time, steady-state margin | **met on preprod** — full fresh sync 1h07m for 5,076,688 blocks; backlog pinned at the 4,320-block finality window; archive 3.7 GB against 27 GB chainstate. Not yet shown at mainnet scale. |
+| 3 | bounded envelope/chunk size and memory | **met and measured, all four sections** — peak retained heap 2,436 KiB at 5 envelopes vs 2,571 KiB at 100 (20x the batch, 5.5% more heap); densest single envelope 5,740 rows / 6,467 KiB. With two sections the same measurement was 1,066 vs 1,111 KiB, so the bound holds as datasets are added rather than only for the first slice. |
+| 4 | average/p95/p99 outbox bytes/block, mainnet model, retention, stopped-sink growth | **partial, and now stale** — averages measured (2,817 B/block outbox, 709 B/block Parquet, 1.4x amplification) but **with two sections only**. The address-transaction section alone encodes at 234 B/participation, so a four-dataset node is materially larger; the model must be re-derived. p95/p99 per-block distribution is still not instrumented. |
+| 5 | logical equivalence with the existing archive | **met for the covered fixture set, and independently corroborated** — byte-identical rows across 21 differential fixtures (10 original + 7 certificate + address-transaction side-by-side against the live dataset on a real spend). Corroborated on a real chain: two independent genesis syncs, different jars and section sets, produce the same MD5 digest over `tx_hash, output_index, address, lovelace` and the same lovelace sum for blocks 4,050,000-4,060,000. Still not covered: reference scripts, Byron genesis output resolution, era-transition blocks and epoch-boundary rollback. |
+| 6 | no missing/duplicate facts across every crash boundary | **met, on both section sets** — graceful restart and `kill -9` on a live preprod archive: 0 gaps, 0 duplicate transactions, 0 duplicate outputs, 0 overlapping receipts. Repeated with all four sections: `kill -9` at tip mid-batch left the acknowledged point unchanged, contributor lag 0, and the node serving again in 21 s. Several restarts with a batch mid-flight left it unacknowledged and rebuilt it identically. |
+| 7 | rollback across blocks, same-block dependencies, epoch boundary | **partial** — block- and slot-keyed rollback, same-block dependencies and buffered-batch discard are covered by tests; rollback across an epoch boundary is not. |
+| 8 | artifact pruning protected then released | **not applicable yet** — no artifacts until Phase 5. The lease-reconciliation gap is identified and must ship with the first artifact. |
+| 9 | startup recovery without full archive scans | **met** — receipt identity is checked against the encoded batch, so a replayed range is recognised without decoding a section; the sink provider no longer builds the replay-worker locator (~61 s saved per restart). |
+| 10 | API coverage/readiness matches the committed archive | **not started** — Phase 6. Near tip a block can be final and durable but not yet queryable in the sink for **the linger plus at most one compaction budget** — 15 min + 5 min at the defaults, because maintenance runs on the drain thread and delays the next batch from opening. An endpoint must serve that range from recent storage or report coverage honestly, never report false absence. Note that `pendingBatchAgeSeconds` measures buffer residency, not finality-to-sink latency, and so understates the window by any maintenance delay. |
+
+The 5% threshold is an initial decision target, not a claim already measured.
+If deterministic projection encoding exceeds it, the design must first remove
+avoidable copies/encoding work. It must not hide the overhead by making the
+canonical/outbox boundary best-effort.
+
+Phase 0 cannot pass with only an isolated DuckLake benchmark. It needs the
+history-disabled core baseline, history-enabled producer rate, and sink drain
+rate measured concurrently on the same retained workload. If the 20% margin is
+not met, implementation pauses for an explicit choice among sink optimization,
+resource/profile changes, accepted core throttling, or revised scope.
+
+## Branching and repository strategy
+
+### Current repository state
+
+At the time of this ADR, `feat/adr-038-archive-throughput` contains the proven
+archive schemas, API/storage contracts, DuckLake and SQLite implementations,
+backend conformance tests, and ADR-038 performance/correctness changes. It also
+contains the independent replay workers, hot-history lifecycle, prefetch
+optimization, synchronous locator integration, and production evidence specific
+to the architecture this ADR replaces.
+
+The branch is materially diverged from `main`; raw `main` does not contain
+`archive-modules`. Starting implementation from raw `main` would produce a clean
+graph but unnecessarily reimplement the valuable backend work. Continuing
+inside ADR-038 would mix a closed throughput campaign with a replacement
+architecture.
+
+### Required branch shape
+
+Use two branches (and preferably separate worktrees):
+
+```text
+main
+  |
+  +-- feat/archive-storage-foundation
+          |
+          +-- feat/archive-projection-outbox
+```
+
+`feat/archive-storage-foundation` extracts or cherry-picks only reusable pieces
+from the current archive line and integrates current `main`:
+
+- archive API identities, schemas, rows, queries, receipts, and errors;
+- DuckLake archive initialization, read/write sessions, staging/Appender path,
+  bounded capacity, maintenance, and conformance tests;
+- standalone SQLite archive schema, read/write sessions, and conformance tests;
+- `EpochArchiveStagingSink`, `EpochArchiveStagingService`,
+  `DurableEpochFileSource`, their codecs/manifests/leases, and their tests as the
+  default durable epoch-artifact baseline;
+- shared sink-independent storage tests and query DTOs;
+- required application packaging/provider wiring that does not start the old
+  worker lifecycle.
+
+It excludes or leaves disabled pending removal:
+
+- `BlockArchiveWorker` and `LiveBlockArchiveWorker` orchestration;
+- block replay sources/decoders used only by archive catch-up;
+- per-dataset catch-up/live cursors and promotion;
+- hot-history row promotion used only by the old lifecycle;
+- ordered UTXO prefetch, which optimizes repeated archive decode;
+- synchronous SQLite transaction-locator update in the DuckLake commit path;
+- ADR-038 runtime tuning and reports as implementation dependencies.
+
+`feat/archive-projection-outbox` begins only after the foundation builds and its
+backend conformance tests pass. ADR-039 implementation commits land there.
+
+If extracting the foundation first is temporarily impractical, branch
+`feat/archive-projection-outbox` from the stable ADR-038 head, integrate current
+`main`, and delete/replace old orchestration early. Do not implement ADR-039
+directly on `feat/adr-038-archive-throughput`.
+
+### ADR numbering integration note
+
+Another development line currently uses `ADR-036` for the per-block credential
+filters and `/scan` proposal, while this archive line already contains
+`ADR-036: Pluggable Hot History Store`. Resolve that number collision during
+branch integration. This ADR refers to the proposal by title, not by number,
+until the merged repository assigns an unambiguous identifier.
+
+### Commit grouping
+
+Keep changes reviewable in this order:
+
+1. archive storage foundation extraction/integration;
+2. ADR-039 envelope, identity, and sink contracts;
+3. fresh-sync startup guard and archive identity;
+4. outbox persistence, manifests, chunks, metrics, and recovery;
+5. transaction/UTXO block-scoped collector;
+6. DuckLake primary sink adapter;
+7. immutable artifact reader and lease protocol;
+8. one epoch artifact vertical slice;
+9. parity, crash, rollback, and performance evidence;
+10. API cutover;
+11. removal of old archive replay workers and unused legacy history;
+12. standalone SQLite primary sink adaptation.
+
+Do not mix production samples, unrelated ADR work, or deployment-specific
+configuration into the implementation commits.
+
+### Module ownership after cutover
+
+Keep the existing `archive-modules` shape, but replace worker-oriented ownership
+with projection-oriented ownership:
+
+```text
+archive-modules/archive-api
+  stable envelope/section/artifact value types
+  projection identity, coordinate, coverage, receipt, and sink contracts
+  archive schemas, rows, queries, and errors
+
+archive-modules/archive-core
+  RocksDB outbox and serialization
+  block-scoped projection collector
+  finality-gated ordered consumer
+  staged-file and immutable-generation artifact readers
+  artifact registry, leases, and cleanup
+  recovery, rollback, health, metrics, and backpressure
+
+archive-modules/archive-store-ducklake
+  DuckLake ProjectionSink
+  physical table/view initialization and migrations
+  batch staging/Appender, verification, receipts, reads, and maintenance
+
+archive-modules/archive-store-sqlite
+  standalone SQLite ProjectionSink
+  physical table/index/view migrations
+  batch verification, receipts, reads, and maintenance
+
+runtime/core integration
+  contribute authoritative facts during ordered canonical apply
+  expose immutable artifact sources and pruning hooks
+  never depend on DuckLake or standalone SQLite implementations
+
+app
+  select and compose exactly one sink
+  enforce fresh-sync/archive identity
+  expose configuration, status, readiness, and lifecycle
+```
+
+Dependency direction is toward `archive-api`; storage backends do not depend on
+runtime internals. Staged files and qualifying immutable live stores expose
+artifact readers through an interface, not raw RocksDB handles. The block-scoped
+collector must not become a service locator through which archive code reaches
+arbitrary mutable node state.
+
+Configuration names are finalized during Phase 1. They must have one source of
+truth for rollback/finality rather than a second archive-only interpretation.
+Required configuration concepts are:
+
+```text
+projection history enabled at genesis
+primary sink = ducklake | sqlite
+aggregate archive-retention soft/hard byte bounds
+outbox soft/hard block bounds
+batch block/row/byte/time/memory bounds
+sink retry/backoff and bounded shutdown
+artifact retention/lease observability
+existing ArchiveSafetyWindows as the finality/eligibility calculation
+runtime common rollback floor as the retained-source health constraint
+required section set and versions
+```
+
+## Implementation plan
+
+### Phase 0 — prove boundaries and establish the foundation
+
+Status: required before implementation.
+
+1. Map canonical block persistence, UTXO apply, ledger/epoch transition, event
+   publication, and rollback transaction boundaries in source.
+2. Prove per-contributor section/cursor atomicity, logical-envelope completion,
+   retained-body replay, and the pruning clamp. Do not introduce a global
+   cross-subsystem batch without new evidence.
+3. Inventory each initial archive column and identify its authoritative live-path
+   or recovery-replay source; no field may depend on state unavailable or
+   unreconstructible when contributor replay occurs.
+4. Prove the dedicated Byron main-block/EBB projection carrier and retained
+   normalizer, including empty EBB envelope continuity.
+5. Inventory immutable epoch CF generation, mutation, rollback, and pruning;
+   compare each candidate with the existing restartable staged-file path and measure
+   synchronous epoch-boundary overhead. Audit staged capture failure semantics,
+   force/rename durability, completion publication, digest/count/version
+   manifests, and acknowledgement versus active leases. Produce a per-column
+   recoverability matrix: exact persisted generation, conditionally
+   recomputable with a proven complete input/version closure, or not
+   reconstructible. Define the atomic evidence or synchronous durability
+   boundary for every field in the last class. Implement or specify the
+   delegation-snapshot pruning clamp, reuse the runtime common rollback-floor
+   calculation as a retention-health assertion, and prove that its
+   reward-input/snapshot floors cover the full archived reward-row input
+   closure. Keep archive eligibility on the existing `ArchiveSafetyWindows`
+   finality calculation.
+6. Establish `feat/archive-storage-foundation` and make all retained backend
+   conformance tests green on current `main`.
+7. Measure history-disabled core rate, history-enabled producer rate, concurrent
+   sink drain rate, outbox bytes/block distribution, RocksDB write/compaction
+   volume, and block/epoch-boundary latency on representative workloads. Produce
+   the full-mainnet-sync wall-clock/backlog model and apply the 20% drain-margin
+   decision gate.
+
+Exit: per-contributor durability/replay is demonstrated by crash tests, not only
+a diagram; every initial row field has a source; Byron/EBB continuity is proven;
+the sink/core/backlog performance gate is met or explicitly decided; and the
+clean foundation builds.
+
+### Phase 1 — contracts, identity, and fresh-sync guard
+
+Define versioned envelope/section/artifact types, sink/receipt contracts,
+projection coordinates, required-section policy, and archive identity. Reject all
+unsupported mid-chain or mismatched starts. Add serialization golden fixtures.
+Define an explicit section-to-existing-dataset/table/projection-version mapping
+and its future version-reconciliation rules; transport grouping must not
+silently change coverage identity.
+
+Exit: malformed, missing, unknown-required, wrong-network, wrong-genesis,
+wrong-version, mid-chain activation, and mismatched-sink cases fail closed.
+
+### Phase 2 — durable block outbox
+
+Implement deterministic headers/chunks, atomic persistence or apply-intent
+reconciliation, finality eligibility, ordered reads, cleanup, metrics,
+soft/hard bounds, and rollback of pending envelopes.
+
+Use a synthetic sink first. Exercise every outbox-only crash boundary before
+adding DuckLake.
+
+Exit: long restart/rollback/failure loops show contiguous coordinates and no
+lost/duplicated envelope identities.
+
+### Phase 3 — transaction and UTXO vertical slice
+
+Capture `transaction:v2` and `utxo-history:v5` from canonical apply while
+preserving the current dataset/table mapping.
+Cover valid/invalid transactions, ordinary/collateral/reference inputs,
+collateral return, same-block parent/child spends, multi-asset outputs, datum
+hashes, inline datums, reference scripts, redeemers, Byron/genesis outputs, and
+pointer-address semantics where applicable.
+
+Drive genuine Byron main blocks through the dedicated projection carrier and
+genuine Byron EBBs through the empty-envelope path. Preserve nullable Byron fee,
+base58 address, parent/EBB bridge, and recovery-replay semantics.
+
+Exit: byte/logical equivalence against the current projection over the same
+devnet/preprod fixture, including all six tables and ordered digests.
+
+### Phase 4 — DuckLake primary sink
+
+Adapt the retained DuckLake storage session to consume projection batches and
+artifact streams. Commit every required table plus receipt atomically. Remove
+the SQLite transaction locator from the acknowledgement/critical path; point
+lookup fallback is explicit.
+
+Exit: sink crash matrix, staging failure, matching receipt replay,
+mismatching-retry rejection, bounded capacity, and sustained drain-rate gates
+pass.
+
+### Phase 4b — remaining shipped block-dataset parity
+
+Add accepted envelope sections for `ACCOUNT_EVENT` and
+`ADDRESS_TRANSACTION`, unless a separately accepted product ADR has already
+retired either dataset and its APIs. Reuse Shelley+ live resolution where it is
+authoritative. Retain an archive-owned sequential outpoint resolver for Byron
+address participation, seeded from Byron genesis and updated in canonical
+order. Include this resolver in contributor atomicity, rollback, replay, and
+pruning protection.
+
+Exit: all four currently shipped block datasets have differential parity across
+Byron and Shelley+ ranges, or every omitted dataset has an explicit accepted
+removal decision and API migration. Rerun the core-overhead, sink-margin,
+bytes/block, and full-sync backlog gates with `ACCOUNT_EVENT` and
+`ADDRESS_TRANSACTION` enabled. High-cardinality address-touch projection is not
+grandfathered past the performance gate merely because the old worker shipped
+it.
+
+### Phase 5 — immutable epoch artifact vertical slice
+
+Start with epoch stake as the representative large artifact because its exact
+persisted generation makes the reconstruction boundary testable without mixing
+in mutable boundary-state joins. Use the existing staged-file output as the
+logical-equivalence baseline, but do not describe its current flush-only path as
+power-loss durable. Adopt an immutable-generation reference only if Phase 0
+proves its eligibility and performance advantage. Implement
+one-safe-boundary-later eligibility, `ArchiveArtifactReader`, streaming sink,
+receipt verification, lease/protection release, restart recovery, and pruning.
+This slice is an actual A/B comparison: epoch stake already has both staged rows
+and a persisted delegation snapshot. Measure boundary latency, sink rate,
+retained bytes, replay equivalence, and sink-lag behavior for both before
+selecting its representation.
+
+Then add ADA pots. Add rewards/reward-rest only after proving and retaining their
+complete deterministic input and calculation-version closure, otherwise capture
+them as non-reconstructible evidence. Add DRep distribution per field: stream
+the persisted amount generation and atomically snapshot or durably stage the
+boundary-time DRep-state columns. Add governance proposal/status snapshots only
+after their observation phase and decision semantics have an immutable source.
+
+Exit: rollback before eligibility removes/replaces the reference; sink lag
+cannot cause pruning; acknowledgement permits eventual pruning; codec upgrades
+with pending artifacts are safe; and required staged artifacts survive the
+power-loss/failure matrix without being silently discarded. Power loss between
+transition commit and deferred force/publish reconstructs output in either of
+the first two recovery classes, or proves that non-reconstructible evidence was
+already durable.
+
+### Phase 6 — operational and API cutover
+
+Expose coverage, backlog, leases, health, and resource bounds. Route historical
+queries to the primary archive. Document slow/fallback transaction-hash lookup
+until a derived index exists. Ensure current-state APIs do not claim immutable
+history coverage.
+
+Exit: fresh mainnet/preprod rehearsal meets throughput, recovery, disk, and API
+coverage gates with retained logs and exact artifact identity.
+
+### Phase 7 — remove superseded history pipelines
+
+After parity evidence is accepted:
+
+- remove independent block-replay archive workers and sources;
+- remove catch-up/live promotion and obsolete hot-history machinery;
+- remove prefetch used only by those workers;
+- remove unused legacy synchronous history CFs/services/configuration;
+- remove duplicate epoch export paths superseded by artifact projection;
+- retain only APIs/storage/query code required by ADR-039.
+
+This phase cannot start after parity over only the six transaction/UTXO tables.
+Every currently shipped block dataset — `TRANSACTION`, `UTXO_HISTORY`,
+`ACCOUNT_EVENT`, and `ADDRESS_TRANSACTION` — must have accepted equivalent
+section coverage, including Byron semantics, or a separately accepted product
+decision must explicitly retire the missing dataset and affected public APIs.
+
+Deletion occurs in a separate commit after the old path has served as the
+differential oracle. Do not keep both architectures active indefinitely.
+
+### Phase 8 — standalone SQLite primary sink
+
+Adapt the retained standalone SQLite backend to the same projection sink
+contract. It is an alternative primary sink, not a second simultaneous consumer.
+Run the same contract/crash/coverage suite and backend-specific performance
+gates.
+
+## Test strategy
+
+The test hierarchy is:
+
+1. serialization golden tests for every envelope/section/artifact version;
+2. outbox store conformance tests across crash and rollback boundaries;
+3. projection collector tests using genuine decoded blocks and live UTXO state;
+4. same-block and cross-block dependency fixtures;
+5. primary sink conformance tests shared by DuckLake and SQLite;
+6. differential archive tests against the current implementation;
+7. pruning-lease race tests;
+8. restart and forced-crash integration tests;
+9. fresh-sync devnet/preprod tests around epoch transitions;
+10. bounded mainnet validation only after all local/preprod gates pass.
+
+Fixtures must include:
+
+- empty and dense blocks;
+- valid and failed script transactions;
+- collateral and collateral return;
+- reference inputs;
+- same-block parent/child transactions;
+- multi-asset values;
+- datum hash, inline datum, reference scripts, and redeemers;
+- Byron main blocks, empty EBB envelopes, Byron/genesis resolution, and era
+  transitions;
+- pre-Conway pointer addresses and Conway pointer behavior;
+- rollback before and across an epoch boundary;
+- an epoch artifact larger than an inline-envelope bound;
+- mixed-source DRep distribution rows whose persisted amount and boundary-time
+  state columns have different reconstruction classes;
+- reward replay with the complete retained input/version closure, plus rejection
+  when any required input or calculation version is absent;
+- staged-file versus immutable-generation epoch-boundary timing and bytes;
+- power loss before deferred force/digest/manifest publication for each
+  recovery class;
+- live-reader lease renewal and fenced stale-owner cleanup races;
+- a sink lag longer than `snapshotRetentionEpochs`, proving the referenced epoch
+  snapshot survives while unrelated unleased generations prune normally;
+- common rollback-floor advancement while an artifact lease is acquired,
+  renewed, acknowledged, and released, asserting it never exceeds the oldest
+  active required slot and that crossing it fails closed without changing
+  archive eligibility;
+- sink outage long enough to cross soft backlog limits;
+- restart after sink receipt but before outbox cleanup.
+
+## Consequences
+
+### Positive
+
+- New history no longer rereads and decodes the chain once per dataset.
+- UTXO facts reuse the authoritative resolution that already occurred.
+- One projection backlog replaces separate dataset catch-up/live lifecycles.
+- DuckLake/SQLite latency and optional locator latency are outside core apply.
+- Epoch-scale facts are streamed from immutable retained generations without
+  giant envelope copies.
+- Qualifying persisted generations such as epoch stake avoid synchronously
+  duplicating roughly 1.3 million staged rows at each mainnet epoch boundary;
+  Phase 0 must confirm the measured saving and replay equivalence.
+- The primary archive becomes a stable source for later derived stores.
+- Schema growth is modular through versioned sections and artifacts.
+- Crash/pruning ownership is expressed through receipts and leases rather than
+  timing assumptions.
+
+### Negative
+
+- Canonical apply performs additional deterministic encoding and RocksDB writes.
+- Outbox CFs share the hot chainstate RocksDB. A sustained sink deficit or outage
+  therefore increases not only disk usage but hot-DB compaction, cache pressure,
+  and write amplification until cleanup catches up or the hard limit throttles
+  core sync.
+- Artifact retention can consume significant additional disk during a sink
+  outage. Non-reconstructible staged artifacts may add synchronous
+  encoding/durability I/O at an epoch boundary unless their minimal source
+  evidence is persisted atomically; this must pass the performance gate.
+- A class-one artifact lease can retain delegation-snapshot keys in the hot
+  chainstate beyond `snapshotRetentionEpochs`, increasing SST/compaction and
+  disk pressure even when the projection outbox itself is small.
+- Fresh-sync-only adoption requires an existing operator to resync or remain on
+  an older architecture until a migration is designed.
+- Existing block bodies and partial archive coverage cannot be adopted as a
+  shortcut. An operator accepting this architecture discards the time and I/O
+  already spent on the old backfill unless a separate offline migration is
+  designed.
+- A removed outbox cannot bootstrap an arbitrary future sink by itself.
+- Source CF codecs become compatibility contracts while live-generation
+  references remain pending; staged files avoid that source-codec coupling at
+  the cost described above.
+- Per-contributor section/cursor writes and completion coordination require
+  changes to current subsystem integration.
+- Preserving `ADDRESS_TRANSACTION` can add high-cardinality row construction and
+  outbox volume to canonical processing; it must pass the expanded performance
+  gate or be explicitly retired by the credential-filter/API decision.
+- DuckLake transaction-hash point lookup remains slow without a derived index.
+
+### Neutral/trade-offs
+
+- Complexity is concentrated rather than eliminated: outbox, receipts,
+  finality, versioning, leases, and backpressure replace multiple worker state
+  machines.
+- The primary archive remains derived data; canonical ledger state remains the
+  authority.
+- Ordinary archive coverage intentionally trails canonical tip by the supported
+  rollback boundary, and epoch artifacts normally trail by one safe boundary.
+
+## Rejected alternatives
+
+### Continue optimizing independent archive workers
+
+ADR-038 proved meaningful speedups, but each new dataset still requires a
+reader/decoder/cursor/lifecycle and repeats canonical work. This remains useful
+for existing-history migration, not the target fresh-sync design.
+
+### Write DuckLake or SQLite synchronously during block apply
+
+Rejected because archive storage, compaction, locking, or availability would
+become part of consensus-critical synchronization latency and failure handling.
+
+### Archive a UTXO only when it is spent
+
+Rejected as the only representation. Never-spent outputs would remain absent
+from immutable historical coverage and every historical query would need to
+merge live and archive storage. Creation is archived after finality; spending is
+a later event.
+
+### Put complete epoch snapshots inside the first block envelope
+
+Rejected because reward/stake/governance distributions can be very large and
+would make block-apply latency and outbox values unbounded. A staged immutable
+file or protected immutable-generation reference lives outside the block
+envelope and is streamed in bounded pages.
+
+### Require live-CF references for every epoch artifact
+
+Rejected because some facts exist only while the transition is evaluated, some
+CFs are not immutable/versioned in the required form, and pending source codecs
+would become long-lived compatibility contracts. Live-generation references are
+an allowed per-artifact optimization after evidence, not the universal format.
+
+### Require staged files for every epoch artifact without measurement
+
+Rejected because the existing staging writer performs synchronous encoding and
+file I/O during epoch processing. For an already immutable retained generation,
+duplicating every row may worsen the epoch-boundary hot path. Staged-file output
+is the logical-equivalence baseline and remains the default candidate for
+ephemeral facts, but the current flush-only implementation is not called
+power-loss durable. Phase 0 selects and hardens the representation per field
+group using correctness and performance evidence.
+
+### Reference mutable live CFs
+
+Rejected because a later in-place update would change the meaning of an already
+persisted reference. Only immutable generation-addressed artifacts qualify.
+
+### Assume normal retention is long enough
+
+Rejected because scheduler timing or future configuration changes can prune an
+artifact before a slow sink reads it. Durable leases are required.
+
+### Feed multiple sinks directly in version one
+
+Rejected because cleanup then depends on per-consumer offsets and the slowest
+consumer. One primary sink is sufficient; later stores derive from it.
+
+### Make the locator part of the primary commit
+
+Rejected because it is a rebuildable query accelerator and has already
+demonstrated that it can dominate writer latency. It must not gate authoritative
+archive progress.
+
+### Start from raw `main` and rewrite storage backends
+
+Rejected because the existing archive branch contains tested schemas, storage
+sessions, receipts, and backend conformance work that remains valid. Extract a
+clean foundation instead of discarding it.
+
+### Implement the replacement directly on ADR-038
+
+Rejected because ADR-038 is a closed, evidence-backed throughput campaign for
+the current worker model. Mixing replacement work into it obscures both the
+decision history and code review.
+
+## Decision — Parquet file granularity, commit batching and compaction
+
+**Raised 2026-08-20 from the first full preprod sync with the real DuckLake sink. Decided and
+implemented the same day; the analysis that led there is retained below because two of the
+obvious diagnoses were wrong and the record is worth keeping.**
+
+### The observation
+
+A complete preprod archive (5,076,688 blocks, 3.7 GB) is spread across **67,603 Parquet
+files** averaging **56 KB**, with a **95 MB** SQLite catalog.
+
+### Two wrong diagnoses, corrected
+
+**Wrong diagnosis 1: `target_file_size` is mis-tuned.** It is not the lever. File count
+tracks *commits x tables*:
+
+```
+receipts x tables = 10,233 x 6 = 61,398      actual files = 67,603
+configured target_file_size = 4 MiB           observed average = 56 KB
+```
+
+Each commit flushes its own file per touched table regardless of how far below target it
+lands, so 4 MiB was never approached. Raising it — to 8 GB or anything else — changes almost
+nothing on its own, because it caps compaction *output*, it does not merge per-commit files.
+
+**Wrong diagnosis 2: the batch cap is too small.** Also not the lever. Measured commit sizes:
+
+```
+avg blocks/commit       495.7
+max                     2,000   (the configured cap)
+commits at the cap         81   of 10,233  = 0.8%
+commits under 100 blocks  2,153  = 21%
+single-block commits       171
+```
+
+The 2,000-block cap binds in under 1% of commits.
+
+### The actual cause
+
+**The drain loop is too eager.** It commits whatever is eligible the moment it becomes
+eligible. Because the sink keeps pace with the producer (measured 1,292 vs 1,193 blocks/s),
+a large backlog never accumulates, so each pass scoops up only the few hundred blocks that
+just crossed the rollback-safety window. The loop's own speed fragments the output.
+
+### The lever that actually works
+
+A **minimum batch size or linger interval**, applied during bootstrap:
+
+- do not commit unless N blocks are available or T seconds have elapsed;
+- costs nothing in correctness — the outbox is durable, so waiting is free;
+- strictly better than compacting afterwards, because small files are never written;
+- archive lag during bootstrap is irrelevant: historical APIs report `catching_up` and
+  nothing is querying.
+
+At a 2,000-block floor: ~2,540 commits, roughly **4x fewer files**. At 10,000: ~500 commits,
+**20x fewer**. Near tip the floor must drop again so the archive continues to track the
+finality window closely, which the measured run does at 4,320 blocks.
+
+### Compaction — secondary, and after tip
+
+`ArchiveBackend.maintain(budget)` implements budgeted `merge_adjacent_files` with deferral on
+active reader snapshots and capacity pressure. Before this decision it had exactly one caller,
+`HistoryArchiveService` (the replay-worker path), and **`ProjectionSink` had no maintenance
+operation at all**, so the projection path could not invoke it even in principle. Adding it was
+a contract change, not a scheduler change; `ProjectionSink.maintain(ProjectionMaintenance.Budget)`
+now exists and the drain coordinator is its only caller.
+
+Compaction should not run during bootstrap:
+
+- it contends for the same bulk pool as the sink (`maxConcurrentBulkJobs` is constrained
+  below `maxConcurrentQueries`), so it would either starve or steal measured throughput;
+- it would re-compact the same neighbourhood repeatedly as the sink keeps appending;
+- nothing is querying yet, so the small-file penalty costs nothing.
+
+Trigger it instead on the bootstrap-to-tip transition — backlog settled at the finality
+window and header gap closed — which is exactly when the bulk pool goes idle.
+
+### On a large target such as 8 GB
+
+Pros: less metadata, faster planning, better compression across large row groups, fewer file
+handles.
+
+Cons: **coarse pruning** — DuckLake prunes at file granularity before row groups, so a
+selective `tx_hash` lookup pulls a far larger candidate set, landing hardest on the
+point-lookup queries §15 already identifies as weak without a locator; **rewrite
+amplification**; compaction memory; awkward backup and incremental sync; coarse snapshot
+cleanup. Common Parquet practice is 128 MB - 1 GB.
+
+### On "one file per day" for mainnet
+
+Sound as a **compaction/target output** goal: mainnet produces ~4,320 blocks/day, landing
+daily files in the hundreds of MB.
+
+Unsound as a **commit interval**: history would be up to 24 hours stale near tip. Commit
+frequency and file granularity must stay decoupled — batch floor high during bootstrap, low
+at tip, compaction to daily granularity afterwards.
+
+### Catalog scaling
+
+Measured 95 MB for 67,603 files. The bulk is `ducklake_file_column_stats`, which holds
+per-column min/max/null statistics for every file, so catalog size scales with
+*columns x files* rather than with data volume. Fewer files shrinks it disproportionately.
+Extrapolated mainnet: ~380 MB at 3x files, ~950 MB at 10x — workable, so this does not by
+itself force mid-sync compaction.
+
+### Decision
+
+1. **A batch policy governs the drain loop**, expressed as *N blocks OR T elapsed, whichever
+   comes first*, with two regimes:
+
+   | | preferred block target | maximum linger |
+   |---|---|---|
+   | bootstrap | 10,000 | 30 s |
+   | near tip | 50 | 15 min |
+
+   Near tip the block count is a *preferred target*, not a freshness requirement, and the
+   15-minute deadline is the hard bound. At normal Cardano production (20 s slots) the
+   deadline fires first, around 40-50 blocks; that is the expected steady state, not a missed
+   target.
+
+2. **The regime is derived from the drain backlog, not from producer-at-tip.** A sink that
+   falls a long way behind while the node sits at tip gets the bootstrap regime and returns to
+   the near-tip regime by itself once it catches up. No separate sync signal is needed and the
+   selection cannot disagree with reality.
+
+3. **Hard ceilings override both targets** and exist for memory, not for file size: 256 MiB
+   encoded, 2,000,000 rows, 512 MiB estimated heap, 20,000 blocks. A refused offer — an
+   envelope that no longer fits — also forces the commit, so the coordinator can never spin
+   re-offering an envelope that will never fit.
+
+4. **`ProjectionSink.maintain(budget)` exists and the drain coordinator is its only caller.**
+   Housekeeping and compaction are scheduled on *different* conditions, not merely budgeted
+   separately: housekeeping becomes due on a wall-clock interval and runs during bootstrap
+   (a mainnet bootstrap easily outlasts the snapshot retention window); compaction requires
+   the sink to be caught up and no eligible backlog to remain. Maintenance runs on the drain
+   thread, never on a worker of its own, and only on a pass that had nothing to commit.
+
+5. `target_file_size` is a compaction *output* target in the 256 MB - 1 GB range. It is not
+   the lever for per-commit file count and never was.
+
+6. Measure file count, catalog size, point- and range-query latency, and compaction I/O
+   before mainnet.
+
+Not a correctness issue: coverage is contiguous with zero gaps and zero drain failures.
+
+### What wiring the policy actually exposed
+
+The accumulator existed as a tested component before this decision but `drainOnce()` never
+consulted it, so batching was inert. Connecting it surfaced four defects that the component
+tests could not have caught, because each lives in the interaction rather than the part:
+
+- **The freshness deadline was unreachable.** The drain pass returned early when no new
+  envelopes were eligible — which is exactly the situation the deadline exists for. A batch
+  could linger indefinitely once arrivals paused. Any pass with a non-empty batch now
+  evaluates the decision, including a pass that reads nothing.
+- **A rollback could have produced a silent coverage gap.** With blocks 0..19 buffered and
+  16..19 rolled back, the next read would have resumed at 20 and the replacement blocks would
+  never have been projected. A duplicate would have been caught by the receipt check; a gap
+  would not. Rollback now sets a discard flag — checked at the top of each pass and again
+  immediately before commit — and a contiguity assertion refuses to commit a batch that does
+  not start exactly where the acknowledged range ends.
+- **A saturated batch could spin.** An envelope refused for space when no ceiling had yet been
+  *reached* would be re-offered every pass forever. A refusal now forces the commit.
+- **An accumulating pass must not back off.** Treating "nothing committed" as "nothing to do"
+  would have idled the drain loop through an entire bootstrap backlog.
+
+### Measured evidence
+
+**Memory bound (offline, `ProjectionPeakRetentionMeasurementTest`).** Peak retained heap during
+row materialisation, measured against a fixture calibrated to the densest genuine preprod
+blocks (300 outputs with inline datums, multi-asset bundles and redeemers per envelope):
+
+```
+  5 envelopes ->   6,100 rows, peak 1,066 KiB, 4,488 B/row
+100 envelopes -> 122,000 rows, peak 1,111 KiB, 4,430 B/row
+```
+
+Twenty times the batch costs **4% more retained heap**. A materialise-the-whole-batch
+implementation would show roughly 20x. The densest single envelope measures 1,220 rows and
+1,125 KiB, which is the figure the singleton safety guard is sized against.
+
+**Before, at tip (old jar, batching inert).** 217 batches for 217 blocks — one commit per
+block, each writing one file per touched table. Baseline archive: 69,375 Parquet files,
+10,514 commits.
+
+**After, at tip (rebuilt jar, preprod, 2026-08-20).** First live batched commit:
+
+```
+reason  = LINGER_EXPIRED          blocks = 37
+rows    = 1,788                   encoded = 318,543 B
+largest envelope = 33,693 B / 175 rows
+acknowledged 5,072,721 -> 5,072,758      drain failures 0
+```
+
+Thirty-seven blocks rather than the 40-50 the 20 s slot average predicts, because preprod
+production was slower than nominal in that window. Thirty-seven blocks in **one** commit
+against thirty-seven separate commits before. The contiguity assertion did not fire, and the
+restart resumed at exactly the pre-restart acknowledged block.
+
+The second live commit took the **other** path, which matters because it shows the policy is
+genuinely `N blocks OR T elapsed` rather than a deadline with a decorative target:
+
+```
+reason MIN_BLOCKS   blocks 50   acknowledged 5,072,758 -> 5,072,808
+```
+
+Exactly fifty — the preferred target was reached before the deadline, because preprod produced
+faster in that window. Both flush reasons are therefore exercised in production, and the
+`flushReasons` distribution distinguishes them without inference.
+
+**Compaction is highly effective, and reclamation is not immediate.** One compaction pass on
+the 5.07M-block preprod archive:
+
+| | before | after |
+|---|---|---|
+| active data files (catalog) | 69,375 | **12,458** |
+| files on disk | 69,375 | 71,258 |
+| files scheduled for deletion | 0 | 58,800 |
+| logical size | 3.7 GB | 3.20 GB |
+| size on disk | 3.7 GB | 6.80 GB |
+
+Active file count fell **5.6x** and per-table medians moved from tens of KiB to low MiB:
+
+```
+transaction_outputs        454 files   p50 2.7M   p95 4.3M   max 10.5M
+transaction_inputs         319 files   p50 2.1M   p95 3.8M
+transaction_redeemers      305 files   p50 1.1M   p95 3.8M
+chain_transaction          291 files   p50 1.1M   p95 2.5M
+transaction_output_assets  286 files   p50 1014K  p95 2.5M
+transaction_datums         283 files   p50 100K   p95 1.1M
+projection_receipts     10,515 files   p50 3K              <- one row per commit, never merged
+```
+
+Two consequences that must be planned for rather than discovered:
+
+1. **Disk roughly doubles for the duration of the cleanup grace.** Compaction's rewritten
+   inputs stay on disk until `ducklake_cleanup_old_files(older_than => now() - grace)` may
+   remove them, and the inherited default grace is **24 hours**. Peak sink footprint is
+   therefore ~2x the logical archive for that window. Sizing a mainnet volume for the logical
+   size alone would be wrong.
+2. **The catalog does not shrink until snapshots expire.** 10,563 snapshots and a 97.6 MB
+   catalog survive compaction, because the inherited snapshot retention is **168 hours** and
+   nothing is old enough to expire. Catalog size tracks *columns x files* and will fall
+   sharply once expiry becomes eligible, but not before.
+
+Both windows are inherited defaults from the replay-worker backend, which has different
+reader assumptions. The projection path has one writer and short-lived readers, so they are
+now independently configurable — `yano.history.projection.sink.snapshot-retention-hours`,
+`.cleanup-grace-hours`, `.target-file-size-bytes`, `.row-group-size` — with the inherited
+values as defaults, so nothing changes until someone chooses. **Choosing them is a product
+decision and is not made here.**
+
+`projection_receipts` was the one table compaction left alone, at 10,515 three-KiB files —
+small in bytes (0.04 GB) but 84% of the active file count, so it dominated catalog statistics.
+The cause was that the compaction loop iterated `DuckLakeSql.tables()`, which enumerates
+dataset tables only, so the sink excluded its own bookkeeping table from its own maintenance.
+Fixed, and the fix is measured rather than assumed: a 12-commit fixture compacts **12 receipt
+files to 1**.
+
+Two further properties were verified rather than argued, because together they decide whether
+repeated maintenance is safe:
+
+- **`merge_adjacent_files` is idempotent.** A second compaction pass over an already-compacted
+  lake rewrites nothing — receipt and dataset file counts are identical afterwards. This
+  matters because every rewrite orphans its inputs and orphans outlive the cleanup grace, so a
+  compaction that re-merged the same neighbourhood every interval would grow disk without
+  bound. It does not.
+- **The compaction gate now counts small files, not all files.** It previously compared the
+  *total* active file count against `minFilesToCompact`, which is true forever on any large
+  archive, so a pass was attempted every interval — acquiring a bulk lease and scanning for
+  nothing. It now reads the size distribution from DuckLake's metadata schema and counts only
+  files below the smallness ceiling. A test pins this by setting the ceiling below every file
+  and asserting the pass declines; the old gate fails that test, so it discriminates a real
+  distribution read from a silent fallback.
+
+### Compaction under the new drain loop, measured (2026-08-20)
+
+The figures above came from a pass on the **old** jar. Verified again under the rewritten
+drain loop, with the compaction interval shortened to 5 minutes so a pass could be observed
+inside a validation session:
+
+| | before | after |
+|---|---|---|
+| active data files (catalog) | 12,470 | **1,799** |
+| `projection_receipts` active files | 10,516 | **9** |
+| logical size | 3.20 GB | 3.16 GB |
+| files awaiting the cleanup grace | 58,800 | 69,645 |
+| size on disk | 7.8 GB | 8.5 GB |
+
+**1,799 active files for a complete 5.07M-block preprod archive**, against 69,375 before any
+compaction — a **38x reduction**. The receipts table, which the sink had been excluding from
+its own maintenance, went from 10,516 files to 9.
+
+Post-compaction distribution:
+
+```
+transaction_outputs        340   p50 3.0M   p95 6.6M   max 10.5M
+transaction_inputs         296   p50 2.1M   p95 4.8M
+transaction_redeemers      292   p50 1.1M   p95 4.1M
+chain_transaction          288   p50 1.1M   p95 2.5M
+transaction_output_assets  282   p50 1013K  p95 2.5M
+transaction_datums         281   p50   99K  p95 1.1M
+projection_receipts          9   p50  166K
+```
+
+Three operational facts this settles:
+
+1. **The post-flush idle window is wide enough in practice.** Compaction fires on the drain
+   pass immediately after a commit, when the buffer is empty and nothing is eligible yet. It
+   is not merely reachable in principle: `lastMaintenance` went from
+   `COMPLETED (housekeeping only) [compaction withheld: sink busy]` to `COMPLETED` on exactly
+   that pass.
+2. **An incremental pass is short.** The next batch opened **6 seconds** after the compaction
+   pass, nowhere near the 5-minute budget. The worst-case staleness bound (linger plus one
+   compaction budget) remains the bound, but the typical cost is seconds.
+3. **Each legitimate compaction generation adds its inputs to the orphan pool for the whole
+   cleanup grace.** Two generations now coexist: 69,645 files awaiting deletion, 8.5 GB on
+   disk against 3.16 GB logical — **2.7x**, not the 2x a single generation costs. This is not
+   the runaway case (a second pass over an already-compacted lake is a verified no-op); it is
+   the cost of two passes that each had real work. Mainnet volume sizing must budget for it.
+
+### Retention decision, and the gates before it may change (2026-08-20)
+
+**Decided: keep the inherited 168 h snapshot retention and 24 h cleanup grace for now.**
+Seven-day user-facing time travel is not a requirement, but retention is not shortened on that
+basis alone — it is shortened only after Phase 6 demonstrates active-reader fencing, maximum
+query duration, restart safety and cleanup behaviour. The target after those gates is **24 h
+snapshot / 6 h cleanup**; 2 h cleanup only with evidence.
+
+The knobs exist (`yano.history.projection.sink.snapshot-retention-hours`,
+`.cleanup-grace-hours`) with the inherited values as defaults, so nothing changes until someone
+decides it should.
+
+### Two maintenance contract gaps, closed
+
+**1. Housekeeping swallowed its failures.** `runHousekeeping` caught every `SQLException`,
+returned zero, and let the pass report `COMPLETED`. An archive that had silently stopped
+reclaiming space looked healthy. Each of the three steps — snapshot expiration, file cleanup,
+orphan deletion — is now mandatory and reports its own outcome; the pass still attempts the
+remaining steps after one fails, but returns `PARTIAL` or `FAILED` carrying per-step
+diagnostics. A step skipped because the housekeeping budget ran out is reported too, rather
+than being indistinguishable from a step that ran and found nothing. A failed `CALL` also
+rolls back its aborted transaction, or every later query on that connection — including the
+file counts the pass reports — fails as well and the diagnostics become useless.
+
+**2. `maxBytesToRewrite` was an enable flag, not a bound.** Compaction now computes
+`max_compacted_files` from the byte budget, divided by the table count because DuckLake applies
+that limit *per table* — passing the aggregate through would let a ten-table catalog rewrite
+ten times the advertised budget. Tables are visited round-robin so one table that repeatedly
+exhausts the reserved memory cannot starve everything behind it.
+
+**Per-call upper bound, documented because it cannot be removed.** DuckLake cannot interrupt a
+`merge_adjacent_files` call safely — it would roll the whole call back and lose the work — so
+the time deadline is checked only *between* calls. The budget therefore holds as: at most one
+in-flight call may run past the deadline, and that call is itself bounded by
+`max_compacted_files x target_file_size`. Size the budget so one table's bounded call is an
+acceptable overshoot.
+
+Rewritten bytes are now reported from the catalog rather than left at zero. Output bytes are
+the right pairing with the budget, since `max_compacted_files` bounds what a call may
+*produce*. Two dead ends worth recording: a compacted input is unmeasurable after the fact —
+DuckLake removes it from `ducklake_data_file` and records only its path, with no size, in the
+deletion queue — and `begin_snapshot` cannot identify this pass's output either, because a
+merged file keeps the earliest snapshot its rows came from and so looks older than the pass
+that wrote it. Monotonic `data_file_id` is what works.
+
+### The pinned-reader gate, and what it found
+
+A test now spans an open read transaction across snapshot expiration and file cleanup, which is
+the gate that must pass before retention is shortened. It found a real constraint:
+
+```
+pinned reader open   -> maintenance FAILED, 0 snapshots expired, 0 orphans deleted
+                        expire_snapshots: Failed to commit: database is locked
+reader released      -> maintenance COMPLETED, 50 snapshots expired
+```
+
+**A long-running reader blocks maintenance entirely**, because the DuckLake catalog is SQLite
+and the reader's open transaction holds its lock. The reader is never harmed and no file is
+deleted underneath it, and the block is transient — the next pass after the reader finishes
+succeeds. But cleanup does not merely defer a step, it fails the whole pass.
+
+This is directly relevant to the retention decision: **shortening the windows does not help if
+a long query can stall reclamation indefinitely.** It also vindicates the first fix — before
+per-step diagnostics existed, this exact run reported `COMPLETED` having reclaimed nothing.
+Maximum query duration is therefore not just a Phase 6 nicety; it bounds how far behind
+reclamation can fall.
+
+### Two maintenance defects the metrics exposed
+
+Adding `maintenancePasses` / `compactionPasses` to status immediately paid for itself.
+
+1. **The compaction counter was lying.** It incremented on what the *scheduler asked for*, not
+   on what the executor was permitted to do. The consumer withholds compaction when the sink is
+   not idle, so a run reporting `compactionPasses = 1` had in fact compacted nothing. Worse,
+   `recordRun` then stamped `lastCompaction`, deferring the next real attempt by a full
+   6-hour interval on the strength of a compaction that never happened. The executor now
+   reports back what it was actually offered (`MaintenancePass.compactionOffered`), and only
+   that is recorded and counted.
+
+2. **A withheld compaction re-fired on every drain tick.** With `lastCompaction` never
+   advancing, compaction stayed permanently due, so a maintenance pass — which acquires a bulk
+   DuckDB lease — was attempted roughly every 250 ms. Measured live: **38 passes in a few
+   minutes**. After the fix: **1**.
+
+   The root cause was that the scheduler and the executor used *different* idle predicates.
+   The scheduler asked "are eligible envelopes waiting?"; the executor asked "are eligible
+   envelopes waiting **and** is the buffer empty?". Near tip the buffer is almost always
+   non-empty, so they disagreed almost always. `hasDrainBacklog()` is now the exact negation of
+   the executor's idle test, and a backstop spaces any future disagreement to one pass per
+   housekeeping interval rather than one per tick.
+
+## Open questions requiring review
+
+**Answered since this list was written**
+
+1. ~~Which live subsystem is the authoritative contributor for datum/redeemer and
+   pointer-address projection facts?~~ **Answered.** Datum and redeemer facts come from the
+   UTXO subsystem's own block batch, alongside the outputs they belong to. Pointer addresses
+   are resolved **as of the block being projected**, by the account-state subsystem, through
+   `PointerCredentialSource` in `core-api` — not by the sink, and not by an append-only
+   approximation. The Shelley ledger's `_ptrs` map removes entries on deregistration, so an
+   append-only index would diverge from cardano-ledger; the index therefore stores full
+   deregistration coordinates and lookups are interval queries. Measured on a real preprod
+   chainstate: **17,036 entries, 42 bytes each, 0.68 MiB — 0.002% of chainstate**, one extra
+   put per ~298 blocks. Completeness is tracked (`COMPLETE` / `INCOMPLETE` / `CLEANED`) and a
+   node whose index cannot be complete fails closed rather than projecting wrong credentials.
+
+3. ~~What are the exact soft/hard aggregate retention limits...~~ **Partly answered.** The
+   aggregate gate exists and is live (`ArchiveIngestGate`, `ArchiveDiskLimits`, defaults
+   8 GiB soft / 32 GiB hard / 16 GiB free reserve / 1.4x amplification, all configurable), it
+   is registered at startup and now reports `diskBackpressureInstalled` so registration is
+   observable rather than inferred, and the operator behaviour at the hard limit is a visible
+   pause with automatic resume at the low-water mark. What remains open is whether those
+   *specific numbers* are right for mainnet, which needs the mainnet sync to answer.
+
+   Note that the gate counts the **outbox and staged artifacts**, not the sink's own Parquet
+   footprint; free-space reserve is what protects against the sink filling the volume. Sizing
+   must also account for compaction transiently roughly doubling sink footprint for the
+   duration of the cleanup grace — see the granularity decision above.
+
+**Still open**
+
+2. For each epoch field group, which recovery class applies, and does a hardened
+   staged representation, an immutable-generation reference, or atomically
+   persisted minimal boundary evidence win the correctness/performance
+   comparison?
+4. Is one-epoch publication delay sufficient on every supported network after
+   independently proving source durability and applying the rollback-cutoff
+   check?
+5. Which historical APIs require a transaction point index before cutover, and
+   which can accept a bounded DuckLake fallback scan?
+6. Should standalone SQLite ship in the first release or follow DuckLake after
+   the architecture is proven?
+7. Which archive fields must be preserved to make the primary archive a
+   sufficient source for the credential-filter and `/scan` proposal?
+8. What coordinated snapshot format is required to avoid treating all snapshot
+   restores as unsupported mid-chain activation?
+9. At what accepted parity point can the old replay workers and legacy history
+   be deleted rather than maintained behind flags?
+
+## Review decision requested
+
+Reviewers are asked to decide, in order:
+
+1. whether fresh-sync-only and one-primary-sink are acceptable product
+   constraints;
+2. whether the canonical projection outbox is the target replacement for the
+   current replay-worker architecture;
+3. whether epoch fields use the per-column recovery classification, with the
+   current staged output as an equivalence baseline and each selected
+   staged/generation/evidence representation required to prove durability and
+   performance;
+4. whether transaction locator/index design is explicitly downstream and
+   deferred;
+5. whether the proposed foundation/outbox branch split is accepted;
+6. whether Phase 0 per-contributor durability/replay and sink/core/backlog
+   performance proofs are hard implementation gates.
+
+~~No implementation beyond storage-foundation extraction should begin until
+those six decisions are recorded.~~ **Superseded.** The six were treated as recorded by the
+instruction to implement this ADR end to end, and the review closed with no open editorial
+items. Phases 0-4 are built and validated to preprod tip; see the status header.

--- a/adr/reports/adr-039-handoff-2026-08-20.md
+++ b/adr/reports/adr-039-handoff-2026-08-20.md
@@ -1,0 +1,983 @@
+# ADR-039 implementation handoff
+
+**Date:** 2026-08-20
+**Branch:** `feat/adr-039-canonical-projection-outbox` (branched from `5a3cebec`)
+**Worktree:** `/Users/satya/work/bloxbean/yano/.claude/worktrees/adr-039`
+**Nothing is committed.** The complete implementation is left uncommitted for review.
+
+---
+
+## 1. Status at a glance
+
+| Phase | State |
+|---|---|
+| 0 — boundary proofs, recovery classification, foundation | **complete** |
+| 1 — contracts, identity, fresh-sync guard | **complete** |
+| 2 — durable block outbox | **complete** |
+| 3 — transaction/UTXO vertical slice + Byron carrier | **complete** |
+| 3b — application composition, live producer measurement | **complete** |
+| 4 — DuckLake primary sink | **complete** — full preprod sync to tip, restart and kill -9 verified, batching and maintenance live |
+| 4b — `ACCOUNT_EVENT` / `ADDRESS_TRANSACTION` parity | **complete and validated to preprod tip** with all four sections required; found two defects unit tests did not |
+| 5 — epoch artifact slice | **not started** |
+| 6 — operational/API cutover | **not started** |
+| 7 — remove superseded pipelines | **not started** (correctly blocked: two of four datasets have sections) |
+| 8 — standalone SQLite sink | **not started** |
+
+One gate remains open: **D2, the core regression budget**. It is now *bounded* rather than
+inconclusive — attribution inside a single run puts the projection at **at most 6.3% of sync
+throughput** against a 5% budget, over 2.27M blocks. D1 was withdrawn on direct measurement.
+
+---
+
+## 2. Decisions — one withdrawn, one still open
+
+### D1 — sink drain margin: **withdrawn, resolved**
+
+The original claim was that ADR-039 acceptance criterion 2 (sink drains >=20% faster than
+concurrent history-enabled canonical production) is unreachable on this hardware, projected
+from ADR-038's replay-worker rate of 59.84 blocks/s.
+
+**That projection was wrong and the conclusion is withdrawn.** ADR-038's number describes a
+different pipeline — one that decodes blocks, which the projection sink does not. Measured
+directly on the new sink:
+
+```
+sink      1,292 blocks/s
+producer  1,193 blocks/s
+```
+
+The margin holds with room to spare. A full fresh preprod sync then confirmed it end to end:
+5,076,688 blocks in **1h07m** with the real DuckLake sink attached, backlog pinned at exactly
+the 4,320-block finality window throughout, 0 drain failures, 0 coverage gaps.
+
+The general lesson is recorded because it nearly cost a scope decision: **do not project a
+new component's throughput from an old component's measurement when the workloads differ.
+Measure the new one.**
+
+### D2 — gate 1: core regression budget — **still open, but INCONCLUSIVE, not failed**
+
+Round 1, before any optimisation: **-14.1%** (range -10% to -18%) against a 5% budget, with
+1.4x disk amplification.
+
+The projection encoding was then profiled and optimised. The profile corrected a wrong
+assumption of mine along the way: buffer copies were **0.8%** of producer cost and address
+decoding was **82%**, so memoising address derivation was the change that mattered.
+
+Round 2 re-ran the A/B — eight legs, alternating, each alone on an idle machine:
+
+```
+off  n=4   median 2,378 blk/s   min 1,935   max 3,098   spread 49%
+on   n=4   median 2,426 blk/s   min 2,119   max 2,499   spread 16%
+
+naive median delta              +2.0%
+paired adjacent-leg delta       -4.8% median, individual pairs -31.6% to +27.3%
+```
+
+**The -14.1% regression is no longer reproducible.** The residual sits somewhere around
+**-5% to +2%**. But the effect under test is 5% and the measurement floor on this host is
+**16-49%**, so the gate is **INCONCLUSIVE** — not passed, and no longer failed at -14%.
+Reporting the naive +2.0% as a pass would repeat exactly the error corrected in D1.
+
+Curiously the variance is concentrated in the history-**disabled** legs (49% spread against
+16%), and an earlier hypothesis in the measurements report that this was a monotone position
+effect was refuted by leg 7 and withdrawn there.
+
+### Round 3 — attribution, not differencing (the current answer)
+
+Rather than run more legs, the cost is now attributed **inside a single run**, so cross-run
+variance cannot enter: there is no second run. `DefaultUtxoStore` records time in the
+contributor, time in the whole apply, and the full block cycle.
+
+(Thread CPU time was tried first and returns nothing: `applyBlock` runs on a virtual thread,
+where `ThreadMXBean` reports no CPU time. Wall time substitutes acceptably here because the
+contributor does no I/O.)
+
+Fresh preprod sync from genesis with the DuckLake sink attached, **2,267,163 blocks**:
+
+```
+per-block cycle        520,033 ns     (1,923 blocks/s cumulative)
+per-block apply        159,789 ns     30.7% of cycle
+per-block projection    32,711 ns      6.3% of cycle, 20.5% of apply
+```
+
+The run continued to **3,107,640 blocks**, where the apply share had settled slightly lower —
+apply 169,818 ns, projection 31,378 ns, **18.5% of apply** — as later, denser blocks made apply
+itself more expensive. The ratio is stable in the 18-21% band across three million blocks, so
+the cycle figure above is not a lucky window.
+
+**The projection contributor costs at most 6.3% of sync throughput**, against a 5% budget —
+"at most" because it assumes apply sits wholly on the critical path, so overlap can only make
+the true figure smaller. Excluded by construction: the asynchronous sink drain, and the ~1.4x
+RocksDB write amplification measured separately.
+
+So the position is no longer "inconclusive on this hardware" but "bounded above by 6.3%, budget
+5%, bound straddles it". Closing the remaining gap needs apply's critical-path share or a
+further cut in staging cost; the 20.5%-of-apply is concentrated in section encoding.
+
+---
+
+## 3. What was built
+
+### Core/runtime changes — the complete list
+
+Total: **+148 / −1 lines across 9 files.** Every one is listed so "minimum necessary"
+can be checked rather than taken on trust.
+
+| File | Δ | Why necessary |
+|---|---|---|
+| `core-api/.../archive/ProjectionCfNames.java` | new | Column-family names both sides need; neither module may depend on the other. |
+| `core-api/.../archive/ProjectionStagingWriter.java` | new | Opaque staging: `core-api` needs no RocksDB dep, runtime needs no encoding knowledge. |
+| `core-api/.../archive/CanonicalProjectionContributor.java` | new | The hook contract, with a `NOOP` for history-disabled nodes. |
+| `core-api/.../events/ByronBlockProjectionEvent.java` | new | Byron carrier (see below). |
+| `core-api/.../config/YanoPropertyKeys.java` | +15 | Configuration surface. |
+| `runtime/.../chain/DirectRocksDBChainState.java` | +10/−1 | Declares 4 projection CFs in the existing descriptor list. |
+| `runtime/.../BodyFetchManager.java` | +12 | Publishes the Byron carrier at the two existing Byron apply sites. |
+| `runtime/.../utxo/DefaultUtxoStore.java` | +30 | Stages projection sections into the existing block `WriteBatch`. |
+| `runtime/.../utxo/UtxoSubsystem.java` | +15 | Installer that returns `false` rather than silently not installing. |
+| `runtime/.../internal/RuntimeNode.java` | +26 | Installer + chainstate RocksDB accessor. |
+| `runtime/.../kernel/NodeKernel.java` | +8 | `context()` so the host reaches the shared event bus. |
+| `runtime/.../assembly/Yano.java` | +19 | Two defaulted host-facing seams. |
+| `runtime/.../assembly/RuntimeYano.java` | +13 | Delegates them to `RuntimeNode`. |
+
+No global cross-subsystem transaction. No archive I/O in canonical apply. Runtime does
+not reference DuckLake, SQLite, or `archive-core`.
+
+### The atomicity mechanism
+
+`DirectRocksDBChainState` opens every subsystem's column family from one descriptor list
+with `setCreateMissingColumnFamilies(true)`, and `rocks()` hands the shared DB to all
+contributors. Adding four projection CFs there means a contributor's
+`batch.put(cfProjection, …)` is atomic with `cfUnspent`/`cfSpent` for free — which is
+the whole reason no cross-subsystem transaction is needed.
+
+Two design choices that came from reading the code rather than the ADR:
+
+- **The header is derived at read time, not promised at write time.** A contributor
+  cannot manifest sections it does not own, so only canonical block identity is stored;
+  the section manifest is assembled from what is actually present. A manifest therefore
+  cannot claim a chunk that is absent.
+- **Rollback rewinds contributor cursors, and is keyed on slot, not on a live tip
+  read.** Deriving the cutoff from `ChainQuery.getLocalTip()` inside a rollback listener
+  is racy — listener order relative to chain-state rollback is unspecified, and a tip
+  read too early leaves stale envelopes above the surviving tip. `rollbackToSlot` uses
+  the envelope's own recorded slot instead.
+
+### Byron
+
+A **new event type**, never a flag on `BlockAppliedEvent` — `block() == null` is
+load-bearing as the Byron/EBB sentinel in five unrelated consumers, all left untouched.
+`ByronBlockNormalizer` was extracted so the replay path and the projection carrier share
+one definition of a normalized Byron block. EBBs emit an empty envelope, which is what
+keeps the greatest *contiguous* coordinate from stopping at the first epoch boundary.
+
+### Sink layering
+
+`archive-store-ducklake` depends on `archive-api` only. That forced a contract change
+that improved the design: **row derivation happens once, in shared archive-core code**,
+before any sink sees the batch. DuckLake and SQLite cannot disagree about what a block
+means, because neither of them decides.
+
+---
+
+## 4. Tests
+
+**Full repository suite, 2026-08-20 after all work described here:**
+
+```
+3,058 tests across 456 classes    0 failures    0 errors    63 skipped
+./gradlew test    BUILD SUCCESSFUL
+```
+
+An earlier run of the same suite failed at `:tx-services:test`. It was re-run in isolation and
+passes; the failing run was competing with two other Gradle daemons and a live 6 GB preprod
+node on the same machine. Recorded rather than omitted, because "it passed the second time" is
+only acceptable with the reason attached.
+
+**The per-suite table below predates the batching, pointer-resolution, maintenance and
+streaming work — it was accurate at 117 new tests and is kept for its coverage description,
+not its counts.** Full repository suite green: **2,927 tests across 444
+test classes, 0 failures, 0 errors** (`./gradlew test`, 12m 32s). `./gradlew
+:app:quarkusBuild` succeeds; artifact SHA-256
+`d6ffc4d218d73169cf3621ecd23923d7d496fdf13449c548005a7070e0af924b`.
+
+| Suite | Tests | Covers |
+|---|---|---|
+| `ProjectionContractsTest` | 22 | section/dataset identity, envelope id determinism, manifest verification, EBB rules, batch contiguity, receipts |
+| `ProjectionEnvelopeCodecTest` | 10 | round-trip, golden fixture, malformed/truncated/trailing/unknown-section rejection |
+| `ProjectionStartupGuardTest` | 14 | mid-chain activation, wrong network/genesis/version/sink, incoherent observations |
+| `ProjectionOutboxStoreTest` | 27 | completion gating, assembly, ordered reads, ack/cleanup, rollback (block + slot), restart, torn records, stalled-contributor health |
+| `ProjectionOutboxConsumerTest` | 14 | finality gating, receipt replay/mismatch, sink failure, backpressure, retention health |
+| `ProjectionDifferentialParityTest` | 12 | byte-identical rows vs the existing path across 10 fixtures |
+| `ByronProjectionCarrierTest` | 10 | genuine Byron main/EBB blocks through the carrier |
+| `DuckLakeProjectionSinkTest` | 8 | atomic multi-table commit, idempotency, reshaped-retry rejection, contiguous coordinate |
+
+### Differential parity — Phase 3 exit criterion, met for the covered fixture set
+
+Both paths end in the same `BlockArchiveDataset.derive`, so a divergence is necessarily
+a transport defect. Fixtures: empty block; simple valid transaction; invalid transaction
+with collateral, collateral return and reference inputs; same-block parent/child spend;
+multi-asset outputs; datum hash and inline datum; redeemers with execution units; dense
+60-transaction block with 3 invalid; Byron null fee and base58 address; multi-chunk
+section reassembly; Conway pointer addresses.
+
+**Fixtures from the ADR's list that are NOT yet covered:** reference scripts
+(`scriptRef` outputs), Byron genesis output resolution, era-transition blocks, rollback
+across an epoch boundary, and pre-Conway pointer addresses (which currently throw — see
+§7). Phase 3's exit criterion is met for what is covered; these remain open.
+
+### Defects found and fixed
+
+Three are worth recording because unit tests could not reach them:
+
+1. **`NodeKernel.subsystem(UtxoSubsystem.class)` silently returns empty** — the kernel is
+   composed of lifecycle *stages*, not subsystem instances. Caught only because the
+   installer fails closed; the node refused to start rather than syncing while capturing
+   nothing.
+2. **`yano.history.rollback.retention-blocks` ships with the literal default `"auto"`** —
+   parsing it as `Long` threw at startup.
+3. **Racy rollback cutoff** — described above; replaced with slot-keyed rollback.
+
+---
+
+## 5. Measurements
+
+Full detail in `adr-039-measurements-2026-08-20.md`.
+
+### Gate 4 — outbox bytes/block (open, first real data)
+
+Live fresh preprod sync, both first-slice sections, `sink=none`:
+
+| block | bytes/block | cumulative |
+|---|---|---|
+| 123,000 | 42 | 5 MB |
+| 699,000 | 1,439 | 0.94 GB |
+| 1,183,000 | 2,059 | 2.27 GB |
+| 1,716,699 | 2,397 | 3.83 GB |
+
+Rises monotonically with density; had not plateaued when stopped. **This is a no-sink
+ceiling — total volume produced — not a steady-state backlog.** p95/p99 per-block
+distribution is not instrumented, so criterion 4 is only partially satisfied.
+
+### Gate 1 — core regression
+
+A first comparison was computed and **rejected as invalid**: the two runs covered the
+same blocks at different times, and the history-enabled run was competing with the
+baseline node on the same machine (load average 5–7.5). Reporting its −20% to −43% would
+have been wrong.
+
+The clean experiment — four legs alternating `off/on/on/off`, each alone on an idle
+machine, fresh chainstate, wall clock to block 1,000,000 — gives:
+
+```
+median off : 2,410 blk/s        (legs: 2,294 / 2,526)
+median on  : 2,070 blk/s        (legs: 2,086 / 2,054)
+delta      : -14.1%   (plausible range -10% to -18%)
+threshold  : -5.0%
+VERDICT    : FAIL
+```
+
+Disk: +3.42 GB chainstate for 1M blocks = **3,419 bytes/block on disk** against ~2,400
+bytes/block logical — roughly **1.4x amplification**, which quantifies review finding D3.
+
+The `off` legs vary by 10% and the `on` legs by 1.5%, so the point estimate carries real
+uncertainty — but the whole plausible range is above the 5% budget, so the verdict does
+not depend on it. No optimisation had been attempted before measuring.
+
+**Superseded by round 2.** The ADR's prescribed response (remove avoidable encoding work, then
+re-measure) was carried out: address derivation, profiled at 82% of producer cost, was
+memoised. An 8-leg round 2 shows the −14.1% is **no longer reproducible**, with the residual
+around −5% to +2% — but the host's spread (49% on the `off` legs) cannot resolve a 5% effect.
+The gate is **inconclusive**, not failed. See §2 D2 and the measurements report.
+
+---
+
+### Sink drain rate and full preprod sync (settles D1)
+
+```
+sink                 1,292 blocks/s          producer   1,193 blocks/s
+full fresh preprod   5,076,688 blocks in 1h07m with the real DuckLake sink
+steady-state backlog 4,320 blocks (= the finality window, exactly)
+drain failures 0     coverage gaps 0        rows 87.4M
+archive 3.7 GB       chainstate 27 GB
+```
+
+Graceful restart (4 s shutdown, clean resume) and `kill -9` both verified: 0 gaps, 0 duplicate
+transactions, 0 duplicate outputs, 0 overlapping receipts.
+
+### Near-tip batching, live (2026-08-20)
+
+Before, on the jar where the accumulator existed but the drain loop never consulted it:
+**217 commits for 217 blocks** — one commit per block, one file per touched table per commit.
+
+After, first live batched commit:
+
+```
+reason LINGER_EXPIRED   blocks 37   rows 1,788   encoded 318,543 B
+largest envelope 33,693 B / 175 rows
+acknowledged 5,072,721 -> 5,072,758        drain failures 0
+```
+
+Thirty-seven rather than the 40-50 predicted from 20 s slots, because preprod production ran
+slower than nominal in that window. The contiguity assertion did not fire.
+
+The second live commit took the **other** path, which matters because it shows the policy is
+genuinely `N blocks OR T elapsed` rather than a deadline with a decorative target:
+
+```
+reason MIN_BLOCKS   blocks 50   acknowledged 5,072,758 -> 5,072,808
+```
+
+Exactly fifty — the preferred target was reached before the deadline, because preprod produced
+faster in that window. Both flush reasons are therefore exercised in production, and the
+`flushReasons` distribution distinguishes them without inference.
+
+### Restart while a batch was lingering — live, not synthetic
+
+The second restart happened to catch **9 blocks buffered and unacknowledged**. After restart:
+
+```
+acknowledgedThroughBlock  5,072,758   (unchanged - nothing was committed to empty the buffer)
+pendingBatchOldestBlock   5,072,759   (= acknowledged + 1, rebuilt from durable state)
+pendingBatchBlocks        12          (the 9 plus 3 that arrived meanwhile)
+drainFailures             0
+```
+
+This is the property the design depends on: a lingering batch has no durable footprint, so a
+restart loses nothing and re-derives the same work. Shutdown deliberately does **not**
+force-flush — writing a small Parquet file purely to empty an in-memory list would create
+exactly the fragment the policy exists to avoid, for no durability benefit.
+
+### Disk backpressure registration — explicit proof
+
+```
+/status: diskBackpressureInstalled = true
+log:     ADR-039 disk backpressure installed
+         (soft=8589934592 B, hard=34359738368 B, freeReserve=17179869184 B, amplification=1.4)
+```
+
+Previously this was only inferable from the *absence* of a warning, which is not a proof.
+
+### Compaction effectiveness and reclamation lag
+
+One compaction pass on the completed preprod archive:
+
+| | before | after |
+|---|---|---|
+| active data files (catalog) | 69,375 | **12,458** |
+| files on disk | 69,375 | 71,258 |
+| scheduled for deletion | 0 | 58,800 |
+| logical size | 3.7 GB | 3.20 GB |
+| size on disk | 3.7 GB | 6.80 GB |
+| snapshots / catalog | 10,563 / 97.6 MB | 10,563 / 97.6 MB |
+
+Per-table active file sizes after compaction:
+
+```
+transaction_outputs        454   p50 2.7M   p95 4.3M   max 10.5M
+transaction_inputs         319   p50 2.1M   p95 3.8M
+transaction_redeemers      305   p50 1.1M   p95 3.8M
+chain_transaction          291   p50 1.1M   p95 2.5M
+transaction_output_assets  286   p50 1014K  p95 2.5M
+transaction_datums         283   p50 100K   p95 1.1M
+projection_receipts     10,515   p50 3K                 <- was excluded from compaction
+```
+
+Three findings:
+
+1. **Compaction works: 5.6x fewer active files, medians from tens of KiB to low MiB.**
+2. **Disk roughly doubles until the cleanup grace elapses** (inherited default 24 h), and the
+   catalog does not shrink until snapshots expire (inherited default 168 h). Sizing a mainnet
+   volume from the logical archive size alone would be wrong. Both windows are now
+   independently configurable for the projection path, with the inherited values as defaults
+   so nothing changes silently; choosing different ones is a product decision.
+3. **`projection_receipts` was excluded from its own sink's compaction** — the loop iterated
+   `DuckLakeSql.tables()`, which enumerates dataset tables only. At 10,515 files it was 84% of
+   the active file count. Fixed and measured: a 12-commit fixture compacts 12 receipt files
+   to 1.
+4. **The compaction gate compared total file count, not small-file count**, so it was true
+   forever on any large archive and attempted a pass every interval. Now reads the size
+   distribution from DuckLake's metadata schema. Pinned by a test that sets the smallness
+   ceiling below every file and asserts the pass declines — a test the old gate fails, so it
+   cannot pass by silently falling back.
+5. **`merge_adjacent_files` is idempotent** — verified, not assumed. A second pass over a
+   compacted lake rewrites nothing, so repeated maintenance cannot accumulate orphan
+   generations inside the 24 h cleanup grace.
+
+### Compaction under the new drain loop, measured (2026-08-20)
+
+The figures above came from a pass on the **old** jar. Verified again under the rewritten
+drain loop, with the compaction interval shortened to 5 minutes so a pass could be observed
+inside a validation session:
+
+| | before | after |
+|---|---|---|
+| active data files (catalog) | 12,470 | **1,799** |
+| `projection_receipts` active files | 10,516 | **9** |
+| logical size | 3.20 GB | 3.16 GB |
+| files awaiting the cleanup grace | 58,800 | 69,645 |
+| size on disk | 7.8 GB | 8.5 GB |
+
+**1,799 active files for a complete 5.07M-block preprod archive**, against 69,375 before any
+compaction — a **38x reduction**. The receipts table, which the sink had been excluding from
+its own maintenance, went from 10,516 files to 9.
+
+Post-compaction distribution:
+
+```
+transaction_outputs        340   p50 3.0M   p95 6.6M   max 10.5M
+transaction_inputs         296   p50 2.1M   p95 4.8M
+transaction_redeemers      292   p50 1.1M   p95 4.1M
+chain_transaction          288   p50 1.1M   p95 2.5M
+transaction_output_assets  282   p50 1013K  p95 2.5M
+transaction_datums         281   p50   99K  p95 1.1M
+projection_receipts          9   p50  166K
+```
+
+Three operational facts this settles:
+
+1. **The post-flush idle window is wide enough in practice.** Compaction fires on the drain
+   pass immediately after a commit, when the buffer is empty and nothing is eligible yet. It
+   is not merely reachable in principle: `lastMaintenance` went from
+   `COMPLETED (housekeeping only) [compaction withheld: sink busy]` to `COMPLETED` on exactly
+   that pass.
+2. **An incremental pass is short.** The next batch opened **6 seconds** after the compaction
+   pass, nowhere near the 5-minute budget. The worst-case staleness bound (linger plus one
+   compaction budget) remains the bound, but the typical cost is seconds.
+3. **Each legitimate compaction generation adds its inputs to the orphan pool for the whole
+   cleanup grace.** Two generations now coexist: 69,645 files awaiting deletion, 8.5 GB on
+   disk against 3.16 GB logical — **2.7x**, not the 2x a single generation costs. This is not
+   the runaway case (a second pass over an already-compacted lake is a verified no-op); it is
+   the cost of two passes that each had real work. Mainnet volume sizing must budget for it.
+
+### Two maintenance defects the metrics exposed
+
+Adding `maintenancePasses` / `compactionPasses` to status immediately paid for itself.
+
+1. **The compaction counter was lying.** It incremented on what the *scheduler asked for*, not
+   on what the executor was permitted to do. The consumer withholds compaction when the sink is
+   not idle, so a run reporting `compactionPasses = 1` had in fact compacted nothing. Worse,
+   `recordRun` then stamped `lastCompaction`, deferring the next real attempt by a full
+   6-hour interval on the strength of a compaction that never happened. The executor now
+   reports back what it was actually offered (`MaintenancePass.compactionOffered`), and only
+   that is recorded and counted.
+
+2. **A withheld compaction re-fired on every drain tick.** With `lastCompaction` never
+   advancing, compaction stayed permanently due, so a maintenance pass — which acquires a bulk
+   DuckDB lease — was attempted roughly every 250 ms. Measured live: **38 passes in a few
+   minutes**. After the fix: **1**.
+
+   The root cause was that the scheduler and the executor used *different* idle predicates.
+   The scheduler asked "are eligible envelopes waiting?"; the executor asked "are eligible
+   envelopes waiting **and** is the buffer empty?". Near tip the buffer is almost always
+   non-empty, so they disagreed almost always. `hasDrainBacklog()` is now the exact negation of
+   the executor's idle test, and a backstop spaces any future disagreement to one pass per
+   housekeeping interval rather than one per tick.
+
+### Phase 4b — all four datasets have sections (2026-08-20)
+
+**`ACCOUNT_EVENT`.** A pure function of the block body: certificates and withdrawals, no ledger
+state and nothing to resolve. Codec, collector case and streaming row derivation added; the
+differential-parity harness now derives account events on both sides.
+
+Seven certificate fixtures were added, because the fourteen existing ones contain no
+certificates at all — parity between two empty row sets proves nothing. Each states the number
+of events it expects, so a fixture that silently stopped producing them would fail rather than
+pass vacuously: registration and deregistration (2), script credentials (1), stake delegation
+(1), a Conway `StakeVoteRegDelegCert` that expands into three events at `index<<32`, `+1`, `+2`
+(3), withdrawals (1), certificates across two transactions (2), and certificates in an
+**invalid** transaction (0 — pinning the existing rule that only valid transactions contribute).
+
+**`ADDRESS_TRANSACTION`.** This one needs live state, and the reason is precise:
+`UtxoHistoryFact.Input` carries the consumed outpoint but not the address that owned it, and by
+the time any sink reads the envelope that output has been deleted from the UTXO set. So input
+addresses are resolved at capture time — the same argument that moved pointer-address
+resolution into canonical apply.
+
+The seam is one small interface, `ConsumedOutputAddresses` in `core-api`. The UTXO subsystem
+already decodes every consumed output during apply in order to delete it, so supplying the
+address costs a map insertion on a lookup that has already happened. A contributor that does
+not require the section answers `needsConsumedOutputAddresses() == false` and the map is never
+allocated, so a node projecting the other three datasets pays nothing.
+
+**Two extractions, so parity is structural rather than tested.** Differential parity between
+two implementations of the same rule is a test that can pass while both are wrong. Rather than
+write a second implementation and compare it, the shared parts were extracted and both paths
+now call them:
+
+- `AddressSubjectRows` — subject accumulation, role counting and row emission. The live
+  `AddressTransactionDataset` delegates to it; its private `SubjectKey`, `SubjectRoles`,
+  `ParticipationRole`, `addSubjects` and `add` were removed.
+- `AddressTransactionDataset.parse(...)` — address decomposition, made static with the
+  pre-Conway pointer lookup **injected**. The live path passes its sequential resolver; the
+  projection passes the ADR-039 as-of index through `PointerCredentialSource`. Everything else
+  about what an address decomposes into is now one piece of code.
+
+Both extractions are behaviour-preserving: the existing suite passes unchanged.
+
+**Failing closed on an unresolvable input.** A skipped input would silently lose a real spend
+from address history, and no later pass could detect it, so `ProjectionAddressParticipation`
+throws instead. A test pins it.
+
+**The fail-closed section guard stayed testable.** With all four sections buildable, the guard
+that refuses an identity requiring a section the collector cannot produce became unreachable
+from the public constructor — and an unreachable guard quietly stops being a guard. A
+package-private constructor takes the buildable set, so the test still exercises it while the
+production path cannot weaken it.
+
+Full suite after Phase 4b: **3,076 tests, 0 failures, 0 errors**.
+
+**Side by side against the live dataset — done.** Block 1 creates outputs, block 2 spends them.
+The live `AddressTransactionDataset` resolves those inputs through its own resolver, populated
+by block 1; the projection resolves them from the addresses the UTXO subsystem would have
+captured while deleting the same outputs. Rows are byte-identical. Row *shape* was already
+guaranteed by the shared code, so what this actually tests is that the two **resolutions**
+agree — which sharing code cannot guarantee, since resolution is exactly the part that differs.
+
+**The four-section configuration has never been run on a chain.** `ProjectionIdentity` includes
+the required-section set, so adding sections changes the identity fingerprint and the startup
+guard fails closed on a mismatch — by design, since a mid-chain section addition would leave
+earlier blocks without it. The consequence is concrete: **the running preprod archive is a
+two-section artifact and cannot be extended**; validating Phase 4b needs a fresh sync. "Phase 4b
+complete" therefore means the code is complete and unit-verified, not that four sections have
+been observed working on a real chain.
+
+**What the projection does not carry over from the live dataset, and why that is safe.** The
+live `AddressTransactionDataset.derive` also maintains `pendingPuts` / `pendingDeletes` and
+emits resolver operations, and it throws on `duplicate address-history outpoint` and
+`conflicting address-history outpoint`. Both were checked rather than assumed: they fire on the
+*resolver's* bookkeeping — the same outpoint written twice into the resolver within a batch, or
+an interrupted replay presenting a different value for an outpoint the resolver already holds.
+Neither is a chain-validity check. The projection path maintains no resolver, and its
+idempotency comes from the outbox receipt mechanism instead, so no fail-closed guard is lost.
+
+**Encoded cost of the new section — measured.** 30 transactions x (2 inputs + 3 outputs) = 150
+participations encode to **35,165 bytes, 234 B/participation**. This is not marginal: a typical
+preprod block with one transaction and four participations adds roughly **900 bytes**, against
+a measured **2,817 B/block** for the two-section outbox. Enabling all four datasets should be
+expected to increase outbox volume substantially, not slightly.
+
+The cause is deliberate duplication: the section carries each output's address, which
+`utxo-history` also carries. Deriving output participations from the `utxo-history` section
+instead would remove it, but would couple two sections that are independent by design — a node
+may require one without the other. The duplication is the price of that independence, and it is
+now a measured price rather than an assumed one. **The gate-4 bytes-per-block model was
+measured with two sections and must be re-derived before mainnet sizing.**
+
+### Four-section preprod sync to tip — Phase 4b validated on a chain (2026-08-20)
+
+A fresh genesis sync with **all four datasets required**
+(`transaction:v2,utxo-history:v5,account-events:v3,address-transaction:v3`), which the existing
+two-section archive could not be extended to: the required-section set is part of the identity
+fingerprint, and the startup guard fails closed on a mismatch.
+
+```
+tip 5,078,482        acknowledged 5,074,159       backlog 4,323 (= finality window)
+contributor lag 0    drain failures 0             sink READY, contributors HEALTHY
+3,077 commits        {MIN_BLOCKS: 3,073, LINGER_EXPIRED: 4}
+```
+
+All four contributors advanced in lockstep for the entire sync — the property that matters,
+since a lagging contributor stalls every envelope behind it.
+
+**Cost of the two extra datasets.** Two different quantities, kept apart because conflating
+them is easy and the ADR previously did:
+
+| | two sections | four sections | ratio |
+|---|---|---|---|
+| archive logical size over the whole sync | 3.16 GB | **4.50 GB** | **1.42x** |
+| ...as Parquet bytes per block | 623 B | **887 B** | 1.42x |
+| outbox backlog density at tip | 2,817 B/block | **4,637 B/block** | 1.65x |
+| largest single envelope | 33,693 B / 175 rows | **750,861 B / 4,717 rows** | 22x / 27x |
+
+**Use the 1.42x logical-size ratio for sizing.** `bytesPerBlock` in status is
+`pendingBytes / pendingBlocks` — the density of the ~4,320 blocks currently in the backlog, not
+an average over the sync. It is a fair like-for-like between the two nodes, since both are at
+tip with the same window, but it describes recent preprod blocks rather than the chain, and it
+moves: the same counter read 6,630 mid-bootstrap, then 1,905, then 4,637 at tip.
+
+Either way the gate-4 model was derived with two sections and understates a four-dataset node.
+
+**The envelope maximum grew far more than the average** — 22x — and that is the quantity the
+singleton safety guard is sized against. 750 KB against a 64 MiB guard leaves ample headroom,
+but it changes what to expect at mainnet density: preprod's flush-reason distribution is
+**3,073 `MIN_BLOCKS` / 4 `LINGER_EXPIRED` / zero `MAX_BYTES`**, so no commit has ever been
+byte-driven. A mainnet block several times denser puts 50-envelope batches within reach of the
+256 MiB batch ceiling, at which point `MAX_BYTES` becomes a live flush reason. That is not a
+problem — it is the ceiling working — but it should be recognised in the histogram rather than
+discovered there.
+
+Active file counts are **not** comparable yet: the four-section archive shows 32,646 active
+files against the two-section archive's 1,821, but only because the two-section archive has run
+compaction and the four-section one reached tip minutes ago. Compare after both have compacted.
+
+**Two defects this run found that unit tests did not.** Both are recorded in full elsewhere;
+noted here because they are the argument for validating on a chain before mainnet:
+
+1. **The address projection could not resolve an output created and spent in the same block.**
+   Addresses were captured only on the spend path, so an intra-block spend had none. Fixed by
+   capturing on creation as well; the regression fixture is the real preprod shape.
+2. **A pre-existing UTXO correctness bug** — see `adr-039-utxo-collateral-return-leak-2026-08-20.md`
+   and [bloxbean/yano#74](https://github.com/bloxbean/yano/issues/74), fixed independently in
+   [PR #75](https://github.com/bloxbean/yano/pull/75) against `main`.
+
+### Determinism across two independent syncs (2026-08-20)
+
+The two-section and four-section preprod archives were built by **separate genesis syncs**, on
+different jars, with different restart and crash histories, and different required-section sets.
+On the datasets they share they agree exactly.
+
+Row counts over blocks 4,000,000-4,100,000:
+
+```
+chain_transaction     four 97,427    two 97,427
+transaction_inputs    four 385,866   two 385,866
+transaction_outputs   four 496,502   two 496,502
+```
+
+Content over blocks 4,050,000-4,060,000 — an MD5 over `tx_hash, output_index, address, lovelace`
+in a fixed order, plus the lovelace sum:
+
+```
+four  rows 29,622  total_lovelace 742,204,167,219,202,983  digest 796ad040a0f9ecca03ceaff86bc71ce1
+two   rows 29,622  total_lovelace 742,204,167,219,202,983  digest 796ad040a0f9ecca03ceaff86bc71ce1
+```
+
+Identical. Row counts alone would only prove equal cardinality; the digest makes it content
+equality. This is the property the whole design rests on — the same canonical chain must produce
+the same archive regardless of how the node got there — and it is now demonstrated end to end
+rather than argued from the code.
+
+### Four-section datasets, as queried (2026-08-20)
+
+Through the catalog's **active** file set, at acknowledged block 5,074,358:
+
+```
+transactions              6,602,529 rows   blocks 47 - 5,074,358
+outputs                  22,059,349 rows   blocks 47 - 5,074,358
+inputs                   27,434,631 rows   blocks 47 - 5,074,358
+account_events              427,713 rows   blocks 48 - 5,074,353
+address_participations   38,998,997 rows   blocks 47 - 5,074,358
+```
+
+**A note on how to query these correctly**, because getting it wrong produced alarming and
+entirely wrong numbers during this validation. Globbing `**/*.parquet` reads *superseded* files
+that are still on disk inside the cleanup grace, so a raw glob double-counts after any
+compaction — it reported 9,185 receipts covering 8.68M blocks on a 5.07M-block chain. Resolve
+the active set from `ducklake_data_file where end_snapshot is null` and query only those paths.
+
+### Crash recovery with four sections (2026-08-20)
+
+`kill -9` at tip, mid-batch:
+
+```
+before   acknowledged 5,074,360   complete 5,078,695   batch 15 blocks buffered
+after    acknowledged 5,074,360   complete 5,078,697   batch 17 blocks
+         contributor lag 0        drain failures 0     READY / HEALTHY
+         recovered and serving in 21 s
+```
+
+The acknowledged point is unchanged, so nothing was lost and nothing was double-committed; the
+buffered batch had no durable footprint and was simply rebuilt from the outbox.
+
+### Configuration, and what an operator has to decide (2026-08-21)
+
+**The fresh-sync default is now every shipped block dataset.** It previously defaulted to the
+two-section first slice, which is wrong as a shipping default for a specific reason: the
+required-section set is part of the archive identity, so a dataset omitted at fresh sync **cannot
+be added later** — the earlier blocks would be missing from it. An archive that quietly shipped
+without `account-events` looks healthy until a query returns nothing, and by then the remedy is a
+full resync from genesis. Choosing fewer must therefore be a deliberate act, not the default.
+
+`yano.history.projection.sections` still accepts a narrower list; it is documented as a legacy or
+testing configuration rather than a tuning knob.
+
+A shipped profile now exists at `app/config/application-projection.yml`, composed after a network
+profile (`./yano.sh start:preprod,projection`). It is explicit that it **replaces** the ADR-034
+`history` profile rather than supplementing it — both write the same DuckLake tables from
+different pipelines, so exactly one may be enabled.
+
+Sink options moved from `projection.sink.*` to `projection.sink-options.*`: `projection.sink` is
+itself a scalar (the engine name), so the two could not coexist in YAML even though they can as
+flat keys.
+
+### Known limitations carried into the PR
+
+- **`PointerHistoryCleanupPolicy` is implemented and tested but has no production caller.** The
+  pointer index measures 0.68 MiB on a full preprod chainstate, so there is nothing worth
+  reclaiming; running cleanup would add risk for no benefit. Marked unwired in its own javadoc so
+  it cannot be mistaken for live code.
+- **Phase 8 (standalone SQLite sink) is deferred**, and the `ProjectionSink` /
+  `ProjectionSinkProvider` boundary is retained precisely so it remains buildable later. Nothing
+  in this PR should be read as closing it.
+- **The artifact-lease reconciliation gap** (ADR-039 §11 case 9) is identified but not fixed: it
+  cannot be exercised until Phase 5 produces artifacts, and it must ship with the first one.
+- **Differential parity fixtures not yet covered**: reference scripts (`scriptRef` outputs),
+  Byron genesis output resolution, era-transition blocks, and rollback across an epoch boundary.
+- **The four-section preprod chainstate carries the #74 UTXO defect** (fixed independently in
+  PR #75, deliberately not merged here). The archive is unaffected — the projection resolved that
+  spend correctly — but the chainstate is not a clean reference for UTXO-set comparison.
+
+### Compaction status by archive — not yet comparable (2026-08-21)
+
+Compaction is measured on the **two-section** archive (69,375 -> 1,799 active files after two
+passes). The **four-section** archive reached tip only minutes before it was stopped for the
+throughput benchmark and had run one compaction pass, so its 32,646 active files are a
+mid-compaction figure, not a steady state. The two are therefore **not comparable yet**, and the
+handoff deliberately does not present them side by side.
+
+What is established: compaction works, it is idempotent, it reduces active files by more than an
+order of magnitude, and the sink's own receipt table is included in it. What is not established:
+the four-section steady-state file count and its per-table size distribution. That needs the
+four-section archive left at tip long enough for the 6-hour compaction interval to run at least
+twice with no drain backlog, and it is listed as remaining work rather than inferred from the
+two-section numbers.
+
+### Defects found by self-review before the PR (2026-08-21)
+
+Reading the diff rather than the tests turned up one the tests could not have caught, because it
+only manifests in a race at shutdown:
+
+**`close()` claimed to let the active batch finish and did not.** It set `draining = false`,
+interrupted the drain thread, and immediately closed the sink — potentially tearing down the
+DuckDB connection while a commit was in flight. Correctness would have survived it: an
+unacknowledged commit is recognised by its receipt on replay. But it turned every clean shutdown
+into a crash-recovery path for no reason, and the comment asserted behaviour the code did not
+have. Shutdown now joins the drain thread with a bounded 30-second wait before closing the sink,
+and says plainly what happens if that wait expires.
+
+The general point is worth keeping: a comment describing intent is not evidence the code does it,
+and this one had been read several times without the discrepancy being noticed.
+
+### Follow-up outside ADR-039: the console-ui History tab
+
+The console-ui **History tab is broken** and needs rewriting against the projection APIs. It is
+**not part of ADR-039** and is deliberately sequenced **after Phase 7**, for a concrete reason:
+Phase 6 defines the endpoints it must call and Phase 7 removes the old ones, so doing it earlier
+means writing it twice.
+
+One design note for whoever picks it up: it cannot be a plain list. Near tip a block is final and
+durable in the outbox but not yet queryable in the sink for up to the batching linger plus one
+compaction budget — 15 + 5 minutes at the defaults. The tab has to render coverage honestly
+rather than show an empty result as "no history", which is the same requirement Phase 6 places on
+the API itself.
+
+### Peak retention, instrumented (offline)
+
+Densest-preprod-calibrated fixture, baseline taken with the encoded envelopes already live so
+the figure isolates materialisation:
+
+```
+  5 envelopes ->   6,100 rows, peak retained 1,066 KiB, 4,488 B/row allocated
+100 envelopes -> 122,000 rows, peak retained 1,111 KiB, 4,430 B/row allocated
+densest single envelope: 1,220 rows, 1,125 KiB
+```
+
+Twenty times the batch for **4% more retained heap**. Allocation scales with rows, as it must;
+retention does not. This is what distinguishes a real bound from a nominal one — a lazy
+`Iterable` alone would not have shown it.
+
+---
+
+## 6. Deployments
+
+| Directory | Purpose | Ports | State |
+|---|---|---|---|
+| `adr039-phase0-baseline-preprod-20260819-230037` | history-disabled baseline | 6291/14291 | reached preprod tip (block 5,074,810), stopped cleanly |
+| `adr039-projection-preprod-20260819-234600` | history-enabled producer, `sink=none` | 6293/14293 | ran to block 1,716,699, stopped cleanly |
+| `adr039-gate1-ab-20260820` | clean sequential gate-1 A/B | 6297/14297 | see results.tsv |
+| `adr039-ducklake-preprod-20260820-0930` | full DuckLake sink sync to tip, then batching/maintenance validation | 6295/14295 | **running**; synced to tip in 1h07m, restarted twice onto rebuilt jars |
+
+All fresh and isolated under `/Users/satya/Downloads/yano-try/`. No pre-existing directory was
+written to, and no existing mainnet or preprod deployment was touched, signalled, or started.
+Logs, configs, samples and jar hashes are preserved in each. The DuckLake deployment also
+keeps `samples-before-batching.tsv`, `batch-samples.tsv` and `file-census.tsv` so the
+before/after comparison is reproducible from data rather than from this report.
+
+---
+
+## 7. Not done, and why
+
+- **Post-optimisation gate-1 A/B (D2).** The highest-value remaining experiment; see §2.
+- **Mainnet fresh-sync validation**, including Byron and EBB coverage at mainnet scale. Now
+  unblocked — D1 is withdrawn and preprod is proven — but not started.
+- **Phases 4b, 5, 6, 7, 8** — see §1. Phase 7 is correctly blocked: it requires parity on all
+  four shipped datasets, and only two have sections.
+- **Long-window preprod comparison the review asked for**: commits/day, files/table/day before
+  compaction, average/p50/p95 file size, compaction input/output, and finalized-but-not-yet-
+  committed envelope age over a multi-day window. The instrumentation now exists
+  (`pendingBatchAgeSeconds`, `flushReasons`, `file-census.py`, `batch-samples.tsv`) and the
+  first data points are in §5, but a day-scale window has not yet elapsed.
+- **Historical API behaviour across the new staleness window (Phase 6).** Near tip a block can
+  be final and durable in the outbox for up to 15 minutes before it is queryable in DuckLake.
+  The product assumption is that live/recent storage continues to serve that range. This must
+  be verified at API cutover: **an endpoint that would instead report false absence must either
+  use the recent-data fallback or report coverage honestly.** `pendingBatchAgeSeconds` and
+  `pendingBatchOldestBlock` exist so the window is observable rather than assumed.
+
+  **Be precise about what that metric measures.** `pendingBatchAgeSeconds` is *buffer
+  residency* — how long the oldest buffered envelope has waited — not finality-to-sink
+  latency. Maintenance runs on the drain thread, so a compaction pass that consumes its budget
+  delays the next batch from *opening*; the residency clock then starts late and the metric
+  understates true staleness by that amount. The honest bound on finality-to-queryable is
+  **linger + at most one compaction budget**, i.e. 15 min + 5 min at the defaults. Phase 6 must
+  size the recent-data fallback against that bound, not against the linger alone.
+- **Artifact-lease reconciliation on startup (a Phase 5 requirement, identified here).**
+  `ProjectionOutboxConsumer` acknowledges the outbox range first and releases artifact
+  protection second, which is the order ADR-039 §10 specifies. But `acknowledgeThrough` also
+  deletes the artifact *references* in `proj_artifact`, so a crash between the two steps leaves
+  a lease with no reference to release it — an orphaned lease that would pin retention
+  indefinitely. This is ADR-039 §11 case 9. Harmless today because no artifacts are produced
+  until Phase 5, but it must be implemented **with** the first artifact, not after.
+- **Fixtures from the ADR's list still not covered by differential parity**: reference scripts
+  (`scriptRef` outputs), Byron genesis output resolution, era-transition blocks, and rollback
+  across an epoch boundary.
+- **`main` merge — deliberately deferred (2026-08-20).** Not a blocker: the branch carries its own
+  capture-at-creation fix, so the address-transaction projection resolves intra-block spends
+  without depending on [#75](https://github.com/bloxbean/yano/pull/75). Two consequences to
+  remember when the merge does happen:
+
+  1. **The four-section preprod chainstate carries the #74 defect.** Its UTXO set has at least one
+     phantom unspent output, at block 1,809,762. The *archive* is unaffected — the projection
+     resolved that spend correctly — so ADR-039 validation stands, but the chainstate is not a
+     clean reference for UTXO-set comparisons until it is resynced on a merged jar.
+  2. **One conflict is expected**, in the collateral-return block of `DefaultUtxoStore`: #75 adds
+     `intraBlockOutputs.put(...)` exactly where this branch adds `consumedAddresses.put(...)`. The
+     changes are complementary and both lines survive.
+
+  Keep the capture-at-creation line after merging even though #75 makes it redundant for the
+  collateral case: it makes the projection independent of the store's intra-block bookkeeping, so
+  a future omission of the same shape breaks nothing, and it costs one map insert on a path that
+  only runs when the address-transaction section is enabled.
+
+- **`main` merge mechanics** — `main` is 13 commits ahead and touches
+  `runtime/utxo/UtxoEventHandler*.java` and `RuntimeNode.java`. Merging requires a merge
+  commit, which the instructions forbid, so it is deferred to the commit stage and listed as
+  step 0 below. This is a real residual risk: the ADR-039 hook lands in files `main` modifies.
+
+### Resolved since the previous revision of this report
+
+- **Pre-Conway pointer addresses** — was the blocker for enabling a sink on a real network.
+  Resolved by core-owned as-of resolution rather than by accepting a semantic divergence from
+  cardano-ledger: `PointerCredentialSource` in `core-api`, backed by a deregistration-coordinate
+  index in `DefaultAccountStateStore`. Measured on a real preprod chainstate at **17,036
+  entries, 42 bytes each, 0.68 MiB — 0.002% of chainstate**, one extra put per ~298 blocks.
+- **Unbounded row materialisation** — resolved by streaming, and now measured rather than
+  argued; see §5.
+- **Tiny Parquet files** — resolved by the batch policy plus sink-owned maintenance; see §5 and
+  the ADR's decision section.
+
+---
+
+## 8. Proposed commit sequence
+
+Refreshed 2026-08-20 against the actual working tree (51 changed paths). Every changed file
+appears in exactly one step, so a reviewer who follows the sequence finishes with nothing
+unaccounted for.
+
+```
+ 0. merge origin/main into the branch (resolve UtxoEventHandler*, RuntimeNode)
+
+ 1. core-api: projection seams
+      api/archive/ProjectionCfNames, ProjectionStagingWriter,
+                  CanonicalProjectionContributor
+      api/events/ByronBlockProjectionEvent
+      api/config/YanoPropertyKeys                                  (M)
+
+ 2. core-api: pointer contracts
+      api/archive/PointerCredentialSource, PointerIndexMaintenance
+
+ 3. archive-api: projection contracts + tests
+      archive/api/projection/**                                    (new package)
+      archive/api/projection tests
+
+ 4. archive-core: envelope + section codecs, startup guard + tests
+
+ 5. runtime: canonical contribution seams
+      chain/DirectRocksDBChainState        declares 4 projection CFs
+      utxo/DefaultUtxoStore, utxo/UtxoSubsystem
+      BodyFetchManager                     Byron carrier publication
+      kernel/NodeKernel                    context() accessor
+      internal/RuntimeNode, assembly/Yano, assembly/RuntimeYano
+
+ 6. runtime: ingest hold
+      sync/IngestHoldRegistry (+ test), sync/SyncSubsystem, HeaderSyncManager
+
+ 7. ledger-state: pointer as-of index
+      DefaultAccountStateStore              (+198/-1)
+      test/PointerIndexAsOfTest
+
+ 8. archive-core: outbox store, keys, stats, finality gate, retention health + tests
+
+ 9. archive-core: ordered consumer, bounds, backpressure, contributor health + tests
+
+10. archive-core: Byron normalizer extraction + BoundedDecodeCache
+      source/ByronBlockNormalizer, source/BoundedDecodeCache
+      source/YaciBlockDecoder (M)          dedup against the extraction
+      source/YaciUtxoHistoryDecoder (M)
+
+11. archive-core: fact codec, chunking, collector, pointer resolution
+      + differential parity and Byron tests
+
+12. archive-core: streaming row builder, batch policy/accumulator/decision,
+      maintenance schedule + tests
+
+13. archive-store-ducklake: projection schema, sink, provider, ServiceLoader registration
+      + tests
+
+14. app: ProjectionHistoryService, NoArtifactReader, YanoProducer wiring,
+      StatusResource surface
+
+15. adr: ADR-039 + review + phase, measurement, memory, pointer and granularity reports
+```
+
+Keep 15 separate; it contains no code. Do not squash 10 into 11 — the decoder dedup is
+independently reviewable. Steps 2 and 7 are the pointer work and can be reviewed as a pair
+without reading the rest.
+
+---
+
+## 9. Four-way split
+
+**Fully validated** (local, reproducible, gated by tests)
+- envelope/section/artifact contracts, identity, fresh-sync guard, serialization goldens
+- durable outbox: completion gating, ordered reads, acknowledgement, cleanup, rollback
+  (block- and slot-keyed), restart survival, torn-record rejection
+- finality gating, receipt replay and mismatch rejection, backpressure, retention health
+- transaction/UTXO differential parity across 10 fixtures, including Byron semantics
+- Byron carrier: main blocks, EBB empty envelopes, contiguity, parent bridge, null fee
+- DuckLake sink: atomic multi-table commit, idempotency, contiguous coordinate, compaction of
+  the sink's own receipt table
+- batch policy: both regimes, all four ceilings, saturation, deadline reachability with zero
+  arrivals, rollback discard, contiguity refusal, restart-while-lingering
+- streaming memory bound, measured rather than asserted
+
+**Validated live** (observed on a real preprod chain, reproducible from preserved samples)
+- full fresh sync to tip with the real sink: 1h07m, backlog pinned at the finality window,
+  0 failures, 0 gaps
+- graceful restart and `kill -9`: no gaps, no duplicates, no overlapping receipts
+- near-tip batching: 37 blocks in one commit at the deadline, against 1 block per commit before
+- restart with a lingering batch: nothing acknowledged, batch rebuilt from `acknowledged + 1`
+- disk backpressure registration, explicit in status and log
+- compaction: 5.6x fewer active files; reclamation lag quantified
+
+**Still to measure**
+- post-optimisation gate-1 A/B (D2) — the open gate
+- day-scale commits/day, files/table/day, file-size distribution over time, compaction I/O,
+  and envelope-age distribution
+- gate 4 p95/p99 per-block outbox distribution — needs per-block instrumentation
+
+**Blocked / not started**
+- Phases 4b, 5, 6, 7, 8
+- mainnet fresh-sync validation
+
+---
+
+## 10. Note on worktree hygiene
+
+During implementation one `python3` heredoc used a relative path before its `cd`, and
+applied the `YaciBlockDecoder` dedup to the source worktree
+(`.claude/worktrees/node-wallet-apis`) instead of this one. It was detected, reverted
+with an explicit single-file `git checkout --`, and reapplied here. That worktree is
+byte-identical to its state at the start of this session; its five untracked files
+(`039-canonical-projection-outbox.md`, the ADR-039 review, two ADR-037 reports,
+`history-test-plan.md`) and its one modified sampler file are intact.

--- a/adr/reports/adr-039-measurements-2026-08-20.md
+++ b/adr/reports/adr-039-measurements-2026-08-20.md
@@ -1,0 +1,505 @@
+# ADR-039 measurements — gates 1 and 4
+
+**Date:** 2026-08-19 / 2026-08-20
+**Branch:** `feat/adr-039-canonical-projection-outbox`
+
+## Deployments
+
+| Run | Purpose | Ports | Artifact SHA-256 | State |
+|---|---|---|---|---|
+| `adr039-phase0-baseline-preprod-20260819-230037` | history **disabled** core baseline | 6291 / 14291 | `d22c9640…50a081` | reached preprod tip (block 5,074,810, Conway), stopped cleanly |
+| `adr039-projection-preprod-20260819-234600` | history **enabled**, `sink=none` | 6293 / 14293 | `42dd0da0…0b6978` | running |
+
+Both are fresh, isolated deployments under `/Users/satya/Downloads/yano-try/`. Neither
+touched any pre-existing directory.
+
+## Gate 4 — outbox bytes per canonical block (OPEN, first real data)
+
+Measured on a live fresh preprod sync with both first-slice sections
+(`transaction:v2`, `utxo-history:v5`) enabled and no sink draining, so the figure is
+total projection volume rather than a steady-state backlog.
+
+| block | bytes/block | cumulative outbox |
+|---|---|---|
+| 123,000 | 42 | 5 MB |
+| 285,000 | 615 | 175 MB |
+| 439,000 | 899 | 0.37 GB |
+| 604,000 | 1,044 | 0.59 GB |
+| 699,000 | 1,439 | 0.94 GB |
+| 771,000 | 1,818 | 1.31 GB |
+| 945,000 | 1,878 | 1.65 GB |
+| 1,082,000 | 1,888 | 1.90 GB |
+| 1,183,000 | 2,059 | 2.27 GB |
+
+The figure rises monotonically with block density and has not yet plateaued; Alonzo and
+Conway ranges are still ahead. This is a **cumulative mean**, not a per-block
+distribution — p95/p99 require per-block instrumentation and are not yet measured, so
+ADR-039 acceptance criterion 4 is only partially satisfied.
+
+Final observed value before the run was stopped: **2,397 bytes/block at block
+1,716,699**, with 3.83 GB of accumulated outbox.
+
+Preliminary capacity implication, to be revised as density rises: at ~2.4 KB/block a
+13.8M-block mainnet genesis sync implies on the order of **33 GB** of projection volume.
+
+**This is a no-sink ceiling, not a working-set estimate.** The measurement ran with
+`sink=none`, so nothing ever acknowledged or deleted an envelope and the figure is
+cumulative *total projection volume produced*. The steady-state outbox size under a
+draining sink is a different quantity — it is the backlog, governed by `(Rc - Rs) * B *
+elapsed`, and it is bounded by the soft/hard limits rather than by total volume. The two
+must not be conflated later:
+
+- **total volume produced** (measured here): what a sink must eventually absorb;
+- **retained outbox size** (not measured): what sits in the hot RocksDB at any moment.
+
+Under the §0.8 sink-paced regime the second approaches the first, which is exactly the
+compaction and write-amplification consequence review finding D3 asked to be named. Under
+a hypothetical sink that kept up, the second would stay near zero.
+
+## Gate 1 — core-sync regression (NOT YET VALIDLY MEASURED)
+
+A comparison was computed and then **rejected as invalid**. It is recorded here rather
+than discarded, because the failure mode is easy to repeat.
+
+Matched-block-range comparison, as computed:
+
+| block range | baseline | projection | apparent delta |
+|---|---|---|---|
+| 0–250k | 3,323 blk/s | 2,534 blk/s | −23.7% |
+| 250k–500k | 3,613 blk/s | 2,666 blk/s | −26.2% |
+| 500k–750k | 2,228 blk/s | 1,783 blk/s | −20.0% |
+| 750k–1000k | 2,440 blk/s | 1,383 blk/s | −43.3% |
+| 1000k–1250k | 2,562 blk/s | 1,866 blk/s | −27.2% |
+
+**Why this does not measure ADR-039.** The two runs covered those blocks at different
+times under different machine load:
+
+- baseline covered blocks 0–1.25M at **15:01–15:08 UTC**, running alone;
+- projection covered blocks 0–1.18M at **15:51–16:00 UTC**, running **concurrently with
+  the baseline node**, which was by then deep in dense Conway blocks. Load average
+  during the projection window was 5–7.5.
+
+So the numbers above conflate projection overhead with CPU and I/O contention from a
+second full node syncing on the same machine. Reporting −20% to −43% as the gate-1
+result would be wrong, and would wrongly condemn the design.
+
+The honest statement is: **gate 1 is unmeasured.** The apparent regression is an upper
+bound that includes contention; the true overhead is somewhere between 0% and that
+figure.
+
+### The valid experiment, specified
+
+Run the two configurations **sequentially, each alone**, over the same bounded block
+range on the same hardware:
+
+1. stop every other Yano process and confirm with `ps`;
+2. fresh chainstate, `projection.enabled=false`, sync to block N, record wall clock;
+3. fresh chainstate, `projection.enabled=true`, `sink=none`, sync to block N, record
+   wall clock;
+4. repeat both at least twice, alternating order, and report the median.
+
+Bounding at N ≈ 1.5M keeps each leg near ten minutes while covering Byron, Shelley,
+Allegra and Mary, so the comparison spans real density change rather than only empty
+early blocks.
+
+### The valid experiment — result
+
+Four legs, alternating `off / on / on / off`, each running **alone** on an otherwise idle
+machine (only 0.1%-CPU Gradle daemons), fresh chainstate each time, wall clock to block
+1,000,000, preprod. Artifact SHA-256 `997a186efca42f0cabe7debce62f54ca6679aa447b01adc3248e828a7ba3bd9b`.
+
+| leg | mode | elapsed | reached block | blk/s | chainstate |
+|---|---|---|---|---|---|
+| 1 | off | 436 s | 1,000,368 | 2,294 | 10.44 GB |
+| 2 | on | 482 s | 1,005,604 | 2,086 | 13.79 GB |
+| 3 | on | 487 s | 1,000,379 | 2,054 | 13.65 GB |
+| 4 | off | 396 s | 1,000,399 | 2,526 | 10.62 GB |
+
+Legs stop at the first sampled block at or beyond the target and so overshoot by
+different amounts; normalising to blocks/s removes that, which comparing raw wall clock
+would not.
+
+```
+median off : 2,410 blk/s
+median on  : 2,070 blk/s
+delta      : -14.1%
+threshold  : -5.0%
+VERDICT    : FAIL
+```
+
+**Uncertainty is real and must be stated.** The two `off` legs differ by 10%
+(2,294 vs 2,526) while the two `on` legs agree to 1.5% (2,086 vs 2,054). Taking the
+extremes, the true regression lies between **-10% and -18%**, with -14% the median
+estimate. Two legs per mode is the minimum useful sample and more would tighten it — but
+the entire plausible range sits well above the 5% threshold, so the verdict does not
+depend on where in that range the truth lies.
+
+**Gate 1 fails.** ADR-039 anticipates exactly this: "If deterministic projection encoding
+exceeds it, the design must first remove avoidable copies/encoding work. It must not hide
+the overhead by making the canonical/outbox boundary best-effort."
+
+### What the regression is made of, and one caveat
+
+Likely contributions, in order:
+
+1. fact derivation — `YaciBlockArchiveDecoder.project` and `YaciUtxoHistoryDecoder.project`
+   on every block, on the apply thread;
+2. deterministic encoding of both sections;
+3. the additional RocksDB write, ~2.4 KB/block logical;
+4. compaction of a column family that, at `sink=none`, **never drains**.
+
+Item 4 deserves care. This ran with no sink, so the outbox grew monotonically and its
+compaction load grew with it. Under a sink that kept up, acknowledged ranges are deleted
+and the CF stays small, so this figure is **pessimistic for a draining configuration** —
+but **representative of the sink-paced regime**, which §0.8 shows is the only reachable
+one. It should not be quoted as the overhead of a hypothetical keeping-up sink.
+
+No attempt was made to optimise before measuring, so the ADR's prescribed next step —
+remove avoidable copies and encoding work, then re-measure — is untried and may well
+recover a meaningful part of the gap.
+
+### Disk amplification — review finding D3, quantified
+
+Same 1,000,000 blocks:
+
+```
+chainstate off : 10.53 GB (median)
+chainstate on  : 13.72 GB (median)
+extra          :  3.42 GB  =  3,419 bytes/block on disk
+logical outbox :             ~2,400 bytes/block
+amplification  :             ~1.4x
+```
+
+D3 asked that the hot-RocksDB consequence be named rather than left implicit in a
+disk-growth bullet. It is now measured: a lagging sink costs roughly 1.4x its logical
+outbox volume in real chainstate, on top of the compaction and cache pressure that the
+throughput loss reflects.
+
+### The two gates are independent failures
+
+Neither rescues the other:
+
+- **§0.8** — no sink approaches core production rate; sink-paced sync is the only
+  reachable mode.
+- **Gate 1** — producing envelopes costs 10–18% of core throughput against a 5% budget.
+
+A change that fixed gate 1 (leaner encoding, fewer copies) would not move §0.8 by a
+meaningful factor, and accepting sink-paced sync does not repair gate 1. Both need an
+explicit answer.
+
+## Relationship to the §0.8 blocking decision
+
+Gate 1 and the §0.8 drain-margin failure are independent.
+
+- §0.8 concerns whether a sink can keep up with core production. Its input — the
+  history-disabled core rate of roughly 1,500–3,600 blk/s depending on density — is
+  measured and uncontended, and no plausible sink approaches it.
+- Gate 1 concerns how much slower core sync becomes when it also produces envelopes.
+  It is unmeasured.
+
+A gate-1 pass would not rescue the drain margin, and a gate-1 failure would be a
+second, separate problem. They must not be reported as one number.
+
+---
+
+# Round 2 — after address memoisation
+
+## The optimisation, attributed
+
+Profiling the projection hot path first (`ProjectionEncodingProfileTest`, dense 40-tx
+block) contradicted the intuition that the copies were the problem:
+
+| stage | before | share | after |
+|---|---|---|---|
+| derive utxo-history facts | 388.9 us | **81.9%** | 229.1 us |
+| encode utxo-history | 48.9 us | 10.3% | 47.8 us |
+| manifest + digest | 19.0 us | 4.0% | 17.9 us |
+| derive transaction facts | 11.7 us | 2.5% | 9.1 us |
+| encode transaction | 2.4 us | 0.5% | 2.4 us |
+| chunk split (copy) | 1.0 us | 0.2% | 1.0 us |
+| section construct (copy) | 1.8 us | 0.4% | 1.0 us |
+| `chunks()` accessor (copy) | 1.0 us | 0.2% | 1.7 us |
+| **total** | **474.7 us** | | **310.1 us** |
+
+All four copy sites together are **0.8%**. The cost is address decoding, and
+`YaciUtxoHistoryDecoder` had **no memoisation**: every output parsed its address,
+extracted both credentials, hashed a key and re-encoded the whole thing back to bech32,
+even when the same address repeated. `seenAddresses` deduplicated only the resulting fact
+list, after the expensive work had already been done.
+
+Per-block memoisation of that decode cut the stage 389 -> 229 us and the total by 35%. It
+is semantics-preserving (a pure function of the display string), is passed as a parameter
+rather than held as a field because one decoder instance can serve two worker threads, and
+lives in the **shared** decoder — so the differential oracle gets the same speedup and
+parity holds by construction.
+
+## Isolated benchmark, round 2
+
+Same protocol: four legs alternating, each alone on an idle machine, fresh chainstate,
+wall clock to block 1,000,000, preprod. Artifact SHA-256
+`0ea8285011349cc7a8f8d9566482060acbb2eb4a065da7de03b1d3494d83bac5`.
+
+| leg | mode | elapsed | reached | blk/s | chainstate |
+|---|---|---|---|---|---|
+| 1 | off | 472 s | 1,005,559 | 2,130 | 10.55 GB |
+| 2 | on | 421 s | 1,005,338 | 2,388 | 13.31 GB |
+| 3 | on | 401 s | 1,001,899 | 2,499 | 13.38 GB |
+| 4 | off | 381 s | 1,000,378 | 2,626 | 10.53 GB |
+
+```
+median off : 2,378 blk/s   (spread 20.8%)
+median on  : 2,443 blk/s   (spread  4.5%)
+delta      : +2.7%
+```
+
+## This is NOT a pass, and the reason matters
+
+The nominal +2.7% clears the -5% threshold, but the `off` legs vary by **20.8%**
+(2,130 vs 2,626). A signal of 2.7% inside noise of 20.8% is not a measurement. Round 1's
+-14.1% *was* meaningful because the signal exceeded that round's 9.6% noise; round 2's
+does not, and reporting it as PASS would repeat the mistake this report already documents
+once.
+
+A curious and consistent asymmetry: the `on` legs are tight in both rounds (1.6%, 4.5%)
+while the `off` legs are wild (9.6%, 20.8%). The faster history-disabled path appears more
+sensitive to whatever the machine is doing between legs.
+
+## What can be claimed
+
+The cross-round comparison is better behaved than either round's within-round delta,
+because the `off` medians are nearly identical:
+
+```
+off  median  round 1  2,410  ->  round 2  2,378     (-1.3%, i.e. comparable machine)
+on   median  round 1  2,070  ->  round 2  2,443     (+18.0%)
+```
+
+So the memoisation is worth roughly **+18% on the history-enabled path**, measured against
+a baseline that did not move. That is the defensible attribution.
+
+The residual regression is now somewhere between "none" and "a few percent" and is **not
+resolvable at this sample size**. Four more legs are running to tighten it.
+
+Disk cost also improved: extra chainstate for 1M blocks fell from 3,420 to
+**3,009 bytes/block**, though part of that may be compaction timing rather than the
+optimisation.
+
+## Status of gate 1
+
+| | round 1 | round 2 |
+|---|---|---|
+| delta | -14.1% | +2.7% |
+| within-mode noise | 9.6% | 20.8% |
+| verdict | **FAIL** (signal > noise) | **INCONCLUSIVE** (signal << noise) |
+
+Gate 1 is no longer a demonstrated failure. It is also not yet a demonstrated pass.
+
+---
+
+# Round 2 extended to 8 legs — gate 1 is INCONCLUSIVE on this hardware
+
+Four more legs were run on the same memoised artifact to bound the residual.
+
+```
+leg 1: off  2130 blk/s      leg 5: on   2119 blk/s
+leg 2: on   2388 blk/s      leg 6: off  3098 blk/s
+leg 3: on   2499 blk/s      leg 7: off  1935 blk/s
+leg 4: off  2626 blk/s      leg 8: on   2464 blk/s
+```
+
+| mode | n | median | min | max | spread |
+|---|---|---|---|---|---|
+| off | 4 | 2,378 | 1,935 | 3,098 | **49%** |
+| on | 4 | 2,426 | 2,119 | 2,499 | 16% |
+
+- naive median delta: **+2.0%**
+- paired adjacent-leg delta (cancels slow-moving shared conditions): median **-4.8%**,
+  individual pairs ranging **-31.6% to +27.3%**
+
+**An earlier hypothesis in this report was wrong and is withdrawn.** After six legs the
+data looked like a monotone position effect (first leg slow, later legs faster). Leg 7
+(1,935 blk/s, the slowest of all, in seventh position) refutes that. The correct
+description is high, unpatterned variance concentrated in the history-**disabled** legs.
+
+The asymmetry is consistent across all eight legs and both rounds: the `on` legs are tight
+(16% spread; three of four within 2,388-2,499) while the `off` legs swing 49%. A plausible
+reading is that the history-disabled node is more I/O-bound and therefore more exposed to
+page-cache and filesystem state, while the history-enabled node is more CPU-bound and
+steadier — but that is a hypothesis, not a measurement, and nothing here tests it.
+
+## Verdict
+
+**Gate 1 cannot be resolved on this host.** The effect being tested is 5%; the measurement
+floor is 16-49%.
+
+What the data does support:
+
+- the round-1 **-14.1%** regression is **no longer reproducible** after the memoisation;
+- the residual sits somewhere around **-5% to +2%**, i.e. bounded far below round 1;
+- the history-enabled path itself improved **+17%** (median 2,070 -> 2,426) against `off`
+  medians that barely moved (2,410 -> 2,378).
+
+What it does not support: any claim that the 5% budget is met. Reporting the naive +2.0%
+as PASS would repeat precisely the error this report documents at the top.
+
+## How to resolve it properly
+
+Wall-clock full-node legs are the wrong instrument for a 5% effect on a shared laptop.
+Better options, in order of expected signal-to-noise:
+
+1. **Per-block CPU time** rather than wall clock — attribute via thread CPU accounting on
+   the apply thread, which excludes I/O jitter entirely.
+2. **The micro-profile harness** (`ProjectionEncodingProfileTest`), which resolved a 35%
+   change cleanly on the same machine that cannot resolve 5% end-to-end.
+3. **Many more legs** (20+ per mode) or a quiet dedicated host.
+
+Option 1 is the recommended next step and is cheap to add; it would make the 5% budget
+testable rather than aspirational.
+
+---
+
+# The real DuckLake sink, measured — §0.8 is WITHDRAWN
+
+**Date:** 2026-08-20
+**Deployment:** `/Users/satya/Downloads/yano-try/adr039-ducklake-preprod-20260820-0930/`
+**Artifact SHA-256:** `4937c4abda22e1899d59a4213cd2fff667d78d2da8f1e724ecf9bbdf8a139d42`
+**Ports:** HTTP 6295, node 14295
+**Config:** history enabled at genesis, `projection.sink=ducklake`, fresh chainstate
+
+## The finding
+
+The ADR-039 DuckLake projection sink **keeps up with full-speed bootstrap**. Measured over a
+61-second window mid-sync, with producer and sink running concurrently:
+
+```
+producer (complete)     1,193 blocks/s
+sink (acknowledged)     1,292 blocks/s
+backlog drift             -95 blocks/s   (shrinking)
+```
+
+The backlog does not accumulate. It sits at **4,319 blocks** — one below the configured
+`archiveFinalityBlocks = 4,320` — from block ~170,000 through ~4.8M. That is not the sink
+falling behind; it is the sink draining every block the moment it becomes rollback-safe and
+then waiting. **Rollback-safety, not sink throughput, is the binding constraint.**
+
+## What this retracts
+
+§0.8 of the Phase 0 report declared the drain margin "unreachable" and raised it as a
+blocking product decision. That conclusion was wrong, and it is withdrawn.
+
+The error was inferential, not arithmetic. ADR-038's **59.84 blocks/s** is the throughput of
+the *old replay-worker* path — independent per-dataset workers, repeated CBOR decode,
+contended shared writer, synchronous transaction locator — measured on mainnet. I used it as
+a proxy for the ADR-039 sink's capability. It is not one. The projection sink does no decode,
+no ledger resolution, and no locator work; it receives pre-derived rows and commits them in
+one transaction. Measured directly, it is roughly **20x** that figure and comfortably ahead of
+canonical production.
+
+The lesson is the one the review already stated and I failed to apply: *"Do not declare the
+new sink incapable of keeping up based solely on ADR-038's old worker rate. Measure the new
+sink directly first."*
+
+## Consequences for the design
+
+- **No bootstrap disk crisis.** The earlier projection of ~33 GB of accumulated outbox for a
+  mainnet genesis sync assumed a sustained producer/sink deficit. There is none: retained
+  outbox stays at the finality window, a few thousand blocks, regardless of chain length.
+- **Disk backpressure remains necessary but is not the normal path.** It protects against a
+  stalled or failed sink, not against ordinary bootstrap.
+- **Criterion 2's replacement still stands.** The bootstrap-capacity / catch-up-time /
+  steady-state-margin / disk-backpressure framing is the right contract; this measurement
+  simply shows the bootstrap-capacity term is satisfied with room to spare.
+
+## Status at the time of writing
+
+```
+block            4,823,565  of ~5.07M preprod tip
+backlog              4,319  blocks (= finality window)
+drain failures           0
+sink health          READY
+contributor status HEALTHY
+bytes/block          1,782-2,817 depending on density
+chainstate            27 GB
+history (DuckLake)   2.6-3.2 GB
+```
+
+Time-to-tip, archive-time-to-tip, and steady-state drain margin are still being collected and
+are reported separately once the run lands.
+
+## Defect found by this run
+
+The disk-backpressure hold was never attached. `installArchiveIngestHold` ran during
+`initialize()`, before any `HeaderSyncManager` exists, and logged its own failure.
+
+The deeper problem was worse than the timing: the manager belongs to a `PeerSession` that is
+**recreated on every reconnect**, so even a correctly ordered one-shot install would have been
+silently lost the first time upstream dropped — exactly when a backlog is most likely to have
+grown. The hold now lives on `SyncSubsystem`, which remembers it and re-applies it to each new
+session.
+
+This is the third composition defect in this project with the same shape: correct logic, wrong
+wiring, caught only because the failure path is loud.
+
+
+# Gate 1 resolved by attribution, not by differencing runs — 2026-08-20
+
+Wall-clock A/B legs could not decide a 5% effect on this host: the `off` legs spread 49%.
+Rather than run more legs, the projection's cost is now attributed **within a single run**, so
+cross-run variance cannot enter at all — there is no second run to difference against.
+
+## The instrument
+
+`DefaultUtxoStore` records, per applied block:
+
+- time inside `CanonicalProjectionContributor.contributeBlock`;
+- time inside the whole of `applyBlock`;
+- the full block cycle — apply plus the gap until the next block reaches apply.
+
+Thread CPU time would have been preferable and was tried first. It returns nothing here:
+`applyBlock` runs on a **virtual thread**, where `ThreadMXBean` reports no CPU time. Wall time
+is an acceptable substitute for this particular ratio because the contributor performs no I/O —
+it stages into an in-memory `WriteBatch` — so its wall time is essentially its CPU time, while
+the denominator legitimately includes the RocksDB write that projection also inflates.
+
+## Result
+
+Fresh preprod sync from genesis, DuckLake sink attached, **2,267,163 blocks**:
+
+```
+per-block cycle        520,033 ns     (1,923 blocks/s cumulative)
+per-block apply        159,789 ns     30.7% of cycle
+per-block projection    32,711 ns      6.3% of cycle, 20.5% of apply
+```
+
+The run continued to **3,107,640 blocks**, where the apply share had settled slightly lower —
+apply 169,818 ns, projection 31,378 ns, **18.5% of apply** — as later, denser blocks made apply
+itself more expensive. The ratio is stable in the 18-21% band across three million blocks, so
+the cycle figure above is not a lucky window.
+
+**The projection contributor costs at most 6.3% of sync throughput**, against a 5% budget.
+
+## Why "at most"
+
+The 6.3% assumes block apply sits wholly on the critical path. Where pipeline stages overlap,
+removing the projection recovers less than its measured share. So 6.3% is an **upper bound on
+the regression**, not a point estimate — which is the useful direction: the true cost is
+somewhere in `(0, 6.3%]`.
+
+It also excludes two things by construction:
+
+- **the sink drain**, which is asynchronous by design and not part of core sync;
+- **RocksDB write amplification** from the extra column families, measured separately at
+  roughly **1.4x** logical. Part of that lands inside the measured `applyBlock` window (the
+  batch write) and part in background compaction that does not.
+
+## What this settles, and what it does not
+
+Settled: the pre-optimisation **-14.1%** is not the current cost, and the residual is bounded
+above by 6.3% on a measurement whose variance is negligible over 2.27M blocks.
+
+Not settled: whether the true figure is under 5%. The bound straddles the budget. Closing it
+needs either apply's critical-path share (how much of the cycle gap is genuinely serialised
+behind apply) or a further reduction in staging cost. The remaining 20.5%-of-apply is
+concentrated in section encoding, which is where any further optimisation should look.
+
+This replaces "gate 1 is inconclusive on this hardware" with a number and an error direction.

--- a/adr/reports/adr-039-memory-invariant-2026-08-20.md
+++ b/adr/reports/adr-039-memory-invariant-2026-08-20.md
@@ -1,0 +1,116 @@
+# ADR-039 — projection memory invariant
+
+**Date:** 2026-08-20 · **Status:** implemented for v1, stated precisely
+
+## The invariant
+
+Deliberately **not** described as a fully configurable hard heap bound, because it is not one.
+
+| stage | bound | governed by |
+|---|---|---|
+| encoded outbox payload for a selected batch | bounded | `maxEncodedBytes` (configuration) |
+| transaction decode and row emission | streaming, one fact at a time | not retained |
+| derived rows across a batch | **not retained** | batch size no longer contributes |
+| UTXO decode | at most **one block's** decoded fact graph | protocol block size |
+| singleton envelope | one valid Cardano block and its deterministic projection expansion | protocol, plus an absolute safety guard |
+
+Two consequences worth stating explicitly:
+
+- **Batch size no longer contributes to decoded-fact or derived-row retention.** It does still
+  govern the encoded side: the selected `ProjectionEnvelope` objects and their chunks occupy
+  memory up to the configured encoded-byte bound.
+- **A singleton envelope may exceed the normal batch estimate.** It remains bounded by one
+  block, not by configuration. Beyond the absolute guard the node pauses visibly rather than
+  risking an OOM.
+
+## Why UTXO decode is not streamed
+
+Row derivation resolves every output's address through a map built from the section's address
+list, so outputs cannot be emitted before the addresses are known. Streaming it would mean
+either duplicating derivation logic — losing the property that the differential oracle and the
+projection path share one implementation — or restructuring `UtxoHistoryDataset`, which the
+oracle also uses.
+
+For v1 the one-envelope working set is accepted. It is already small and protocol-bounded, and
+restructuring shared code to turn a small bounded singleton into a configurable bound is not a
+good trade.
+
+## What changed to make the rest hold
+
+- `ProjectionChunkedInput` reads the chunk list as one stream, so `ProjectionChunking.join` is
+  gone from the pipeline and encoded bytes are never duplicated. Verified against 64-byte
+  chunks, which force facts to straddle boundaries ~1,000 times.
+- `ProjectionFactCodec.streamTransactions` decodes and releases one fact at a time.
+- The row source is **single-use**: a second `iterator()` throws. A partially consumed source
+  iterated again would produce a short or duplicated pass that looks like valid data. After a
+  failure the caller re-materialises from the still-unacknowledged outbox batch.
+
+## Absolute singleton safety guard
+
+`maxSingletonEncodedBytes` (64 MiB) and `maxSingletonRows` (4,000,000), configurable because a
+protocol upgrade may legitimately raise block limits. Set far above any plausible block, so
+they never fire in normal operation. Beyond them the accumulator returns `REJECTED_UNSAFE` and
+the coordinator must pause visibly with diagnostics — never skip, which would lose projection
+data, and never materialise, which risks taking the node down.
+
+## Observability
+
+`ProjectionBatchAccumulator.Stats` reports:
+
+- largest encoded envelope;
+- largest envelope row count;
+- count of singleton envelopes exceeding normal batch limits;
+- estimated singleton working-set high watermark;
+- largest envelope refused by the absolute guard (non-zero means the node paused);
+- the distribution of flush reasons.
+
+All of these are surfaced on `/api/v1/status` under `projection`, alongside the batch regime
+and both configured targets, so the observed distribution can be read next to the policy that
+produced it.
+
+## Evidence
+
+- **~2.96 MB** largest retained working set, observed on a production preprod sync. This is an
+  observation on one chain, **not a protocol maximum**, and must not be quoted as one.
+- Structural streaming is covered by 8 tests: multi-chunk decode across ~1,000 boundaries,
+  chunked-vs-joined equivalence, per-envelope retention across a 200-envelope batch, a dense
+  datum/redeemer/multi-asset block, an oversized singleton, mid-iteration sink failure with
+  deterministic retry, and single-use enforcement.
+### Instrumented peak retention (measured 2026-08-20)
+
+`ProjectionPeakRetentionMeasurementTest` measures retained heap directly rather than asserting
+it by construction. The fixture is calibrated to the densest genuine preprod blocks — 300
+outputs per envelope carrying 512-byte inline datums, multi-asset bundles and 512-byte
+redeemers, plus 20 transactions — which is far above the average block.
+
+Baseline is taken with the encoded envelopes already live, so the figure isolates the cost of
+materialising rows from the cost of holding the batch:
+
+```
+two sections (transaction, utxo-history)
+  5 envelopes ->   6,100 rows, peak retained 1,066 KiB, 4,488 B/row allocated
+100 envelopes -> 122,000 rows, peak retained 1,111 KiB, 4,430 B/row allocated
+
+all four sections (+ account-events, address-transaction)
+  5 envelopes ->  28,700 rows, peak retained 2,436 KiB, 3,280 B/row allocated
+100 envelopes -> 574,000 rows, peak retained 2,571 KiB, 3,265 B/row allocated
+```
+
+The four-section figures matter because the bound is a claim about the *design*, not about the
+first two datasets. Twenty times the batch still costs **5.5% more retained heap** with every
+shipped dataset enabled, and the address-transaction section — the heaviest per row — streams
+one transaction at a time rather than one envelope, so it is finer-grained than the bound
+requires.
+
+**Twenty times the batch costs 4% more retained heap.** Allocation scales with total rows, as
+it must — every row is still produced — but retention does not. A materialise-the-whole-batch
+implementation would show roughly 20x here, so this distinguishes a real bound from a nominal
+one.
+
+The densest single envelope measures **1,220 rows and 1,125 KiB** with two sections, and
+**5,740 rows and 6,467 KiB** with all four. That is the
+figure the absolute singleton safety guard (64 MiB encoded / 4,000,000 rows) is sized against;
+the guard sits roughly two orders of magnitude above anything observed.
+
+Still not measured: the same instrumentation against a densest *mainnet* fixture. Preprod
+density is the calibration source today.

--- a/adr/reports/adr-039-parquet-granularity-brief-2026-08-20.md
+++ b/adr/reports/adr-039-parquet-granularity-brief-2026-08-20.md
@@ -1,0 +1,223 @@
+# ADR-039 — Parquet granularity, commit batching and compaction
+
+**Design brief for review. Self-contained; assumes no prior context from the implementation
+session.**
+**Date:** 2026-08-20 · **Status:** open decision, not blocking correctness
+
+---
+
+## 1. Context
+
+ADR-039 replaces per-dataset replay workers with a canonical projection outbox:
+
+```
+canonical apply -> per-contributor RocksDB outbox -> finality gate -> DuckLake sink
+```
+
+A full fresh preprod sync with the real DuckLake sink completed successfully:
+
+| | |
+|---|---|
+| blocks | 5,076,688 (genesis to tip) |
+| wall clock | 1 h 07 m |
+| producer rate | 1,193 blocks/s |
+| sink rate | 1,292 blocks/s (concurrent, keeps up) |
+| outbox backlog | 4,320 blocks, pinned at the finality window |
+| drain failures | 0 |
+| coverage gaps | 0 |
+| archive size | 3.7 GB (chainstate 27 GB) |
+| rows committed | 87.4 M across 6 tables |
+
+Correctness is not in question. This brief is about **file granularity**.
+
+---
+
+## 2. The observation
+
+```
+67,603 Parquet files    average 56 KB    catalog 95 MB
+```
+
+---
+
+## 3. Cause — measured, and it is not the obvious one
+
+**File count tracks commits x tables.**
+
+```
+receipts x tables = 10,233 x 6 = 61,398        actual files 67,603
+configured target_file_size = 4 MiB            observed average 56 KB
+```
+
+Two candidate explanations were tested and rejected:
+
+- **`target_file_size` mis-tuned** — no. Each commit flushes its own file per touched table
+  regardless of how far below target it lands; 4 MiB was never approached. The setting caps
+  compaction *output*; it does not merge per-commit files. Raising it changes nothing alone.
+- **Batch cap too small** — no. Measured commit sizes:
+
+  ```
+  avg blocks/commit  495.7      max 2,000 (the cap)
+  commits at cap        81 of 10,233  = 0.8%
+  under 100 blocks   2,153       = 21%
+  single-block         171
+  ```
+
+**Actual cause: the drain loop commits whatever is eligible the instant it is eligible.**
+Because the sink outpaces the producer, a backlog never accumulates, so each pass takes only
+the few hundred blocks that just crossed the rollback-safety window. The loop's own speed
+fragments the output.
+
+---
+
+## 4. The fact that governs steady state
+
+```
+archiveFinalityBlocks = 4,320 blocks x 20 s = 24 HOURS
+```
+
+A block is not archive-eligible until ~24 h after production. **The archive is already a day
+behind tip by design.** Freshness was never measured in seconds, which makes a generous
+commit interval cheap in relative terms.
+
+---
+
+## 5. Two regimes with opposite characteristics
+
+| | bootstrap | at tip |
+|---|---|---|
+| block arrival | ~1,200 blocks/s | 1 block / 20 s |
+| binding limit | throughput | freshness |
+| 10,000-block floor costs | **8.4 s** of added lag | **2.3 days** of stalling |
+| query load | none (`catching_up`) | real |
+
+A block-count floor works for bootstrap and is unusable at tip. A time interval works at tip
+and is pointless during bootstrap. The rule must be **N blocks OR T elapsed, whichever comes
+first**, with different values per regime.
+
+### Bootstrap, with a 10,000-block floor
+
+| | now | with floor |
+|---|---|---|
+| commits | 10,233 | **508** (20x fewer) |
+| Parquet files | 67,603 | **3,046** (22x fewer) |
+| avg file | 56 KB | 1.2 MB |
+| catalog | 95 MB | 4.3 MB |
+| added lag | — | 8.4 s |
+
+### At tip, files are a pure function of commit interval
+
+| interval | blocks/commit | files/day | files/year | added staleness |
+|---|---|---|---|---|
+| 1 min | 3 | 8,640 | 3,153,600 | +1 min |
+| 10 min | 30 | 864 | 315,360 | +10 min |
+| 1 hour | 180 | 144 | 52,560 | +1 hour |
+| 6 hours | 1,080 | 24 | 8,760 | +6 hours |
+| 1 day | 4,320 | **6** | 2,190 | +1 day |
+
+Relative to an already-24 h-stale archive, an hourly interval adds ~4%.
+
+---
+
+## 6. Goal
+
+**~1 Parquet file per table per day at mainnet scale, without compromising throughput during
+initial sync or freshness at tip.**
+
+---
+
+## 7. Compaction — required, and constrained
+
+`ArchiveBackend.maintain(budget)` already implements budgeted `merge_adjacent_files`, with
+correct deferral on active reader snapshots and on capacity pressure.
+
+Two obstacles:
+
+1. **`ProjectionSink` has no maintenance operation at all.** Its contract is `append`,
+   `coordinate`, `receiptFor`, `health`, `close`. The only caller of `maintain` is
+   `HistoryArchiveService`, the replay-worker path being replaced. Wiring compaction into the
+   projection path is a **contract change**, not a scheduler change.
+2. **It contends with the sink.** `DuckDbManagerConfig` constrains
+   `maxConcurrentBulkJobs < maxConcurrentQueries`; sink commits and compaction draw from the
+   same bulk pool. During bootstrap the sink uses it continuously.
+
+Compaction cannot be avoided at tip: any time-based commit produces small files indefinitely,
+so steady state accumulates them regardless of how well bootstrap is tuned.
+
+---
+
+## 8. Resolved: unbounded row materialisation
+
+`ProjectionRowBuilder.materialise()` builds the whole batch's `ArchiveRow` list in heap before
+the sink sees it. Three different sizes for the same 10,000 blocks:
+
+| stage | size | bounded? |
+|---|---|---|
+| outbox section payload | 28 MB | yes — `maxBytesPerBatch` |
+| materialised `ArchiveRow` objects | ~86 MB+ | **no** |
+| final Parquet on disk | 7.1 MB | n/a |
+
+Measured 2,817 B/block in the outbox vs 709 B/block as Parquet: the archive is **4x smaller**
+than the payload it came from. The one stage that determines peak heap is the one stage
+unmeasured, and the ratio is not constant — redeemer- or datum-heavy blocks inflate it.
+
+Invisible at today's ~500-block commits (~4 MB). Material at a 10,000-block floor. ADR-039
+requires bounded memory, so raising the floor without bounding this trades a file-count
+problem for a heap problem.
+
+**Resolved.** `ProjectionRowBuilder` now streams: `ProjectionRowBatch` carries a single-use
+`Iterable<ArchiveRow>` that decodes one envelope at a time and never concatenates chunks.
+Instrumented measurement against a densest-preprod fixture (see
+`adr-039-memory-invariant-2026-08-20.md`) shows peak retained heap of **1,066 KiB at 5
+envelopes and 1,111 KiB at 100 envelopes** — 20x the batch for 4% more retained heap. Batch
+size no longer contributes to peak heap, so the block floor can be raised on file-count
+grounds alone.
+
+---
+
+## 9. Design choices — decided
+
+1. **Batch policy shape** — `N blocks OR T elapsed`, separate bootstrap and tip values.
+   Bootstrap 10,000 blocks / 30 s; near tip a **preferred target** of 50 envelopes with a hard
+   15-minute deadline. The regime is derived from the **eligible drain backlog**, not from a
+   header gap or an explicit switch: a sink that falls behind while the node sits at tip gets
+   the bootstrap regime and returns on its own. Self-correcting in both directions, and it
+   cannot disagree with reality.
+2. **Tip commit interval** — 15 minutes, which at 20 s slots flushes around 40-50 blocks and
+   yields ~96 commits/day. Neither hourly nor daily: daily commits would make history up to
+   24 h stale, and commit frequency is decoupled from file granularity because compaction
+   supplies the daily-file goal afterwards.
+3. **Compaction trigger** — on a timer (6 h default) **and** only when the sink is caught up
+   with no eligible backlog. Housekeeping is scheduled separately, on a 30-minute interval,
+   and runs during bootstrap: a mainnet bootstrap easily outlasts the snapshot retention
+   window, and an archive that waits for tip before ever cleaning up accumulates obsolete
+   files for the whole sync. Bulk-pool contention is arbitrated by construction — maintenance
+   runs on the drain thread itself, only on a pass with nothing to commit, so it can never
+   overlap an in-flight sink transaction.
+4. **Contract change** — `ProjectionSink.maintain(ProjectionMaintenance.Budget)` was added.
+   The result carries `UNSUPPORTED` so a backend without maintenance opts out honestly rather
+   than reporting a no-op as success.
+5. **`target_file_size`** — compaction output size in the 256 MB - 1 GB range. 8 GB is too
+   coarse: DuckLake prunes at file granularity before row groups, which penalises exactly the
+   `tx_hash` point lookups §15 already flags as weak without a locator, plus rewrite
+   amplification and compaction memory.
+6. **Bounding row materialisation** — resolved by streaming rather than by a cap; see §8. Row
+   and estimated-heap ceilings exist as well (2,000,000 rows, 512 MiB) but as a backstop, not
+   as the mechanism.
+
+---
+
+## 10. What is measured versus estimated
+
+| claim | basis |
+|---|---|
+| 67,603 files / 56 KB / 95 MB catalog | measured |
+| commits x tables drives file count | measured |
+| avg 495.7 blocks/commit, 0.8% at cap | measured (`projection_receipts`) |
+| sink 1,292 vs producer 1,193 blocks/s | measured, 61 s window |
+| outbox 2,817 B/block, Parquet 709 B/block | measured |
+| 24 h finality window | derived from config, exact |
+| 10,000-floor projections | arithmetic from measured rates |
+| ~86 MB materialised rows | superseded — streaming measured at 1.1 MiB peak retained regardless of batch size |
+| peak retained flat across 20x batch size | measured, instrumented (2026-08-20) |
+| mainnet file/catalog counts | extrapolated, not measured |

--- a/adr/reports/adr-039-phase-0-2026-08-19.md
+++ b/adr/reports/adr-039-phase-0-2026-08-19.md
@@ -1,0 +1,300 @@
+# ADR-039 Phase 0 — boundary proofs, recovery classification, foundation
+
+**Date:** 2026-08-19
+**Branch:** `feat/adr-039-canonical-projection-outbox`
+**Worktree:** `/Users/satya/work/bloxbean/yano/.claude/worktrees/adr-039`
+**Baseline commit:** `5a3cebec` (head of `feat/adr-038-archive-throughput`)
+
+All `file:line` citations below were read on this branch during Phase 0. Nothing is
+carried over from the review report on trust; each claim was re-verified in source.
+
+## 0.1 Baseline and branch decision
+
+`main` does not contain `archive-modules` at all (`git ls-tree main --name-only`),
+so branching from raw `main` is the alternative ADR-039 explicitly rejects
+(ADR §"Start from raw `main` and rewrite storage backends"). The ADR's own fallback
+(lines 1226–1230) authorises branching from the stable ADR-038 head and integrating
+`main`. This worktree branches from `5a3cebec`.
+
+**Deferred `main` merge — decided, with evidence.** `main` is 13 commits ahead
+(`git log --oneline HEAD..main`), touching mempool chained-transaction support,
+launcher `JAVA_OPTS` handling, and the plugin-catalog build. Two of those files are
+also ADR-039 integration points:
+
+- `runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoEventHandler.java` (+35/-…)
+- `runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoEventHandlerAsync.java` (+31/-…)
+- `runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java` (+34)
+
+Merging `main` requires a merge **commit**, which the implementation instructions
+forbid ("Do not commit, push, tag, or open a PR"). The merge is therefore deferred to
+the manual commit stage and recorded here as commit-plan step 0. This is a real
+residual risk: the ADR-039 contributor hook lands in the same two UTXO handler files
+`main` modifies, so that merge will need conflict resolution rather than a
+fast-forward.
+
+## 0.2 Canonical apply and contributor boundaries (ADR §8)
+
+**Verified: there is no shared canonical apply transaction, and ADR-039 must not
+create one.**
+
+| Boundary | Source | Finding |
+|---|---|---|
+| Canonical block store | `BodyFetchManager.java:673-703` | `chainState.storeBlock(...)` commits its own batch; `BlockAppliedEvent` is published *after* it returns (`:703`). |
+| UTXO apply | `DefaultUtxoStore.java:743` | Own `WriteBatch` + `WriteOptions` per block; own cursor. |
+| UTXO replay recovery | `DefaultUtxoStore.java:1714-1766` | Replays `lastAppliedBlock+1 .. tipBlock` from stored bodies — the production recovery model already exists. |
+| Byron sentinel | `DefaultUtxoStore.java:710` | `if (e.block() == null) return;` — the live UTXO path never applies a Byron transaction. |
+| Block-body prune clamp | `BlockPruner.java:73-77` | `cutoff = Math.min(cutoff, oldestRequired - 1)`, fed by `BlockBodyRetentionBoundary`. `oldestRequired == 0` disables pruning entirely. |
+
+**The atomicity enabler is confirmed in source.** `DirectRocksDBChainState`
+declares every subsystem's column family in one descriptor list at open
+(`:147-181`) and opens with
+`setCreateIfMissing(true).setCreateMissingColumnFamilies(true)` (`:117-118`).
+`rocks()` (`:282`) returns a `RocksDbContext(db, cfByName)` shared by all
+contributors. Therefore:
+
+1. New projection CFs can be added to that descriptor list and will be **created
+   on open** for both a fresh DB and an existing one — no migration step, no
+   open failure.
+2. A projection `batch.put(cfProjection, …)` inside the UTXO store's existing
+   `WriteBatch` (`:743`) is atomic with `cfUnspent`/`cfSpent` at zero extra cost.
+
+This is the cheapest correct boundary and is what ADR-039 §8 requires. No global
+cross-subsystem transaction is introduced.
+
+**Carried into implementation as a hazard:** `db.get()` cannot observe writes still
+pending in an uncommitted `WriteBatch`. A collector that writes a section and then
+reads it back within the same block must keep its own in-memory view. This is a
+known trap in this codebase and is called out in the Phase 2/3 design.
+
+## 0.3 Byron projection carrier (ADR §3, review B1)
+
+Verified: `BlockAppliedEvent` is published with a `null` block for **both** Byron
+paths — main blocks at `BodyFetchManager.java:896`, EBBs at `:1039` — and
+`BlockReceivedEvent` likewise at `:834` and `:977`.
+
+The `block() == null` sentinel is load-bearing outside the archive, so the carrier
+must be a **new event type**, never a flag or an overload. Consumers left untouched:
+`DefaultUtxoStore.java:710`, `DefaultUtxoProcessor.java:22`,
+`DefaultMempoolEvictionPolicy.java:38`, `InMemoryAccountStateStore.java:246`,
+`AppChainSubsystem.java:4952`.
+
+Byron main-block projection is a strict subset: nullable `chain_transaction.fee`
+(the column is nullable in `ArchiveSchemas.java`), base58 raw addresses, and no
+invalid-transaction, collateral, reference-input, datum, redeemer, multi-asset, or
+pointer-address facts. EBBs carry no transactions but do occupy block numbers, so
+they must emit an **empty** envelope or the "greatest contiguous coordinate" of
+§16 acquires a permanent hole.
+
+## 0.4 Staged-artifact durability audit (ADR §5/§7)
+
+Audited `DurableEpochFileSource` and `EpochArchiveStagingSink` directly. Every
+weakness the review reported is present on this branch:
+
+| Property | Status | Evidence |
+|---|---|---|
+| Row-file durability | **Absent** | `output.flush()` at `:282` is the only sync. No `FileChannel.force`, no fd fsync. |
+| Parent-directory durability | **Absent** | `move(...)` at `:234-237` uses `ATOMIC_MOVE` with a non-atomic fallback; no directory fsync follows. |
+| Content digest | **Absent** | No `MessageDigest`/checksum anywhere in the file. |
+| Row-count / version manifest | **Partial** | A `.properties` manifest is written at `:286-289` but carries no digest. |
+| Completion ordering | **Ordering only** | rows renamed (`:288`) then manifest renamed (`:289`). Gives ordering, not durability — after power loss a manifest can exist while the rows file is short. |
+| Capture failure isolation | **Fail-open by design** | `EpochArchiveStagingSink` javadoc: implementations "must isolate failures from the authoritative ledger transition". A required fresh-sync artifact cannot disappear that way. |
+| Lease safety | **Wall-clock only** | `:223-228` deletes a `.lease-` file once its stored deadline passes, with no proof the reader is gone. `:160` rejects reads on an expired lease. Time-based expiry races a slow reader. |
+
+Consequence for Phase 5: the staged path is a correct **logical-equivalence
+baseline** and is retained as such, but it is not power-loss durable and must not
+be described as such until forced writes, a digest, and fenced reader leases are
+added.
+
+## 0.5 Per-column recovery classification (ADR §5)
+
+Classification verified against the producing code, not inferred from schema.
+
+**Class 1 — exact persisted generation** (protect and stream; no boundary force needed)
+
+- `EPOCH_STAKE` — staged facts are appended in the *same pass* that builds the
+  persisted delegation snapshot, which is written through the epoch `WriteBatch`
+  (`DefaultAccountStateStore.java:3547-3560`). Largest artifact (~1.3M rows/epoch
+  on mainnet) and the one driving the epoch-boundary cost — and it needs no forcing.
+- `ADA_POT` — persisted per epoch under an epoch-keyed state key
+  (`AdaPotTracker.storeAdaPot`). One row per epoch, so representation is
+  performance-irrelevant.
+- `DREP_DISTRIBUTION` **amount column only** — `storeDRepDistEntry(newEpoch, …)`
+  plus a snapshot marker (`GovernanceEpochProcessor.java:670-675`).
+
+**Class 2 — conditionally recomputable** (retain the complete input closure + versions)
+
+- `REWARD` — captured mid-calculation (`EpochRewardCalculator.java:144`). There is
+  no rewards column family in `AccountStateCfNames`; per-account amounts are applied
+  to accounts and the decomposition (source pool, reward type, earned/spendable
+  epoch) is not retained. Recomputation therefore imposes a *retention* contract on
+  its inputs, not just a recompute step.
+
+**Class 3 — not reconstructible** (needs atomic evidence or fail-closed durable capture)
+
+- `DREP_DISTRIBUTION` boundary-state columns `stored_expiry`, `dormant_epochs`,
+  `effective_expiry`, `active` (`ArchiveSchemas.java`, drep table). They are read
+  from `getAllDRepStates()` / `getNumDormantEpochs()` **at the boundary**
+  (`GovernanceEpochProcessor.java:679-695`) while only the amount is persisted per
+  `(epoch, drepType, hash)`. Re-deriving them later recomputes from DRep state that
+  has since mutated and silently produces different values for an epoch-keyed row.
+  ADR §5 eligibility criterion 2 ("never updated in place after closure") therefore
+  has to be evaluated **per column**.
+- `GOVERNANCE_PROPOSAL_STATUS` observation phase and decision reason, derived at
+  ratification time (`GovernanceEpochProcessor.java:789`).
+
+## 0.6 Retention floor and the delegation-snapshot clamp
+
+`DefaultAccountStateStore.getRollbackFloorSlot()` (`:3934-3966`) already computes
+the reward input closure boundary as the max of two floors:
+
+- **reward-input floor** — from the earliest retained per-block issuer/fee facts;
+  reward calc for epoch N reads stakeEpoch N-2, so the earliest replayable boundary
+  is `earliestRewardEpoch + 2`.
+- **snapshot floor** — `earliestSnapshot + 4`, because reward calculation for epoch
+  N reads the snapshot at N-4.
+
+Both degenerate branches return `getLatestAppliedSlot()` (the tip) when no replay
+window exists (`:3946`, `:3961`). Combined with `RollbackCapableStore`'s documented
+"0 means unbounded retention" and the runtime's `max` across stores
+(`RuntimeNode.java:2891-2895`), this confirms the ADR's corrected direction: a
+**lower** floor means **more** capability, so the floor belongs in a retention-health
+assertion, never inside an eligibility `min()`.
+
+The clamp point for the class-1 `EPOCH_STAKE` lease is exact and single:
+`pruneOldSnapshots(newEpoch - snapshotRetentionEpochs, batch)`
+(`DefaultAccountStateStore.java:2513`, implementation `:3772-3786`). The lease must
+lower `oldestToKeep` to the oldest active artifact requirement. Without it a sink
+lagging more than `snapshotRetentionEpochs` loses the generation its reference
+points at.
+
+Archive eligibility stays on `ArchiveSafetyWindows.resolve(...)`, which was read and
+confirmed to enforce `finality >= rollback >= k` and to default both windows to `2k`
+(`ArchiveSafetyWindows.java:20-30`).
+
+## 0.7 Dataset / table / projection-version map (input to Phase 1)
+
+Read from `ArchiveSchemas.java` and `ArchiveDatasetId.java`. Phase 1 preserves this
+mapping exactly; transport section grouping must not alter it.
+
+| Dataset | projectionVersion | Tables |
+|---|---|---|
+| `TRANSACTION` | 2 | `chain_transaction` |
+| `UTXO_HISTORY` | 5 | `transaction_outputs`, `transaction_output_assets`, `transaction_inputs`, `transaction_datums`, `transaction_redeemers` |
+| `ACCOUNT_EVENT` | 3 | `account_events` |
+| `ADDRESS_TRANSACTION` | 3 | `address_transactions` |
+
+`transaction_datums` and `transaction_redeemers` stay under `UTXO_HISTORY:v5`. The
+first slice is therefore `transaction:v2` (1 table) + `utxo-history:v5` (5 tables) =
+the six physical tables ADR §3 names.
+
+Confirms review D4: `transaction_inputs` records the *referenced outpoint*
+(`spending_tx_hash, spending_tx_index, input_index, input_role, referenced_tx_hash,
+referenced_output_index, consumes_output, block_*`) and does **not** denormalise the
+consumed output. The first slice therefore needs no consumed-output lookup;
+decode-once is the real win. `ADDRESS_TRANSACTION`/`ACCOUNT_EVENT` are the datasets
+that need resolved outputs, and for Byron they cannot use live state at all.
+
+## 0.8 BLOCKING DECISION — the sink drain margin is unreachable as specified
+
+ADR-039 acceptance criterion 2 requires the primary sink to sustain a drain rate **at
+least 20% greater** than concurrent history-enabled canonical production, "or an
+explicit product decision accepting sink-paced core sync with sized disk/backpressure".
+
+The first branch is unreachable. The second is the only live option, and it is a
+product decision this implementation cannot make on its own.
+
+### The measurement
+
+History-disabled fresh preprod sync, this branch's artifact, isolated deployment:
+
+```
+average           2190 blocks/s   (block 115,299 -> 2,745,475 over 1201 s)
+early chain       ~2400-3300 blocks/s   (sparse Byron/Shelley blocks)
+dense Conway      ~1500-2000 blocks/s
+```
+
+The only measured sink rate is ADR-038's 59.84 blocks/s in its accepted production
+window.
+
+### What this does and does not prove — stated narrowly
+
+These two numbers are **not the same workload** and must not be reported as a single
+ratio:
+
+- 2190 blocks/s is *history-disabled core on preprod*, weighted toward sparse
+  early-chain blocks.
+- 59.84 blocks/s is the *mainnet* four-dataset replay worker, including the repeated
+  CBOR decode that ADR-039 exists to remove.
+
+The defensible statement is therefore narrower than a raw ratio:
+
+> The history-disabled preprod core rate exceeds the only measured sink rate by
+> roughly 1.5 orders of magnitude. Removing repeated decode — measured by ADR-038 at
+> ~82–86% of per-block worker cost — cannot close a gap of that size. Even the
+> optimistic 100–190 blocks/s the review projected for a decode-free sink leaves core
+> production an order of magnitude ahead.
+
+So criterion 2's 20% margin is not a tuning target that better batching might reach.
+It is unreachable on this hardware and profile.
+
+### Consequence, per ADR §"Performance model"
+
+`Rs < Rc` means retained bytes grow as `(Rc - Rs) * B * elapsedSeconds`. On a genesis
+sync that is not a transient backlog but a product mode: either the outbox holds a
+material fraction of the entire archive inside the hot RocksDB — inflating its
+compaction and write amplification, per review D3 — or the hard limit throttles
+canonical ingestion to sink speed.
+
+**This is the fork ADR-039 says must be chosen explicitly:**
+
+1. accept sink-paced core sync with sized disk and backpressure (the ADR's own
+   fallback, and the only option consistent with the measurement);
+2. invest in sink optimisation beyond decode removal;
+3. change resources/profile;
+4. revise scope — most concretely, retire `ADDRESS_TRANSACTION` rather than
+   implementing Phase 4b parity for it.
+
+Implementation continues on every phase that does not depend on which branch is
+chosen. Phase 3 in particular is required under all four and additionally produces the
+missing input to this decision.
+
+### What is still unmeasured
+
+`B` — outbox bytes per canonical block — cannot be measured until contributors write,
+which is Phase 3. Until then the full-sync backlog model has no input, and no wall-clock
+estimate for a history-enabled mainnet sync is offered here. Gate 4 is open.
+
+## 0.9 Measurement gate — status
+
+The history-disabled core baseline (the number review B4 calls "the single most
+decision-relevant number in this ADR") is **being measured now**, not estimated.
+
+- Deployment: `/Users/satya/Downloads/yano-try/adr039-phase0-baseline-preprod-20260819-230037/`
+- Artifact: `yano.jar`, SHA-256 `d22c9640b04940b99e89a525844e924ff796cf310663c0466b2eb28aee554081`
+- Build: `./gradlew :app:quarkusBuild` at `5a3cebec`, exit 0
+- Config: fresh chainstate, `yano.history.enabled=false`, HTTP 6291, node 14291
+  (both verified free before launch), profile `preprod`
+- Command: `java -Xmx6g -Dquarkus.profile=preprod -jar yano.jar`
+- Sampler: `sampler.sh 60` → `samples.tsv` (resumable; exits when the node exits)
+
+No other Yano process was running when this was launched (`ps` enumerated: only
+Gradle daemons, jshell, and IntelliJ). Existing deployments under
+`/Users/satya/Downloads/yano-try/` were read for config shape only and never
+written to, signalled, or started.
+
+## Phase 0 exit status
+
+| Exit criterion | Status |
+|---|---|
+| Per-contributor durability/replay boundaries mapped in source | **Met** — §0.2 |
+| No global cross-subsystem batch required | **Met** — shared RocksDB + per-contributor `WriteBatch` |
+| Byron/EBB carrier design proven against source | **Met** — §0.3 |
+| Every initial row field has an identified source | **Met** — §0.7 (first slice needs no consumed-output resolution) |
+| Staged-artifact audit | **Met** — §0.4, all seven properties assessed |
+| Per-column recovery matrix | **Met** — §0.5 |
+| Delegation-snapshot clamp point identified | **Met** — §0.6 |
+| Foundation builds | **Met** — `:app:quarkusBuild` exit 0 |
+| Crash tests proving per-contributor replay | **Deferred to Phase 2** — the outbox must exist before its crash boundaries can be exercised |
+| Core-rate baseline measured | **Met** — 2190 blocks/s, §0.8 |
+| Sink drain margin (criterion 2) | **FAILED — blocking product decision**, §0.8 |
+| Outbox bytes/block and backlog model (gate 4) | **Open** — requires Phase 3 contributors |

--- a/adr/reports/adr-039-phase-1-2-2026-08-19.md
+++ b/adr/reports/adr-039-phase-1-2-2026-08-19.md
@@ -1,0 +1,159 @@
+# ADR-039 Phases 1–2 — contracts, identity, fresh-sync guard, durable outbox
+
+**Date:** 2026-08-19
+**Branch:** `feat/adr-039-canonical-projection-outbox`
+
+## Phase 1 — contracts, identity, and fresh-sync guard
+
+### What was built
+
+`archive-modules/archive-api/.../projection/` (18 types), `archive-modules/archive-core/.../projection/`
+(codec + guard). Both compile and are covered by 46 tests.
+
+### Design decisions worth review
+
+**Section identity is derived, not declared.** `ProjectionSectionType` binds each
+section permanently to one `ArchiveDatasetId` and reads its version from
+`ArchiveSchemas.schema(dataset).projectionVersion()` rather than declaring one. That
+makes the ADR's rule — "section names are transport groupings, not permission to
+change archive dataset identity" — a compile-time property instead of a review
+convention. A test asserts the resulting wire names:
+
+```
+transaction:v2   utxo-history:v5   account-events:v3   address-transaction:v3
+```
+
+Note `account-events:v3`, not the ADR §4 illustrative `account-events:v1`. The
+shipped `ACCOUNT_EVENT` projectionVersion is 3, and preserving it is what §3 requires.
+A separate test pins `transaction_datums` / `transaction_redeemers` under
+`UTXO_HISTORY`, which is review finding D2.
+
+**Envelope identity is derived and unforgeable.** `ProjectionEnvelopeHeader.envelopeId()`
+is a method over network identity, block number, slot, block hash, parent hash and
+projection version — not a stored field. A caller cannot supply an id that disagrees
+with the header it labels, and a replacement block at the same height necessarily gets
+a different id because its hash participates. Tests cover determinism, replacement
+divergence, and sensitivity to projection version and network.
+
+**Completeness is proven by construction.** `ProjectionEnvelope`'s constructor verifies
+every manifested section against its actual payload (chunk count, row count, byte
+count, digest). An envelope that exists is internally consistent, so invariant 11 ("a
+sink cannot acknowledge an envelope with a missing chunk") cannot be violated by
+forgetting a check. `ProjectionDigest` length-prefixes chunks, so a differently split
+but byte-identical concatenation is a different digest — chunking is part of the
+contract, not an incidental transport detail.
+
+**EBBs are modelled explicitly.** `ProjectionBlockKind` has `BYRON_EBB`, and the header
+constructor *rejects* a non-empty EBB envelope. Empty EBB envelopes are what keep the
+"greatest contiguous coordinate" of §16 from acquiring a permanent hole.
+
+### Exit criteria
+
+| Case | Result | Test |
+|---|---|---|
+| malformed record | fails closed | `aForeignRecordIsRejected` |
+| unsupported format version | fails closed | `anUnsupportedFormatVersionIsRejected` |
+| truncated record | fails closed | `aTruncatedRecordIsRejected` |
+| trailing bytes | fails closed | `trailingBytesAreRejected` |
+| unknown required section | fails closed | `anUnknownSectionWireNameIsRejectedRatherThanSkipped` |
+| sink cannot serve a required section | fails closed at startup | `aSinkThatCannotServeARequiredSectionFailsAtStartupNotAtFirstUse` |
+| wrong network | fails closed | `aWrongNetworkArchiveIsRejected` |
+| wrong genesis (same magic) | fails closed | `aWrongGenesisArchiveIsRejectedEvenOnTheSameMagic` |
+| wrong projection version | fails closed | `aMismatchedOutboxIdentityIsRejectedBeforeTheArchiveIsConsidered` |
+| mid-chain activation | fails closed | `enablingHistoryMidChainIsRejected` |
+| mismatched sink engine | fails closed | `aMismatchedSinkEngineIsRejected` |
+| fresh chainstate + populated archive | fails closed | `aFreshChainstatePointedAtAPopulatedArchiveIsRejected` |
+| existing chainstate + empty archive | fails closed | `anExistingChainstatePointedAtAnEmptyArchiveIsRejected` |
+
+Golden serialization fixture pinned at
+`4d41e29892b91f4c01982d0f4b0c30e6072ea99103cd32b8374e3fd6d824c848`. A change to that
+digest means the persisted wire format changed and requires a format-version bump, not
+a test edit.
+
+## Phase 2 — durable block outbox
+
+### The atomicity mechanism, as built
+
+`ProjectionCfNames` lives in **core-api** and declares four column families
+(`proj_header`, `proj_section`, `proj_meta`, `proj_artifact`). They are added to the
+single descriptor list in `DirectRocksDBChainState` (`:181`), which opens with
+`setCreateMissingColumnFamilies(true)` — so they are created on open for both fresh
+and existing databases, with no migration step and no dependency from runtime on any
+archive module or on DuckLake/SQLite.
+
+`ProjectionOutboxStore.putSection(WriteBatch, …)` writes the section manifest, its
+chunks, and the contributor's cursor into a **caller-supplied** batch. A contributor
+therefore commits its section in the same batch as the state it derived it from. There
+is no batch spanning chain, UTXO and ledger, exactly as §8 requires.
+
+Two design points that came out of reading the code rather than the ADR:
+
+- **The header is not written by one contributor.** A contributor cannot manifest
+  sections it does not own. So `putBlockIdentity` stores only canonical block identity,
+  and the full header — with section manifests — is *derived at read time from what is
+  actually stored*. The manifest therefore cannot claim a chunk that is absent. This is
+  strictly stronger than storing a promised manifest up front.
+- **Cursors rewind on rollback.** `rollbackFrom` pulls every contributor cursor back
+  with the deleted data. Leaving a cursor ahead would make the outbox believe a block
+  it no longer holds was already contributed, and the replacement block at that height
+  would never be projected. A test covers this, including the case where a cursor is
+  already behind and must not be moved forward.
+
+`advanceContributor` exists because a block that legitimately produces no rows for a
+dataset must still advance that contributor, or the envelope would wait forever on a
+contributor with nothing to say.
+
+### Finality and retention are separate quantities
+
+`ProjectionFinalityGate` computes `tip - max(archiveFinalityBlocks,
+rollbackRetentionBlocks)` from the existing `ArchiveSafetyWindows`; because `resolve`
+enforces `finality >= rollback >= k`, that reduces to `tip - archiveFinalityBlocks`. No
+second archive-only finality calculation was introduced.
+
+`ProjectionRetentionHealth` is deliberately *not* a term in eligibility. It asserts
+`commonRollbackFloor <= oldestActiveRequiredSlot`, with equality as an exhaustion
+warning and a greater floor as fail-closed. This is the correction from review
+Addendum 3: a lower floor means more capability, so a `min()` would make the archive
+most restricted exactly when retention is best and would stall at slot 0 under
+unbounded retention. A test asserts that unbounded retention (`floor = 0`) allows
+progress, and that a violation **pauses** without narrowing eligibility, skipping work,
+or pruning the source.
+
+### Crash boundaries covered (ADR §11)
+
+| Case | Covered | Test |
+|---|---|---|
+| 2. crash after a contributor commit before envelope completion | yes | `aPartiallyContributedBlockSurvivesRestartAndRemainsIncomplete` |
+| 3. crash after complete durable outbox commit before sink start | yes | `aCompleteEnvelopeSurvivesRestartIntact` |
+| 6. sink commit failure | yes | `aSinkFailureBeforeCommitLeavesTheOutboxIntact` |
+| 7. crash after sink commit before acknowledgement | yes | `aCrashBetweenSinkCommitAndAcknowledgementReplaysWithoutDuplicating` |
+| 8. crash after acknowledgement during cleanup | yes | `acknowledgementSurvivesRestartAndDoesNotResurrectCleanedData` |
+| 11. sink unavailability to soft/hard thresholds | yes | `softAndHardBacklogBoundsAreReportedRatherThanDiscardingData` |
+| rollback of pending envelopes | yes | `rollbackRemovesPendingEnvelopesAndRewindsEveryCursor` |
+| receipt replay / mismatch | yes | `aDifferentlyShapedRetryForTheSameRangeIsRejected` |
+| torn section record | yes | `aSectionWithFewerChunksThanItsManifestDeclaresIsRejected` |
+
+Cases 1, 4, 5, 9, 10, 12, 13 involve a real sink or artifacts and belong to Phases 3–5.
+
+### Exit criteria
+
+Long restart/rollback/failure loops show contiguous coordinates with no lost or
+duplicated envelope identities: `repeatedDrainsAdvanceContiguouslyAndThenGoIdle`
+(101 blocks, batch bound 10, asserts contiguity and exact final coverage),
+`repeatedSinkOutageKeepsTheBacklogBoundedAndOrderedOnRecovery`, and
+`acknowledgedChunksAreDeletedSoTheOutboxDoesNotGrowWithoutBound`.
+
+## Test totals
+
+| Suite | Tests |
+|---|---|
+| `ProjectionContractsTest` (archive-api) | 22 |
+| `ProjectionEnvelopeCodecTest` | 10 |
+| `ProjectionStartupGuardTest` | 14 |
+| `ProjectionOutboxStoreTest` | 21 |
+| `ProjectionOutboxConsumerTest` | 14 |
+| **total new** | **81** |
+
+Full `:archive-modules:archive-core:test` and `:archive-modules:archive-api:test`
+suites pass, including all pre-existing tests. `:runtime:compileJava` passes with the
+new column families declared.

--- a/adr/reports/adr-039-phase-3-2026-08-19.md
+++ b/adr/reports/adr-039-phase-3-2026-08-19.md
@@ -1,0 +1,199 @@
+# ADR-039 Phase 3 — transaction and UTXO vertical slice
+
+**Date:** 2026-08-19
+**Branch:** `feat/adr-039-canonical-projection-outbox`
+
+## The core/runtime change, in full
+
+This is the complete set of changes to runtime and core. Each is listed so the
+"minimum necessary" constraint can be checked rather than asserted.
+
+| File | Change | Why it is necessary |
+|---|---|---|
+| `core-api/.../archive/ProjectionCfNames.java` | new, 4 constants | Both runtime and archive need the column-family names and neither may depend on the other. |
+| `core-api/.../archive/ProjectionStagingWriter.java` | new, 1 method | Opaque staging so `core-api` needs no RocksDB dependency and runtime needs no encoding knowledge. |
+| `core-api/.../archive/CanonicalProjectionContributor.java` | new SPI + `NOOP` | The hook contract. `NOOP` is what a history-disabled node holds. |
+| `core-api/.../events/ByronBlockProjectionEvent.java` | new event type | Byron has no live-path source; see below. |
+| `runtime/.../chain/DirectRocksDBChainState.java` | +4 CF descriptors, +1 import | Puts the outbox in the same physical RocksDB as UTXO/account state, which is what makes per-contributor atomicity free. |
+| `runtime/.../BodyFetchManager.java` | +2 publish calls, +1 import | Publishes the Byron carrier at the two existing Byron apply sites. |
+| `runtime/.../utxo/DefaultUtxoStore.java` | +2 fields, +1 setter, +1 hook, +1 import | Stages projection sections into the existing block `WriteBatch`. |
+
+No global cross-subsystem transaction was introduced. No archive backend I/O occurs in
+canonical apply. Runtime does not reference DuckLake, SQLite, or `archive-core`.
+
+**History-disabled cost.** The hook is guarded by `projectionContributor.enabled()` on a
+`volatile` field holding `CanonicalProjectionContributor.NOOP`, whose `enabled()` returns
+a constant `false`. The Byron publications go to an event bus with no subscriber.
+
+## Why the collector adds no second interpretation of the chain
+
+Both existing decoders already expose an entry point that derives facts from an
+**already-decoded** block — `YaciBlockArchiveDecoder.project(BlockSourceContext<Block>)`
+and `YaciUtxoHistoryDecoder.project(...)`. The collector calls exactly those. It performs
+no CBOR parsing.
+
+More importantly, the section payload carries the same `TransactionFact` and
+`UtxoHistoryFact` types the archive datasets already consume, so the sink rebuilds rows
+through the very same `BlockArchiveDataset.derive` implementations the replay workers
+use. ADR-039 therefore changes *when and how often* facts are produced, not *what they
+are*. Any parity divergence is necessarily a transport defect — a lossy encoding, a
+reordering, a dropped nullable — rather than two hand-written row builders drifting
+apart. This was a deliberate choice over writing a second row builder, and it is what
+makes the differential gate meaningful rather than tautological.
+
+## Byron
+
+`ByronBlockProjectionEvent` is a **new type**, published at `BodyFetchManager:896`
+(main) and `:1039` (EBB), alongside the existing `BlockAppliedEvent`. It carries the
+already-decoded block, so the cost is one allocation and a bus dispatch.
+
+The five consumers that rely on `BlockAppliedEvent.block() == null` as a Byron/EBB
+sentinel are untouched: `DefaultUtxoStore:710`, `DefaultUtxoProcessor:22`,
+`DefaultMempoolEvictionPolicy:38`, `InMemoryAccountStateStore:246`,
+`AppChainSubsystem:4952`.
+
+`ByronBlockNormalizer` was **extracted** from `YaciBlockDecoder.decodeByron`, which now
+delegates to it. That removes the duplicated mapping and, more importantly, makes the
+replay path and the projection carrier share one definition of what a normalized Byron
+block is — they cannot drift.
+
+EBBs contribute an empty envelope and advance every required contributor. Without that,
+the greatest *contiguous* committed coordinate would stop permanently at the first epoch
+boundary.
+
+## Bounded envelopes
+
+`ProjectionChunking` splits an encoded section deterministically at a configured bound
+(default 1 MiB). Splitting is part of the digested contract — `ProjectionDigest`
+length-prefixes chunks — so a differently split but byte-identical payload is a
+different digest, and reassembly is verified against the manifest.
+
+## Differential parity — Phase 3 exit criterion
+
+`ProjectionDifferentialParityTest` renders both paths' `ArchiveRow` output to a
+canonical string (hex for `byte[]`) and asserts exact equality.
+
+| Fixture | Status |
+|---|---|
+| empty block | pass |
+| simple valid transaction | pass |
+| invalid transaction + collateral + collateral return + reference inputs | pass |
+| same-block parent/child spend, canonical order | pass |
+| multi-asset outputs | pass |
+| datum hash + inline datum | pass |
+| redeemers with execution units | pass |
+| dense block, 60 transactions, 3 invalid | pass |
+| Byron-style block: null fee, base58 address | pass |
+| multi-chunk section reassembly | pass |
+
+`ByronProjectionCarrierTest` drives genuine `ByronMainBlock`/`ByronEbBlock` values:
+
+| Case | Status |
+|---|---|
+| genuine Byron main block produces a projectable envelope | pass |
+| Byron fee reaches `chain_transaction` as SQL NULL, not zero | pass |
+| Byron outputs keep raw base58 addresses | pass |
+| Byron has no collateral/reference/datum/redeemer/asset facts | pass |
+| EBB emits an empty envelope and advances every contributor | pass |
+| EBB between two main blocks keeps the coordinate contiguous | pass |
+| Byron parent bridge preserved through the envelope header | pass |
+| empty Byron main block still produces an envelope | pass |
+| normalizer agrees with the carrier path | pass |
+
+## Test totals after Phase 3
+
+| Suite | Tests |
+|---|---|
+| `ProjectionContractsTest` | 22 |
+| `ProjectionEnvelopeCodecTest` | 10 |
+| `ProjectionStartupGuardTest` | 14 |
+| `ProjectionOutboxStoreTest` | 24 |
+| `ProjectionOutboxConsumerTest` | 14 |
+| `ProjectionDifferentialParityTest` | 10 |
+| `ByronProjectionCarrierTest` | 9 |
+| **total new** | **103** |
+
+## What Phase 3 does not yet do
+
+- `ACCOUNT_EVENT` and `ADDRESS_TRANSACTION` return no section; their contributors are
+  advanced rather than marked complete, so they cannot silently look finished. Phase 4b.
+- The collector is built and unit-tested but **not yet wired into application
+  composition**, so no measurement of outbox bytes per block on a live sync exists yet.
+  Gate 4 remains open.
+- Byron address/account participation still needs the archive-owned sequential resolver
+  (Phase 4b); the first slice does not require it, because `transaction_inputs` records
+  the referenced outpoint rather than denormalising the consumed output.
+
+---
+
+# Phase 3b — application composition and first live measurement
+
+Added after the unit-tested slice, so the producer side could be measured on a real
+fresh preprod sync rather than estimated.
+
+## Additional core/runtime changes
+
+| File | Change | Why |
+|---|---|---|
+| `core-api/.../YanoPropertyKeys.java` | +11 `History.PROJECTION_*` keys | Configuration surface. |
+| `runtime/.../kernel/NodeKernel.java` | +`context()` accessor | Reaches the shared event bus without creating a second one. |
+| `runtime/.../utxo/UtxoSubsystem.java` | +`installProjectionContributor` | Returns `false` when no contributing store exists, so the caller can fail closed. |
+| `runtime/.../internal/RuntimeNode.java` | +`installProjectionContributor`, +`chainstateRocksAccess` | See the kernel-lookup finding below. |
+| `runtime/.../assembly/Yano.java` | +2 defaulted methods | Host-facing seam; both default to "not available". |
+| `runtime/.../assembly/RuntimeYano.java` | +2 overrides | Delegates to `RuntimeNode`. |
+| `app/.../archive/ProjectionHistoryService.java` | new | Composes identity, guard, outbox, collector, subscriptions, status. |
+| `app/.../YanoProducer.java` | +init/close call, +inject | Startup wiring. |
+| `app/.../api/status/StatusResource.java` | +`projection` status block | Measurement and operator visibility. |
+
+`ProjectionHistoryService` is deliberately **separate** from the 2,251-line
+`HistoryArchiveService`: that service orchestrates the replay-worker architecture
+ADR-039 replaces, and the two must run side by side while the old path is the
+differential oracle. Mixing them would make the eventual removal commit far harder to
+review.
+
+## Two defects the live run caught that tests did not
+
+1. **`NodeKernel.subsystem(UtxoSubsystem.class)` finds nothing.** The kernel is composed
+   of lifecycle *stages* (`RuntimeKernelStages.create(...)`), not subsystem instances, so
+   a type lookup silently returns empty. Installation is therefore routed through
+   `RuntimeNode`, which holds the subsystem directly. This was caught only because the
+   installer **fails closed** — the node refused to start rather than syncing while
+   capturing nothing. Had it been best-effort, the run would have looked healthy and
+   produced an empty archive.
+
+2. **`yano.history.rollback.retention-blocks` ships with the literal default `"auto"`.**
+   Reading it as `Long` threw at startup. The existing service has an `autoLong` helper
+   for exactly this; the projection service now uses the same handling.
+
+Both are recorded because they are the class of bug a unit test cannot reach: they live
+in composition, not logic.
+
+## First live measurement — gate 4 opens
+
+Fresh preprod sync, history enabled at genesis, `sink=none` (producer-only, so core
+overhead and outbox growth are measured without a sink in the loop).
+
+- Deployment: `/Users/satya/Downloads/yano-try/adr039-projection-preprod-20260819-234600/`
+- Artifact SHA-256: `42dd0da090e37a1e514fd9b531bb490621be84952b95bb79153ef1ad0c0b6978`
+- Ports: HTTP 6293, node 14293 (both verified free)
+
+Observed at block ~123,000 (sparse early chain):
+
+```
+identity            1:162d29c4…|none|v1|transaction:v2,utxo-history:v5
+pendingBlocks       122,139
+pendingBytes        5,134,647
+bytesPerBlock       42
+completeThrough     123,053
+contributorStatus   HEALTHY
+contributorCursors  transaction:v2 = 123,053   utxo-history:v5 = 123,053
+```
+
+Both contributors advance in lockstep with canonical apply, the envelope coordinate is
+contiguous from block 0, and nothing has stalled. 42 bytes/block is an early-chain
+figure over near-empty blocks and will rise substantially through Alonzo/Babbage; the
+sampler records it across density for the backlog model.
+
+The `sink=none` mode is itself a deliberate product affordance, not a test hack: it is
+the configuration in which the drain-margin fork of §0.8 can be re-measured against any
+future sink without re-running the producer.

--- a/adr/reports/adr-039-phase-4-2026-08-20.md
+++ b/adr/reports/adr-039-phase-4-2026-08-20.md
@@ -1,0 +1,96 @@
+# ADR-039 Phase 4 — DuckLake primary sink
+
+**Date:** 2026-08-20
+**Branch:** `feat/adr-039-canonical-projection-outbox`
+
+## The layering decision this phase forced
+
+`archive-store-ducklake` depends on `archive-api` only — not on `archive-core`. That is
+the dependency direction ADR-039 requires ("dependency direction is toward
+`archive-api`; storage backends do not depend on runtime internals"), and it is
+incompatible with the sink contract as originally drafted: `ProjectionSink.append` took
+a `ProjectionBatch`, whose section payloads are encoded facts that only the archive-core
+codec can decode. Honouring the signature would have dragged the fact model and codec
+into every storage backend.
+
+The contract was therefore changed so **row derivation happens once, in shared
+archive-core code, before any sink sees the batch**:
+
+```
+outbox envelopes -> ProjectionRowBuilder (archive-core) -> ProjectionRowBatch -> sink
+```
+
+New/changed contracts:
+
+- `ProjectionJob` — the identity of one deterministic job (identity, range, envelope
+  ids, ordered digest). Implemented by both `ProjectionBatch` and `ProjectionRowBatch`,
+  so receipt identity and idempotency are defined exactly once instead of twice.
+- `ProjectionRowBatch` — a batch already materialised into `ArchiveRow`s.
+- `ProjectionSink.append(ProjectionRowBatch, ArchiveArtifactReader)`.
+- `ProjectionReceipt.of/matches` now take `ProjectionJob`.
+
+This is strictly better than the draft: DuckLake and SQLite cannot disagree about what a
+block means, because neither of them decides. It also makes the ADR's own sentence
+literally true in code — "a sink does format translation and batching; it does not
+repeat ledger resolution."
+
+`ProjectionRowBuilder` derives rows through the same `BlockArchiveDataset`
+implementations the existing archive path uses, and gives each envelope a deterministic
+`ArchiveJob`, so the `archive_job_id` column stays reproducible on replay.
+
+## What the sink does
+
+`DuckLakeProjectionSink` commits one batch as one DuckLake transaction:
+
+```
+BEGIN
+  create a temp staging table per physical table
+  append rows through the DuckDB Appender (the ADR-038 fast path)
+  INSERT ... SELECT each staging table into history_lake.<table>
+  insert the projection receipt
+COMMIT
+```
+
+Every required table and the receipt become visible together, which is what turns
+at-least-once delivery into exactly-once effect. On failure the appenders are closed and
+the transaction rolls back, so a failed batch leaves nothing behind.
+
+**The transaction locator is absent from this path by design.** The existing
+`DuckLakeWriteSession.commit()` calls `backend.updateTransactionLocator(...)` inside the
+commit path; ADR-038 measured that holding shared archive capacity for seconds to
+minutes. It is a rebuildable query accelerator, not authoritative archive data, and
+ADR-039 §15 requires it off the acknowledgement path. Nothing in
+`DuckLakeProjectionSink` touches it.
+
+Identity is enforced at both ends: `initialize` rejects a catalog written by a different
+projection identity and refuses to start if any required section maps to a table the
+catalog lacks; `append` rejects a batch whose identity does not match the sink's.
+
+`coordinate()` is derived from **receipts**, walking them in order and stopping at the
+first gap. A range committed beyond a gap therefore does not advance the contiguous
+coordinate — a partially visible history must never look committed.
+
+## Tests
+
+`DuckLakeProjectionSinkTest` — 8 tests, all passing against a real DuckLake catalog:
+
+| Case | Asserts |
+|---|---|
+| all required tables + receipt commit together | row counts across two tables and one receipt |
+| matching retry is idempotent | same digest, no duplicate rows, one receipt |
+| reshaped retry for the same range is rejected | `ProjectionReceiptMismatchException`, rows unchanged |
+| coordinate advances only over contiguous ranges | 0–4 → 4; +10–12 → still 4; +5–9 → 12 |
+| unknown table commits nothing | rollback leaves zero rows and zero receipts |
+| foreign projection identity rejected | `ProjectionSinkException` |
+| reopening with a different identity fails closed | catalog fingerprint mismatch |
+| receipts readable across sink instances | receipt survives close/reopen |
+
+## Not yet done in Phase 4
+
+- The consumer is not yet wired to a DuckLake sink in application composition; the live
+  run still uses `sink=none`. Enabling it is a configuration change plus a drain thread,
+  and is gated on the §0.8 product decision because a DuckLake sink cannot keep up with
+  core production.
+- Sustained drain-rate measurement against this sink — blocked on the same decision.
+- Artifact streaming (`ArchiveArtifactReader`) is accepted by `append` but unused until
+  Phase 5.

--- a/adr/reports/adr-039-phase-5-artifact-identity-2026-08-21.md
+++ b/adr/reports/adr-039-phase-5-artifact-identity-2026-08-21.md
@@ -1,0 +1,78 @@
+# ADR-039 Phase 5 — artifact reconstructibility and identity
+
+**Analysis before implementation, per the directive that epoch artifacts must not be assumed
+enable-able later without rebuilding.** Written from the existing epoch pipeline
+(`EpochArchiveStagingSink`, `EpochBoundaryProcessor`, `EpochArchiveStagingService`,
+`StandardEpochDatasets`) rather than from the ADR's description of it.
+
+## The question that decides everything
+
+For each artifact: **can it be recomputed later from data the node still retains, or is it a
+measurement of state that exists only at the boundary instant?**
+
+The distinction is not "is it expensive to recompute" but "is the input still there". An
+artifact whose inputs are pruned, superseded, or never persisted is *irreproducible*, and an
+archive that lacks it can never be completed — only rebuilt from genesis.
+
+## Per artifact
+
+| artifact | source today | reconstructible later? | therefore |
+|---|---|---|---|
+| **EPOCH_STAKE** | `EpochBoundaryProcessor` snapshot at the transition | **Yes, from a retained generation.** The stake distribution is a function of the UTXO set and delegation state at the boundary, and the node persists the delegation snapshot it used. This is the ADR's chosen first slice precisely because both representations — staged rows and an immutable persisted generation — exist and can be compared. | implement first; A/B the two representations before choosing |
+| **ADA_POT** | `EpochBoundaryProcessor` | **Yes, but only with the boundary's own inputs.** Treasury/reserves/fees are the *output* of the transition calculation; recomputing needs the pre-transition pot state plus that epoch's fees and deposits. The node has them at the boundary and does not retain them indefinitely. | capture at the boundary; small and bounded, so evidence rather than a staged file |
+| **REWARD** | `EpochRewardCalculator` | **No, not safely.** Rewards are the output of a long calculation over a snapshot taken two epochs earlier, parameterised by protocol version and by the calculation's own version. ADR-039 already says to add these only after proving complete deterministic input closure *and* calculation-version closure. Neither is proven. | capture as **non-reconstructible evidence**; never claim completeness without it |
+| **DREP_DISTRIBUTION** | boundary state | **Partly.** The amount is a distribution over the same stake inputs, but `storedExpiry`, `dormantEpochs`, `effectiveExpiry` and `active` are boundary-time DRep-state columns that later state overwrites. | stream the amount from the persisted generation; atomically snapshot the state columns |
+| **GOVERNANCE_PROPOSAL_STATUS** | boundary observation | **No.** `observationPhase`, `statusCode` and `decisionReason` are decisions made *at* a boundary about ratification and expiry. Later state records the outcome, not the observation that produced it. | irreproducible; requires an immutable source before it can be claimed complete |
+
+Two of five (**REWARD**, **GOVERNANCE_PROPOSAL_STATUS**) are irreproducible, and one
+(**DREP_DISTRIBUTION**) is half. That is the fact that forces the identity question below.
+
+## Identity: why the fingerprint must cover artifacts
+
+The block-section fingerprint is
+`network | sink | canonicalProjectionVersion | sorted section wire names`. It does **not**
+mention artifacts, because artifacts are referenced from an envelope's artifact list rather than
+carried as a section.
+
+That is convenient — adding epoch artifacts does not invalidate an existing four-section archive —
+and it is **exactly why it is dangerous**. Without a change, a node configured to capture epoch
+stake and a node configured to capture nothing produce archives with the *same* fingerprint. The
+second would then report itself complete for an artifact it never captured and, for rewards and
+governance status, could never reconstruct.
+
+**Decision: a separate durable artifact-contract identity**, not an extension of the section
+fingerprint. Reasons:
+
+1. **Different lifecycle.** Sections are fixed for the life of an archive; an artifact set can
+   legitimately grow *if and only if* every artifact added is reconstructible from retained data.
+   Folding both into one string would forbid the safe case along with the unsafe one.
+2. **Different failure mode.** A missing section is discovered by a query returning nothing. A
+   missing irreproducible artifact is discovered when someone asks for epoch N's rewards years
+   later, and by then the inputs are gone.
+3. **It must record capture semantics, not just names.** `epoch-stake:v2` is not enough; the
+   archive must record *how* it was captured, because a staged-file capture and a
+   persisted-generation reference have different recovery classes.
+
+The artifact contract therefore records, per artifact: dataset id, schema/codec version,
+representation (`STAGED_FILE` / immutable generation reference / atomically persisted evidence),
+and whether the archive holds it as reconstructible or as evidence.
+
+## Fail-closed rules this implies
+
+1. An archive **must not** report coverage for an epoch whose required artifacts it did not
+   capture. Absence is reported as absence, never as an empty result.
+2. A node configured with a **larger** artifact set than the archive records may proceed **only**
+   for artifacts that are reconstructible from retained data; encountering an irreproducible one
+   fails closed with the epoch it cannot satisfy.
+3. A node configured with a **smaller** set than the archive records fails closed: it would
+   otherwise silently stop maintaining artifacts the archive claims.
+4. Changing an artifact's representation or codec version is a **rebuild**, exactly as a section
+   version bump is.
+
+## Consequence for the four-section preprod archive
+
+It records no artifact contract. Under rule 1 it is complete for its four block datasets and
+**explicitly incomplete for every epoch artifact** — it cannot be upgraded in place to a
+Phase 5 archive for rewards or governance status, and the final production validation therefore
+needs a fresh sync with the artifact set enabled from genesis. That is the intended cost of
+fail-closed, and it is better paid knowingly now than discovered at the first query.

--- a/adr/reports/adr-039-pointer-index-measurements-2026-08-20.md
+++ b/adr/reports/adr-039-pointer-index-measurements-2026-08-20.md
@@ -1,0 +1,75 @@
+# ADR-039 as-of pointer index — measured overhead
+
+**Date:** 2026-08-20
+**Method:** read-only census of a real preprod chainstate synced to tip (block 5,074,810,
+Conway), counting the authoritative `PREFIX_STAKE_EVENT` log. That log records every stake
+registration and deregistration, and the derived index holds exactly one entry per
+deregistration — so the count is exact, not modelled.
+
+## Preprod, full sync to tip
+
+```
+stake events total      68,476
+registrations           51,440
+deregistrations         17,036     <- one index entry each
+pointer registrations   51,440
+```
+
+| quantity | value |
+|---|---|
+| index entries | **17,036** |
+| bytes per entry | **42** (1 prefix + 1 credType + 28 hash + 8 slot + 2 txIdx + 2 certIdx; empty value) |
+| index logical bytes | **715,512 B = 0.68 MiB** |
+| chainstate total | 31 GB |
+| **index share of chainstate** | **0.002%** |
+| extra RocksDB writes | 17,036 puts over 5,074,810 blocks = **one per ~298 blocks** |
+| extra delta ops | one per put, in the batch that already writes the stake event |
+
+## History-disabled regression
+
+The index write is unconditional in core — it happens on every deregistration certificate
+whether or not projection history is enabled. That is the "unconditional low-volume core
+index" case, and its overhead is now measured rather than assumed:
+
+```
+3.4e-6 additional puts per block
+```
+
+An end-to-end A/B cannot meaningfully measure this. The isolated benchmark's noise floor is
+16–49% (see `adr-039-measurements-2026-08-20.md`); an effect of one small put per 298 blocks
+is many orders of magnitude below it. Claiming a measured pass from such a benchmark would
+be false precision. The honest basis is the write count itself, which is exact.
+
+The write is also inside the batch the deregistration path already commits, so it adds no
+additional batch, no additional sync, and no additional lock acquisition — only 42 bytes to
+an existing write.
+
+## Mainnet extrapolation, explicitly not measured
+
+Mainnet was **not** measured: the only mainnet chainstates on this machine belong to
+existing deployments, which must not be touched. Scaling by activity rather than by block
+count, mainnet plausibly holds low millions of deregistrations, i.e. order **100–250 MiB**
+of index at 42 B/entry. That is an estimate and is labelled as one; it should be confirmed
+on the first fresh mainnet sync, where `pointerIndexStatus()` reports entry count and bytes
+directly.
+
+Even at the top of that range the index is reclaimable in full once the Conway gates pass,
+and it is included in the aggregate archive-retained disk accounting until then.
+
+## Lookup cost
+
+Resolution is one bounded `seek` into a credential-major prefix, returning at the first
+entry past the registration coordinate. No scan of the slot-major event log, and no
+iteration proportional to chain length. p50/p95/p99 under load are not yet measured; they
+require the DuckLake sink wiring and are listed as outstanding.
+
+## What is measured versus inferred
+
+| claim | basis |
+|---|---|
+| 17,036 entries, 0.68 MiB on preprod-to-tip | **measured** (read-only census) |
+| 42 bytes per entry | **exact** (key layout) |
+| one extra put per ~298 blocks on preprod | **measured** |
+| history-disabled overhead negligible | **inferred from the exact write count**, not from an end-to-end A/B, which cannot resolve it |
+| mainnet 100–250 MiB | **estimated**, not measured |
+| lookup p50/p95/p99 | **not yet measured** |

--- a/adr/reports/adr-039-pointer-resolution-2026-08-20.md
+++ b/adr/reports/adr-039-pointer-resolution-2026-08-20.md
@@ -1,0 +1,139 @@
+# ADR-039 pointer-address resolution — design, divergence, and open decision
+
+**Date:** 2026-08-20
+**Branch:** `feat/adr-039-canonical-projection-outbox`
+
+## What was built
+
+Pointer-address resolution moved from an archive-private sequential resolver to the
+authoritative account-state contributor, resolved at **capture** time.
+
+```
+DefaultAccountStateStore  implements PointerCredentialSource   (core-api SPI)
+        -> RuntimeNode.pointerCredentialSource()
+        -> Yano.pointerCredentialSource()
+        -> ProjectionHistoryService
+        -> CanonicalProjectionCollector
+        -> ProjectionPointerResolution.resolve(fact, blockSlot, source)
+```
+
+The collector writes one of `pointer_resolved` / `pointer_unresolved` /
+`pointer_not_effective` into the fact before the envelope is complete. Consequences:
+
+- the sink holds **no resolver state** and can never fail for lack of it;
+- `archive-store-ducklake` keeps its `archive-api`-only dependency;
+- a missing mapping is `pointer_unresolved`, never an exception.
+
+Resolution consults, in order: an **in-block overlay** built from this block's own
+registration/deregistration certificates sorted by `(txIndex, certIndex)`, then the
+authoritative mapping.
+
+### Why it is replay-deterministic
+
+Core's mapping is **append-only**: `DefaultAccountStateStore` writes
+`PREFIX_POINTER_ADDR | slot | txIdx | certIdx -> credType | credHash` on registration
+(one `batch.put`, delta-tracked for rollback) and there is **no corresponding delete**
+anywhere in the file. So:
+
+- a coordinate resolvable when block N was first applied stays resolvable on replay;
+- a coordinate registered *after* block N cannot satisfy a pointer in block N, since the
+  key's slot is the registering certificate's own slot.
+
+A pointer address can encode arbitrary numbers, so resolution additionally refuses any
+coordinate whose slot is **newer than the block being projected**. Without that guard a
+coordinate registered later in the chain could resolve during a replay while being
+unresolvable on the first pass. Two tests cover this directly.
+
+## The divergence, and it is not a free choice
+
+12 differential tests run against the **real** shipped sequential resolver as oracle. All
+agree except one case, which is pinned by
+`crossBlockDeregistrationBehaviourIsRecorded`:
+
+| scenario | shipped sequential resolver | this implementation |
+|---|---|---|
+| register (block 1), deregister (block 2), pointer used (block 3) | `pointer_unresolved` | `pointer_resolved` |
+
+The shipped resolver calls `deleteCredential`, removing every coordinate that maps to a
+deregistered credential. Core's append-only mapping keeps it.
+
+### Which is correct
+
+**The shipped resolver matches Cardano ledger semantics, and this implementation does
+not.** In the Shelley-era ledger the delegation state holds
+`_ptrs :: Map Ptr (Credential 'Staking)`, and processing a key-deregistration certificate
+removes the credential from the reward and delegation maps *and* removes the pointer
+entries that map to it. A pointer address whose target credential has been deregistered
+therefore resolves to no stake credential.
+
+Core's mapping is not wrong for core's own purpose: it is consulted while building
+delegation snapshots, where a deregistered account is already excluded by account state,
+so a stale pointer entry is harmless there. It is only wrong as a *direct* source for the
+archive's `transaction_outputs.stake_credential`.
+
+This is recorded as a **fidelity gap**, not a preference. Per the project's standing rule
+that cardano-ledger is authoritative for ledger semantics, the shipped behaviour is the
+target.
+
+### Why it was not simply fixed
+
+Every obvious fix breaks replay determinism, which ADR-039 requires
+("contributor recovery must not depend on mutable state that has advanced beyond the
+replayed block"):
+
+1. **Delete the mapping on deregistration in core.** Replaying block N while the store is
+   at N+100 would then see a coordinate deleted at N+50 as already gone, producing a
+   different answer than the first pass.
+2. **Consult account registration status at resolution time.** Same defect: "is this
+   credential registered" is a property of *now*, not of block N.
+3. **Keep a deregistration tombstone in the contributor's own column family.** Replay-safe
+   and ledger-correct, but reintroduces an archive-owned pointer lifecycle — the thing
+   moving resolution to core was meant to remove.
+4. **Resolve as-of a slot.** Correct in principle and replay-safe, but requires core to
+   retain a *historical* registration timeline keyed by slot, which it does not have. This
+   is the only option that is both correct and clean, and it is a real core change.
+
+### Scope of the gap
+
+Narrow, and quantifiable:
+
+- pointer addresses are pre-Conway only — Conway records `pointer_not_effective` and is
+  unaffected;
+- core's own javadoc puts pointer usage at **under 1% of mainnet UTXOs**;
+- of those, only outputs whose target credential was deregistered in a **later block** are
+  affected — same-block deregistration is handled correctly by the overlay and agrees with
+  the oracle.
+
+The affected rows record a credential where the shipped archive records none. No row is
+lost, no exception is raised, and coverage is unaffected.
+
+## Decision requested
+
+Option 4 (as-of-slot resolution backed by a retained registration timeline in core) is the
+only variant that is both ledger-correct and replay-deterministic. It is a genuine core
+change and was not undertaken without a decision, since ADR-039's instruction is to keep
+core changes minimal.
+
+Until that decision is recorded, this is **not complete** and should not be treated as
+such. The three viable paths:
+
+1. accept the narrow divergence and document it in the archive's query contract;
+2. implement option 4 (core retains a slot-keyed registration/deregistration timeline);
+3. implement option 3 (contributor-owned tombstones, atomic with the contributor batch)
+   and accept that the archive keeps a small pointer lifecycle after all.
+
+## Test coverage
+
+`PointerResolutionDifferentialTest` — 12 tests, oracle = the shipped sequential resolver
+backed by a real `RocksDbHotHistoryStore`:
+
+same-block registration and use; cross-block registration and use (genuine two-block
+oracle); missing mapping becomes unresolved rather than throwing; Conway not-effective;
+same-block deregistration; re-registration after deregistration; unrelated deregistration
+does not remove the coordinate; future-coordinate pointer stays unresolved on replay;
+replay with an advanced mapping reproduces the same result; resolution is idempotent;
+non-pointer addresses untouched; and the cross-block deregistration divergence above.
+
+Deliberately **not** used as oracle: the resolver-less `UtxoHistoryDataset` constructor.
+Comparing two resolver-less paths is tautological for pointer addresses, which is exactly
+how the original crash-on-pointer defect stayed hidden through a full parity suite.

--- a/adr/reports/adr-039-review-2026-08-19.md
+++ b/adr/reports/adr-039-review-2026-08-19.md
@@ -1,0 +1,516 @@
+# ADR-039 review — Canonical Projection Outbox
+
+**Date:** 2026-08-19
+**Reviewed:** `adr/in-progress/039-canonical-projection-outbox.md`
+**Verified against:** branch `feat/adr-038-archive-throughput` @ `5a3cebec`
+
+Every claim below was checked against source on that branch; `file:line` citations
+are given so each point can be verified independently rather than taken on trust.
+
+## Summary
+
+The architecture is sound and I would accept it as the target replacement for the
+replay-worker model. The decode-once premise is well supported by ADR-038's own
+evidence (decode measured at ~82–86% of per-block cost; four datasets currently
+decode the same block independently), and §8's rejection of a best-effort
+post-commit listener is correct and worth keeping verbatim.
+
+Four items should be resolved before the six requested decisions are recorded.
+One of them (B1) is a coverage hole that the current phasing would ship; two (B2,
+D1) are cases where the codebase already contains a working answer that the ADR
+does not reference.
+
+## Verdict on the six requested decisions
+
+| # | Decision | Verdict |
+|---|---|---|
+| 1 | Fresh-sync-only and one primary sink | **Accept** — state the discarded-backfill cost explicitly |
+| 2 | Outbox as the target replacement | **Accept** — with B2's reframing of the atomicity boundary |
+| 3 | Large epoch artifacts referenced under leases | **Challenge** — see D1; accept leases, contest live-CF references |
+| 4 | Locator design downstream and deferred | **Accept** — document per-endpoint fallback before cutover |
+| 5 | Foundation/outbox branch split | **Accept** — add the epoch staging path to the retain list |
+| 6 | Phase 0 atomicity proof as a hard gate | **Accept** — narrowed; half is answerable from source today |
+
+## Blocking findings
+
+### B1. Byron has no live-path source, and Phase 7 deletes the only one that exists
+
+`BlockAppliedEvent` is published with a `null` Block for Byron
+(`BodyFetchManager.java:834`, `:896`, `:1039` — "Byron blocks are not Block
+type"), and the live UTXO path bails immediately on it: `if (e.block() == null)
+return;` (`DefaultUtxoStore.java:710`). Reconcile agrees — "UTXO reconcile
+skipped: tip block is Byron era, nothing to index" (`:1744`). The live UTXO set
+holds Byron *genesis* UTXOs (`:1085`) and removes them at the Allegra bootstrap
+(`:774`); it never applies a single Byron transaction. Nothing outside
+`BodyFetchManager`/`PipelineDataListener` references `ByronMainBlock` at all.
+
+The current archive covers Byron only because it owns a decoder —
+`YaciBlockDecoder.decodeByron` (`source/YaciBlockDecoder.java:59`), the EBB parent
+bridge (`ChainBlockArchiveSource.java:51-55`), Byron addresses in
+`YaciUtxoHistoryDecoder.java:344`. That is exactly the machinery Phase 7 removes.
+On mainnet this is roughly a third of the chain (~4.5M of ~13.8M blocks).
+
+**Recommended fix (agreed):** publish a dedicated `ByronBlockAppliedEvent`
+carrying the already-decoded `ByronMainBlock`, alongside the existing
+`BlockAppliedEvent`, from `applyByronBlock` (`BodyFetchManager.java:801`). The
+block is already decoded at that point, so this costs one allocation and a bus
+dispatch — no new decode on the hot path.
+
+Four details to get right:
+
+1. **New type, not an overload.** `block() == null` is load-bearing as the
+   Byron/EBB sentinel in five places — `DefaultUtxoStore.java:710`,
+   `DefaultUtxoProcessor.java:22`, `DefaultMempoolEvictionPolicy.java:38`,
+   `InMemoryAccountStateStore.java:246`, `AppChainSubsystem.java:4952`. A separate
+   event type leaves all of them untouched.
+2. **EBBs get the same treatment.** `applyByronEbBlock` (`:945`) also publishes
+   with `null` (`:1039`). EBBs carry no transactions, but they do occupy block
+   numbers, and the archive already emits a zero-transaction block context for
+   them (`YaciBlockDecoder.java:85-88`). Under "one envelope per canonical block"
+   plus "greatest *contiguous* committed coordinate" (§16), an EBB with no
+   envelope is a permanent hole in contiguity — so it should produce an empty
+   envelope. This is also where the three recent Byron-bridge fixes live
+   (`58471b36`, `a8e1887c`, `cf6b7ed5`).
+3. **Carry the raw block; normalize in the collector.** `decodeByron`
+   (`:59-100`) already maps `ByronMainBlock` into the Shelley `Block` model the
+   projection code expects. Keeping the event raw means non-history nodes pay
+   nothing, and it means Phase 7 must **retain** that normalizer rather than
+   delete it with the workers.
+4. **Byron is a strict subset, and §3 should say so.** The synthetic Byron
+   `TransactionBody` never sets a fee (`:78-80`), so `chain_transaction.fee` is
+   null for Byron — fine, the column is nullable (`ArchiveSchemas.java:32`), but
+   it is a projection semantic, not an accident. Byron also has no invalid
+   transactions, collateral, reference inputs, datums, redeemers, multi-asset
+   values, or pointer addresses, and uses base58 raw addresses (`:73`). §3's
+   validity-semantics list is Shelley+-only as written.
+
+With that in place, B1 drops from a correctness hole to a scoped addition for the
+first slice. The residual — Byron address/account history — folds into B3.
+
+### B2. Open question #1 is already answered in source, and the answer is neither option as written
+
+There is no shared canonical apply transaction today. `chainState.storeBlock(...)`
+commits its own batch and `BlockAppliedEvent` is published *after* it returns
+(`BodyFetchManager.java:673-703`). UTXO apply is an EventBus listener that can be
+fully asynchronous on its own thread (`UtxoEventHandlerAsync.java:53`), with its
+own `WriteBatch` (`DefaultUtxoStore.java:743`), its own cursor, and its own
+replay-from-stored-bodies recovery (`:1712-1766`). Ledger state does the same
+(`LedgerStateSubsystem.java:629-634`).
+
+So §8's option 2 ("durable apply intent") is not a new mechanism — it is the
+production recovery model. And option 1 (one batch across chain + UTXO + ledger +
+projection) would be a substantial `BodyFetchManager` refactor the design does not
+need.
+
+The cheap boundary is **per-contributor**: write projection sections into the
+contributing subsystem's existing `WriteBatch`. It is the same RocksDB —
+`DirectRocksDBChainState implements RocksDbSupplier` (`:48`, `rocks()` at `:282`)
+and hands the handles to the UTXO store — so a projection put is atomic with
+`cfUnspent`/`cfSpent` for free. Block-body retention already has the lease
+primitive required: `BlockBodyRetentionBoundary` clamps the prune cutoff
+(`BlockPruner.java:73-77`).
+
+Consequent ADR edit: Phase 0 step 3's "no field may depend on later block
+re-decode" is too strong. It should read "no field may depend on state that is
+unreconstructible at replay time" — pre-state *is* reconstructible, because replay
+re-runs the same apply sequence from the contributor's cursor. "Decode once" then
+means once in normal operation, re-decode only on crash replay. That is worth
+saying plainly rather than leaving as an implied absolute.
+
+### B3. Phase 7's removal gate drops two shipping datasets
+
+Production ships four block datasets — `ACCOUNT_EVENT`, `ADDRESS_TRANSACTION`,
+`TRANSACTION`, `UTXO_HISTORY` (`ArchiveDatasetId.java:4-7`) — and all four are
+visibly advancing in the mainnet sampler. The first slice defines sections for
+two (§3); `account-events:v1` and the address/credential section are "later
+releases" (§4). Phase 7 removes the replay workers after parity, where parity is
+defined over six tables. As written, that silently drops `address_transactions`
+and `account_events` — the tables the wallet History APIs (PR #58) sit on.
+
+One sentence fixes it: **Phase 7 requires section coverage for every currently
+shipped dataset**, or v1 explicitly decides to drop them.
+
+Note the Byron residual lands here too. `address_transactions` resolves each input
+back to its funding address and hard-fails when the outpoint is unresolvable
+(`AddressTransactionDataset.java:169` throws `ArchiveStoreException`), which is
+why `SequentialOutpointResolver` exists. For Byron the live UTXO set is no help at
+all, so that section will need an archive-owned resolver seeded from Byron
+genesis — essentially what exists today.
+
+### B4. Acceptance criteria 1 and 2 are in unstated tension, and the deciding number is unmeasured
+
+"≤5% core-sync regression with history enabled" and "sink drain rate > core
+production" can both hold only if the sink genuinely outruns core sync.
+
+ADR-038 measured the sink at 59.84 blocks/s in the accepted window. With decode at
+~82–86% of per-block cost and writes sustaining ~313k rows/s, removing decode
+plausibly lands around 100–190 blocks/s — but the **core-only fresh-sync rate is
+nowhere measured**, and it is the single most decision-relevant number in this
+ADR. Phase 0 step 6 records a history-disabled baseline; make that number a gate,
+not a footnote.
+
+The reason it matters: an outbox absorbs variance, not a sustained deficit. If
+sink < core across an ~11M-block genesis backfill, the outbox either holds a large
+fraction of the entire archive inside the hot RocksDB, or the hard limit throttles
+core to sink speed. Either is an acceptable product decision; neither is currently
+stated. Open question #4 should be promoted to a decision gate with a stated
+bytes-per-block estimate and an expected wall-clock/backlog model for a
+history-enabled mainnet fresh sync.
+
+## Design challenges
+
+### D1. §5–§7 competes with a simpler mechanism that already ships
+
+`EpochArchiveStagingSink` (`core-api/.../archive/EpochArchiveStagingSink.java`) →
+`EpochArchiveStagingService` ("Streams ephemeral epoch facts to immutable
+restartable source files", `:20`) → `DurableEpochFileSource` already implements
+capture-at-boundary into immutable staged files with manifests, job ids,
+`acknowledge()` cleanup (`:81-85`), and lease files (`:139-152`).
+
+Staged files freeze the codec at capture time, which eliminates the ADR's hardest
+ongoing contract — "retain readers for every codec version referenced by pending
+artifacts" (§7) — and the entire live-CF eligibility checklist (§5). The rejected-
+alternatives section rejects "complete epoch snapshots inside the envelope" but
+never considers "staged durable files outside the envelope", which is the thing
+already in production.
+
+Request: either adopt staged files as the default artifact representation, or
+justify reference-into-live-CF per artifact type.
+
+### D2. The section→table re-partitioning changes coverage semantics
+
+`transaction_datums` and `transaction_redeemers` currently belong to the
+`UTXO_HISTORY` dataset at projectionVersion 5 (`ArchiveSchemas.java:51-75`); §3
+moves them into `transaction-summary:v1`. Dataset-keyed identity, coverage
+reporting, and the conformance suite all key off the existing mapping. Phase 1
+should define the mapping and version-reconciliation rules explicitly rather than
+discovering them during Phase 4.
+
+### D3. The outbox lives in the hot RocksDB — name the consequence
+
+Because the projection must commit atomically with hot state, the outbox CFs sit
+in the working database. A lagging sink therefore inflates the hot DB and its
+compaction load, not just a side directory. The consequences section should say
+this alongside the disk-growth bullet.
+
+### D4. §3 overstates what the first slice needs from live state
+
+§3 justifies the design partly on having "the original consumed output from the
+live UTXO set". For the first slice that is not required: `transaction_inputs`
+does not denormalize the consumed output — its columns are `spending_tx_hash,
+spending_tx_index, input_index, input_role, referenced_tx_hash,
+referenced_output_index, consumes_output, block_*` (`ArchiveSchemas.java:63-66`) —
+and `UtxoHistoryDataset`'s only stateful dependency is the pointer-address
+resolver (`UtxoHistoryDataset.java:37`), which has no Byron analogue.
+
+Conversely, the datasets that *do* need resolved outputs (`ADDRESS_TRANSACTION`,
+`ACCOUNT_EVENT`) cannot use live state for Byron at all. So the motivation should
+be stated precisely: decode-once is the real win; live-state reuse applies to
+Shelley+ address/credential sections only, and an archive-owned resolver remains
+necessary regardless.
+
+## Smaller notes
+
+- §12's "a replacement canonical block at the same height has a different
+  deterministic envelope identity" is sound as specified — the header carries hash
+  and parent (§2).
+- §8's rejection of a best-effort post-commit listener is correct and well argued.
+  Keep it: `UtxoEventHandlerAsync` is exactly the shape someone would otherwise
+  reach for.
+- The ADR-036 numbering collision is already acknowledged in the ADR; just resolve
+  it before the branches merge.
+- Branch split (decision 5): add `EpochArchiveStagingSink`,
+  `EpochArchiveStagingService`, and `DurableEpochFileSource` to the foundation
+  *retain* list. They are not mentioned today and are reusable for §5.
+- Locator (decision 4): before cutover, document the fallback behaviour per
+  endpoint for the PR #58 wallet APIs (`/txs/{hash}`, address history) — they are
+  the concrete consumers of the deferred point index.
+- The "5% is a decision target, not a measurement" caveat and the ADR-038
+  retrospective are unusually honest for an ADR of this size. Hold the same
+  standard for the outbox-sizing number in B4.
+
+---
+
+# Addendum — second round, 2026-08-19
+
+Reviewing the revised ADR (1501 lines) and the author's response.
+
+The revision lands. The D1 resolution — staged files as correctness baseline,
+live-generation references admitted only on per-artifact correctness *and*
+performance evidence, with two symmetric rejected alternatives — is better than
+what the original review proposed, because it keeps the decision per artifact
+type instead of picking a global winner. Phase 0 step 5 already scopes the
+staging audit and step 7 adds the drain-margin gate; Phase 4b closes B3 properly.
+
+## The author's new finding is confirmed
+
+`DurableEpochFileSource` calls `output.flush()` and nothing else (`:282`). There
+is no `FileChannel.force`, no file or parent-directory fsync, and no
+digest/checksum anywhere in either `DurableEpochFileSource` or
+`EpochArchiveStagingService`. The temp-file-plus-atomic-rename pattern
+(`:55-56`, `:234`) gives *ordering*, not durability — after a power loss a
+manifest can be present while the rows file is short. Two further gaps in the
+same area:
+
+- Capture failure is swallowed by design. `EpochArchiveStagingSink`'s contract
+  says implementations "must isolate failures from the authoritative ledger
+  transition", and the service's `fail(...)` path (`:197-208`) writes a marker
+  rather than propagating. So the caller's own rethrow — e.g.
+  `DefaultAccountStateStore.createAndCommitDelegationSnapshot` (`:3553-3556`) —
+  never fires on a staging failure.
+- Interrupted-write cleanup deletes lease files on a wall-clock expiry
+  (`DurableEpochFileSource.java:226`). Time-based expiry races a slow reader;
+  "lease-safe cleanup" should key off reader liveness, not a deadline.
+
+## Classify the five staged datasets — it makes the scope decidable
+
+Fail-closed hardening and forced durability are expensive at exactly the wrong
+moment. They are not needed uniformly. Verified from source:
+
+**Reconstructible by reading a persisted generation** — cheap failure handling
+(detect and re-derive); forced durability at the boundary is not required.
+
+- `EPOCH_STAKE` — the staged facts are appended in the *same pass* that builds
+  the persisted delegation snapshot: `createDelegationSnapshot(epoch, batch, …,
+  archiveWriter)` writes `EPOCH_DELEG_SNAPSHOT` through the WriteBatch while
+  appending `StakeFact`s (`DefaultAccountStateStore.java:3547-3560`). This is the
+  largest artifact (~1.3M rows/epoch on mainnet) and the one driving the author's
+  performance risk 2 — and it is exactly the one that does not need it.
+- `ADA_POT` — persisted per epoch under an epoch-keyed state key
+  (`AdaPotTracker.storeAdaPot`, `:95-99`). Also one row per epoch, so the
+  representation choice is performance-irrelevant either way.
+- `DREP_DISTRIBUTION` *amounts* — `governanceStore.storeDRepDistEntry(newEpoch,
+  …)` plus a snapshot marker (`GovernanceEpochProcessor.java:670-675`).
+
+**Reconstructible only by recomputation** — deterministic given retained inputs,
+but expensive, and the recompute depends on the N-2 snapshot still existing.
+
+- `REWARD` — captured mid-calculation (`EpochRewardCalculator.java:144`). There
+  is no rewards column family in `AccountStateCfNames`; per-account amounts are
+  applied to accounts and the decomposition (source pool, reward type,
+  earned/spendable epoch) is not retained. Recomputation is possible from the
+  epoch stake snapshot and pot state, which makes the reward artifact's
+  fail-closed contract also a *retention* contract on those inputs.
+
+**Not reconstructible at all** — these are the ones that genuinely need
+fail-closed, forced-durable capture.
+
+- The mutable-state joins on `DREP_DISTRIBUTION` rows (below).
+- `GOVERNANCE_PROPOSAL_STATUS` observation phase and decision reason, derived at
+  ratification time (`GovernanceEpochProcessor.java:789`).
+
+Recommendation: make this classification the explicit output of Phase 0 step 5,
+and scope the hardening to the third group (plus the retention contract for the
+second). That answers performance risk 2 directly — the boundary-latency cost is
+concentrated in artifacts that do not need the forcing.
+
+## New finding: `DREP_DISTRIBUTION` rows join mutable state into an epoch key
+
+`drep_distributions` carries `stored_expiry`, `dormant_epochs`,
+`effective_expiry`, and `active` (`ArchiveSchemas.java:91-97`). Those come from
+`governanceStore.getAllDRepStates()` and `getNumDormantEpochs()` evaluated *at
+the boundary* (`GovernanceEpochProcessor.java:679-695`), while
+`storeDRepDistEntry` persists only the stake amount per `(epoch, drepType,
+hash)`.
+
+So re-deriving these rows later from the persisted generation recomputes expiry
+and active flags from DRep state that has since mutated, and silently produces
+different values for an epoch-keyed row. §5's eligibility criterion 2 ("never
+updated in place after closure") therefore has to be evaluated **per column, not
+per dataset**: the amounts qualify, the joined DRep state does not.
+
+This strengthens the author's caution on D1 — for `DREP_DISTRIBUTION` the staged
+file is required for *correctness*, not merely preferred on performance. The
+schema already has a `source_state_version` column, which is the natural place to
+record which representation produced the row.
+
+## §6's publication delay already buys the slack for durability forcing
+
+Performance risk 2 assumes the fsync sits inside the transition. It does not have
+to. §6 publishes an artifact one safe boundary later, so there is a full epoch
+between capture and eligibility.
+
+Split the two properties: *capture* must be synchronous with the transition
+(the facts are ephemeral), but the durability barrier — force, digest, manifest
+publish, completion marker — can run as a post-transition task, provided the
+artifact cannot become *eligible* until that barrier completes. Fail-closed then
+reads as "the boundary cannot be published as archive-complete until the artifact
+is durable", not "the transition cannot commit until fsync returns". That keeps
+the strong guarantee and removes almost all of it from epoch-boundary latency.
+
+> **Superseded — see Addendum 2.** This is wrong for non-reconstructible facts.
+> Unforced staged bytes plus a durably committed transition plus power loss loses
+> the only copy; delayed eligibility detects the loss but cannot recover it. The
+> ADR's resolution — commit minimal immutable evidence in the contributor's
+> RocksDB batch, or put durable staged capture on the transition's fail-closed
+> path — is correct.
+
+---
+
+# Addendum 2 — third round, 2026-08-19
+
+The author is right and the deferred-durability suggestion above is withdrawn.
+The unsafe-sequence block now in §5 states the failure exactly, and the
+evidence-in-the-contributor-batch route is better than what it replaces: it makes
+the synchronous cost proportional to the irreproducible facts (kilobytes of DRep
+boundary state) instead of the full artifact.
+
+The revised recovery-class table is accurate against source, including the
+hardening of the `REWARD` row — the input closure genuinely is wider than stake
+and pots.
+
+## The class-1 decision has an unnamed retention consequence
+
+`EPOCH_STAKE` as a "protected persisted generation" is not free: the delegation
+snapshot is **already pruned on a configurable window**, inside the epoch
+boundary's own batch — `pruneOldSnapshots(newEpoch - snapshotRetentionEpochs,
+batch)` (`DefaultAccountStateStore.java:2513`, implementation at `:3772-3786`).
+
+So criterion 5 ("pruning observes durable leases") needs a concrete clamp for
+this CF, exactly analogous to `BlockBodyRetentionBoundary` for block bodies.
+Without it, a sink lagging more than `snapshotRetentionEpochs` loses the
+generation its artifact reference points at.
+
+That also adds a disk consequence the ADR does not currently name: under the
+class-1 representation a lagging sink pins **epoch delegation snapshots in the
+chainstate** as well as growing the outbox. Both belong in the same operator
+story and the same hard-limit policy.
+
+## The reward input closure is already defined in code
+
+§5 requires, for the conditionally-recomputable class, retention of "every
+required stake snapshot, pot/fee value, block-production count, protocol
+parameter, era/rule configuration, source identity, and calculation version".
+`DefaultAccountStateStore.getRollbackFloorSlot()` (`:3935-3968`) already computes
+the boundary of that closure: an earliest-retained-reward-input floor derived
+from per-block issuer/fee facts, and a snapshot floor of
+`earliestRetainedSnapshot + 4` (because reward calculation for epoch N reads the
+snapshot at N-4).
+
+Two consequences:
+
+1. The Phase 0 reward-recomputability proof has an existing definition to test
+   against rather than a new inventory to invent. The lease work is "clamp the
+   existing prune cutoffs and reuse this floor", not new retention machinery.
+2. This is the single source of truth for rollback depth that the ADR's
+   configuration section already asks for ("one source of truth for
+   rollback/finality rather than a second archive-only interpretation"). The
+   archive's rollback-safe cutoff should be derived from
+   `RollbackCapableStore.getRollbackFloorSlot()`, not defined independently
+   alongside it. The coupling runs the safe way — archive leases hold retention
+   open, which moves the rollback floor further back, never forward.
+
+## Two smaller points
+
+- **`PREPARING → forced file → READY` needs a class-dependent recovery action.**
+  The protocol detects an interrupted publication; what to do about it differs by
+  recovery class — re-derive from the generation (class 1), recompute from the
+  retained closure (class 2), fail closed (class 3). For class 3 the marker is
+  only a detector, and safety still comes from the evidence committed in the
+  transition batch. Worth stating so the protocol is not read as sufficient on
+  its own.
+- **Phase 5 starting with epoch stake is the right call, and it is also the ideal
+  A/B.** Epoch stake is the one artifact where *both* representations exist
+  today — the staged file and the persisted snapshot — so the slice can implement
+  and measure both and give §5 criterion 8 a real comparison instead of a
+  projected one.
+
+---
+
+# Addendum 3 — fourth round, 2026-08-19
+
+The clamp, the aggregate resource budget, the visible-pause hard limit, the
+class-dependent `PREPARING` recovery, and the Phase 5 A/B all land. The author is
+also right that rollback floor and recent-chain finality are related but not
+identical.
+
+One correction, and the fault is partly mine: Addendum 2 said "derive the
+archive's rollback-safe cutoff from `getRollbackFloorSlot()`" without pinning the
+direction of that quantity. The new combining rule inherits the ambiguity and
+inverts.
+
+## The `min()` eligibility rule fails in the healthy case
+
+`RollbackCapableStore.getRollbackFloorSlot()` is documented as "Earliest slot this
+store can safely rollback to with currently retained data. **0 means the store can
+rollback to any point** (no pruning / unbounded retention)"
+(`core-api/.../rollback/RollbackCapableStore.java:60-65`). The runtime's common
+floor is the `max` across stores (`RuntimeNode.java:2891-2895`), and adhoc
+rollback aborts when `targetSlot < commonFloor` (`:2913`).
+
+So a *lower* floor means *more* rollback capability, and the degenerate
+"cannot roll back at all" branches return `getLatestAppliedSlot()` — the tip
+(`DefaultAccountStateStore.java:3946`, `:3961`).
+
+Substituting into the proposed rule:
+
+```text
+eligible slot = min(network rollback-safe slot, common retained-state floor)
+
+unbounded retention  → floor = 0   → eligible = 0    → archive never ingests
+long retention       → floor old   → eligible = floor → archive lags by the
+                                                        entire retention window
+no retention         → floor = tip → eligible = tip − k → normal gating
+```
+
+The rule is most restrictive exactly when retention is best, and permissive when
+retention is worst. With unbounded retention it stalls the archive at slot 0.
+
+## The two quantities belong in different places
+
+They are opposite ends of the same interval and should not meet in one `min()`:
+
+- **Finality gate — an upper bound on what may be archived.** A depth from tip.
+  This already exists and already encodes the conservative combination:
+  `ArchiveSafetyWindows.resolve` derives `securityParam`,
+  `rollbackRetentionBlocks`, and `archiveFinalityBlocks` from Shelley genesis `k`
+  and enforces `finality >= rollback >= k`. So
+  `eligibleSlot = tip − archiveFinalityBlocks` is already never newer than
+  `tip − rollbackRetentionBlocks` or `tip − k`. If an explicit combination is
+  wanted, it belongs on the depth side —
+  `tip − max(archiveFinalityBlocks, rollbackRetentionBlocks)` — which the existing
+  invariant already reduces to the same value.
+- **Retention health — a lower bound on what must still be reachable.** The
+  common floor is a precondition, not a term in eligibility: it must stay at or
+  below the oldest slot any unacknowledged envelope, artifact reference, or
+  reward-input closure still needs. A violation means retention was lost under a
+  lagging sink, and the correct response is the fail-closed/pause path the ADR
+  already defines for the hard limit — not a silent narrowing of eligibility.
+
+Stated that way the clamp and the floor reinforce each other: the clamp holds
+retention open so the floor stays below the oldest active requirement, and the
+floor rising to meet that requirement is the alarm that the clamp failed. That is
+also the right shape for the new "sink lag beyond snapshot retention" and
+"lease/floor advancement race" tests — the assertion is that the floor never
+crosses the oldest active requirement, not that eligibility moved.
+
+## Resolution
+
+Applied in the ADR. Eligibility is `tip - ArchiveSafetyWindows.archiveFinalityBlocks`
+with the depth-side equivalence recorded; retention health is a separate
+invariant, `runtime common rollback floor <= oldest active required slot`, with
+equality as an exhaustion warning and a greater floor as the fail-closed
+condition. The requirement is registered "for every pending envelope, artifact,
+**or recomputation closure**", so the reward input closure is inside the
+protected set rather than assumed. §7's publication order was also corrected: the
+file reaches forced, digest-verified completion first, then the RocksDB `READY`
+marker makes it referenceable.
+
+# Review closed — 2026-08-19
+
+All eight original findings and the four raised across the addenda are resolved
+in the ADR text. No open review items remain.
+
+What remains is empirical, not editorial, and is concentrated in Phase 0:
+
+1. The four measurement gates — history-disabled core rate, concurrent sink drain
+   rate, outbox bytes/block, and the full-sync backlog model. These decide
+   whether the architecture is viable at mainnet scale, and none of them is
+   measured yet.
+2. The reward input-closure proof. If `getRollbackFloorSlot()` does not cover the
+   complete archived reward-row closure, `REWARD` moves to the non-reconstructible
+   class and its capture cost rises.
+3. The `ADDRESS_TRANSACTION` outbox-volume question in Phase 4b, which may force
+   an explicit retirement decision rather than a parity implementation.
+4. The six product decisions the ADR asks reviewers to record. Those are
+   unchanged by this review and still need signing off.

--- a/adr/reports/adr-039-samples/hung-plugin-test-threaddump-2026-08-21.txt
+++ b/adr/reports/adr-039-samples/hung-plugin-test-threaddump-2026-08-21.txt
@@ -1,0 +1,475 @@
+Hung Gradle test worker, preserved before termination.
+Captured: 2026-08-21T04:13:28Z
+PID 28223, module :runtime, cpu time 2:16 (i.e. idle-blocked, not spinning)
+Reported stall: PluginOperationsRegistry.awaitNoActiveSamplesLocked
+  from processFatalActivationCommitRetainsPrimaryAndRollsBackOwnedProduct
+
+==================== jstack ====================
+2026-08-21 12:13:28
+Full thread dump OpenJDK 64-Bit Server VM (25.0.2+12-LTS mixed mode, sharing):
+
+Threads class SMR info:
+_java_thread_list=0x00000007bf1d8880, length=26, elements={
+0x0000000104d66690, 0x00000007b0890000, 0x00000007b0890800, 0x00000007b0891000,
+0x00000007b0891800, 0x00000007b0892000, 0x00000007b0c5a800, 0x00000007b0c5b200,
+0x00000007b0892800, 0x00000007b0893000, 0x00000007b05af000, 0x00000007b05dc000,
+0x00000007b05dc800, 0x00000007b009c800, 0x00000007b009e800, 0x00000007affd9800,
+0x00000007b05ae000, 0x00000007af5e8000, 0x00000007afa2c000, 0x00000007afa2e800,
+0x00000007afab7000, 0x00000007afbd5000, 0x00000007b014b000, 0x00000007af6f8000,
+0x00000007af97a800, 0x00000007b0613000
+}
+
+"Test worker" #3 [4611] prio=5 os_prio=31 cpu=16655.81ms elapsed=80294.42s tid=0x0000000104d66690 nid=4611 in Object.wait()  [0x000000016ba2f000]
+   java.lang.Thread.State: WAITING (on object monitor)
+	at java.lang.Object.wait0(java.base@25.0.2/Native Method)
+	- waiting on <no object reference available>
+	at java.lang.Object.wait(java.base@25.0.2/Object.java:389)
+	at java.lang.Object.wait(java.base@25.0.2/Object.java:351)
+	at com.bloxbean.cardano.yano.runtime.plugins.PluginOperationsRegistry.awaitNoActiveSamplesLocked(PluginOperationsRegistry.java:860)
+	at com.bloxbean.cardano.yano.runtime.plugins.PluginOperationsRegistry.sealAndAwait(PluginOperationsRegistry.java:320)
+	- locked <0x0000000462700000> (a java.lang.Object)
+	- locked <0x0000000462700010> (a java.lang.Object)
+	at com.bloxbean.cardano.yano.runtime.plugins.PluginOperationsRegistry.close(PluginOperationsRegistry.java:1146)
+	- locked <0x0000000462700010> (a java.lang.Object)
+	at com.bloxbean.cardano.yano.runtime.plugins.PluginOperationsRegistryTest.assertProcessFatalActivationCommitCleanup(PluginOperationsRegistryTest.java:1257)
+	at com.bloxbean.cardano.yano.runtime.plugins.PluginOperationsRegistryTest.processFatalActivationCommitRetainsPrimaryAndRollsBackOwnedProduct(PluginOperationsRegistryTest.java:622)
+	at java.lang.invoke.LambdaForm$DMH/0x000007f8011e4000.invokeVirtual(java.base@25.0.2/LambdaForm$DMH)
+	at java.lang.invoke.LambdaForm$MH/0x000007f8010a0800.invoke(java.base@25.0.2/LambdaForm$MH)
+	at java.lang.invoke.Invokers$Holder.invokeExact_MT(java.base@25.0.2/Invokers$Holder)
+	at jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(java.base@25.0.2/DirectMethodHandleAccessor.java:154)
+	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(java.base@25.0.2/DirectMethodHandleAccessor.java:104)
+	at java.lang.reflect.Method.invoke(java.base@25.0.2/Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor$$Lambda/0x000007f8011aec40.apply(Unknown Source)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(ExecutableInvoker.java:115)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall$$Lambda/0x000007f8011af070.apply(Unknown Source)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.lambda$invoke$0(ExecutableInvoker.java:105)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$$Lambda/0x000007f8011de0e0.apply(Unknown Source)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$InterceptedInvocation.proceed(InvocationInterceptorChain.java:106)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.proceed(InvocationInterceptorChain.java:64)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.chainAndInvoke(InvocationInterceptorChain.java:45)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain.invoke(InvocationInterceptorChain.java:37)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:104)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker.invoke(ExecutableInvoker.java:98)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.lambda$invokeTestMethod$7(TestMethodTestDescriptor.java:214)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor$$Lambda/0x000007f80120dfb0.execute(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.invokeTestMethod(TestMethodTestDescriptor.java:210)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:135)
+	at org.junit.jupiter.engine.descriptor.TestMethodTestDescriptor.execute(TestMethodTestDescriptor.java:66)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:151)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ced20.execute(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ceaf0.invoke(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ce6b8.execute(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService$$Lambda/0x000007f8011cf860.accept(Unknown Source)
+	at java.util.ArrayList.forEach(java.base@25.0.2/ArrayList.java:1604)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ced20.execute(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ceaf0.invoke(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ce6b8.execute(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService$$Lambda/0x000007f8011cf860.accept(Unknown Source)
+	at java.util.ArrayList.forEach(java.base@25.0.2/ArrayList.java:1604)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.invokeAll(SameThreadHierarchicalTestExecutorService.java:41)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$6(NodeTestTask.java:155)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ced20.execute(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$8(NodeTestTask.java:141)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ceaf0.invoke(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.Node.around(Node.java:137)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.lambda$executeRecursively$9(NodeTestTask.java:139)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask$$Lambda/0x000007f8011ce6b8.execute(Unknown Source)
+	at org.junit.platform.engine.support.hierarchical.ThrowableCollector.execute(ThrowableCollector.java:73)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.executeRecursively(NodeTestTask.java:138)
+	at org.junit.platform.engine.support.hierarchical.NodeTestTask.execute(NodeTestTask.java:95)
+	at org.junit.platform.engine.support.hierarchical.SameThreadHierarchicalTestExecutorService.submit(SameThreadHierarchicalTestExecutorService.java:35)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestExecutor.execute(HierarchicalTestExecutor.java:57)
+	at org.junit.platform.engine.support.hierarchical.HierarchicalTestEngine.execute(HierarchicalTestEngine.java:54)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:107)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:88)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.lambda$execute$0(EngineExecutionOrchestrator.java:54)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator$$Lambda/0x000007f8011b9ad8.accept(Unknown Source)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.withInterceptedStreams(EngineExecutionOrchestrator.java:67)
+	at org.junit.platform.launcher.core.EngineExecutionOrchestrator.execute(EngineExecutionOrchestrator.java:52)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:114)
+	at org.junit.platform.launcher.core.DefaultLauncher.execute(DefaultLauncher.java:86)
+	at org.junit.platform.launcher.core.DefaultLauncherSession$DelegatingLauncher.execute(DefaultLauncherSession.java:86)
+	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.processAllTestDefinitions(JUnitPlatformTestDefinitionProcessor.java:179)
+	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor$CollectThenExecuteTestDefinitionConsumer.access$000(JUnitPlatformTestDefinitionProcessor.java:122)
+	at org.gradle.api.internal.tasks.testing.junitplatform.JUnitPlatformTestDefinitionProcessor.stop(JUnitPlatformTestDefinitionProcessor.java:116)
+	at org.gradle.api.internal.tasks.testing.SuiteTestDefinitionProcessor.stop(SuiteTestDefinitionProcessor.java:63)
+	at java.lang.invoke.LambdaForm$DMH/0x000007f8010a0000.invokeInterface(java.base@25.0.2/LambdaForm$DMH)
+	at java.lang.invoke.LambdaForm$MH/0x000007f8010a0800.invoke(java.base@25.0.2/LambdaForm$MH)
+	at java.lang.invoke.Invokers$Holder.invokeExact_MT(java.base@25.0.2/Invokers$Holder)
+	at jdk.internal.reflect.DirectMethodHandleAccessor.invokeImpl(java.base@25.0.2/DirectMethodHandleAccessor.java:154)
+	at jdk.internal.reflect.DirectMethodHandleAccessor.invoke(java.base@25.0.2/DirectMethodHandleAccessor.java:104)
+	at java.lang.reflect.Method.invoke(java.base@25.0.2/Method.java:565)
+	at org.gradle.internal.dispatch.MethodInvocation.invokeOn(MethodInvocation.java:77)
+	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:28)
+	at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:19)
+	at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:33)
+	at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:88)
+	at jdk.proxy1.$Proxy4.stop(jdk.proxy1/Unknown Source)
+	at org.gradle.api.internal.tasks.testing.worker.TestWorker$3.run(TestWorker.java:195)
+	at org.gradle.api.internal.tasks.testing.worker.TestWorker.executeAndMaintainThreadName(TestWorker.java:126)
+	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:103)
+	at org.gradle.api.internal.tasks.testing.worker.TestWorker.execute(TestWorker.java:63)
+	at org.gradle.process.internal.worker.child.ActionExecutionWorker.execute(ActionExecutionWorker.java:56)
+	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:122)
+	at org.gradle.process.internal.worker.child.SystemApplicationClassLoaderWorker.call(SystemApplicationClassLoaderWorker.java:72)
+	at worker.org.gradle.process.internal.worker.GradleWorkerMain.run(GradleWorkerMain.java:69)
+	at worker.org.gradle.process.internal.worker.GradleWorkerMain.main(GradleWorkerMain.java:74)
+
+"Reference Handler" #15 [24835] daemon prio=10 os_prio=31 cpu=2.12ms elapsed=80294.41s tid=0x00000007b0890000 nid=24835 waiting on condition  [0x000000016cbaa000]
+   java.lang.Thread.State: RUNNABLE
+	at java.lang.ref.Reference.waitForReferencePendingList(java.base@25.0.2/Native Method)
+	at java.lang.ref.Reference.processPendingReferences(java.base@25.0.2/Reference.java:246)
+	at java.lang.ref.Reference$ReferenceHandler.run(java.base@25.0.2/Reference.java:208)
+
+"Finalizer" #16 [29443] daemon prio=8 os_prio=31 cpu=0.51ms elapsed=80294.41s tid=0x00000007b0890800 nid=29443 in Object.wait()  [0x000000016cdb6000]
+   java.lang.Thread.State: WAITING (on object monitor)
+	at java.lang.Object.wait0(java.base@25.0.2/Native Method)
+	- waiting on <no object reference available>
+	at java.lang.Object.wait(java.base@25.0.2/Object.java:389)
+	at java.lang.Object.wait(java.base@25.0.2/Object.java:351)
+	at java.lang.ref.ReferenceQueue.remove0(java.base@25.0.2/ReferenceQueue.java:137)
+	at java.lang.ref.ReferenceQueue.remove(java.base@25.0.2/ReferenceQueue.java:215)
+	- locked <0x00000004601028c8> (a java.lang.ref.ReferenceQueue$Lock)
+	at java.lang.ref.Finalizer$FinalizerThread.run(java.base@25.0.2/Finalizer.java:165)
+
+"Signal Dispatcher" #17 [29187] daemon prio=9 os_prio=31 cpu=0.10ms elapsed=80294.41s tid=0x00000007b0891000 nid=29187 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"Service Thread" #18 [25347] daemon prio=9 os_prio=31 cpu=1949.37ms elapsed=80294.41s tid=0x00000007b0891800 nid=25347 runnable  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"Monitor Deflation Thread" #19 [28419] daemon prio=9 os_prio=31 cpu=5985.14ms elapsed=80294.41s tid=0x00000007b0892000 nid=28419 runnable  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"C2 CompilerThread0" #20 [28163] daemon prio=9 os_prio=31 cpu=7385.77ms elapsed=80294.41s tid=0x00000007b0c5a800 nid=28163 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+   No compile task
+
+"C1 CompilerThread0" #28 [25859] daemon prio=9 os_prio=31 cpu=1681.48ms elapsed=80294.41s tid=0x00000007b0c5b200 nid=25859 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+   No compile task
+
+"Notification Thread" #32 [27395] daemon prio=9 os_prio=31 cpu=0.03ms elapsed=80294.40s tid=0x00000007b0892800 nid=27395 runnable  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"Common-Cleaner" #33 [27139] daemon prio=8 os_prio=31 cpu=68.14ms elapsed=80294.40s tid=0x00000007b0893000 nid=27139 in Object.wait()  [0x000000016de16000]
+   java.lang.Thread.State: TIMED_WAITING (on object monitor)
+	at java.lang.Object.wait0(java.base@25.0.2/Native Method)
+	- waiting on <no object reference available>
+	at java.lang.Object.wait(java.base@25.0.2/Object.java:389)
+	at java.lang.ref.ReferenceQueue.remove0(java.base@25.0.2/ReferenceQueue.java:123)
+	at java.lang.ref.ReferenceQueue.remove(java.base@25.0.2/ReferenceQueue.java:201)
+	- locked <0x0000000460101098> (a java.lang.ref.ReferenceQueue$Lock)
+	at jdk.internal.ref.CleanerImpl.run(java.base@25.0.2/CleanerImpl.java:146)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+	at jdk.internal.misc.InnocuousThread.run(java.base@25.0.2/InnocuousThread.java:148)
+
+"/127.0.0.1:55500 to /127.0.0.1:55499 workers" #35 [42243] prio=5 os_prio=31 cpu=5.83ms elapsed=80294.26s tid=0x00000007b05af000 nid=42243 waiting on condition  [0x000000016e852000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x00000004601018d0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at org.gradle.internal.remote.internal.hub.queue.EndPointQueue.take(EndPointQueue.java:49)
+	at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:403)
+	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1090)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"/127.0.0.1:55500 to /127.0.0.1:55499 workers Thread 2" #36 [33795] prio=5 os_prio=31 cpu=385.03ms elapsed=80294.26s tid=0x00000007b05dc000 nid=33795 waiting on condition  [0x000000016ea5e000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x0000000460100890> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at org.gradle.internal.remote.internal.hub.queue.EndPointQueue.take(EndPointQueue.java:49)
+	at org.gradle.internal.remote.internal.hub.MessageHub$ConnectionDispatch.run(MessageHub.java:322)
+	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1090)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"/127.0.0.1:55500 to /127.0.0.1:55499 workers Thread 3" #37 [34307] prio=5 os_prio=31 cpu=4.94ms elapsed=80294.26s tid=0x00000007b05dc800 nid=34307 runnable  [0x000000016ec69000]
+   java.lang.Thread.State: RUNNABLE
+	at sun.nio.ch.KQueue.poll(java.base@25.0.2/Native Method)
+	at sun.nio.ch.KQueueSelectorImpl.doSelect(java.base@25.0.2/KQueueSelectorImpl.java:121)
+	at sun.nio.ch.SelectorImpl.lockAndDoSelect(java.base@25.0.2/SelectorImpl.java:130)
+	- locked <0x0000000460102178> (a sun.nio.ch.Util$2)
+	- locked <0x0000000460102120> (a sun.nio.ch.KQueueSelectorImpl)
+	at sun.nio.ch.SelectorImpl.select(java.base@25.0.2/SelectorImpl.java:147)
+	at org.gradle.internal.remote.internal.inet.SocketConnection$SocketInputStream.read(SocketConnection.java:187)
+	at com.esotericsoftware.kryo.io.Input.fill(Input.java:146)
+	at com.esotericsoftware.kryo.io.Input.require(Input.java:178)
+	at com.esotericsoftware.kryo.io.Input.readByte(Input.java:295)
+	at org.gradle.internal.serialize.kryo.KryoBackedDecoder.readByte(KryoBackedDecoder.java:88)
+	at org.gradle.internal.remote.internal.hub.InterHubMessageSerializer$MessageReader.read(InterHubMessageSerializer.java:64)
+	at org.gradle.internal.remote.internal.hub.InterHubMessageSerializer$MessageReader.read(InterHubMessageSerializer.java:52)
+	at org.gradle.internal.remote.internal.inet.SocketConnection.receive(SocketConnection.java:83)
+	at org.gradle.internal.remote.internal.hub.MessageHub$ConnectionReceive.run(MessageHub.java:270)
+	at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:64)
+	at org.gradle.internal.concurrent.AbstractManagedExecutor$1.run(AbstractManagedExecutor.java:47)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1090)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"VirtualThread-unblocker" #49 [64515] daemon prio=5 os_prio=31 cpu=0.27ms elapsed=80293.91s tid=0x00000007b009c800 nid=64515 runnable  [0x0000000170f36000]
+   java.lang.Thread.State: RUNNABLE
+	at java.lang.VirtualThread.takeVirtualThreadListToUnblock(java.base@25.0.2/Native Method)
+	at java.lang.VirtualThread.unblockVirtualThreads(java.base@25.0.2/VirtualThread.java:1507)
+	at java.lang.VirtualThread$$Lambda/0x000007f8012420f8.run(java.base@25.0.2/Unknown Source)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+	at jdk.internal.misc.InnocuousThread.run(java.base@25.0.2/InnocuousThread.java:148)
+
+"ForkJoinPool-1-delayScheduler" #52 [63747] daemon prio=5 os_prio=31 cpu=43293.19ms elapsed=80293.90s tid=0x00000007b009e800 nid=63747 waiting on condition  [0x000000017134e000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	at java.util.concurrent.DelayScheduler.loop(java.base@25.0.2/DelayScheduler.java:253)
+	at java.util.concurrent.DelayScheduler.run(java.base@25.0.2/DelayScheduler.java:221)
+
+"junit-jupiter-timeout-watcher" #132 [49443] prio=10 os_prio=31 cpu=10.04ms elapsed=80284.54s tid=0x00000007affd9800 nid=49443 waiting on condition  [0x0000000171d22000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x00000004617c2878> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:1154)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:883)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@25.0.2/ThreadPoolExecutor.java:1016)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1076)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"Attach Listener" #134 [55907] daemon prio=9 os_prio=31 cpu=2.85ms elapsed=80283.87s tid=0x00000007b05ae000 nid=55907 waiting on condition  [0x0000000000000000]
+   java.lang.Thread.State: RUNNABLE
+
+"ForkJoinPool-1-worker-2" #2513 [171107] daemon prio=5 os_prio=31 cpu=14068.30ms elapsed=79998.90s tid=0x00000007af5e8000 nid=171107 waiting on condition  [0x000000016d9fe000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x0000000460101168> (a java.util.concurrent.ForkJoinPool)
+	at java.util.concurrent.ForkJoinPool.awaitWork(java.base@25.0.2/ForkJoinPool.java:2109)
+	at java.util.concurrent.ForkJoinPool.deactivate(java.base@25.0.2/ForkJoinPool.java:2063)
+	at java.util.concurrent.ForkJoinPool.runWorker(java.base@25.0.2/ForkJoinPool.java:2027)
+	at java.util.concurrent.ForkJoinWorkerThread.run(java.base@25.0.2/ForkJoinWorkerThread.java:187)
+
+"yano-plugin-sampler-timer" #2621 [133875] daemon prio=5 os_prio=31 cpu=0.69ms elapsed=79976.36s tid=0x00000007afa2c000 nid=133875 waiting on condition  [0x000000017213a000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x000000046271da80> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:1154)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:883)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@25.0.2/ThreadPoolExecutor.java:1016)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1076)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"yano-plugin-sampler-1" #2622 [71027] daemon prio=5 os_prio=31 cpu=1.51ms elapsed=79976.36s tid=0x00000007afa2e800 nid=71027 waiting on condition  [0x000000017275e000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x0000000462727770> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at java.util.concurrent.ArrayBlockingQueue.take(java.base@25.0.2/ArrayBlockingQueue.java:421)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@25.0.2/ThreadPoolExecutor.java:1016)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1076)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"yano-plugin-sampler-timer" #2623 [107819] daemon prio=5 os_prio=31 cpu=0.47ms elapsed=79974.35s tid=0x00000007afab7000 nid=107819 waiting on condition  [0x0000000171142000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x0000000462731530> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:1154)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:883)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@25.0.2/ThreadPoolExecutor.java:1016)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1076)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"yano-plugin-sampler-1" #2624 [133587] daemon prio=5 os_prio=31 cpu=0.57ms elapsed=79974.35s tid=0x00000007afbd5000 nid=133587 waiting on condition  [0x0000000171b16000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x000000046273b2f0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at java.util.concurrent.ArrayBlockingQueue.take(java.base@25.0.2/ArrayBlockingQueue.java:421)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@25.0.2/ThreadPoolExecutor.java:1016)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1076)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"yano-plugin-sampler-timer" #2625 [92899] daemon prio=5 os_prio=31 cpu=0.46ms elapsed=79972.35s tid=0x00000007b014b000 nid=92899 waiting on condition  [0x000000016e45e000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x00000004627450b0> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:1154)
+	at java.util.concurrent.ScheduledThreadPoolExecutor$DelayedWorkQueue.take(java.base@25.0.2/ScheduledThreadPoolExecutor.java:883)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@25.0.2/ThreadPoolExecutor.java:1016)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1076)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"yano-plugin-sampler-2" #2627 [89091] daemon prio=5 os_prio=31 cpu=0.13ms elapsed=79972.34s tid=0x00000007af6f8000 nid=89091 waiting on condition  [0x0000000172346000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x00000004627278d8> (a java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject)
+	at java.util.concurrent.locks.LockSupport.park(java.base@25.0.2/LockSupport.java:369)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionNode.block(java.base@25.0.2/AbstractQueuedSynchronizer.java:520)
+	at java.util.concurrent.ForkJoinPool.unmanagedBlock(java.base@25.0.2/ForkJoinPool.java:4364)
+	at java.util.concurrent.ForkJoinPool.managedBlock(java.base@25.0.2/ForkJoinPool.java:4310)
+	at java.util.concurrent.locks.AbstractQueuedSynchronizer$ConditionObject.await(java.base@25.0.2/AbstractQueuedSynchronizer.java:1752)
+	at java.util.concurrent.ArrayBlockingQueue.take(java.base@25.0.2/ArrayBlockingQueue.java:421)
+	at java.util.concurrent.ThreadPoolExecutor.getTask(java.base@25.0.2/ThreadPoolExecutor.java:1016)
+	at java.util.concurrent.ThreadPoolExecutor.runWorker(java.base@25.0.2/ThreadPoolExecutor.java:1076)
+	at java.util.concurrent.ThreadPoolExecutor$Worker.run(java.base@25.0.2/ThreadPoolExecutor.java:614)
+	at java.lang.Thread.runWith(java.base@25.0.2/Thread.java:1487)
+	at java.lang.Thread.run(java.base@25.0.2/Thread.java:1474)
+
+"ForkJoinPool-1-worker-3" #2628 [55747] daemon prio=5 os_prio=31 cpu=15344.73ms elapsed=79968.53s tid=0x00000007af97a800 nid=55747 waiting on condition  [0x0000000171f2e000]
+   java.lang.Thread.State: TIMED_WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x0000000460101168> (a java.util.concurrent.ForkJoinPool)
+	at java.util.concurrent.ForkJoinPool.awaitWork(java.base@25.0.2/ForkJoinPool.java:2109)
+	at java.util.concurrent.ForkJoinPool.deactivate(java.base@25.0.2/ForkJoinPool.java:2063)
+	at java.util.concurrent.ForkJoinPool.runWorker(java.base@25.0.2/ForkJoinPool.java:2027)
+	at java.util.concurrent.ForkJoinWorkerThread.run(java.base@25.0.2/ForkJoinWorkerThread.java:187)
+
+"ForkJoinPool-1-worker-4" #2629 [186063] daemon prio=5 os_prio=31 cpu=14124.19ms elapsed=79968.53s tid=0x00000007b0613000 nid=186063 waiting on condition  [0x0000000172552000]
+   java.lang.Thread.State: WAITING (parking)
+	at jdk.internal.misc.Unsafe.park(java.base@25.0.2/Native Method)
+	- parking to wait for  <0x0000000460101168> (a java.util.concurrent.ForkJoinPool)
+	at java.util.concurrent.ForkJoinPool.awaitWork(java.base@25.0.2/ForkJoinPool.java:2109)
+	at java.util.concurrent.ForkJoinPool.deactivate(java.base@25.0.2/ForkJoinPool.java:2063)
+	at java.util.concurrent.ForkJoinPool.runWorker(java.base@25.0.2/ForkJoinPool.java:2027)
+	at java.util.concurrent.ForkJoinWorkerThread.run(java.base@25.0.2/ForkJoinWorkerThread.java:187)
+
+"G1 Conc#2" os_prio=31 cpu=234.54ms elapsed=80291.15s tid=0x00000007bb640500 nid=38243 runnable  
+
+"G1 Conc#1" os_prio=31 cpu=238.71ms elapsed=80291.15s tid=0x00000007bb640000 nid=46131 runnable  
+
+"GC Thread#12" os_prio=31 cpu=57.25ms elapsed=80291.15s tid=0x00000007ba77b700 nid=33139 runnable  
+
+"GC Thread#11" os_prio=31 cpu=66.83ms elapsed=80294.12s tid=0x00000007b3f0d400 nid=36611 runnable  
+
+"GC Thread#10" os_prio=31 cpu=70.31ms elapsed=80294.12s tid=0x00000007b3f0cf00 nid=36355 runnable  
+
+"GC Thread#9" os_prio=31 cpu=69.82ms elapsed=80294.12s tid=0x00000007b3f0ca00 nid=36099 runnable  
+
+"GC Thread#8" os_prio=31 cpu=65.29ms elapsed=80294.12s tid=0x00000007b3f0c500 nid=35843 runnable  
+
+"GC Thread#7" os_prio=31 cpu=58.35ms elapsed=80294.12s tid=0x00000007b3f0c000 nid=35331 runnable  
+
+"GC Thread#6" os_prio=31 cpu=67.32ms elapsed=80294.12s tid=0x00000007b3ed7700 nid=39427 runnable  
+
+"GC Thread#5" os_prio=31 cpu=62.01ms elapsed=80294.12s tid=0x00000007b3ed7200 nid=34819 runnable  
+
+"GC Thread#4" os_prio=31 cpu=68.55ms elapsed=80294.12s tid=0x00000007b3ed6d00 nid=40195 runnable  
+
+"GC Thread#3" os_prio=31 cpu=54.74ms elapsed=80294.12s tid=0x00000007b3ed6800 nid=40707 runnable  
+
+"GC Thread#2" os_prio=31 cpu=74.63ms elapsed=80294.12s tid=0x00000007b3ed6300 nid=34563 runnable  
+
+"GC Thread#1" os_prio=31 cpu=65.71ms elapsed=80294.12s tid=0x00000007b3ed5e00 nid=41475 runnable  
+
+"VM Thread" os_prio=31 cpu=75.92ms elapsed=80294.42s tid=0x00000007b0855c00 nid=18691 runnable  
+
+"VM Periodic Task Thread" os_prio=31 cpu=412.78ms elapsed=80294.42s tid=0x00000007b0855800 nid=20751 waiting on condition  
+
+"G1 Service" os_prio=31 cpu=2890.30ms elapsed=80294.42s tid=0x0000000104d78fd0 nid=21251 runnable  
+
+"G1 Refine#0" os_prio=31 cpu=0.02ms elapsed=80294.42s tid=0x0000000104d784a0 nid=16643 runnable  
+
+"G1 Conc#0" os_prio=31 cpu=234.88ms elapsed=80294.42s tid=0x0000000104d75470 nid=13059 runnable  
+
+"G1 Main Marker" os_prio=31 cpu=4.38ms elapsed=80294.42s tid=0x0000000104d74950 nid=13827 runnable  
+
+"GC Thread#0" os_prio=31 cpu=67.40ms elapsed=80294.42s tid=0x0000000104d717d0 nid=12547 runnable  
+
+JNI global refs: 26, weak refs: 0
+
+
+==================== analysis ====================
+The worker is blocked in Object.wait() inside
+PluginOperationsRegistry.awaitNoActiveSamplesLocked, reached from close() ->
+sealAndAwait(), while holding two monitors (0x462700000 and 0x462700010).
+
+It is waiting for active samples to drain while holding the very lock that a
+sampler would need to release itself, so nothing can wake it. CPU time is 2:16
+against ~21 hours wall: it is idle-blocked, not spinning.
+
+Origin: PluginOperationsRegistry and its test are NOT touched by ADR-039. Both
+are inherited from the parent stack (present in #67 / main lineage), so this is
+a pre-existing deadlock exposed by running the full suite, not something this
+campaign introduced.
+
+Consequence for verification: a suite run containing this test never terminates,
+so "the suite is still running" is indistinguishable from "the suite is hung".
+No ADR-039 layer may be called green on the strength of a run that included it
+without a bounded timeout.

--- a/adr/reports/adr-039-samples/pinned-reader-failure-2026-08-21.md
+++ b/adr/reports/adr-039-samples/pinned-reader-failure-2026-08-21.md
@@ -1,0 +1,76 @@
+# Failing run: aPinnedReaderSurvivesSnapshotExpirationAndFileCleanup
+
+Captured 2026-08-20T23:43:13Z from the full-suite run that failed (BUILD FAILED in 14m 3s).
+Preserved verbatim before any diagnosis, so a later 'it passes now' cannot quietly replace it.
+
+## Environment at the time of failure
+```
+disk:            6.6T used of 7.3T, 90% full, 746G free
+load average:    : 3.76, 4.57, 5.75
+concurrent JVMs: 6
+yano nodes up:   1
+suite scope:     ./gradlew test -x :testkit:test  (14m 3s wall)
+```
+
+## Failure
+```
+classname="com.bloxbean.cardano.yano.archive.ducklake.DuckLakeProjectionSinkTest" time="42.311">
+    java.lang.AssertionError: [the diagnostic must say why nothing was reclaimed] 
+Expecting actual:
+  "projection_receipts: TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction.
+Failed to commit: Failed to execute query "COMMIT": database is locked; transaction_redeemers: Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result
+Error: Invalid Error: Failed to query most recent snapshot for DuckLake: Failed to prepare query "SELECT type FROM sqlite_master WHERE lower(name)=lower('ducklake_snapshot');": database is locked; rewards: Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result
+Error: Invalid Error: Failed to query most recent snapshot for DuckLake: Failed to prepare query "SELECT type FROM sqlite_master WHERE lower(name)=lower('ducklake_snapshot');": database is locked; transaction_datums: Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result
+Error: Invalid Error: Failed to query most recent snapshot for DuckLake: Failed to prepare query "SELECT type FROM sqlite_master WHERE lower(name)=lower('ducklake_snapshot');": database is locked; address_transactions: Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result
+Error: Invalid Error: Failed to query most recent snapshot for DuckLake: Failed to prepare query "SELECT type FROM sqlite_master WHERE lower(name)=lower('ducklake_snapshot');": database is locked; transaction_redeemers: Invalid Input Error: Attempting to execute an unsuccessful or closed pending query result
+Error: Invalid Error: Failed to query most recent snapshot for DuckLake: Failed to prepare query "SELECT type FROM sqlite_master WHERE lower(name)=lower('ducklake_snapshot');": database is locked"
+to contain:
+  "expire_snapshots" 
+	at com.bloxbean.cardano.yano.archive.ducklake.DuckLakeProjectionSinkTest.aPinnedReaderSurvivesSnapshotExpirationAndFileCleanup(DuckLakeProjectionSinkTest.java:492)
+	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
+	at java.base/java.lang.reflect.Method.invoke(Method.java:565)
+	at org.junit.platform.commons.util.ReflectionUtils.invokeMethod(ReflectionUtils.java:725)
+	at org.junit.jupiter.engine.execution.MethodInvocation.proceed(MethodInvocation.java:60)
+	at org.junit.jupiter.engine.execution.InvocationInterceptorChain$ValidatingInvocation.proceed(InvocationInterceptorChain.java:131)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.intercept(TimeoutExtension.java:149)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestableMethod(TimeoutExtension.java:140)
+	at org.junit.jupiter.engine.extension.TimeoutExtension.interceptTestMethod(TimeoutExtension.java:84)
+	at org.junit.jupiter.engine.execution.ExecutableInvoker$ReflectiveInterceptorCall.lambda$ofVoidMethod$0(Exe
+```
+
+## Captured stdout from that test
+```
+ADR-039 pinned reader: maintenance PARTIAL, snapshots expired 0, orphans deleted 0, files 35 -> 0, detail=projection_receipts: TransactionContext Error: Failed to commit: Failed to commit DuckLake transaction.
+```
+
+## Diagnosis
+
+**The test was wrong, not the implementation.** The assertion required the diagnostic to name
+`expire_snapshots` specifically:
+
+```java
+assertThat(result.detail().orElse(""))
+        .as("the diagnostic must say why nothing was reclaimed")
+        .contains("expire_snapshots");
+```
+
+In the failing run the detail instead began `projection_receipts: ... database is locked`, listing
+per-table **compaction** failures. Both are the same underlying condition — the pinned reader's
+open transaction holds the SQLite catalog lock — but *which step reaches the lock first* is a
+matter of timing. In the isolated runs, snapshot expiration got there first; in a contended
+14-minute suite with six JVMs and the machine at load 3.8, housekeeping got through and compaction
+was the step that hit it.
+
+So the assertion encoded an incidental scheduling detail as if it were the contract.
+
+**The safety property held throughout.** The failing run shows every operation refused with
+`database is locked`, which means nothing was expired and nothing was deleted — exactly what the
+test exists to protect. The reader was never at risk. What failed was the test's description of
+*how* the refusal would be reported.
+
+**Fix:** assert the contract instead of the timing — the pass must not claim success, must carry a
+diagnostic, must name whichever operation could not proceed, and must have reclaimed nothing. That
+holds regardless of which step loses the race, and it still fails if maintenance ever reports
+success while a reader is pinned, which is the property that matters.
+
+No timeout was increased and no test was disabled.

--- a/adr/reports/adr-039-utxo-collateral-return-leak-2026-08-20.md
+++ b/adr/reports/adr-039-utxo-collateral-return-leak-2026-08-20.md
@@ -1,0 +1,85 @@
+# Pre-existing UTXO bug: a collateral return spent in its own block leaks a phantom unspent output
+
+**Found 2026-08-20 during ADR-039 Phase 4b live validation. Not caused by ADR-039, and not
+fixed here — it changes core UTXO accounting, so the fix is a decision, not a detail.**
+
+**Tracked as [bloxbean/yano#74](https://github.com/bloxbean/yano/issues/74); to be fixed in a
+separate PR.**
+
+## What happens
+
+`DefaultUtxoStore.applyBlock` resolves a spent input in two steps:
+
+1. `ctx.getUnspent(key)` — a prefetched read of the **committed** database;
+2. failing that, `intraBlockOutputs` — outputs created earlier in the *same* block, which the
+   committed read cannot see because they are still in the open `WriteBatch`.
+
+The ordinary output-creation path populates `intraBlockOutputs`. **The collateral-return path
+does not.** It writes the return to `cfUnspent` through the batch and stops there.
+
+So when an invalid transaction's collateral return is spent later in the same block, both
+lookups miss, `prev` is null, and the whole spend is skipped by the surrounding
+`if (prev != null)` — silently, because an unresolvable input is not an error to this code.
+
+## Consequences
+
+For that outpoint:
+
+- it stays in `utxo_unspent` **permanently** — a phantom unspent output;
+- it is never written to `utxo_spent`;
+- its `utxo_addr` index entry is never deleted;
+- `addStakeBalanceDelta` is never applied, so the owner's stake balance stays overstated by
+  the return's lovelace.
+
+## Evidence
+
+Preprod block **1,809,762** (slot 49,425,634): transaction `ef4a3c84ae917f6305c418647a504d1b1b74a03b651474dabb356f94049d03ba`
+is invalid (`valid=false`), its collateral return is output index 1 (7,000,000 lovelace), and
+that output is consumed inside the same block. Both facts come from the archive of a node
+synced to tip.
+
+Probing that node's live chainstate for the outpoint, at block 5,077,000+, long after the
+spend:
+
+```
+utxo_unspent   present, 169 bytes          <- still unspent, ~3.27M blocks later
+utxo_spent     ABSENT
+utxo_addr      2 entries at slot 49425634  <- address hash + payment credential, both stale
+```
+
+An earlier revision of this report showed `utxo_addr ABSENT`, which contradicted its own text. The
+probe was wrong, not the analysis: it used the 34-byte outpoint key against a column family keyed
+by `addrHash28 ‖ slot ‖ txHash ‖ index` (70 bytes). Re-probed by scanning for entries whose
+trailing 34 bytes match the outpoint: 8,750,751 entries scanned, **2 matching** — both stale.
+
+## Why it stayed invisible
+
+Nothing ever asked. The store treats an unresolvable input as a no-op, and no downstream
+consumer needed the spent output's identity — until ADR-039's address-transaction projection
+needed the address of every consumed output and **failed closed** rather than dropping the
+participation. The node halted on that block with a clear diagnostic, which is how the bug
+surfaced.
+
+The ADR-039 side is fixed independently: addresses are now captured when an output is
+**created** as well as when it is spent, so the projection resolves intra-block spends without
+depending on the store's intra-block map.
+
+## The fix, and why it is not applied here
+
+One line, in the collateral-return branch:
+
+```java
+intraBlockOutputs.put(tx.getTxHash() + ":" + outIdx, val);
+```
+
+It is not applied in this branch because it changes what the UTXO set contains and what stake
+balances report, on every network, for every node — well outside "minimum necessary changes to
+runtime/core" for ADR-039, and it deserves its own change with its own validation. Two further
+questions belong with it:
+
+1. **Existing chainstates are already wrong.** Every node that has passed such a block carries
+   phantom unspent outputs. Correcting them needs either a resync or a repair pass; the
+   population is small (one preprod occurrence found in 5.07M blocks) but non-zero.
+2. **The silent skip itself is questionable.** `if (prev != null)` treats an input the store
+   cannot resolve as nothing to do. That is what turned a one-line omission into a
+   permanently wrong UTXO set rather than a loud failure at the first occurrence.

--- a/app/config/application-projection.yml
+++ b/app/config/application-projection.yml
@@ -1,0 +1,77 @@
+# Canonical projection outbox archive profile (ADR-039).
+#
+# Compose this after a network profile, for example:
+#   ./yano.sh start:preprod,projection
+#   ./yano.sh start:mainnet,projection
+#
+# This is the replacement for the ADR-034 replay-worker archive (the `history`
+# profile), not an addition to it. Enable one or the other, never both: they write
+# the same DuckLake tables from different pipelines.
+#
+# FRESH SYNC ONLY. The set of projected datasets is part of the archive's identity,
+# so an archive cannot gain a dataset later - the earlier blocks would be missing
+# from it. A node started against an archive written with a different dataset set,
+# network, or schema version fails closed at startup rather than appending rows of
+# a second shape into the same tables.
+
+yano:
+  account-state:
+    # Required: pre-Conway pointer addresses are resolved from the account-state
+    # subsystem's deregistration index while the mapping is still current for the
+    # block being projected. Without it the node refuses to project.
+    enabled: true
+  history:
+    # The ADR-034 replay-worker archive stays off; this profile replaces it.
+    enabled: false
+    dir: ${YANO_HISTORY_DIR:./history}
+    projection:
+      enabled: true
+
+      # DuckLake (DuckDB + Parquet + a SQLite catalog) is the validated primary sink.
+      # Exactly one primary sink is supported at a time.
+      sink: ${YANO_PROJECTION_SINK:ducklake}
+
+      # Datasets to project. Defaults to every shipped block dataset:
+      #   transaction:v2, utxo-history:v5, account-events:v3, address-transaction:v3
+      #
+      # Set this ONLY to deliberately project fewer, which is a legacy or testing
+      # configuration. A dataset omitted here can be added back only by resyncing
+      # from genesis, and an archive missing one looks healthy until a query
+      # returns nothing.
+      # sections: transaction:v2,utxo-history:v5
+
+      # How often the drain loop polls when it has nothing eligible to commit.
+      drain-interval-millis: ${YANO_PROJECTION_DRAIN_INTERVAL_MILLIS:250}
+
+      maintenance:
+        # Housekeeping - expiring snapshots, deleting superseded and orphaned files -
+        # runs on this interval and is allowed during bootstrap, because a long sync
+        # can outlast the retention windows.
+        housekeeping-interval-minutes: ${YANO_PROJECTION_HOUSEKEEPING_INTERVAL_MINUTES:30}
+        housekeeping-budget-seconds: ${YANO_PROJECTION_HOUSEKEEPING_BUDGET_SECONDS:30}
+        # Compaction additionally requires the sink to be caught up with no backlog,
+        # so it never competes with ingestion for the bulk pool.
+        compaction-interval-minutes: ${YANO_PROJECTION_COMPACTION_INTERVAL_MINUTES:360}
+        compaction-budget-seconds: ${YANO_PROJECTION_COMPACTION_BUDGET_SECONDS:300}
+        compaction-rewrite-bytes: ${YANO_PROJECTION_COMPACTION_REWRITE_BYTES:8589934592}
+
+      sink-options:
+        # Compaction output target. Not the per-commit file size: each commit writes
+        # its own file per touched table, and compaction merges them afterwards.
+        target-file-size-bytes: ${YANO_PROJECTION_TARGET_FILE_SIZE_BYTES:4194304}
+        # Retention windows inherited from the replay-worker backend. Compaction's
+        # rewritten inputs stay on disk for the cleanup grace, so peak sink footprint
+        # is roughly twice the logical archive for that long. Shorten only after
+        # active-reader fencing and query duration are proven (ADR-039 Phase 6).
+        snapshot-retention-hours: ${YANO_PROJECTION_SNAPSHOT_RETENTION_HOURS:168}
+        cleanup-grace-hours: ${YANO_PROJECTION_CLEANUP_GRACE_HOURS:24}
+
+      # Aggregate archive-retained disk budget. Canonical sync runs ahead of the sink
+      # by design; these bounds exist so a lagging sink cannot exhaust the disk, not
+      # to pace core to sink speed. Ingestion pauses visibly at the hard limit and
+      # resumes automatically below the low-water mark.
+      disk:
+        soft-bytes: ${YANO_PROJECTION_DISK_SOFT_BYTES:8589934592}
+        hard-bytes: ${YANO_PROJECTION_DISK_HARD_BYTES:34359738368}
+        low-water-bytes: ${YANO_PROJECTION_DISK_LOW_WATER_BYTES:4294967296}
+        free-space-reserve-bytes: ${YANO_PROJECTION_DISK_FREE_RESERVE_BYTES:17179869184}

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
@@ -28,6 +28,7 @@ import com.bloxbean.cardano.yano.api.plugin.PluginCatalogView;
 import com.bloxbean.cardano.yano.api.plugin.operations.PluginOperationsView;
 import com.bloxbean.cardano.yano.app.bootstrap.BootstrapConfigParser;
 import com.bloxbean.cardano.yano.app.archive.HistoryArchiveService;
+import com.bloxbean.cardano.yano.app.archive.ProjectionHistoryService;
 import com.bloxbean.cardano.yano.bootstrap.providers.DefaultBootstrapDataProviderFactory;
 import com.bloxbean.cardano.yano.devnet.YanoDevnetAssembly;
 import com.bloxbean.cardano.yano.runtime.assembly.YanoAssembly;
@@ -98,6 +99,9 @@ public class YanoProducer {
 
     @Inject
     HistoryArchiveService historyArchive;
+
+    @Inject
+    ProjectionHistoryService projectionHistory;
 
     @ConfigProperty(name = YanoPropertyKeys.NETWORK, defaultValue = "mainnet")
     String network;
@@ -962,6 +966,15 @@ public class YanoProducer {
                     assembledYano.chain(),
                     assembledYano.ledger(),
                     (YanoConfig) assembledYano.lifecycle().getConfig());
+            // ADR-039 projection history. Composed separately from the replay-worker
+            // service above so the two can run side by side while the old path serves as
+            // the differential oracle. Disabled by default; a disabled node installs no
+            // contributor and keeps its current behaviour.
+            projectionHistory.initialize(
+                    assembledYano,
+                    assembledYano.chain(),
+                    assembledYano.ledger(),
+                    (YanoConfig) assembledYano.lifecycle().getConfig());
             if (autoSyncStart) {
                 log.info("Auto-starting Yano synchronization...");
                 assembledYano.start();
@@ -1345,6 +1358,7 @@ public class YanoProducer {
         // Stop and join optional archive work while its core query dependencies
         // and native stores are still valid.
         try {
+            projectionHistory.close();
             historyArchive.close();
         } finally {
             if (yano != null) {

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/api/status/StatusResource.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/api/status/StatusResource.java
@@ -7,6 +7,7 @@ import com.bloxbean.cardano.yano.api.LedgerQuery;
 import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.runtime.utxo.UtxoStatusProvider;
 import com.bloxbean.cardano.yano.app.archive.HistoryArchiveService;
+import com.bloxbean.cardano.yano.app.archive.ProjectionHistoryService;
 import jakarta.inject.Inject;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
@@ -28,6 +29,9 @@ public class StatusResource {
 
     @Inject
     HistoryArchiveService historyArchive;
+
+    @Inject
+    ProjectionHistoryService projectionHistory;
 
     @GET
     public Response status() {
@@ -77,6 +81,7 @@ public class StatusResource {
         body.put("chain", chain);
         body.put("utxo", utxo);
         body.put("history", historyArchive.status());
+        body.put("projection", projectionHistory.status());
         body.put("cfEstimates", cfEstimates);
         return Response.ok(body).build();
     }

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/archive/NoArtifactReader.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/archive/NoArtifactReader.java
@@ -1,0 +1,35 @@
+package com.bloxbean.cardano.yano.app.archive;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ArchiveArtifactReader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Artifact reader for the block-only slice.
+ *
+ * <p>The first vertical slice produces no epoch artifacts, so any request here means an
+ * envelope referenced one that cannot exist. Failing loudly is correct: silently returning an
+ * empty stream would let the sink acknowledge an artifact it never read, which is exactly the
+ * silent-loss failure ADR-039 exists to prevent. Replaced in Phase 5.
+ */
+final class NoArtifactReader implements ArchiveArtifactReader {
+
+    @Override
+    public ArtifactLease acquire(ProjectionArtifactRef ref, Instant expiresAt) {
+        throw new UnsupportedOperationException("epoch artifacts are not produced by this slice: " + ref);
+    }
+
+    @Override
+    public ArtifactPage read(ProjectionArtifactRef ref, ArtifactLease lease, Optional<String> cursor, int limit) {
+        throw new UnsupportedOperationException("epoch artifacts are not produced by this slice: " + ref);
+    }
+
+    @Override
+    public void acknowledge(ProjectionArtifactRef ref) {
+        throw new UnsupportedOperationException("epoch artifacts are not produced by this slice: " + ref);
+    }
+}

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/archive/ProjectionHistoryService.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/archive/ProjectionHistoryService.java
@@ -157,9 +157,24 @@ public class ProjectionHistoryService implements AutoCloseable {
         // silently discarded; the guard is the single place that decides a start is unsupported.
         boolean hasStoredIdentity = outbox.identityFingerprint().isPresent();
 
+        // The sink is opened and inspected BEFORE the guard runs. Passing synthetic state here -
+        // sinkEmpty=true, no identity, coordinate NONE - made the most dangerous case
+        // unreachable: an outbox that has acknowledged and pruned five million blocks against a
+        // history directory that was deleted or repointed would have been accepted, a fresh
+        // empty archive created, and every block below the acknowledgement lost with the archive
+        // reporting itself healthy.
+        openSink();
+
+        // Real observed sink state, not an assumption about it.
+        long acknowledgedThrough = outbox.acknowledgedThrough();
+        ProjectionCoordinate sinkCoordinate = projectionSink == null
+                ? ProjectionCoordinate.NONE : projectionSink.coordinate();
+        boolean sinkEmpty = !sinkCoordinate.isPresent();
+        Optional<ProjectionIdentity> sinkIdentity = projectionSink == null || sinkEmpty
+                ? Optional.empty() : Optional.of(identity);
         ProjectionStartupGuard.verify(identity, new ProjectionStartupGuard.Observed(
                 tipBlock, hasStoredIdentity, storedIdentity,
-                true, Optional.empty(), ProjectionCoordinate.NONE, required));
+                sinkEmpty, sinkIdentity, sinkCoordinate, required, acknowledgedThrough));
 
         outbox.putIdentity(identity);
 
@@ -215,7 +230,7 @@ public class ProjectionHistoryService implements AutoCloseable {
                 config.getOptionalValue(YanoPropertyKeys.History.DIR, String.class).orElse("./history"))
                 .toAbsolutePath().normalize();
 
-        openSinkAndConsumer(chain, ledger, genesis, nodeConfig);
+        startConsumerAndDrain(chain);
 
         installShelleyPlusContributor(yano);
         // Hold canonical ingestion only when the archive's aggregate disk budget or the
@@ -251,8 +266,14 @@ public class ProjectionHistoryService implements AutoCloseable {
      * silently running with no sink while claiming one is configured would look like a healthy
      * archive that never receives anything.
      */
-    private void openSinkAndConsumer(ChainQuery chain, LedgerQuery ledger,
-                                     NetworkGenesisConfig genesis, YanoConfig nodeConfig) {
+    /**
+     * Open and initialise the sink, without starting to drain.
+     *
+     * <p>Separate from starting the drain loop on purpose: the startup guard must see the real
+     * sink - its identity and its coordinate - before anything is written, and it cannot do that
+     * if the sink is opened as part of starting up.
+     */
+    private void openSink() {
         if ("none".equals(sink)) {
             log.info("ADR-039 projection sink is 'none'; the outbox will accumulate for measurement");
             return;
@@ -275,7 +296,11 @@ public class ProjectionHistoryService implements AutoCloseable {
         // Every later use of the sink goes through this, so shutdown can guarantee it is never
         // closed while a commit or a maintenance pass is in flight.
         sinkLifecycle = new ProjectionSinkLifecycle(projectionSink);
+    }
 
+    /** Start the ordered drain, once the guard has accepted the sink. */
+    private void startConsumerAndDrain(ChainQuery chain) {
+        if (projectionSink == null) return;
         consumer = new ProjectionOutboxConsumer(outbox, projectionSink, identity,
                 new ProjectionFinalityGate(safetyWindows), consumerBounds(),
                 new com.bloxbean.cardano.yano.app.archive.NoArtifactReader(),

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/archive/ProjectionHistoryService.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/archive/ProjectionHistoryService.java
@@ -1,0 +1,700 @@
+package com.bloxbean.cardano.yano.app.archive;
+
+import com.bloxbean.cardano.yaci.events.api.EventBus;
+import com.bloxbean.cardano.yaci.events.api.SubscriptionOptions;
+import com.bloxbean.cardano.yano.api.ChainQuery;
+import com.bloxbean.cardano.yano.api.LedgerQuery;
+import com.bloxbean.cardano.yano.api.config.YanoConfig;
+import com.bloxbean.cardano.yano.runtime.config.NetworkGenesisConfig;
+import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
+import com.bloxbean.cardano.yano.api.config.YanoPropertyKeys;
+import com.bloxbean.cardano.yano.api.events.ByronBlockProjectionEvent;
+import com.bloxbean.cardano.yano.api.events.RollbackEvent;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveSafetyWindows;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSink;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkProvider;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionConsumerBounds;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionFinalityGate;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionOutboxConsumer;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionConsumerResult;
+import com.bloxbean.cardano.yano.archive.core.projection.ArchiveDiskLimits;
+import com.bloxbean.cardano.yano.archive.core.projection.ArchiveIngestGate;
+import com.bloxbean.cardano.yano.archive.core.projection.ArchiveRetainedFootprint;
+import com.bloxbean.cardano.yano.archive.core.projection.CanonicalProjectionCollector;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionChunking;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionContributorHealth;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionMaintenanceSchedule;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionOutboxStats;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionOutboxStore;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionSinkLifecycle;
+import com.bloxbean.cardano.yano.archive.core.projection.ProjectionStartupGuard;
+import com.bloxbean.cardano.yano.runtime.assembly.Yano;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.config.Config;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.RocksDB;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Composes ADR-039 projection history for the node.
+ *
+ * <p>Kept separate from {@link HistoryArchiveService} deliberately: that service
+ * orchestrates the replay-worker architecture ADR-039 replaces, and the two must be able
+ * to run side by side while the old path serves as the differential oracle. Mixing them
+ * would make the eventual removal commit far harder to review.
+ *
+ * <p>When {@code yano.history.projection.enabled} is false this initialises nothing and
+ * installs no contributor, so a history-disabled node keeps its current behaviour.
+ */
+@ApplicationScoped
+public class ProjectionHistoryService implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(ProjectionHistoryService.class);
+
+    private final Config config;
+
+    private volatile boolean enabled;
+    private volatile ProjectionOutboxStore outbox;
+    private volatile CanonicalProjectionCollector collector;
+    private volatile ProjectionIdentity identity;
+    private volatile ArchiveSafetyWindows safetyWindows;
+    private volatile ProjectionContributorHealth.Monitor contributorMonitor;
+    private volatile ArchiveIngestGate ingestGate;
+    private volatile double diskAmplification = 1.4;
+    private volatile java.nio.file.Path historyDirectory;
+    private volatile ProjectionSink projectionSink;
+    private volatile ProjectionSinkLifecycle sinkLifecycle;
+    private volatile ProjectionOutboxConsumer consumer;
+    private volatile Thread drainThread;
+    private volatile boolean draining;
+    private final java.util.concurrent.atomic.LongAdder drainedBatches = new java.util.concurrent.atomic.LongAdder();
+    private final java.util.concurrent.atomic.LongAdder drainedBlocks = new java.util.concurrent.atomic.LongAdder();
+    private final java.util.concurrent.atomic.LongAdder drainFailures = new java.util.concurrent.atomic.LongAdder();
+    private volatile String lastDrainFailure;
+    private volatile String sink = "none";
+    private volatile ProjectionMaintenanceSchedule maintenanceSchedule = ProjectionMaintenanceSchedule.defaults();
+    private volatile java.time.Duration maintenanceHousekeepingBudget = java.time.Duration.ofSeconds(30);
+    private volatile java.time.Duration maintenanceCompactionBudget = java.time.Duration.ofMinutes(5);
+    private volatile long maintenanceRewriteBytes = 8L << 30;
+    private final java.util.concurrent.atomic.LongAdder maintenancePasses =
+            new java.util.concurrent.atomic.LongAdder();
+    private final java.util.concurrent.atomic.LongAdder compactionPasses =
+            new java.util.concurrent.atomic.LongAdder();
+    private volatile String lastMaintenanceOutcome;
+    private volatile boolean diskBackpressureInstalled;
+
+    /**
+     * How long shutdown waits for an in-flight sink commit. Bounded rather than unbounded: a
+     * wedged sink must not prevent the node from stopping, and the receipt protocol makes an
+     * abandoned commit safe to replay.
+     */
+    private static final Duration SHUTDOWN_DRAIN_WAIT = Duration.ofSeconds(30);
+
+    @Inject
+    public ProjectionHistoryService(Config config) {
+        this.config = Objects.requireNonNull(config, "config");
+    }
+
+    public synchronized void initialize(Yano yano, ChainQuery chain, LedgerQuery ledger,
+                                       YanoConfig nodeConfig) {
+        if (outbox != null) return;
+        enabled = config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_ENABLED, Boolean.class).orElse(false);
+        if (!enabled) {
+            log.info("ADR-039 projection history is disabled");
+            return;
+        }
+
+        var access = yano.chainstateRocksAccess().orElseThrow(() -> new IllegalStateException(
+                "projection history requires a RocksDB-backed chain state; the outbox must share the"
+                        + " chainstate database so contributor writes are atomic with their source state"));
+
+        RocksDB db = (RocksDB) access.getDb();
+        outbox = new ProjectionOutboxStore(db,
+                handle(access, ProjectionCfNames.PROJ_HEADER),
+                handle(access, ProjectionCfNames.PROJ_SECTION),
+                handle(access, ProjectionCfNames.PROJ_META),
+                handle(access, ProjectionCfNames.PROJ_ARTIFACT));
+
+        sink = config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_SINK, String.class)
+                .orElse("none").trim().toLowerCase();
+
+        NetworkGenesisConfig genesis;
+        try {
+            genesis = NetworkGenesisConfig.load(nodeConfig.getShelleyGenesisFile(),
+                    nodeConfig.getByronGenesisFile(), nodeConfig.getAlonzoGenesisFile(),
+                    nodeConfig.getConwayGenesisFile());
+        } catch (Exception e) {
+            throw new IllegalStateException("projection history requires readable genesis configuration", e);
+        }
+        var network = new ArchiveNetworkIdentity(Math.toIntExact(genesis.getNetworkMagic()),
+                genesisHash(nodeConfig));
+        // Which datasets this node projects. The default is every shipped block dataset:
+        // a fresh sync that silently omitted one would produce an archive that looks healthy
+        // while a whole dataset is missing, and the omission is undiscoverable later because
+        // the sections cannot be added without resyncing.
+        Set<ProjectionSectionType> required = configuredSections();
+        identity = new ProjectionIdentity(network, sink, 1, required);
+
+        long tipBlock = chain.getLocalTip() == null ? 0 : chain.getLocalTip().getBlockNumber();
+        Optional<ProjectionIdentity> storedIdentity = outbox.identityFingerprint()
+                .filter(fingerprint -> fingerprint.equals(identity.fingerprint()))
+                .map(ignored -> identity);
+        // A fingerprint that does not match ours is reported through the guard rather than
+        // silently discarded; the guard is the single place that decides a start is unsupported.
+        boolean hasStoredIdentity = outbox.identityFingerprint().isPresent();
+
+        ProjectionStartupGuard.verify(identity, new ProjectionStartupGuard.Observed(
+                tipBlock, hasStoredIdentity, storedIdentity,
+                true, Optional.empty(), ProjectionCoordinate.NONE, required));
+
+        outbox.putIdentity(identity);
+
+        safetyWindows = ArchiveSafetyWindows.resolve(genesis.getSecurityParam(),
+                autoLong(YanoPropertyKeys.History.ROLLBACK_RETENTION_BLOCKS),
+                autoLong(YanoPropertyKeys.History.FINALITY_BLOCKS));
+
+        int chunkBytes = config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_CHUNK_BYTES, Integer.class)
+                .orElse(ProjectionChunking.DEFAULT_CHUNK_BYTES);
+        // Pointer resolution is owned by the authoritative account-state contributor, so the
+        // sink never needs resolver state and never fails on a pointer address.
+        var pointerSource = yano.pointerCredentialSource();
+
+        // Fail closed on an index that was not maintained from genesis. A partially populated
+        // index would silently resolve pre-Conway pointers whose deregistration predates the
+        // upgrade, producing rows that look correct and are not. ADR-039 history is
+        // fresh-sync only, so the only supported state here is COMPLETE.
+        // On a genuinely fresh chainstate, establish the marker first. The store refuses this
+        // once the chain has advanced, so this cannot paper over a mid-chain activation.
+        if (tipBlock <= 0
+                && pointerSource.completeness() == com.bloxbean.cardano.yano.api.archive
+                        .PointerCredentialSource.IndexCompleteness.INCOMPLETE) {
+            yano.markPointerIndexFromGenesis();
+        }
+
+        var completeness = pointerSource.completeness();
+        if (completeness != com.bloxbean.cardano.yano.api.archive.PointerCredentialSource
+                .IndexCompleteness.COMPLETE) {
+            throw new com.bloxbean.cardano.yano.archive.core.projection.ProjectionActivationException(
+                    "projection history requires an as-of pointer index maintained from genesis, but the"
+                            + " account-state store reports " + completeness + ". Start a fresh sync;"
+                            + " an existing chainstate cannot be adopted because pre-Conway pointer"
+                            + " deregistrations applied before the upgrade were never indexed.");
+        }
+
+        collector = new CanonicalProjectionCollector(outbox, identity,
+                ledger::slotToEpoch, ledger::slotToUnixTime, chunkBytes, true, pointerSource);
+        contributorMonitor = new ProjectionContributorHealth.Monitor(Duration.ofMinutes(5));
+
+        // Disk backpressure. Canonical sync runs ahead of the sink by design; these bounds
+        // exist so a lagging sink cannot exhaust the disk, not to pace core to sink speed.
+        var defaults = ArchiveDiskLimits.defaults();
+        var diskLimits = new ArchiveDiskLimits(
+                bytes(YanoPropertyKeys.History.PROJECTION_DISK_SOFT_BYTES, defaults.softBytes()),
+                bytes(YanoPropertyKeys.History.PROJECTION_DISK_HARD_BYTES, defaults.hardBytes()),
+                bytes(YanoPropertyKeys.History.PROJECTION_DISK_LOW_WATER_BYTES, defaults.lowWaterBytes()),
+                bytes(YanoPropertyKeys.History.PROJECTION_DISK_FREE_RESERVE_BYTES,
+                        defaults.freeSpaceReserveBytes()));
+        ingestGate = new ArchiveIngestGate(diskLimits);
+        diskAmplification = config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_DISK_AMPLIFICATION, Double.class).orElse(1.4);
+        historyDirectory = java.nio.file.Path.of(
+                config.getOptionalValue(YanoPropertyKeys.History.DIR, String.class).orElse("./history"))
+                .toAbsolutePath().normalize();
+
+        openSinkAndConsumer(chain, ledger, genesis, nodeConfig);
+
+        installShelleyPlusContributor(yano);
+        // Hold canonical ingestion only when the archive's aggregate disk budget or the
+        // filesystem reserve is reached. Core otherwise runs ahead of the sink freely.
+        boolean holdInstalled = yano.installArchiveIngestHold(
+                () -> ingestDecision().pausesIngest(), "adr-039 archive-retained disk limit");
+        diskBackpressureInstalled = holdInstalled;
+        if (holdInstalled) {
+            log.info("ADR-039 disk backpressure installed (soft={} B, hard={} B, freeReserve={} B,"
+                            + " amplification={})",
+                    diskLimits.softBytes(), diskLimits.hardBytes(), diskLimits.freeSpaceReserveBytes(),
+                    diskAmplification);
+        }
+        if (!holdInstalled) {
+            log.warn("ADR-039 disk backpressure could not be installed; canonical ingestion will not"
+                    + " pause on archive disk pressure. Monitor retainedPhysicalBytes in /status.");
+        }
+        subscribeByronCarrier(yano);
+
+        log.info("ADR-039 projection history enabled (sink={}, sections={}, chunkBytes={}, finalityBlocks={}, pointerSource={})",
+                sink, required.stream().map(ProjectionSectionType::wireName).sorted().toList(),
+                chunkBytes, safetyWindows.archiveFinalityBlocks(),
+                pointerSource == com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.NONE
+                        ? "none" : "account-state(" + completeness + ")");
+    }
+
+    /**
+     * Open the configured primary sink and start the ordered drain loop.
+     *
+     * <p>{@code sink=none} is a supported measurement mode: the producer runs and the outbox
+     * accumulates, which is how producer cost and total projection volume are measured without
+     * a sink in the loop. Any other engine must resolve to a provider, or startup fails —
+     * silently running with no sink while claiming one is configured would look like a healthy
+     * archive that never receives anything.
+     */
+    private void openSinkAndConsumer(ChainQuery chain, LedgerQuery ledger,
+                                     NetworkGenesisConfig genesis, YanoConfig nodeConfig) {
+        if ("none".equals(sink)) {
+            log.info("ADR-039 projection sink is 'none'; the outbox will accumulate for measurement");
+            return;
+        }
+        var provider = java.util.ServiceLoader.load(ProjectionSinkProvider.class).stream()
+                .map(java.util.ServiceLoader.Provider::get)
+                .filter(candidate -> candidate.engine().equals(sink))
+                .findFirst()
+                .orElseThrow(() -> new IllegalStateException(
+                        "no projection sink provider packaged for engine " + sink));
+
+        var archiveIdentity = new ArchiveIdentity(
+                java.util.UUID.nameUUIDFromBytes(identity.fingerprint()
+                        .getBytes(java.nio.charset.StandardCharsets.UTF_8)),
+                sink, 1, identity.networkIdentity().networkMagic(),
+                identity.networkIdentity().genesisHash());
+
+        projectionSink = provider.openProjectionSink(archiveIdentity, historyDirectory, sinkProperties());
+        projectionSink.initialize(identity);
+        // Every later use of the sink goes through this, so shutdown can guarantee it is never
+        // closed while a commit or a maintenance pass is in flight.
+        sinkLifecycle = new ProjectionSinkLifecycle(projectionSink);
+
+        consumer = new ProjectionOutboxConsumer(outbox, projectionSink, identity,
+                new ProjectionFinalityGate(safetyWindows), consumerBounds(),
+                new com.bloxbean.cardano.yano.app.archive.NoArtifactReader(),
+                () -> chain.getLocalTip() == null ? -1 : chain.getLocalTip().getBlockNumber(),
+                () -> 0L);
+
+        configureMaintenance();
+
+        long interval = config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_DRAIN_INTERVAL_MILLIS, Long.class).orElse(250L);
+        draining = true;
+        drainThread = Thread.ofVirtual().name("adr039-projection-drain").start(() -> drainLoop(interval));
+        log.info("ADR-039 projection sink '{}' opened; drain loop started ({} ms idle interval)",
+                sink, interval);
+    }
+
+    /**
+     * Sections to project, defaulting to <strong>every shipped block dataset</strong>.
+     *
+     * <p>Narrowing this is a legacy/testing configuration, not a tuning knob. The required set
+     * is part of the projection identity, so a section omitted at fresh sync cannot be added
+     * later without resyncing from genesis — an archive that silently shipped without a dataset
+     * would be discovered only when a query returned nothing, and by then the fix is a full
+     * resync. Choosing less must therefore be explicit.
+     *
+     * <p>Fails on an unknown name rather than projecting less than asked for.
+     */
+    private Set<ProjectionSectionType> configuredSections() {
+        String configured = config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_SECTIONS, String.class).orElse("").trim();
+        if (configured.isEmpty()) {
+            return java.util.Set.of(ProjectionSectionType.values());
+        }
+        var byWireName = java.util.Arrays.stream(ProjectionSectionType.values())
+                .collect(java.util.stream.Collectors.toMap(ProjectionSectionType::wireName, t -> t));
+        var selected = new java.util.LinkedHashSet<ProjectionSectionType>();
+        for (String name : configured.split(",")) {
+            String trimmed = name.trim();
+            if (trimmed.isEmpty()) continue;
+            ProjectionSectionType type = byWireName.get(trimmed);
+            if (type == null) {
+                throw new IllegalArgumentException("unknown projection section '" + trimmed
+                        + "'; known sections are " + byWireName.keySet().stream().sorted().toList());
+            }
+            selected.add(type);
+        }
+        if (selected.isEmpty()) {
+            throw new IllegalArgumentException(
+                    YanoPropertyKeys.History.PROJECTION_SECTIONS + " was set but selected no sections");
+        }
+        return Set.copyOf(selected);
+    }
+
+    /**
+     * Sink-engine settings the projection path owns independently of the legacy archive.
+     *
+     * <p>Only keys that were explicitly configured are passed through, so an unset key keeps
+     * the engine's own default rather than this method's idea of one.
+     */
+    private java.util.Map<String, String> sinkProperties() {
+        var properties = new LinkedHashMap<String, String>();
+        putIfPresent(properties, "target-file-size-bytes",
+                YanoPropertyKeys.History.PROJECTION_SINK_TARGET_FILE_SIZE_BYTES);
+        putIfPresent(properties, "row-group-size",
+                YanoPropertyKeys.History.PROJECTION_SINK_ROW_GROUP_SIZE);
+        putIfPresent(properties, "snapshot-retention-hours",
+                YanoPropertyKeys.History.PROJECTION_SINK_SNAPSHOT_RETENTION_HOURS);
+        putIfPresent(properties, "cleanup-grace-hours",
+                YanoPropertyKeys.History.PROJECTION_SINK_CLEANUP_GRACE_HOURS);
+        return java.util.Map.copyOf(properties);
+    }
+
+    private void putIfPresent(java.util.Map<String, String> target, String engineKey, String configKey) {
+        config.getOptionalValue(configKey, String.class)
+                .filter(value -> !value.isBlank())
+                .ifPresent(value -> target.put(engineKey, value.trim()));
+    }
+
+    /**
+     * Maintenance cadence and budgets. Housekeeping is frequent and cheap; compaction is rare
+     * and bounded, so neither can starve the drain thread they share.
+     */
+    private void configureMaintenance() {
+        long housekeepingInterval = config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_HOUSEKEEPING_INTERVAL_MINUTES, Long.class).orElse(30L);
+        long compactionInterval = config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_COMPACTION_INTERVAL_MINUTES, Long.class).orElse(360L);
+        maintenanceSchedule = new ProjectionMaintenanceSchedule(
+                java.time.Duration.ofMinutes(housekeepingInterval),
+                java.time.Duration.ofMinutes(compactionInterval));
+        maintenanceHousekeepingBudget = java.time.Duration.ofSeconds(config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_HOUSEKEEPING_BUDGET_SECONDS, Long.class).orElse(30L));
+        maintenanceCompactionBudget = java.time.Duration.ofSeconds(config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_COMPACTION_BUDGET_SECONDS, Long.class).orElse(300L));
+        maintenanceRewriteBytes = config.getOptionalValue(
+                YanoPropertyKeys.History.PROJECTION_COMPACTION_REWRITE_BYTES, Long.class).orElse(8L << 30);
+    }
+
+    private ProjectionConsumerBounds consumerBounds() {
+        var defaults = ProjectionConsumerBounds.defaults();
+        return new ProjectionConsumerBounds(
+                Math.toIntExact(config.getOptionalValue(
+                        YanoPropertyKeys.History.PROJECTION_MAX_BLOCKS_PER_BATCH, Long.class)
+                        .orElse((long) defaults.maxBlocksPerBatch())),
+                config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_MAX_BYTES_PER_BATCH, Long.class)
+                        .orElse(defaults.maxBytesPerBatch()),
+                config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_SOFT_BACKLOG_BLOCKS, Long.class)
+                        .orElse(defaults.softBacklogBlocks()),
+                config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_HARD_BACKLOG_BLOCKS, Long.class)
+                        .orElse(defaults.hardBacklogBlocks()),
+                config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_SOFT_BACKLOG_BYTES, Long.class)
+                        .orElse(defaults.softBacklogBytes()),
+                config.getOptionalValue(YanoPropertyKeys.History.PROJECTION_HARD_BACKLOG_BYTES, Long.class)
+                        .orElse(defaults.hardBacklogBytes()));
+    }
+
+    /**
+     * Drains continuously while work is available and backs off only when idle, so a large
+     * bootstrap backlog is consumed as fast as the sink allows. A failure is logged and
+     * retried after a pause: the outbox is durable, so nothing is lost by retrying, and
+     * stopping the loop would silently freeze the archive.
+     */
+    private void drainLoop(long idleIntervalMillis) {
+        while (draining) {
+            try {
+                ProjectionSinkLifecycle lifecycle = sinkLifecycle;
+                if (lifecycle == null || lifecycle.isClosed()) {
+                    Thread.sleep(idleIntervalMillis);
+                    continue;
+                }
+                // Every sink touch happens under the lifecycle lock, so shutdown can prove
+                // nothing is in flight before it closes anything.
+                ProjectionConsumerResult result = lifecycle.use(ignored -> consumer.drainOnce());
+                if (result.madeProgress()) {
+                    drainedBatches.increment();
+                    drainedBlocks.add(result.lastBlock() - result.firstBlock() + 1);
+                }
+                // Keep draining while envelopes are still waiting, even when this pass only
+                // accumulated. Backing off mid-bootstrap because nothing was committed yet
+                // would idle the loop through the whole backlog.
+                if (result.workPending()) continue;
+
+                if (result.outcome() == ProjectionConsumerResult.Outcome.PAUSED) {
+                    log.warn("ADR-039 projection drain paused: {}", result.detail().orElse("unknown"));
+                } else {
+                    runMaintenanceIfDue();
+                }
+                Thread.sleep(idleIntervalMillis);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                return;
+            } catch (Throwable t) {
+                drainFailures.increment();
+                lastDrainFailure = t.toString();
+                log.error("ADR-039 projection drain failed; retrying: {}", t.toString());
+                try {
+                    Thread.sleep(Math.max(idleIntervalMillis, 1_000L));
+                } catch (InterruptedException interrupted) {
+                    Thread.currentThread().interrupt();
+                    return;
+                }
+            }
+        }
+    }
+
+    /**
+     * Maintenance runs on the drain thread, never on a worker of its own, and only on a pass
+     * that had nothing to commit. Housekeeping becomes due on an interval and may run during
+     * bootstrap; compaction additionally requires the sink to be caught up.
+     */
+    private void runMaintenanceIfDue() {
+        ProjectionOutboxConsumer active = consumer;
+        if (active == null) return;
+        Instant now = Instant.now();
+        var action = maintenanceSchedule.decide(false, active.nearTip(), active.hasDrainBacklog(), now);
+        if (action == ProjectionMaintenanceSchedule.Action.NONE) return;
+
+        ProjectionSinkLifecycle lifecycle = sinkLifecycle;
+        if (lifecycle == null || lifecycle.isClosed()) return;
+        var pass = lifecycle.use(ignored -> active.maintain(maintenanceHousekeepingBudget,
+                maintenanceCompactionBudget, maintenanceRewriteBytes));
+        var result = pass.result();
+
+        // Record only what actually ran. The consumer withholds compaction when the sink is
+        // busy, and recording it anyway would defer the next attempt by a full interval.
+        var ran = pass.compactionOffered()
+                ? action
+                : ProjectionMaintenanceSchedule.Action.HOUSEKEEPING;
+        maintenanceSchedule.recordRun(ran, now);
+        if (action == ProjectionMaintenanceSchedule.Action.HOUSEKEEPING_AND_COMPACTION
+                && !pass.compactionOffered()) {
+            maintenanceSchedule.recordWithheldCompaction(now);
+        }
+        maintenancePasses.increment();
+        if (pass.compactionOffered()) compactionPasses.increment();
+
+        lastMaintenanceOutcome = result.outcome().name()
+                + result.detail().map(detail -> " (" + detail + ")").orElse("")
+                + (pass.compactionOffered() ? "" : " [compaction withheld: sink busy]");
+        log.debug("ADR-039 projection maintenance {} -> {}", ran, lastMaintenanceOutcome);
+    }
+
+    private void installShelleyPlusContributor(Yano yano) {
+        boolean installed = yano.installProjectionContributor(collector);
+        if (!installed) {
+            // Failing closed matters here: a silently uninstalled contributor would produce
+            // an archive that looks healthy while missing every Shelley+ block.
+            throw new IllegalStateException("projection history could not install its Shelley+ contributor;"
+                    + " the UTXO subsystem is absent or does not support contribution");
+        }
+    }
+
+    private void subscribeByronCarrier(Yano yano) {
+        EventBus bus = yano.kernel()
+                .map(kernel -> kernel.context().eventBus())
+                .orElseThrow(() -> new IllegalStateException("projection history requires the node event bus"));
+
+        // Byron has no other subsystem batch to join: the live UTXO path never applies a
+        // Byron transaction. The section and its cursor still commit atomically with each
+        // other, and the retained canonical body plus that cursor remain the durable
+        // replay intent.
+        bus.subscribe(ByronBlockProjectionEvent.class,
+                ctx -> outbox.commit(writer -> collector.contributeByronBlock(ctx.event(), writer)),
+                SubscriptionOptions.builder().build());
+
+        // Pending envelopes newer than the rollback point must go. The cutoff comes from
+        // the rollback event's own slot, not from a live tip read: listener order relative
+        // to chain-state rollback is unspecified, and a tip read too early would leave
+        // stale envelopes above the surviving tip.
+        bus.subscribe(RollbackEvent.class, ctx -> {
+            var target = ctx.event().target();
+            if (target == null) return;
+            long removed = collector.rollbackToSlot(target.getSlot());
+            // Whatever the drain thread has buffered may describe the discarded fork. The
+            // flag is observed at its next safe point; taking a lock here would stall the
+            // event bus behind an in-flight sink commit.
+            ProjectionOutboxConsumer active = consumer;
+            if (active != null) active.discardPendingBatch();
+            if (removed > 0) {
+                log.info("ADR-039 rollback to slot {} removed {} pending projection envelope(s)",
+                        target.getSlot(), removed);
+            }
+        }, SubscriptionOptions.builder().build());
+    }
+
+    private static String genesisHash(YanoConfig nodeConfig) {
+        if (nodeConfig.getShelleyGenesisHash() != null && !nodeConfig.getShelleyGenesisHash().isBlank()) {
+            return nodeConfig.getShelleyGenesisHash().toLowerCase(java.util.Locale.ROOT);
+        }
+        if (nodeConfig.getShelleyGenesisFile() == null || nodeConfig.getShelleyGenesisFile().isBlank()) {
+            throw new IllegalArgumentException("Shelley genesis hash or file is required for projection identity");
+        }
+        try {
+            return com.bloxbean.cardano.yaci.core.util.HexUtil.encodeHexString(
+                    com.bloxbean.cardano.client.crypto.Blake2bUtil.blake2bHash256(
+                            java.nio.file.Files.readAllBytes(
+                                    java.nio.file.Path.of(nodeConfig.getShelleyGenesisFile()))));
+        } catch (Exception e) {
+            throw new IllegalStateException("cannot compute Shelley genesis hash for projection identity", e);
+        }
+    }
+
+    /**
+     * Reads a window override that ships with the literal default {@code "auto"}, meaning
+     * "derive it from genesis". Parsing it as a number would fail on the bundled default.
+     */
+    private long bytes(String name, long fallback) {
+        return config.getOptionalValue(name, Long.class).orElse(fallback);
+    }
+
+    /**
+     * Current aggregate archive-retained footprint. Staged-artifact and pinned-generation
+     * bytes are zero until Phase 5 produces artifacts; they are part of the budget from the
+     * start so enabling artifacts cannot silently exceed a limit sized without them.
+     */
+    public ArchiveRetainedFootprint footprint() {
+        long outboxBytes = outbox == null ? 0 : outbox.stats(identity.requiredSections()).pendingBytes();
+        long free = 0;
+        try {
+            java.io.File root = historyDirectory == null ? null : historyDirectory.toFile();
+            if (root != null) free = root.getUsableSpace();
+        } catch (Exception ignored) {
+            // An unreadable free-space probe must not itself stop ingestion.
+        }
+        return new ArchiveRetainedFootprint(outboxBytes, 0, 0, diskAmplification, free);
+    }
+
+    /** Whether canonical ingestion may continue. Re-evaluated against the live footprint. */
+    public ArchiveIngestGate.Decision ingestDecision() {
+        return ingestGate == null ? new ArchiveIngestGate.Decision(
+                ArchiveIngestGate.Decision.State.RUNNING, Optional.empty(), 0, 0, 0)
+                : ingestGate.evaluate(footprint());
+    }
+
+    private Long autoLong(String name) {
+        String value = config.getOptionalValue(name, String.class).orElse("auto").trim();
+        return value.isEmpty() || value.equalsIgnoreCase("auto") ? null : Long.parseLong(value);
+    }
+
+    private static ColumnFamilyHandle handle(com.bloxbean.cardano.yano.api.db.RocksDbAccess access, String name) {
+        Object handle = access.getColumnFamilyHandle(name);
+        if (handle == null) {
+            throw new IllegalStateException("projection column family " + name + " is not open; "
+                    + "the chain state must declare it at open time");
+        }
+        return (ColumnFamilyHandle) handle;
+    }
+
+    // ------------------------------------------------------------------- status
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public Map<String, Object> status() {
+        Map<String, Object> status = new LinkedHashMap<>();
+        status.put("enabled", enabled);
+        if (!enabled || outbox == null) return status;
+        status.put("sink", sink);
+        status.put("drainedBatches", drainedBatches.sum());
+        status.put("drainedBlocks", drainedBlocks.sum());
+        status.put("drainFailures", drainFailures.sum());
+        if (lastDrainFailure != null) status.put("lastDrainFailure", lastDrainFailure);
+        if (projectionSink != null) {
+            var coordinate = projectionSink.coordinate();
+            status.put("sinkCoordinate", coordinate.isPresent() ? coordinate.blockNumber() : -1);
+            status.put("sinkHealth", projectionSink.health().state().name());
+        }
+        status.put("identity", identity.fingerprint());
+        ProjectionOutboxStats stats = outbox.stats(identity.requiredSections());
+        status.put("pendingBlocks", stats.pendingBlocks());
+        status.put("pendingBytes", stats.pendingBytes());
+        status.put("pendingRows", stats.pendingRows());
+        status.put("oldestPendingBlock", stats.oldestPendingBlock());
+        status.put("completeThroughBlock", stats.completeThroughBlock());
+        status.put("acknowledgedThroughBlock", stats.acknowledgedThroughBlock());
+        status.put("bytesPerBlock", stats.pendingBlocks() == 0 ? 0
+                : stats.pendingBytes() / stats.pendingBlocks());
+        var decision = ingestDecision();
+        status.put("ingestState", decision.state().name());
+        decision.reason().ifPresent(reason -> status.put("ingestPauseReason", reason));
+        status.put("retainedPhysicalBytes", decision.observedBytes());
+        status.put("retainedLimitBytes", decision.limitBytes());
+        status.put("filesystemFreeBytes", decision.freeBytes());
+        ProjectionOutboxConsumer active = consumer;
+        if (active != null) {
+            var policy = active.batchPolicy();
+            status.put("batchRegime", active.nearTip() ? "NEAR_TIP" : "BOOTSTRAP");
+            status.put("batchTargetBlocksNearTip", policy.minBlocks(true));
+            status.put("batchMaxLingerNearTip", policy.maxLinger(true).toString());
+            status.put("batchTargetBlocksBootstrap", policy.minBlocks(false));
+            status.put("batchMaxLingerBootstrap", policy.maxLinger(false).toString());
+            status.put("pendingBatchBlocks", active.pendingBatchBlocks());
+            status.put("pendingBatchOldestBlock", active.pendingBatchOldestBlock());
+            status.put("pendingBatchAgeSeconds", active.pendingBatchAgeSeconds(Instant.now()));
+            var batchStats = active.batchStats();
+            status.put("flushReasons", batchStats.flushReasons());
+            status.put("largestEnvelopeBytes", batchStats.largestEnvelopeEncodedBytes());
+            status.put("largestEnvelopeRows", batchStats.largestEnvelopeRows());
+            status.put("oversizedSingletons", batchStats.oversizedSingletons());
+            status.put("singletonHighWatermarkBytes", batchStats.singletonHighWatermarkBytes());
+            status.put("largestRejectedSingletonBytes", batchStats.largestRejectedSingletonBytes());
+            var last = active.lastBatchDecision();
+            if (last != null) {
+                status.put("lastFlushReason", last.reason().name());
+                status.put("lastFlushBlocks", last.blocks());
+                status.put("lastFlushRows", last.rows());
+                status.put("lastFlushEncodedBytes", last.encodedBytes());
+            }
+        }
+        status.put("diskBackpressureInstalled", diskBackpressureInstalled);
+        status.put("maintenancePasses", maintenancePasses.sum());
+        status.put("compactionPasses", compactionPasses.sum());
+        if (lastMaintenanceOutcome != null) status.put("lastMaintenance", lastMaintenanceOutcome);
+        var health = contributorMonitor.evaluate(outbox, identity.requiredSections(), Instant.now());
+        status.put("contributorStatus", health.status().name());
+        status.put("contributorCursors", health.contributorCursors());
+        health.detail().ifPresent(detail -> status.put("contributorDetail", detail));
+        return status;
+    }
+
+    @Override
+    public void close() {
+        // Stop new sink work, let an in-flight commit finish, and preserve the outbox.
+        // Shutdown never deletes pending projection data.
+        draining = false;
+        Thread thread = drainThread;
+        if (thread != null) {
+            // The interrupt breaks the idle sleep; the join is what actually matters. Closing
+            // the sink while a commit is in flight would tear down the connection mid
+            // transaction. Correctness would survive it - an unacknowledged commit is
+            // recognised by its receipt on replay - but it would turn every clean shutdown
+            // into a crash-recovery path for no reason.
+            thread.interrupt();
+            try {
+                thread.join(SHUTDOWN_DRAIN_WAIT.toMillis());
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+        }
+        ProjectionSinkLifecycle lifecycle = sinkLifecycle;
+        if (lifecycle != null) {
+            try {
+                // Closes only if nothing is using the sink. A bounded maintenance pass can
+                // legitimately outlast this wait - housekeeping plus compaction is 30 s + 300 s
+                // at the defaults - so declining to close is an expected outcome, not a failure
+                // path. The sink is then left open for the process to take with it: an
+                // incomplete shutdown replays from the durable outbox, whereas closing a
+                // connection mid transaction is undefined behaviour in the driver.
+                if (!lifecycle.closeWhenIdle(SHUTDOWN_DRAIN_WAIT)) {
+                    log.warn("ADR-039 projection sink is still in use after {}; leaving it open."
+                                    + " Shutdown is incomplete and the in-flight commit replays on"
+                                    + " restart.", SHUTDOWN_DRAIN_WAIT);
+                }
+            } catch (Exception e) {
+                log.warn("closing the projection sink failed: {}", e.toString());
+            }
+        }
+        // The outbox lives in the chainstate database, which the runtime owns and closes.
+        collector = null;
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ArchiveArtifactReader.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ArchiveArtifactReader.java
@@ -64,5 +64,14 @@ public interface ArchiveArtifactReader {
      * this may the source become eligible for deletion, and never while a live
      * reader lease exists.
      */
+    /**
+     * Release an artifact's source protection, once a durable receipt covers the batch.
+     *
+     * <p><strong>Must be idempotent.</strong> The consumer calls this <em>before</em> the outbox
+     * drops the artifact reference, because the reference is the only thing a restart could
+     * reconcile from - dropping it first turns a crash in the gap into a permanently pinned
+     * source. That ordering means a crash after acknowledging replays the acknowledgement on the
+     * next pass, so a second call for the same artifact must be a no-op rather than an error.
+     */
     void acknowledge(ProjectionArtifactRef ref);
 }

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ArchiveArtifactReader.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ArchiveArtifactReader.java
@@ -1,0 +1,68 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * Bounded, leased access to a large immutable epoch artifact.
+ *
+ * <p>The sink reaches artifacts only through this interface: DuckLake and SQLite code
+ * never receive raw column-family handles and never depend on physical key encoding
+ * (ADR-039 §5).
+ *
+ * <p>A lease is a durable pruning contract, not a timer. It carries a fenced owner
+ * identity so that abandonment cleanup can prove an owner is stale before releasing
+ * protection; a wall-clock deadline alone is a liveness signal and never authority to
+ * delete a source a reader may still be using (ADR-039 §7).
+ */
+public interface ArchiveArtifactReader {
+
+    /** Fenced, renewable protection over one artifact's source bytes. */
+    interface ArtifactLease extends AutoCloseable {
+        UUID leaseId();
+
+        /** Owner fence; cleanup must prove this owner is gone, not merely late. */
+        String ownerFence();
+
+        Instant expiresAt();
+
+        ArtifactLease renew(Instant newExpiry);
+
+        boolean isOpen();
+
+        @Override
+        void close();
+    }
+
+    /** One bounded page of artifact rows plus the cursor that continues it. */
+    record ArtifactPage(List<byte[]> rows, Optional<String> nextCursor) {
+        public ArtifactPage {
+            rows = List.copyOf(Objects.requireNonNull(rows, "rows"));
+            Objects.requireNonNull(nextCursor, "nextCursor");
+        }
+
+        public boolean hasMore() {
+            return nextCursor.isPresent();
+        }
+    }
+
+    /**
+     * Acquire protection before any read. Throws when the artifact is absent or its
+     * source cannot be verified, so a missing artifact fails closed rather than
+     * producing an empty stream that would look like a legitimately empty epoch.
+     */
+    ArtifactLease acquire(ProjectionArtifactRef ref, Instant expiresAt);
+
+    /** Read one bounded page. The lease must be open; an expired lease is rejected. */
+    ArtifactPage read(ProjectionArtifactRef ref, ArtifactLease lease, Optional<String> cursor, int limit);
+
+    /**
+     * Report that the primary sink has durably committed this artifact. Only after
+     * this may the source become eligible for deletion, and never while a live
+     * reader lease exists.
+     */
+    void acknowledge(ProjectionArtifactRef ref);
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionArtifactRef.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionArtifactRef.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+
+import java.util.Objects;
+import java.util.OptionalLong;
+
+/**
+ * Reference to a large immutable epoch artifact streamed by the sink rather than
+ * copied into the block envelope (ADR-039 §5).
+ *
+ * <p>{@code producingBlockNumber} is the transition that created the artifact and is
+ * the coordinate compared against the rollback-safe cutoff; {@code semanticEpoch} is
+ * the epoch the resulting rows are labelled with. They differ by design: the
+ * artifact produced at transition {@code E-1 -> E} carries semantic epoch {@code E}
+ * but only becomes eligible one safe boundary later.
+ */
+public record ProjectionArtifactRef(ArchiveDatasetId dataset, int semanticEpoch,
+                                    long producingBlockNumber, long producingSlot,
+                                    ProjectionArtifactRepresentation representation,
+                                    String sourceGeneration, int sourceCodecVersion,
+                                    String sourceStateVersion,
+                                    OptionalLong expectedRowCount, String contentDigest,
+                                    long oldestRequiredSlot) {
+    public ProjectionArtifactRef {
+        Objects.requireNonNull(dataset, "dataset");
+        Objects.requireNonNull(representation, "representation");
+        sourceGeneration = Objects.requireNonNull(sourceGeneration, "sourceGeneration").trim();
+        sourceStateVersion = Objects.requireNonNull(sourceStateVersion, "sourceStateVersion").trim();
+        Objects.requireNonNull(expectedRowCount, "expectedRowCount");
+        contentDigest = contentDigest == null ? "" : contentDigest.trim().toLowerCase();
+        if (semanticEpoch < 0 || producingBlockNumber < 0 || producingSlot < 0) {
+            throw new IllegalArgumentException("invalid artifact coordinate");
+        }
+        if (sourceGeneration.isEmpty() || sourceStateVersion.isEmpty()) {
+            throw new IllegalArgumentException("sourceGeneration and sourceStateVersion are required");
+        }
+        if (sourceCodecVersion < 1) throw new IllegalArgumentException("sourceCodecVersion must be positive");
+        if (oldestRequiredSlot < 0) throw new IllegalArgumentException("oldestRequiredSlot must not be negative");
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionArtifactRepresentation.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionArtifactRepresentation.java
@@ -1,0 +1,9 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+/** How an artifact's durable source is materialised (ADR-039 §5). */
+public enum ProjectionArtifactRepresentation {
+    /** Immutable staged file written at the transition; freezes its codec at capture time. */
+    STAGED_FILE,
+    /** Immutable epoch-keyed generation retained in the live store under a pruning lease. */
+    IMMUTABLE_GENERATION
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionBatch.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionBatch.java
@@ -1,0 +1,79 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A contiguous run of complete, rollback-safe envelopes offered to the sink as one
+ * deterministic job (ADR-039 §9, §10).
+ *
+ * <p>Contiguity is enforced here rather than trusted from the caller: the sink may
+ * batch blocks 100..120 only when every envelope in that range is present and in
+ * canonical order. A gap is a bug in the consumer, and failing at construction keeps
+ * it from reaching a sink transaction where it would look like legitimate progress.
+ */
+public record ProjectionBatch(ProjectionIdentity identity, List<ProjectionEnvelope> envelopes)
+        implements ProjectionJob {
+    public ProjectionBatch {
+        Objects.requireNonNull(identity, "identity");
+        envelopes = List.copyOf(Objects.requireNonNull(envelopes, "envelopes"));
+        if (envelopes.isEmpty()) throw new IllegalArgumentException("a projection batch must not be empty");
+        for (int i = 1; i < envelopes.size(); i++) {
+            long previous = envelopes.get(i - 1).blockNumber();
+            long current = envelopes.get(i).blockNumber();
+            if (current != previous + 1) {
+                throw new IllegalArgumentException(
+                        "projection batch is not contiguous at block " + current + " (previous " + previous + ")");
+            }
+        }
+    }
+
+    public long firstBlock() {
+        return envelopes.get(0).blockNumber();
+    }
+
+    public long lastBlock() {
+        return envelopes.get(envelopes.size() - 1).blockNumber();
+    }
+
+    public long blockCount() {
+        return envelopes.size();
+    }
+
+    @Override
+    public String firstEnvelopeId() {
+        return envelopes.get(0).envelopeId();
+    }
+
+    @Override
+    public String lastEnvelopeId() {
+        return envelopes.get(envelopes.size() - 1).envelopeId();
+    }
+
+    public long byteCount() {
+        return envelopes.stream()
+                .flatMap(e -> e.sections().stream())
+                .mapToLong(ProjectionSection::byteCount)
+                .sum();
+    }
+
+    public long rowCount() {
+        return envelopes.stream()
+                .flatMap(e -> e.sections().stream())
+                .mapToLong(ProjectionSection::rowCount)
+                .sum();
+    }
+
+    public List<ProjectionArtifactRef> artifacts() {
+        return envelopes.stream().flatMap(e -> e.header().artifacts().stream()).toList();
+    }
+
+    /** Ordered digest over every envelope identity and section digest in canonical order. */
+    public String orderedDigest() {
+        return ProjectionDigest.ofDigests(envelopes.stream()
+                .flatMap(e -> java.util.stream.Stream.concat(
+                        java.util.stream.Stream.of(e.envelopeId()),
+                        e.header().sections().stream().map(ProjectionSectionManifest::digest)))
+                .toList());
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionBlockKind.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionBlockKind.java
@@ -1,0 +1,32 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+/**
+ * Canonical block shape behind an envelope.
+ *
+ * <p>Byron is a strict subset of the Shelley+ projection, not a degraded version of
+ * it: no invalid transactions, collateral, reference inputs, datums, redeemers,
+ * multi-asset values, or pointer addresses, a null {@code chain_transaction.fee},
+ * and base58 raw addresses. Epoch-boundary blocks carry no transactions at all but
+ * still occupy a block number, so they emit an empty envelope to keep the projection
+ * coordinate contiguous (ADR-039 §3, §16).
+ */
+public enum ProjectionBlockKind {
+    SHELLEY_PLUS(false),
+    BYRON_MAIN(true),
+    BYRON_EBB(true);
+
+    private final boolean byron;
+
+    ProjectionBlockKind(boolean byron) {
+        this.byron = byron;
+    }
+
+    public boolean isByron() {
+        return byron;
+    }
+
+    /** An EBB never carries a section; a required-section policy must not demand one. */
+    public boolean allowsEmptyEnvelope() {
+        return this == BYRON_EBB;
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionCoordinate.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionCoordinate.java
@@ -1,0 +1,54 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * The greatest <em>contiguous</em> canonical block envelope durably committed by the
+ * primary sink (ADR-039 §16). Epoch-artifact coverage is reported separately by type
+ * and semantic epoch because its publication delay differs.
+ */
+public record ProjectionCoordinate(long blockNumber, long slot, byte[] blockHash, String envelopeId) {
+    /** No envelope has been committed yet; a fresh archive starts here. */
+    public static final ProjectionCoordinate NONE = new ProjectionCoordinate(-1, -1, new byte[0], "");
+
+    public ProjectionCoordinate {
+        Objects.requireNonNull(blockHash, "blockHash");
+        envelopeId = Objects.requireNonNull(envelopeId, "envelopeId").trim().toLowerCase();
+        blockHash = Arrays.copyOf(blockHash, blockHash.length);
+        boolean empty = blockNumber < 0;
+        if (empty && (slot >= 0 || blockHash.length != 0 || !envelopeId.isEmpty())) {
+            throw new IllegalArgumentException("an empty coordinate must carry no block identity");
+        }
+        if (!empty && (slot < 0 || blockHash.length == 0 || envelopeId.isEmpty())) {
+            throw new IllegalArgumentException("a present coordinate requires slot, hash and envelope id");
+        }
+    }
+
+    public boolean isPresent() {
+        return blockNumber >= 0;
+    }
+
+    public static ProjectionCoordinate of(ProjectionEnvelopeHeader header) {
+        return new ProjectionCoordinate(header.blockNumber(), header.slot(), header.blockHash(), header.envelopeId());
+    }
+
+    public Optional<Long> nextExpectedBlock() {
+        return isPresent() ? Optional.of(blockNumber + 1) : Optional.empty();
+    }
+
+    @Override public byte[] blockHash() { return Arrays.copyOf(blockHash, blockHash.length); }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || other instanceof ProjectionCoordinate c
+                && blockNumber == c.blockNumber && slot == c.slot
+                && Arrays.equals(blockHash, c.blockHash) && envelopeId.equals(c.envelopeId);
+    }
+
+    @Override
+    public int hashCode() {
+        return 31 * Long.hashCode(blockNumber) + Arrays.hashCode(blockHash);
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionDigest.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionDigest.java
@@ -1,0 +1,61 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.List;
+
+/**
+ * Deterministic digest over an ordered chunk list.
+ *
+ * <p>Chunks are length-prefixed before hashing so that a differently split but
+ * byte-identical concatenation produces a different digest. Splitting is part of the
+ * projection contract the sink verifies, not an incidental transport detail.
+ */
+public final class ProjectionDigest {
+    private ProjectionDigest() {}
+
+    public static String ofChunks(List<byte[]> chunks) {
+        MessageDigest digest = sha256();
+        ByteBuffer prefix = ByteBuffer.allocate(4).order(ByteOrder.BIG_ENDIAN);
+        for (byte[] chunk : chunks) {
+            prefix.clear();
+            prefix.putInt(chunk.length);
+            digest.update(prefix.array());
+            digest.update(chunk);
+        }
+        return hex(digest.digest());
+    }
+
+    /** Ordered digest over already-computed section digests, used for a batch receipt. */
+    public static String ofDigests(List<String> orderedDigests) {
+        MessageDigest digest = sha256();
+        for (String value : orderedDigests) {
+            digest.update(value.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            digest.update((byte) 0);
+        }
+        return hex(digest.digest());
+    }
+
+    public static byte[] concat(List<byte[]> parts) {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        for (byte[] part : parts) out.writeBytes(part);
+        return out.toByteArray();
+    }
+
+    private static MessageDigest sha256() {
+        try {
+            return MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+    }
+
+    public static String hex(byte[] value) {
+        StringBuilder sb = new StringBuilder(value.length * 2);
+        for (byte b : value) sb.append(Character.forDigit((b >> 4) & 0xF, 16)).append(Character.forDigit(b & 0xF, 16));
+        return sb.toString();
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionEnvelope.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionEnvelope.java
@@ -1,0 +1,48 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * A complete logical projection envelope: header plus the section payloads its
+ * manifest describes.
+ *
+ * <p>Construction verifies the header against the payloads, so an envelope that
+ * exists is by definition internally consistent. A sink that reassembles one from
+ * outbox records therefore proves completeness by construction rather than by a
+ * separate check it might forget to run (ADR-039 invariant 11).
+ */
+public record ProjectionEnvelope(ProjectionEnvelopeHeader header, List<ProjectionSection> sections) {
+    public ProjectionEnvelope {
+        Objects.requireNonNull(header, "header");
+        sections = List.copyOf(Objects.requireNonNull(sections, "sections"));
+        if (sections.size() != header.sections().size()) {
+            throw new IllegalArgumentException("envelope section count does not match its manifest");
+        }
+        for (ProjectionSectionManifest manifest : header.sections()) {
+            ProjectionSection section = sections.stream()
+                    .filter(s -> s.type() == manifest.type())
+                    .findFirst()
+                    .orElseThrow(() -> new IllegalArgumentException(
+                            "envelope is missing required section " + manifest.type().wireName()));
+            ProjectionSectionManifest actual = section.manifest();
+            if (!actual.equals(manifest)) {
+                throw new IllegalArgumentException("section " + manifest.type().wireName()
+                        + " does not match its manifest (expected " + manifest + " but was " + actual + ")");
+            }
+        }
+    }
+
+    public long blockNumber() {
+        return header.blockNumber();
+    }
+
+    public String envelopeId() {
+        return header.envelopeId();
+    }
+
+    public Optional<ProjectionSection> section(ProjectionSectionType type) {
+        return sections.stream().filter(s -> s.type() == type).findFirst();
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionEnvelopeHeader.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionEnvelopeHeader.java
@@ -1,0 +1,92 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Logical header for one canonical block's projection envelope (ADR-039 §2).
+ *
+ * <p>{@link #envelopeId()} is <em>derived</em> rather than stored. Replaying the same
+ * canonical block therefore addresses the same logical envelope, and a replacement
+ * block at the same height necessarily addresses a different one because its hash and
+ * parent participate in the derivation. Because the identifier cannot be supplied by a
+ * caller it also cannot disagree with the header it labels.
+ */
+public record ProjectionEnvelopeHeader(ArchiveNetworkIdentity networkIdentity,
+                                       ProjectionBlockKind blockKind,
+                                       long blockNumber, byte[] blockHash, byte[] parentHash,
+                                       long slot, int epoch, long blockTime,
+                                       int canonicalProjectionVersion,
+                                       List<ProjectionSectionManifest> sections,
+                                       List<ProjectionArtifactRef> artifacts) {
+    public ProjectionEnvelopeHeader {
+        Objects.requireNonNull(networkIdentity, "networkIdentity");
+        Objects.requireNonNull(blockKind, "blockKind");
+        if (blockNumber < 0 || slot < 0 || epoch < 0) throw new IllegalArgumentException("invalid block coordinate");
+        if (blockHash == null || blockHash.length == 0) throw new IllegalArgumentException("blockHash is required");
+        if (parentHash == null) throw new IllegalArgumentException("parentHash is required");
+        if (canonicalProjectionVersion < 1) throw new IllegalArgumentException("canonicalProjectionVersion must be positive");
+        blockHash = Arrays.copyOf(blockHash, blockHash.length);
+        parentHash = Arrays.copyOf(parentHash, parentHash.length);
+        sections = List.copyOf(Objects.requireNonNull(sections, "sections"));
+        artifacts = List.copyOf(Objects.requireNonNull(artifacts, "artifacts"));
+        if (blockKind.allowsEmptyEnvelope() && !sections.isEmpty()) {
+            throw new IllegalArgumentException("an epoch-boundary block must produce an empty envelope");
+        }
+        if (sections.stream().map(ProjectionSectionManifest::type).distinct().count() != sections.size()) {
+            throw new IllegalArgumentException("duplicate section type in envelope header");
+        }
+    }
+
+    @Override public byte[] blockHash() { return Arrays.copyOf(blockHash, blockHash.length); }
+    @Override public byte[] parentHash() { return Arrays.copyOf(parentHash, parentHash.length); }
+
+    /** Deterministic identity over canonical coordinates and projection version only. */
+    public String envelopeId() {
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("SHA-256");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 unavailable", e);
+        }
+        digest.update(networkIdentity.canonicalForm().getBytes(StandardCharsets.UTF_8));
+        digest.update((byte) 0);
+        ByteBuffer numbers = ByteBuffer.allocate(8 + 8 + 4).order(ByteOrder.BIG_ENDIAN);
+        numbers.putLong(blockNumber).putLong(slot).putInt(canonicalProjectionVersion);
+        digest.update(numbers.array());
+        digest.update(blockHash);
+        digest.update((byte) 0);
+        digest.update(parentHash);
+        return ProjectionDigest.hex(digest.digest());
+    }
+
+    public java.util.Optional<ProjectionSectionManifest> section(ProjectionSectionType type) {
+        return sections.stream().filter(s -> s.type() == type).findFirst();
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return this == other || other instanceof ProjectionEnvelopeHeader h
+                && blockNumber == h.blockNumber && slot == h.slot && epoch == h.epoch
+                && blockTime == h.blockTime && canonicalProjectionVersion == h.canonicalProjectionVersion
+                && blockKind == h.blockKind && networkIdentity.equals(h.networkIdentity)
+                && Arrays.equals(blockHash, h.blockHash) && Arrays.equals(parentHash, h.parentHash)
+                && sections.equals(h.sections) && artifacts.equals(h.artifacts);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = Long.hashCode(blockNumber);
+        result = 31 * result + Arrays.hashCode(blockHash);
+        result = 31 * result + Arrays.hashCode(parentHash);
+        return 31 * result + sections.hashCode();
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionIdentity.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionIdentity.java
@@ -1,0 +1,44 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+
+import java.util.Objects;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * Identity a projection-outbox history must match on every start (ADR-039 §1).
+ *
+ * <p>The required-section set is part of identity, not configuration: a sink that
+ * cannot read a required section must fail at startup rather than quietly acknowledge
+ * envelopes that omit it.
+ */
+public record ProjectionIdentity(ArchiveNetworkIdentity networkIdentity, String sinkEngine,
+                                 int canonicalProjectionVersion, Set<ProjectionSectionType> requiredSections) {
+    public ProjectionIdentity {
+        Objects.requireNonNull(networkIdentity, "networkIdentity");
+        sinkEngine = Objects.requireNonNull(sinkEngine, "sinkEngine").trim().toLowerCase();
+        if (sinkEngine.isEmpty()) throw new IllegalArgumentException("sinkEngine is required");
+        if (canonicalProjectionVersion < 1) throw new IllegalArgumentException("canonicalProjectionVersion must be positive");
+        requiredSections = Set.copyOf(Objects.requireNonNull(requiredSections, "requiredSections"));
+        if (requiredSections.isEmpty()) throw new IllegalArgumentException("at least one required section is expected");
+    }
+
+    /**
+     * Stable comparable form. Sections are sorted by wire name so that the fingerprint
+     * depends on the section set and their shipped versions, never on iteration order.
+     */
+    public String fingerprint() {
+        String sections = requiredSections.stream()
+                .map(ProjectionSectionType::wireName)
+                .collect(Collectors.toCollection(TreeSet::new))
+                .stream()
+                .collect(Collectors.joining(","));
+        return networkIdentity.canonicalForm() + "|" + sinkEngine + "|v" + canonicalProjectionVersion + "|" + sections;
+    }
+
+    public boolean matches(ProjectionIdentity other) {
+        return other != null && fingerprint().equals(other.fingerprint());
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionJob.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionJob.java
@@ -1,0 +1,24 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+/**
+ * The identity of one deterministic projection job.
+ *
+ * <p>Shared by the encoded {@link ProjectionBatch} the outbox produces and the
+ * materialised {@link ProjectionRowBatch} a sink consumes, so receipt identity and
+ * idempotency are defined exactly once rather than reimplemented on each side.
+ */
+public interface ProjectionJob {
+    ProjectionIdentity identity();
+
+    long firstBlock();
+
+    long lastBlock();
+
+    long blockCount();
+
+    String firstEnvelopeId();
+
+    String lastEnvelopeId();
+
+    String orderedDigest();
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionMaintenance.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionMaintenance.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yano.archive.api.projection;
 import java.time.Duration;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.OptionalLong;
 
 /** Value types for bounded sink maintenance (ADR-039). */
 public final class ProjectionMaintenance {
@@ -79,11 +80,21 @@ public final class ProjectionMaintenance {
      * backend that genuinely has nothing to maintain should say so, so an operator can tell
      * that apart from maintenance that is configured but never running.
      */
+    /**
+     * What a maintenance pass did.
+     *
+     * <p>The file and byte figures are {@link OptionalLong} rather than {@code long} on purpose.
+     * They are read with SQL against a catalog that can be locked or in a failed transaction, and
+     * an earlier version returned {@code 0} when the query failed. That produced the diagnostic
+     * "files 35 -> 0", which reads as "maintenance deleted everything" when it means "the
+     * measurement could not be taken". An unavailable measurement must be distinguishable from a
+     * measured zero, because they call for opposite reactions.
+     */
     public record Result(Outcome outcome,
                          Duration duration,
-                         long filesBefore,
-                         long filesAfter,
-                         long bytesRewritten,
+                         OptionalLong filesBefore,
+                         OptionalLong filesAfter,
+                         OptionalLong bytesRewritten,
                          long snapshotsExpired,
                          long orphanedFilesDeleted,
                          Duration writerWait,
@@ -97,22 +108,35 @@ public final class ProjectionMaintenance {
         }
 
         public static Result unsupported(String why) {
-            return new Result(Outcome.UNSUPPORTED, Duration.ZERO, 0, 0, 0, 0, 0,
-                    Duration.ZERO, Optional.of(why));
+            return new Result(Outcome.UNSUPPORTED, Duration.ZERO, OptionalLong.empty(),
+                    OptionalLong.empty(), OptionalLong.empty(), 0, 0, Duration.ZERO, Optional.of(why));
         }
 
         public static Result deferred(String why) {
-            return new Result(Outcome.DEFERRED, Duration.ZERO, 0, 0, 0, 0, 0,
-                    Duration.ZERO, Optional.of(why));
+            return new Result(Outcome.DEFERRED, Duration.ZERO, OptionalLong.empty(),
+                    OptionalLong.empty(), OptionalLong.empty(), 0, 0, Duration.ZERO, Optional.of(why));
+        }
+
+        /** Whether every file/byte figure in this result was actually measured. */
+        public boolean measurementsAvailable() {
+            return filesBefore.isPresent() && filesAfter.isPresent() && bytesRewritten.isPresent();
         }
 
         public static Result unnecessary(long files) {
-            return new Result(Outcome.UNNECESSARY, Duration.ZERO, files, files, 0, 0, 0,
-                    Duration.ZERO, Optional.empty());
+            return new Result(Outcome.UNNECESSARY, Duration.ZERO, OptionalLong.of(files),
+                    OptionalLong.of(files), OptionalLong.of(0), 0, 0, Duration.ZERO, Optional.empty());
         }
 
-        public long filesReclaimed() {
-            return Math.max(0, filesBefore - filesAfter);
+        /**
+         * Files reclaimed, or empty when either end of the comparison was not measured.
+         *
+         * <p>Deliberately not "0 when unknown": a pass that could not read the catalog has not
+         * reclaimed nothing, it has not been measured, and reporting the two the same way is how
+         * "files 35 -> 0" came to look like a catastrophic deletion.
+         */
+        public OptionalLong filesReclaimed() {
+            if (filesBefore.isEmpty() || filesAfter.isEmpty()) return OptionalLong.empty();
+            return OptionalLong.of(Math.max(0, filesBefore.getAsLong() - filesAfter.getAsLong()));
         }
     }
 }

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionMaintenance.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionMaintenance.java
@@ -1,0 +1,118 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.Optional;
+
+/** Value types for bounded sink maintenance (ADR-039). */
+public final class ProjectionMaintenance {
+
+    private ProjectionMaintenance() {}
+
+    /**
+     * Bounds one maintenance pass.
+     *
+     * <p>Housekeeping and compaction are budgeted <strong>separately</strong> and deliberately
+     * so. Expiring snapshots and deleting orphaned files are how the archive reclaims space;
+     * compaction is an optimisation. A single shared budget lets a large compaction consume
+     * everything and starve the cleanup that actually matters, which is how a lagging archive
+     * turns into a full disk.
+     */
+    public record Budget(Duration housekeepingTimeLimit,
+                         Duration compactionTimeLimit,
+                         long maxBytesToRewrite,
+                         long targetFileSizeBytes,
+                         int minFilesToCompact,
+                         long minSmallFileBytes,
+                         boolean compactionAllowed) {
+
+        public Budget {
+            Objects.requireNonNull(housekeepingTimeLimit, "housekeepingTimeLimit");
+            Objects.requireNonNull(compactionTimeLimit, "compactionTimeLimit");
+            if (housekeepingTimeLimit.isNegative() || compactionTimeLimit.isNegative()) {
+                throw new IllegalArgumentException("time limits must not be negative");
+            }
+            if (maxBytesToRewrite < 0 || targetFileSizeBytes < 1) {
+                throw new IllegalArgumentException("invalid compaction bounds");
+            }
+            if (minFilesToCompact < 2) {
+                throw new IllegalArgumentException("compacting fewer than two files cannot help");
+            }
+            if (minSmallFileBytes < 1) throw new IllegalArgumentException("minSmallFileBytes must be positive");
+        }
+
+        /**
+         * Housekeeping only; compaction withheld. Used during bootstrap, where compaction
+         * would contend with the sink for the same bounded bulk pool and would re-merge the
+         * same neighbourhood as the sink keeps appending.
+         */
+        public static Budget housekeepingOnly(Duration timeLimit) {
+            return new Budget(timeLimit, Duration.ZERO, 0, 512L << 20, 8, 32L << 20, false);
+        }
+
+        /** Housekeeping plus bounded compaction, for an idle sink caught up at the tip. */
+        public static Budget full(Duration housekeeping, Duration compaction, long maxBytesToRewrite) {
+            return new Budget(housekeeping, compaction, maxBytesToRewrite, 512L << 20, 8, 32L << 20, true);
+        }
+    }
+
+    /** What a maintenance pass actually did. */
+    public enum Outcome {
+        /** Ran and finished within budget. */
+        COMPLETED,
+        /** Ran partially and stopped at a bound; safe to call again. */
+        PARTIAL,
+        /** Withheld deliberately, e.g. a pinned reader or an active writer. */
+        DEFERRED,
+        /** Nothing needed doing; thresholds were not met. */
+        UNNECESSARY,
+        /** This backend has no maintenance to perform. */
+        UNSUPPORTED,
+        /** Attempted and failed; the reason is carried. */
+        FAILED
+    }
+
+    /**
+     * Result of a pass, with enough detail to tune the thresholds.
+     *
+     * <p>{@code UNSUPPORTED} is a first-class outcome rather than a silent default no-op: a
+     * backend that genuinely has nothing to maintain should say so, so an operator can tell
+     * that apart from maintenance that is configured but never running.
+     */
+    public record Result(Outcome outcome,
+                         Duration duration,
+                         long filesBefore,
+                         long filesAfter,
+                         long bytesRewritten,
+                         long snapshotsExpired,
+                         long orphanedFilesDeleted,
+                         Duration writerWait,
+                         Optional<String> detail) {
+
+        public Result {
+            Objects.requireNonNull(outcome, "outcome");
+            Objects.requireNonNull(duration, "duration");
+            Objects.requireNonNull(writerWait, "writerWait");
+            Objects.requireNonNull(detail, "detail");
+        }
+
+        public static Result unsupported(String why) {
+            return new Result(Outcome.UNSUPPORTED, Duration.ZERO, 0, 0, 0, 0, 0,
+                    Duration.ZERO, Optional.of(why));
+        }
+
+        public static Result deferred(String why) {
+            return new Result(Outcome.DEFERRED, Duration.ZERO, 0, 0, 0, 0, 0,
+                    Duration.ZERO, Optional.of(why));
+        }
+
+        public static Result unnecessary(long files) {
+            return new Result(Outcome.UNNECESSARY, Duration.ZERO, files, files, 0, 0, 0,
+                    Duration.ZERO, Optional.empty());
+        }
+
+        public long filesReclaimed() {
+            return Math.max(0, filesBefore - filesAfter);
+        }
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionReceipt.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionReceipt.java
@@ -1,0 +1,56 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Durable proof that one deterministic projection batch was committed by the sink,
+ * written in the same sink transaction as its rows (ADR-039 §10).
+ *
+ * <p>{@link #matches} is the whole idempotency contract: a retry that agrees on
+ * identity, range, counts and digest is accepted as already-done, and a retry that
+ * disagrees on any of them is rejected rather than reconciled. Cleanup is scoped to a
+ * verified receipt and never infers success from the sink's current maximum block.
+ */
+public record ProjectionReceipt(String identityFingerprint, long firstBlock, long lastBlock,
+                                String firstEnvelopeId, String lastEnvelopeId,
+                                long blockCount, Map<String, Long> rowCounts,
+                                String orderedDigest, Instant committedAt) {
+    public ProjectionReceipt {
+        identityFingerprint = Objects.requireNonNull(identityFingerprint, "identityFingerprint").trim();
+        firstEnvelopeId = Objects.requireNonNull(firstEnvelopeId, "firstEnvelopeId").trim().toLowerCase();
+        lastEnvelopeId = Objects.requireNonNull(lastEnvelopeId, "lastEnvelopeId").trim().toLowerCase();
+        orderedDigest = Objects.requireNonNull(orderedDigest, "orderedDigest").trim().toLowerCase();
+        rowCounts = Map.copyOf(Objects.requireNonNull(rowCounts, "rowCounts"));
+        Objects.requireNonNull(committedAt, "committedAt");
+        if (firstBlock < 0 || lastBlock < firstBlock) throw new IllegalArgumentException("invalid receipt range");
+        if (blockCount != lastBlock - firstBlock + 1) {
+            throw new IllegalArgumentException("receipt blockCount does not match its range");
+        }
+        if (identityFingerprint.isEmpty() || orderedDigest.isEmpty()
+                || firstEnvelopeId.isEmpty() || lastEnvelopeId.isEmpty()) {
+            throw new IllegalArgumentException("receipt identity fields are required");
+        }
+        if (rowCounts.values().stream().anyMatch(v -> v == null || v < 0)) {
+            throw new IllegalArgumentException("receipt row counts must not be negative");
+        }
+    }
+
+    public static ProjectionReceipt of(ProjectionJob job, Map<String, Long> rowCounts, Instant committedAt) {
+        return new ProjectionReceipt(job.identity().fingerprint(), job.firstBlock(), job.lastBlock(),
+                job.firstEnvelopeId(), job.lastEnvelopeId(), job.blockCount(), rowCounts,
+                job.orderedDigest(), committedAt);
+    }
+
+    /** True only when a retry is the same job; deliberately ignores {@code committedAt}. */
+    public boolean matches(ProjectionJob job) {
+        return identityFingerprint.equals(job.identity().fingerprint())
+                && firstBlock == job.firstBlock()
+                && lastBlock == job.lastBlock()
+                && blockCount == job.blockCount()
+                && firstEnvelopeId.equals(job.firstEnvelopeId())
+                && lastEnvelopeId.equals(job.lastEnvelopeId())
+                && orderedDigest.equals(job.orderedDigest());
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionReceiptMismatchException.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionReceiptMismatchException.java
@@ -1,0 +1,13 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+/**
+ * A durable receipt exists for this range but describes a different job.
+ *
+ * <p>This is never retried into success. It means two differently shaped projections
+ * claim the same canonical range, which the outbox cannot resolve on its own.
+ */
+public class ProjectionReceiptMismatchException extends ProjectionSinkException {
+    public ProjectionReceiptMismatchException(String message) {
+        super(message);
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionRowBatch.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionRowBatch.java
@@ -1,0 +1,45 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * A projection batch presented to a sink as a <em>stream</em> of archive rows.
+ *
+ * <p>Row derivation happens once, in shared archive-core code, so every backend sees the same
+ * interpretation of the chain and a storage module needs only {@code archive-api} — no
+ * projection codec, no fact model. A sink does format translation and batching; it does not
+ * repeat ledger resolution.
+ *
+ * <p>{@code rows} is an {@link Iterable} rather than a {@code List} deliberately. Holding the
+ * whole batch as a list made peak heap proportional to batch size, which meant the configured
+ * memory ceiling was nominal: a single dense block larger than the ceiling was still
+ * materialised in full. Streaming keeps only one envelope's rows live at a time, so the bound
+ * holds however dense a block turns out to be.
+ *
+ * <p>Implementations must be <strong>re-iterable</strong>. A sink may need a second pass — to
+ * retry after a recoverable failure, or to verify — and a single-shot iterator would silently
+ * produce an empty second pass rather than failing.
+ */
+public record ProjectionRowBatch(ProjectionIdentity identity, long firstBlock, long lastBlock,
+                                 long blockCount, String firstEnvelopeId, String lastEnvelopeId,
+                                 String orderedDigest, Iterable<ArchiveRow> rows,
+                                 List<ProjectionArtifactRef> artifacts) implements ProjectionJob {
+    public ProjectionRowBatch {
+        Objects.requireNonNull(identity, "identity");
+        firstEnvelopeId = Objects.requireNonNull(firstEnvelopeId, "firstEnvelopeId").trim().toLowerCase();
+        lastEnvelopeId = Objects.requireNonNull(lastEnvelopeId, "lastEnvelopeId").trim().toLowerCase();
+        orderedDigest = Objects.requireNonNull(orderedDigest, "orderedDigest").trim().toLowerCase();
+        Objects.requireNonNull(rows, "rows");
+        artifacts = List.copyOf(Objects.requireNonNull(artifacts, "artifacts"));
+        if (firstBlock < 0 || lastBlock < firstBlock) throw new IllegalArgumentException("invalid batch range");
+        if (blockCount != lastBlock - firstBlock + 1) {
+            throw new IllegalArgumentException("blockCount does not match the batch range");
+        }
+        if (firstEnvelopeId.isEmpty() || lastEnvelopeId.isEmpty() || orderedDigest.isEmpty()) {
+            throw new IllegalArgumentException("batch identity fields are required");
+        }
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSection.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSection.java
@@ -1,0 +1,40 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+/** One section's ordered chunk payloads together with the counts its manifest claims. */
+public record ProjectionSection(ProjectionSectionType type, int version, List<byte[]> chunks, long rowCount) {
+    public ProjectionSection {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(chunks, "chunks");
+        if (version < 1) throw new IllegalArgumentException("version must be positive");
+        if (rowCount < 0) throw new IllegalArgumentException("rowCount must not be negative");
+        List<byte[]> copies = new ArrayList<>(chunks.size());
+        for (byte[] chunk : chunks) {
+            Objects.requireNonNull(chunk, "chunk");
+            copies.add(Arrays.copyOf(chunk, chunk.length));
+        }
+        chunks = List.copyOf(copies);
+    }
+
+    @Override
+    public List<byte[]> chunks() {
+        List<byte[]> copies = new ArrayList<>(chunks.size());
+        for (byte[] chunk : chunks) copies.add(Arrays.copyOf(chunk, chunk.length));
+        return List.copyOf(copies);
+    }
+
+    public long byteCount() {
+        long total = 0;
+        for (byte[] chunk : chunks) total += chunk.length;
+        return total;
+    }
+
+    public ProjectionSectionManifest manifest() {
+        return new ProjectionSectionManifest(type, version, chunks.size(), rowCount, byteCount(),
+                ProjectionDigest.ofChunks(chunks));
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSectionManifest.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSectionManifest.java
@@ -1,0 +1,23 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.util.Objects;
+
+/**
+ * Header-level description of one section, sufficient for a sink to prove the section
+ * it read is complete before acknowledging the envelope (ADR-039 invariant 11).
+ */
+public record ProjectionSectionManifest(ProjectionSectionType type, int version, int chunkCount,
+                                        long rowCount, long byteCount, String digest) {
+    public ProjectionSectionManifest {
+        Objects.requireNonNull(type, "type");
+        digest = Objects.requireNonNull(digest, "digest").trim().toLowerCase();
+        if (version < 1) throw new IllegalArgumentException("version must be positive");
+        if (chunkCount < 0 || rowCount < 0 || byteCount < 0) {
+            throw new IllegalArgumentException("manifest counts must not be negative");
+        }
+        if (digest.isEmpty()) throw new IllegalArgumentException("digest is required");
+        if (chunkCount == 0 && (rowCount != 0 || byteCount != 0)) {
+            throw new IllegalArgumentException("a chunkless section cannot carry rows or bytes");
+        }
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSectionType.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSectionType.java
@@ -1,0 +1,70 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.schema.ArchiveSchemas;
+
+import java.util.Objects;
+
+/**
+ * Transport grouping for one logical projection section.
+ *
+ * <p>A section type is permanently bound to exactly one {@link ArchiveDatasetId} and
+ * derives its version from that dataset's shipped {@code projectionVersion} rather
+ * than declaring one of its own. ADR-039 §3 requires that section names stay
+ * transport groupings and never become permission to repartition tables between
+ * datasets or to renumber a projection version; deriving the version here makes the
+ * two impossible to drift apart silently.
+ */
+public enum ProjectionSectionType {
+    TRANSACTION(1, "transaction", ArchiveDatasetId.TRANSACTION),
+    UTXO_HISTORY(2, "utxo-history", ArchiveDatasetId.UTXO_HISTORY),
+    ACCOUNT_EVENT(3, "account-events", ArchiveDatasetId.ACCOUNT_EVENT),
+    ADDRESS_TRANSACTION(4, "address-transaction", ArchiveDatasetId.ADDRESS_TRANSACTION);
+
+    private final int code;
+    private final String wirePrefix;
+    private final ArchiveDatasetId dataset;
+
+    ProjectionSectionType(int code, String wirePrefix, ArchiveDatasetId dataset) {
+        this.code = code;
+        this.wirePrefix = wirePrefix;
+        this.dataset = dataset;
+    }
+
+    /**
+     * Stable persisted code, deliberately not {@code ordinal()}: outbox keys outlive
+     * the process, so reordering this enum must not reinterpret stored records.
+     */
+    public int code() {
+        return code;
+    }
+
+    public static ProjectionSectionType fromCode(int code) {
+        for (ProjectionSectionType type : values()) {
+            if (type.code == code) return type;
+        }
+        throw new IllegalArgumentException("unknown projection section code: " + code);
+    }
+
+    public ArchiveDatasetId dataset() {
+        return dataset;
+    }
+
+    /** Shipped projection version of the owning dataset; never independently chosen. */
+    public int version() {
+        return ArchiveSchemas.schema(dataset).projectionVersion();
+    }
+
+    /** Stable wire name, e.g. {@code utxo-history:v5}. */
+    public String wireName() {
+        return wirePrefix + ":v" + version();
+    }
+
+    public static ProjectionSectionType fromWireName(String wireName) {
+        String name = Objects.requireNonNull(wireName, "wireName").trim();
+        for (ProjectionSectionType type : values()) {
+            if (type.wireName().equals(name)) return type;
+        }
+        throw new IllegalArgumentException("unknown projection section: " + wireName);
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSink.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSink.java
@@ -1,0 +1,58 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.util.Optional;
+
+/**
+ * The one configured authoritative historical store for this node (ADR-039 §13).
+ *
+ * <p>Exactly one sink is active. Version one deliberately does not support two
+ * simultaneous primary sinks, because cleanup would then depend on per-consumer
+ * offsets and the slowest consumer would retain every envelope.
+ */
+public interface ProjectionSink extends AutoCloseable {
+
+    /** Engine name recorded in archive identity, e.g. {@code ducklake} or {@code sqlite}. */
+    String engine();
+
+    /**
+     * Bind this sink to the expected identity, failing closed on any mismatch of
+     * network, genesis, sink engine, projection version, or required section set.
+     * A sink that cannot read a required section must fail here, not at first use.
+     */
+    void initialize(ProjectionIdentity expected);
+
+    /** Greatest contiguous committed block envelope, or {@link ProjectionCoordinate#NONE}. */
+    ProjectionCoordinate coordinate();
+
+    /** Durable receipt for a range starting at this block, when one was committed. */
+    Optional<ProjectionReceipt> receiptFor(long firstBlock);
+
+    /**
+     * Commit every required row and the receipt in one sink transaction.
+     *
+     * <p>A matching existing receipt is returned without duplicate effect; a receipt
+     * that describes a differently shaped job for the same range raises
+     * {@link ProjectionReceiptMismatchException}.
+     */
+    ProjectionReceipt append(ProjectionRowBatch batch, ArchiveArtifactReader artifacts);
+
+    /**
+     * Run one bounded maintenance pass.
+     *
+     * <p>Called by the single projection coordinator when it is caught up and idle — never on
+     * a separate schedule and never by an independent worker. Mandatory housekeeping (expiring
+     * snapshots, deleting obsolete and orphaned files) runs first and is budgeted separately
+     * from optional compaction, so compaction can never starve the cleanup that reclaims
+     * space.
+     *
+     * <p>Implementations must be restart-safe and idempotent, must yield to ingestion, and
+     * must return {@link ProjectionMaintenance.Outcome#UNSUPPORTED} rather than silently doing
+     * nothing when they have no maintenance to perform.
+     */
+    ProjectionMaintenance.Result maintain(ProjectionMaintenance.Budget budget);
+
+    ProjectionSinkHealth health();
+
+    @Override
+    void close();
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSinkException.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSinkException.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+/** Sink-side failure that must not be interpreted as progress. */
+public class ProjectionSinkException extends RuntimeException {
+    public ProjectionSinkException(String message) {
+        super(message);
+    }
+
+    public ProjectionSinkException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSinkHealth.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSinkHealth.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/** Visible sink state; a degraded sink must be observable rather than merely slow. */
+public record ProjectionSinkHealth(State state, Optional<String> lastFailure) {
+    public enum State { READY, DEGRADED, UNAVAILABLE }
+
+    public ProjectionSinkHealth {
+        Objects.requireNonNull(state, "state");
+        Objects.requireNonNull(lastFailure, "lastFailure");
+    }
+
+    public static ProjectionSinkHealth ready() {
+        return new ProjectionSinkHealth(State.READY, Optional.empty());
+    }
+
+    public static ProjectionSinkHealth unavailable(String reason) {
+        return new ProjectionSinkHealth(State.UNAVAILABLE, Optional.of(reason));
+    }
+}

--- a/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSinkProvider.java
+++ b/archive-modules/archive-api/src/main/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionSinkProvider.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveIdentity;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * ServiceLoader boundary for selecting exactly one primary projection sink.
+ *
+ * <p>Mirrors {@code ArchiveBackendProvider} deliberately: the host names an engine and
+ * receives a {@link ProjectionSink}, never a backend-specific type. That is what keeps
+ * DuckLake and standalone SQLite out of the application module and preserves ADR-039's
+ * dependency direction toward {@code archive-api}.
+ */
+public interface ProjectionSinkProvider {
+
+    /** Engine name, matching the configured {@code history.projection.sink}. */
+    String engine();
+
+    /**
+     * Open the sink, creating any physical schema it requires.
+     *
+     * <p>The returned sink is not yet bound to an identity; the caller invokes
+     * {@link ProjectionSink#initialize} so identity mismatches fail closed at startup.
+     */
+    ProjectionSink openProjectionSink(ArchiveIdentity expectedIdentity, Path historyDirectory,
+                                      Map<String, String> validatedProperties);
+}

--- a/archive-modules/archive-api/src/test/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionContractsTest.java
+++ b/archive-modules/archive-api/src/test/java/com/bloxbean/cardano/yano/archive/api/projection/ProjectionContractsTest.java
@@ -1,0 +1,276 @@
+package com.bloxbean.cardano.yano.archive.api.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.schema.ArchiveSchemas;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProjectionContractsTest {
+
+    static final ArchiveNetworkIdentity PREPROD = new ArchiveNetworkIdentity(1, "162d29c4e1cf6b8a");
+
+    static ProjectionSection section(ProjectionSectionType type, long rows, byte[]... chunks) {
+        return new ProjectionSection(type, type.version(), List.of(chunks), rows);
+    }
+
+    static ProjectionEnvelopeHeader header(long blockNumber, List<ProjectionSection> sections) {
+        return new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, blockNumber,
+                new byte[]{(byte) blockNumber, 1, 2}, new byte[]{(byte) (blockNumber - 1), 1, 2},
+                blockNumber * 20, 5, 1_600_000_000L + blockNumber, 1,
+                sections.stream().map(ProjectionSection::manifest).toList(), List.of());
+    }
+
+    static ProjectionEnvelope envelope(long blockNumber, List<ProjectionSection> sections) {
+        return new ProjectionEnvelope(header(blockNumber, sections), sections);
+    }
+
+    // --- section identity is bound to shipped dataset identity -------------------
+
+    @Test
+    void sectionVersionsTrackTheShippedDatasetProjectionVersion() {
+        assertThat(ProjectionSectionType.TRANSACTION.wireName()).isEqualTo("transaction:v2");
+        assertThat(ProjectionSectionType.UTXO_HISTORY.wireName()).isEqualTo("utxo-history:v5");
+        assertThat(ProjectionSectionType.ACCOUNT_EVENT.wireName()).isEqualTo("account-events:v3");
+        assertThat(ProjectionSectionType.ADDRESS_TRANSACTION.wireName()).isEqualTo("address-transaction:v3");
+
+        for (ProjectionSectionType type : ProjectionSectionType.values()) {
+            assertThat(type.version())
+                    .isEqualTo(ArchiveSchemas.schema(type.dataset()).projectionVersion());
+            assertThat(ProjectionSectionType.fromWireName(type.wireName())).isEqualTo(type);
+        }
+    }
+
+    @Test
+    void everyShippedBlockDatasetHasExactlyOneSection() {
+        Set<ArchiveDatasetId> covered = Set.of(
+                ProjectionSectionType.TRANSACTION.dataset(), ProjectionSectionType.UTXO_HISTORY.dataset(),
+                ProjectionSectionType.ACCOUNT_EVENT.dataset(), ProjectionSectionType.ADDRESS_TRANSACTION.dataset());
+        Set<ArchiveDatasetId> shippedBlockDatasets = java.util.Arrays.stream(ArchiveDatasetId.values())
+                .filter(d -> d.sourceKind() == com.bloxbean.cardano.yano.archive.api.SourceKind.BLOCK)
+                .collect(java.util.stream.Collectors.toUnmodifiableSet());
+        assertThat(covered).isEqualTo(shippedBlockDatasets);
+    }
+
+    @Test
+    void datumAndRedeemerTablesRemainUnderUtxoHistory() {
+        // Guards ADR-039 review D2: transport grouping must not move these to TRANSACTION.
+        assertThat(ArchiveSchemas.schema(ArchiveDatasetId.UTXO_HISTORY).tables())
+                .extracting(com.bloxbean.cardano.yano.archive.api.schema.ArchiveTableSchema::physicalName)
+                .contains("transaction_datums", "transaction_redeemers");
+        assertThat(ArchiveSchemas.schema(ArchiveDatasetId.TRANSACTION).tables())
+                .extracting(com.bloxbean.cardano.yano.archive.api.schema.ArchiveTableSchema::physicalName)
+                .containsExactly("chain_transaction");
+    }
+
+    @Test
+    void unknownSectionWireNameIsRejected() {
+        assertThatThrownBy(() -> ProjectionSectionType.fromWireName("transaction:v99"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown projection section");
+    }
+
+    // --- envelope identity ------------------------------------------------------
+
+    @Test
+    void envelopeIdIsDeterministicForTheSameCanonicalBlock() {
+        var a = header(100, List.of(section(ProjectionSectionType.TRANSACTION, 2, new byte[]{1, 2, 3})));
+        var b = header(100, List.of(section(ProjectionSectionType.TRANSACTION, 2, new byte[]{1, 2, 3})));
+        assertThat(a.envelopeId()).isEqualTo(b.envelopeId()).hasSize(64);
+    }
+
+    @Test
+    void aReplacementBlockAtTheSameHeightGetsADifferentEnvelopeId() {
+        var original = header(100, List.of());
+        var replacement = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, 100,
+                new byte[]{9, 9, 9}, original.parentHash(), original.slot(), original.epoch(),
+                original.blockTime(), 1, List.of(), List.of());
+        assertThat(replacement.envelopeId()).isNotEqualTo(original.envelopeId());
+    }
+
+    @Test
+    void envelopeIdChangesWithProjectionVersionAndNetwork() {
+        var base = header(100, List.of());
+        var otherVersion = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, 100,
+                base.blockHash(), base.parentHash(), base.slot(), base.epoch(), base.blockTime(), 2,
+                List.of(), List.of());
+        var otherNetwork = new ProjectionEnvelopeHeader(new ArchiveNetworkIdentity(764824073, "abcdef"),
+                ProjectionBlockKind.SHELLEY_PLUS, 100, base.blockHash(), base.parentHash(),
+                base.slot(), base.epoch(), base.blockTime(), 1, List.of(), List.of());
+        assertThat(otherVersion.envelopeId()).isNotEqualTo(base.envelopeId());
+        assertThat(otherNetwork.envelopeId()).isNotEqualTo(base.envelopeId());
+    }
+
+    // --- completeness is proven at construction ---------------------------------
+
+    @Test
+    void anEnvelopeMissingAManifestedSectionIsRejected() {
+        var tx = section(ProjectionSectionType.TRANSACTION, 1, new byte[]{7});
+        var utxo = section(ProjectionSectionType.UTXO_HISTORY, 3, new byte[]{8});
+        var head = header(100, List.of(tx, utxo));
+        assertThatThrownBy(() -> new ProjectionEnvelope(head, List.of(tx)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void aTamperedSectionPayloadIsRejectedAgainstItsManifest() {
+        var declared = section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1, 2, 3});
+        var head = header(100, List.of(declared));
+        var tampered = section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1, 2, 4});
+        assertThatThrownBy(() -> new ProjectionEnvelope(head, List.of(tampered)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("does not match its manifest");
+    }
+
+    @Test
+    void aWrongRowCountIsRejectedEvenWhenBytesMatch() {
+        var declared = section(ProjectionSectionType.TRANSACTION, 5, new byte[]{1, 2, 3});
+        var head = header(100, List.of(declared));
+        var wrongRows = section(ProjectionSectionType.TRANSACTION, 6, new byte[]{1, 2, 3});
+        assertThatThrownBy(() -> new ProjectionEnvelope(head, List.of(wrongRows)))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void chunkSplittingIsPartOfTheDigestedContract() {
+        String oneChunk = ProjectionDigest.ofChunks(List.of(new byte[]{1, 2, 3, 4}));
+        String twoChunks = ProjectionDigest.ofChunks(List.of(new byte[]{1, 2}, new byte[]{3, 4}));
+        assertThat(oneChunk).isNotEqualTo(twoChunks);
+    }
+
+    @Test
+    void sectionPayloadsAreDefensivelyCopied() {
+        byte[] mutable = {1, 2, 3};
+        var section = new ProjectionSection(ProjectionSectionType.TRANSACTION, 2, List.of(mutable), 1);
+        String before = section.manifest().digest();
+        mutable[0] = 99;
+        assertThat(section.manifest().digest()).isEqualTo(before);
+    }
+
+    // --- Byron / EBB ------------------------------------------------------------
+
+    @Test
+    void anEpochBoundaryBlockProducesAnEmptyEnvelopeAndStillHasIdentity() {
+        var ebb = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.BYRON_EBB, 42,
+                new byte[]{4, 2}, new byte[]{4, 1}, 900, 2, 1_500_000_000L, 1, List.of(), List.of());
+        var envelope = new ProjectionEnvelope(ebb, List.of());
+        assertThat(envelope.sections()).isEmpty();
+        assertThat(envelope.envelopeId()).hasSize(64);
+        assertThat(ebb.blockKind().isByron()).isTrue();
+        assertThat(ebb.blockKind().allowsEmptyEnvelope()).isTrue();
+    }
+
+    @Test
+    void anEpochBoundaryBlockCannotCarrySections() {
+        var tx = section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1});
+        assertThatThrownBy(() -> new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.BYRON_EBB, 42,
+                new byte[]{4, 2}, new byte[]{4, 1}, 900, 2, 1L, 1, List.of(tx.manifest()), List.of()))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("empty envelope");
+    }
+
+    @Test
+    void byronMainBlocksMayCarrySections() {
+        var tx = section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1});
+        var head = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.BYRON_MAIN, 43,
+                new byte[]{4, 3}, new byte[]{4, 2}, 920, 2, 1L, 1, List.of(tx.manifest()), List.of());
+        assertThat(new ProjectionEnvelope(head, List.of(tx)).sections()).hasSize(1);
+        assertThat(ProjectionBlockKind.BYRON_MAIN.allowsEmptyEnvelope()).isFalse();
+    }
+
+    // --- batches ----------------------------------------------------------------
+
+    @Test
+    void aBatchWithAGapIsRejected() {
+        var e100 = envelope(100, List.of());
+        var e102 = envelope(102, List.of());
+        var identity = identity();
+        assertThatThrownBy(() -> new ProjectionBatch(identity, List.of(e100, e102)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not contiguous");
+    }
+
+    @Test
+    void aContiguousBatchReportsItsRangeAndTotals() {
+        var batch = new ProjectionBatch(identity(), List.of(
+                envelope(100, List.of(section(ProjectionSectionType.TRANSACTION, 2, new byte[]{1, 2}))),
+                envelope(101, List.of(section(ProjectionSectionType.TRANSACTION, 3, new byte[]{3})))));
+        assertThat(batch.firstBlock()).isEqualTo(100);
+        assertThat(batch.lastBlock()).isEqualTo(101);
+        assertThat(batch.blockCount()).isEqualTo(2);
+        assertThat(batch.rowCount()).isEqualTo(5);
+        assertThat(batch.byteCount()).isEqualTo(3);
+    }
+
+    @Test
+    void anEmptyBatchIsRejected() {
+        assertThatThrownBy(() -> new ProjectionBatch(identity(), List.of()))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // --- receipts ---------------------------------------------------------------
+
+    @Test
+    void aMatchingRetryIsRecognisedAndAReshapedOneIsNot() {
+        var batch = new ProjectionBatch(identity(), List.of(
+                envelope(100, List.of(section(ProjectionSectionType.TRANSACTION, 2, new byte[]{1, 2})))));
+        var receipt = ProjectionReceipt.of(batch, Map.of("chain_transaction", 2L), java.time.Instant.EPOCH);
+
+        assertThat(receipt.matches(batch)).isTrue();
+
+        var reshaped = new ProjectionBatch(identity(), List.of(
+                envelope(100, List.of(section(ProjectionSectionType.TRANSACTION, 2, new byte[]{9, 9})))));
+        assertThat(receipt.matches(reshaped)).isFalse();
+
+        var longer = new ProjectionBatch(identity(), List.of(
+                envelope(100, List.of(section(ProjectionSectionType.TRANSACTION, 2, new byte[]{1, 2}))),
+                envelope(101, List.of())));
+        assertThat(receipt.matches(longer)).isFalse();
+    }
+
+    @Test
+    void aReceiptRangeMustAgreeWithItsBlockCount() {
+        assertThatThrownBy(() -> new ProjectionReceipt("fp", 100, 105, "a", "b", 2,
+                Map.of(), "d", java.time.Instant.EPOCH))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("blockCount");
+    }
+
+    // --- identity ---------------------------------------------------------------
+
+    static ProjectionIdentity identity() {
+        return new ProjectionIdentity(PREPROD, "ducklake", 1,
+                Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY));
+    }
+
+    @Test
+    void identityFingerprintIsOrderIndependentButSetSensitive() {
+        var a = new ProjectionIdentity(PREPROD, "ducklake", 1,
+                Set.of(ProjectionSectionType.UTXO_HISTORY, ProjectionSectionType.TRANSACTION));
+        var b = new ProjectionIdentity(PREPROD, "ducklake", 1,
+                Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY));
+        var c = new ProjectionIdentity(PREPROD, "ducklake", 1, Set.of(ProjectionSectionType.TRANSACTION));
+        var d = new ProjectionIdentity(PREPROD, "sqlite", 1,
+                Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY));
+
+        assertThat(a.matches(b)).isTrue();
+        assertThat(a.matches(c)).isFalse();
+        assertThat(a.matches(d)).isFalse();
+        assertThat(a.fingerprint()).contains("transaction:v2", "utxo-history:v5", "ducklake");
+    }
+
+    @Test
+    void coordinateEmptyAndPresentStatesAreDistinct() {
+        assertThat(ProjectionCoordinate.NONE.isPresent()).isFalse();
+        assertThat(ProjectionCoordinate.NONE.nextExpectedBlock()).isEmpty();
+        var present = ProjectionCoordinate.of(header(100, List.of()));
+        assertThat(present.isPresent()).isTrue();
+        assertThat(present.nextExpectedBlock()).contains(101L);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/dataset/AddressParticipationFact.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/dataset/AddressParticipationFact.java
@@ -1,0 +1,40 @@
+package com.bloxbean.cardano.yano.archive.core.dataset;
+
+import java.util.List;
+
+/**
+ * One block's address participations, already resolved.
+ *
+ * <p>Carried in the ADR-039 {@code address-transaction} section. Everything a sink needs to
+ * emit {@code address_transactions} rows is here, because the sink has neither the block nor
+ * the UTXO set: consumed inputs were resolved at capture time, and outputs were parsed from the
+ * block then rather than re-parsed later.
+ *
+ * @param transactions per-transaction participations, in block order
+ */
+public record AddressParticipationFact(List<Transaction> transactions) {
+
+    public AddressParticipationFact {
+        transactions = List.copyOf(transactions);
+    }
+
+    /**
+     * @param txHash        transaction id
+     * @param txIndex       index within the block
+     * @param participations every address that took part, with the role it played, in the order
+     *                      the archive first encountered it
+     */
+    public record Transaction(byte[] txHash, int txIndex, List<Participation> participations) {
+        public Transaction {
+            participations = List.copyOf(participations);
+        }
+    }
+
+    /**
+     * @param role        {@code INPUT}, {@code OUTPUT}, {@code COLLATERAL_INPUT} or
+     *                    {@code COLLATERAL_RETURN}, as the wire name of
+     *                    {@link AddressSubjectRows.Role}
+     * @param participant the resolved address parts
+     */
+    public record Participation(String role, AddressSubjectRows.Participant participant) { }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/dataset/AddressSubjectRows.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/dataset/AddressSubjectRows.java
@@ -1,0 +1,127 @@
+package com.bloxbean.cardano.yano.archive.core.dataset;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.core.address.StakeAddressCodec;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+
+/**
+ * Turns one transaction's participating addresses into {@code address_transactions} rows.
+ *
+ * <p>Extracted so the live path and the ADR-039 projection path cannot disagree about what an
+ * address transaction row <em>is</em>. Differential parity between two implementations of the
+ * same rule is a test that can pass while both are wrong; sharing the rule makes the question
+ * not arise. The same argument already applies to {@code UtxoHistoryDataset}, which both paths
+ * call.
+ *
+ * <p>Everything here is a pure function of already-resolved inputs. The one thing that needs
+ * live state — mapping a consumed outpoint back to the address that owned it — happens before
+ * this class is reached, in the live resolver on one path and at capture time on the other.
+ */
+public final class AddressSubjectRows {
+
+    /** How an address took part in a transaction. */
+    public enum Role { INPUT, OUTPUT, COLLATERAL_INPUT, COLLATERAL_RETURN }
+
+    /**
+     * An address that participated, already resolved to its parts.
+     *
+     * @param addressKey          hash the archive indexes the address by
+     * @param address             display form, carried only for the {@code address} subject
+     * @param paymentCredential   payment credential, null when the address has none
+     * @param stakeCredentialType {@code key} or {@code script}; null when there is no stake part
+     * @param stakeCredential     stake credential, null when there is no stake part
+     */
+    public record Participant(byte[] addressKey, String address, byte[] paymentCredential,
+                              String stakeCredentialType, byte[] stakeCredential) { }
+
+    private final AddressTransactionSubjects selected;
+    private final long networkMagic;
+    private final Map<SubjectKey, SubjectRoles> subjects = new LinkedHashMap<>();
+
+    public AddressSubjectRows(AddressTransactionSubjects selected, long networkMagic) {
+        this.selected = selected;
+        this.networkMagic = networkMagic;
+    }
+
+    /** Record one participation. Order of first appearance determines row order. */
+    public void add(Participant participant, Role role) {
+        if (selected.address()) {
+            put(AddressTransactionSubjects.ADDRESS, participant.addressKey(),
+                    participant.address(), null, role);
+        }
+        if (selected.paymentCredential()) {
+            put(AddressTransactionSubjects.PAYMENT_CREDENTIAL, participant.paymentCredential(),
+                    null, null, role);
+        }
+        if (selected.stakeCredential()) {
+            put(AddressTransactionSubjects.STAKE_CREDENTIAL, participant.stakeCredential(), null,
+                    StakeAddressCodec.encode(networkMagic, participant.stakeCredentialType(),
+                            participant.stakeCredential()),
+                    role);
+        }
+    }
+
+    private void put(String type, byte[] key, String address, String stakeAddress, Role role) {
+        if (key == null) return;
+        subjects.computeIfAbsent(new SubjectKey(type, key), ignored ->
+                new SubjectRoles(new AddressSubject(type, key), address, stakeAddress)).increment(role);
+    }
+
+    /** Emit the accumulated rows for one transaction, in first-appearance order. */
+    public void emit(byte[] txHash, int txIndex, byte[] blockHash, long blockNumber, long slot,
+                     long epoch, long blockTimeSeconds, java.util.UUID jobId, Consumer<ArchiveRow> sink) {
+        for (SubjectRoles roles : subjects.values()) {
+            AddressSubject subject = roles.subject;
+            sink.accept(new ArchiveRow("address_transactions", Arrays.asList(subject.subjectType(),
+                    subject.subjectKey(), roles.address, roles.stakeAddress, txHash, blockHash,
+                    blockNumber, slot, epoch, blockTimeSeconds, txIndex, roles.inputCount,
+                    roles.outputCount, roles.collateralInputCount, roles.collateralReturnCount, jobId)));
+        }
+    }
+
+    /** Subjects accumulated so far; exposed for assertions and diagnostics. */
+    public List<AddressSubject> subjects() {
+        List<AddressSubject> result = new ArrayList<>(subjects.size());
+        for (SubjectRoles roles : subjects.values()) result.add(roles.subject);
+        return List.copyOf(result);
+    }
+
+    private static final class SubjectRoles {
+        private final AddressSubject subject;
+        private final String address;
+        private final String stakeAddress;
+        private int inputCount;
+        private int outputCount;
+        private int collateralInputCount;
+        private int collateralReturnCount;
+
+        private SubjectRoles(AddressSubject subject, String address, String stakeAddress) {
+            this.subject = subject;
+            this.address = address;
+            this.stakeAddress = stakeAddress;
+        }
+
+        private void increment(Role role) {
+            switch (role) {
+                case INPUT -> inputCount++;
+                case OUTPUT -> outputCount++;
+                case COLLATERAL_INPUT -> collateralInputCount++;
+                case COLLATERAL_RETURN -> collateralReturnCount++;
+            }
+        }
+    }
+
+    private record SubjectKey(String type, byte[] key) {
+        private SubjectKey { key = key.clone(); }
+        @Override public boolean equals(Object other) {
+            return other instanceof SubjectKey that && type.equals(that.type) && Arrays.equals(key, that.key);
+        }
+        @Override public int hashCode() { return 31 * type.hashCode() + Arrays.hashCode(key); }
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/dataset/AddressTransactionDataset.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/dataset/AddressTransactionDataset.java
@@ -160,7 +160,8 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
             TransactionBody tx = transactions.get(txIndex);
             boolean valid = !invalid.contains(txIndex);
             byte[] txHash = HexUtil.decodeHexString(tx.getTxHash());
-            LinkedHashMap<SubjectKey, SubjectRoles> subjects = new LinkedHashMap<>();
+            AddressSubjectRows accumulator = new AddressSubjectRows(this.subjects,
+                    job.networkIdentity().networkMagic());
 
             var consumed = valid ? tx.getInputs() : tx.getCollateralInputs();
             if (consumed != null) {
@@ -168,8 +169,8 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
                     Outpoint outpoint = new Outpoint(HexUtil.decodeHexString(input.getTransactionId()), input.getIndex());
                     ResolvedOutput resolved = resolve(outpoint).orElseThrow(() -> new ArchiveStoreException(
                             "unresolved address-history input " + input.getTransactionId() + '#' + input.getIndex()));
-                    addSubjects(subjects, resolved, job.networkIdentity().networkMagic(),
-                            valid ? ParticipationRole.INPUT : ParticipationRole.COLLATERAL_INPUT);
+                    accumulator.add(participant(resolved),
+                            valid ? AddressSubjectRows.Role.INPUT : AddressSubjectRows.Role.COLLATERAL_INPUT);
                     pendingPuts.remove(outpoint);
                     pendingDeletes.add(outpoint);
                     resolverOperations.add(durableResolver.consumeOperation(outpoint, txHash,
@@ -180,31 +181,29 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
             if (valid && tx.getOutputs() != null) {
                 for (int outputIndex = 0; outputIndex < tx.getOutputs().size(); outputIndex++) {
                     addOutput(txHash, outputIndex, tx.getOutputs().get(outputIndex), era,
-                            job.networkIdentity().networkMagic(), subjects,
-                            resolverOperations, ParticipationRole.OUTPUT);
+                            accumulator, resolverOperations, AddressSubjectRows.Role.OUTPUT);
                 }
             } else if (!valid && tx.getCollateralReturn() != null) {
                 addOutput(txHash, tx.getOutputs() == null ? 0 : tx.getOutputs().size(), tx.getCollateralReturn(), era,
-                        job.networkIdentity().networkMagic(), subjects, resolverOperations,
-                        ParticipationRole.COLLATERAL_RETURN);
+                        accumulator, resolverOperations, AddressSubjectRows.Role.COLLATERAL_RETURN);
             }
-            for (SubjectRoles roles : subjects.values()) {
-                AddressSubject subject = roles.subject;
-                sink.accept(new ArchiveRow("address_transactions", Arrays.asList(subject.subjectType(),
-                        subject.subjectKey(), roles.address, roles.stakeAddress, txHash, context.blockHash(),
-                        context.blockNumber(), context.slot(),
-                        context.epoch(), context.blockTime().getEpochSecond(), txIndex, roles.inputCount,
-                        roles.outputCount, roles.collateralInputCount, roles.collateralReturnCount, job.jobId())));
-            }
+            accumulator.emit(txHash, txIndex, context.blockHash(), context.blockNumber(), context.slot(),
+                    context.epoch(), context.blockTime().getEpochSecond(), job.jobId(), sink);
         }
         updates.add(new HotBlockUpdate(new HotBlockCheckpoint(context.blockNumber(), context.slot(),
                 context.blockHash(), context.parentHash()), resolverOperations));
         blockIndex++;
     }
 
-    private void addOutput(byte[] txHash, int index, TransactionOutput output, int era, long networkMagic,
-                           Map<SubjectKey, SubjectRoles> subjects,
-                           List<HotHistoryOperation> operations, ParticipationRole role) {
+    /** Bridge from the live resolver's shape to the shared accumulator's. */
+    static AddressSubjectRows.Participant participant(ResolvedOutput resolved) {
+        return new AddressSubjectRows.Participant(resolved.addressKey(), resolved.address(),
+                resolved.paymentCredential(), resolved.stakeCredentialType(), resolved.stakeCredential());
+    }
+
+    private void addOutput(byte[] txHash, int index, TransactionOutput output, int era,
+                           AddressSubjectRows accumulator,
+                           List<HotHistoryOperation> operations, AddressSubjectRows.Role role) {
         AddressParts parts = address(output.getAddress(), era);
         ResolvedOutput resolved = new ResolvedOutput(parts.addressKey(), parts.displayAddress(),
                 parts.paymentCredential(), parts.stakeCredentialType(), parts.stakeCredential());
@@ -223,14 +222,14 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
                 // An interrupted rollback/replay can present the already-applied
                 // resolver value. Identical content is idempotent; a different
                 // value for the same outpoint remains fatal.
-                addSubjects(subjects, resolved, networkMagic, role);
+                accumulator.add(participant(resolved), role);
                 return;
             }
         }
         pendingDeletes.remove(outpoint);
         pendingPuts.put(outpoint, resolved);
         operations.add(durableResolver.putOperation(outpoint, resolved));
-        addSubjects(subjects, resolved, networkMagic, role);
+        accumulator.add(participant(resolved), role);
     }
 
     private static boolean sameOutput(ResolvedOutput left, ResolvedOutput right) {
@@ -247,35 +246,40 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
         return pending != null ? Optional.of(pending) : durableResolver.resolve(outpoint);
     }
 
-    private void addSubjects(Map<SubjectKey, SubjectRoles> result, ResolvedOutput output,
-                             long networkMagic, ParticipationRole role) {
-        if (subjects.address()) {
-            add(result, AddressTransactionSubjects.ADDRESS,
-                    output.addressKey(), output.address(), null, role);
-        }
-        if (subjects.paymentCredential()) {
-            add(result, AddressTransactionSubjects.PAYMENT_CREDENTIAL,
-                    output.paymentCredential(), null, null, role);
-        }
-        if (subjects.stakeCredential()) {
-            add(result, AddressTransactionSubjects.STAKE_CREDENTIAL, output.stakeCredential(), null,
-                    StakeAddressCodec.encode(networkMagic, output.stakeCredentialType(),
-                            output.stakeCredential()), role);
-        }
-    }
-
-    private static void add(Map<SubjectKey, SubjectRoles> subjects, String type, byte[] key,
-                            String address, String stakeAddress, ParticipationRole role) {
-        if (key == null) return;
-        subjects.computeIfAbsent(new SubjectKey(type, key), ignored ->
-                new SubjectRoles(new AddressSubject(type, key), address, stakeAddress)).increment(role);
-    }
-
     public AddressParts address(String display) {
         return address(display, Era.Conway.getValue());
     }
 
     public AddressParts address(String display, int era) {
+        return parse(display, era, addressKeys, coordinate ->
+                pendingDeletedPointers.contains(coordinate) ? null
+                        : Optional.ofNullable(pendingPointers.get(coordinate))
+                                .or(() -> pointerResolver.resolve(coordinate)).orElse(null));
+    }
+
+    /**
+     * Resolves a pre-Conway pointer stake reference to the credential it pointed at.
+     *
+     * <p>Injected rather than fixed, because the two archive paths answer it from different
+     * places: the replay path from its sequential resolver, the ADR-039 projection path from
+     * the account-state subsystem's as-of index. Everything else about address decomposition is
+     * identical and lives below.
+     */
+    @FunctionalInterface
+    public interface PointerLookup {
+        SequentialPointerResolver.ResolvedStakeCredential resolve(
+                SequentialPointerResolver.PointerCoordinate coordinate);
+    }
+
+    /**
+     * Decompose an address into the parts the archive indexes it by.
+     *
+     * <p>Static and shared so the live path and the projection path cannot disagree about what
+     * an address <em>is</em>. Differential parity between two implementations of this would be
+     * a test that can pass while both are wrong.
+     */
+    public static AddressParts parse(String display, int era, AddressKeyCodec addressKeys,
+                                     PointerLookup pointers) {
         try {
             byte[] raw;
             try {
@@ -306,9 +310,7 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
                     var pointer = new PointerAddress(raw).getPointer();
                     var coordinate = new SequentialPointerResolver.PointerCoordinate(pointer.getSlot(),
                             pointer.getTxIndex(), pointer.getCertIndex());
-                    var credential = pendingDeletedPointers.contains(coordinate) ? null
-                            : Optional.ofNullable(pendingPointers.get(coordinate))
-                                    .or(() -> pointerResolver.resolve(coordinate)).orElse(null);
+                    var credential = pointers.resolve(coordinate);
                     stake = credential == null ? null : credential.hash();
                     stakeType = credential == null ? null : credential.type();
                 }
@@ -316,7 +318,7 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
             String normalized;
             try { normalized = AddressUtil.bytesToAddress(raw); }
             catch (Exception ignored) { normalized = display; }
-            return new AddressParts(raw, addressKeys.key(raw), normalized,
+            return new AddressParts(raw, addressKeys.key(raw),  normalized,
                     AddressKeyUtil.paymentCred28(display), stakeType, stake);
         } catch (Exception e) {
             throw new ArchiveStoreException("cannot decode canonical output address", e);
@@ -366,38 +368,4 @@ public final class AddressTransactionDataset implements LiveStatefulBlockArchive
                                byte[] paymentCredential, String stakeCredentialType,
                                byte[] stakeCredential) { }
 
-    private enum ParticipationRole { INPUT, OUTPUT, COLLATERAL_INPUT, COLLATERAL_RETURN }
-
-    private static final class SubjectRoles {
-        private final AddressSubject subject;
-        private final String address;
-        private final String stakeAddress;
-        private int inputCount;
-        private int outputCount;
-        private int collateralInputCount;
-        private int collateralReturnCount;
-
-        private SubjectRoles(AddressSubject subject, String address, String stakeAddress) {
-            this.subject = subject;
-            this.address = address;
-            this.stakeAddress = stakeAddress;
-        }
-
-        private void increment(ParticipationRole role) {
-            switch (role) {
-                case INPUT -> inputCount++;
-                case OUTPUT -> outputCount++;
-                case COLLATERAL_INPUT -> collateralInputCount++;
-                case COLLATERAL_RETURN -> collateralReturnCount++;
-            }
-        }
-    }
-
-    private record SubjectKey(String type, byte[] key) {
-        private SubjectKey { key = key.clone(); }
-        @Override public boolean equals(Object other) {
-            return other instanceof SubjectKey that && type.equals(that.type) && Arrays.equals(key, that.key);
-        }
-        @Override public int hashCode() { return 31 * type.hashCode() + Arrays.hashCode(key); }
-    }
 }

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveDiskLimits.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveDiskLimits.java
@@ -1,0 +1,27 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+/**
+ * Disk thresholds governing whether canonical ingestion may keep running ahead of the sink.
+ *
+ * <p>Hysteresis is deliberate: ingestion pauses at {@code hardBytes} but only resumes once
+ * cleanup has brought usage back under {@code lowWaterBytes}. Resuming at the same threshold
+ * that triggered the pause would oscillate — each resumed block immediately re-crosses the
+ * limit — which would look like a stall while thrashing.
+ */
+public record ArchiveDiskLimits(long softBytes, long hardBytes, long lowWaterBytes,
+                                long freeSpaceReserveBytes) {
+
+    public ArchiveDiskLimits {
+        if (softBytes < 1) throw new IllegalArgumentException("softBytes must be positive");
+        if (hardBytes < softBytes) throw new IllegalArgumentException("hardBytes must be at least softBytes");
+        if (lowWaterBytes < 1 || lowWaterBytes > softBytes) {
+            throw new IllegalArgumentException("lowWaterBytes must be positive and at or below softBytes");
+        }
+        if (freeSpaceReserveBytes < 0) throw new IllegalArgumentException("freeSpaceReserveBytes must not be negative");
+    }
+
+    /** 8 GiB soft, 32 GiB hard, resume under 4 GiB, keep 16 GiB of filesystem headroom. */
+    public static ArchiveDiskLimits defaults() {
+        return new ArchiveDiskLimits(8L << 30, 32L << 30, 4L << 30, 16L << 30);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveIngestGate.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveIngestGate.java
@@ -1,0 +1,110 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+
+/**
+ * Decides whether canonical ingestion may continue while the sink drains behind it
+ * (ADR-039 disk backpressure).
+ *
+ * <p>The default is emphatically <em>not</em> sink-paced sync. Core runs ahead freely, and
+ * the outbox absorbs the difference; asynchrony is the point. Ingestion pauses only when the
+ * node would otherwise run out of the disk it was given — either the configured aggregate
+ * archive budget or the filesystem's own free-space reserve.
+ *
+ * <p>Nothing here can discard data to recover space. Envelopes, artifact evidence, receipts
+ * and protected source generations are all off limits: the only way out of a pause is the
+ * sink acknowledging work and cleanup releasing it. A pause is therefore always visible and
+ * always attributable, never a silent slowdown.
+ */
+public final class ArchiveIngestGate {
+
+    /** Why ingestion is paused, or that it is not. */
+    public record Decision(State state, Optional<String> reason, long observedBytes, long limitBytes,
+                           long freeBytes) {
+        public enum State {
+            /** Running normally; the outbox may keep growing. */
+            RUNNING,
+            /** Past the soft bound: health is degraded and metrics should show it, but ingestion continues. */
+            DEGRADED,
+            /** Paused: the aggregate budget or the free-space reserve was reached. */
+            PAUSED
+        }
+
+        public Decision {
+            Objects.requireNonNull(state, "state");
+            Objects.requireNonNull(reason, "reason");
+        }
+
+        public boolean pausesIngest() {
+            return state == State.PAUSED;
+        }
+    }
+
+    private final ArchiveDiskLimits limits;
+    private final AtomicReference<Decision> current = new AtomicReference<>(
+            new Decision(Decision.State.RUNNING, Optional.empty(), 0, 0, 0));
+
+    public ArchiveIngestGate(ArchiveDiskLimits limits) {
+        this.limits = Objects.requireNonNull(limits, "limits");
+    }
+
+    /**
+     * Re-evaluate against the current footprint.
+     *
+     * <p>Once paused, the gate stays paused until usage falls below the low-water mark and
+     * free space recovers, rather than releasing the moment it dips under the hard limit.
+     */
+    public Decision evaluate(ArchiveRetainedFootprint footprint) {
+        Objects.requireNonNull(footprint, "footprint");
+        long used = footprint.estimatedPhysicalBytes();
+        long free = footprint.filesystemFreeBytes();
+        boolean wasPaused = current.get().pausesIngest();
+
+        if (wasPaused) {
+            boolean recovered = used <= limits.lowWaterBytes() && free > limits.freeSpaceReserveBytes();
+            if (!recovered) {
+                return set(new Decision(Decision.State.PAUSED, Optional.of(
+                        "waiting for archive cleanup: " + used + " bytes retained, resuming below "
+                                + limits.lowWaterBytes() + " bytes with more than "
+                                + limits.freeSpaceReserveBytes() + " bytes free (currently " + free + ")"),
+                        used, limits.lowWaterBytes(), free));
+            }
+            return set(new Decision(Decision.State.RUNNING, Optional.empty(), used, limits.hardBytes(), free));
+        }
+
+        if (free <= limits.freeSpaceReserveBytes()) {
+            return set(new Decision(Decision.State.PAUSED, Optional.of(
+                    "filesystem free space " + free + " reached the configured safety reserve "
+                            + limits.freeSpaceReserveBytes() + "; canonical ingestion paused rather than"
+                            + " discarding projection data"),
+                    used, limits.hardBytes(), free));
+        }
+        if (used >= limits.hardBytes()) {
+            return set(new Decision(Decision.State.PAUSED, Optional.of(
+                    "archive-retained disk usage " + used + " reached the configured hard limit "
+                            + limits.hardBytes() + "; canonical ingestion paused until the sink drains"),
+                    used, limits.hardBytes(), free));
+        }
+        if (used >= limits.softBytes()) {
+            return set(new Decision(Decision.State.DEGRADED, Optional.of(
+                    "archive-retained disk usage " + used + " crossed the soft bound " + limits.softBytes()),
+                    used, limits.softBytes(), free));
+        }
+        return set(new Decision(Decision.State.RUNNING, Optional.empty(), used, limits.softBytes(), free));
+    }
+
+    private Decision set(Decision decision) {
+        current.set(decision);
+        return decision;
+    }
+
+    public Decision current() {
+        return current.get();
+    }
+
+    public ArchiveDiskLimits limits() {
+        return limits;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveRetainedFootprint.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveRetainedFootprint.java
@@ -1,0 +1,44 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.Objects;
+
+/**
+ * Aggregate disk obligation of projection history at a point in time (ADR-039 operational
+ * model).
+ *
+ * <p>Counting only the outbox column families would understate the obligation badly. The
+ * node is also holding staged artifact files and chainstate generations pinned beyond their
+ * normal retention window by artifact leases, and RocksDB stores none of it at its logical
+ * size. So the budget is expressed over everything the archive is keeping alive.
+ *
+ * <p>{@code amplificationFactor} converts logical outbox bytes into expected physical cost.
+ * Exact attribution is impossible because RocksDB shares SST files across column families,
+ * so this is a measured estimate rather than an accounting identity: the isolated benchmark
+ * observed roughly 1.4x (3,419 bytes on disk per ~2,400 logical) for the first slice.
+ */
+public record ArchiveRetainedFootprint(long logicalOutboxBytes,
+                                       long stagedArtifactBytes,
+                                       long pinnedGenerationBytes,
+                                       double amplificationFactor,
+                                       long filesystemFreeBytes) {
+
+    public ArchiveRetainedFootprint {
+        if (logicalOutboxBytes < 0 || stagedArtifactBytes < 0 || pinnedGenerationBytes < 0) {
+            throw new IllegalArgumentException("retained byte counts must not be negative");
+        }
+        if (amplificationFactor < 1.0) {
+            throw new IllegalArgumentException("amplification factor cannot be below 1.0");
+        }
+        if (filesystemFreeBytes < 0) throw new IllegalArgumentException("free space must not be negative");
+    }
+
+    /** Physical bytes the archive is responsible for keeping on disk. */
+    public long estimatedPhysicalBytes() {
+        return Math.round(logicalOutboxBytes * amplificationFactor) + stagedArtifactBytes + pinnedGenerationBytes;
+    }
+
+    public static ArchiveRetainedFootprint ofOutboxOnly(long logicalOutboxBytes, double amplification,
+                                                        long freeBytes) {
+        return new ArchiveRetainedFootprint(logicalOutboxBytes, 0, 0, amplification, freeBytes);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/CanonicalProjectionCollector.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/CanonicalProjectionCollector.java
@@ -1,0 +1,261 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.archive.CanonicalProjectionContributor;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource;
+import com.bloxbean.cardano.yano.api.archive.ConsumedOutputAddresses;
+import com.bloxbean.cardano.yano.api.archive.ProjectionStagingWriter;
+import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.ByronBlockProjectionEvent;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext;
+import com.bloxbean.cardano.yano.archive.core.source.ByronBlockNormalizer;
+import com.bloxbean.cardano.yano.archive.core.source.YaciBlockArchiveDecoder;
+import com.bloxbean.cardano.yano.archive.core.source.YaciUtxoHistoryDecoder;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.LongUnaryOperator;
+
+/**
+ * Builds one canonical block's projection sections during apply (ADR-039 Phase 3).
+ *
+ * <p>The block arrives already decoded, so this performs no CBOR parsing on the hot
+ * path. Both existing decoders expose a {@code project(BlockSourceContext&lt;Block&gt;)}
+ * entry point that derives facts from a parsed block, and those are reused verbatim —
+ * this class contributes the transport, not a second interpretation of the chain.
+ *
+ * <p>What runs here is deterministic fact derivation, deterministic encoding, and a
+ * bounded staging write. No archive session is opened, no writer is awaited, and no
+ * artifact is scanned.
+ */
+public final class CanonicalProjectionCollector implements CanonicalProjectionContributor {
+
+    private final ProjectionOutboxStore outbox;
+    private final ProjectionIdentity identity;
+    private final ArchiveNetworkIdentity network;
+    private final YaciBlockArchiveDecoder blockFacts;
+    private final YaciUtxoHistoryDecoder utxoFacts;
+    private final LongUnaryOperator slotToEpoch;
+    private final LongUnaryOperator slotToUnixTime;
+    private final int chunkBytes;
+    private final boolean enabled;
+    /** Authoritative pointer mapping, owned by the account-state contributor. */
+    private final PointerCredentialSource pointerSource;
+
+    public CanonicalProjectionCollector(ProjectionOutboxStore outbox, ProjectionIdentity identity,
+                                        LongUnaryOperator slotToEpoch, LongUnaryOperator slotToUnixTime) {
+        this(outbox, identity, slotToEpoch, slotToUnixTime, ProjectionChunking.DEFAULT_CHUNK_BYTES, true,
+                PointerCredentialSource.NONE);
+    }
+
+    public CanonicalProjectionCollector(ProjectionOutboxStore outbox, ProjectionIdentity identity,
+                                        LongUnaryOperator slotToEpoch, LongUnaryOperator slotToUnixTime,
+                                        int chunkBytes, boolean enabled) {
+        this(outbox, identity, slotToEpoch, slotToUnixTime, chunkBytes, enabled, PointerCredentialSource.NONE);
+    }
+
+    public CanonicalProjectionCollector(ProjectionOutboxStore outbox, ProjectionIdentity identity,
+                                        LongUnaryOperator slotToEpoch, LongUnaryOperator slotToUnixTime,
+                                        int chunkBytes, boolean enabled, PointerCredentialSource pointerSource) {
+        this(outbox, identity, slotToEpoch, slotToUnixTime, chunkBytes, enabled, pointerSource,
+                BUILDABLE_SECTIONS);
+    }
+
+    /**
+     * @param buildableSections which sections this collector can produce; overridable so the
+     *                          fail-closed guard remains testable once every shipped section is
+     *                          buildable and the guard would otherwise be unreachable
+     */
+    CanonicalProjectionCollector(ProjectionOutboxStore outbox, ProjectionIdentity identity,
+                                 LongUnaryOperator slotToEpoch, LongUnaryOperator slotToUnixTime,
+                                 int chunkBytes, boolean enabled, PointerCredentialSource pointerSource,
+                                 java.util.Set<ProjectionSectionType> buildableSections) {
+        this.pointerSource = Objects.requireNonNull(pointerSource, "pointerSource");
+        this.outbox = Objects.requireNonNull(outbox, "outbox");
+        this.identity = Objects.requireNonNull(identity, "identity");
+        this.network = identity.networkIdentity();
+        this.slotToEpoch = Objects.requireNonNull(slotToEpoch, "slotToEpoch");
+        this.slotToUnixTime = Objects.requireNonNull(slotToUnixTime, "slotToUnixTime");
+        this.blockFacts = new YaciBlockArchiveDecoder(slotToEpoch, slotToUnixTime);
+        this.utxoFacts = new YaciUtxoHistoryDecoder(slotToEpoch, slotToUnixTime);
+        this.chunkBytes = chunkBytes;
+        this.enabled = enabled;
+
+        // Fail closed on an identity demanding a section this collector cannot build.
+        // Without this the contributor would advance its cursor while never writing a
+        // section, so the envelope could never complete and the archive would stall
+        // silently at the first block — the worst possible shape for the failure.
+        var unbuildable = identity.requiredSections().stream()
+                .filter(section -> !buildableSections.contains(section))
+                .map(ProjectionSectionType::wireName)
+                .sorted()
+                .toList();
+        if (!unbuildable.isEmpty()) {
+            throw new IllegalArgumentException("projection identity requires section(s) this collector cannot"
+                    + " produce yet: " + unbuildable + ". Remove them from the required set or implement their"
+                    + " contributor before enabling them.");
+        }
+    }
+
+    /** Sections this collector can produce. */
+    private static final java.util.Set<ProjectionSectionType> BUILDABLE_SECTIONS =
+            java.util.Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY,
+                    ProjectionSectionType.ACCOUNT_EVENT, ProjectionSectionType.ADDRESS_TRANSACTION);
+
+    private static final com.bloxbean.cardano.yano.archive.core.address.AddressKeyCodec ADDRESS_KEYS =
+            new com.bloxbean.cardano.yano.archive.core.address.AddressKeyCodec();
+
+    /**
+     * Consumed-output addresses for the block being contributed.
+     *
+     * <p>Passed through a field rather than threaded through {@code buildSection} because only
+     * one of four sections needs it and the alternative is a parameter every other case ignores.
+     * Safe because contribution happens on the apply thread, inside one block's write batch.
+     */
+    private ConsumedOutputAddresses consumedAddresses = ConsumedOutputAddresses.NONE;
+
+    @Override
+    public boolean enabled() {
+        return enabled;
+    }
+
+    @Override
+    public boolean needsConsumedOutputAddresses() {
+        return identity.requiredSections().contains(ProjectionSectionType.ADDRESS_TRANSACTION);
+    }
+
+    @Override
+    public void contributeBlock(BlockAppliedEvent event, ConsumedOutputAddresses consumed,
+                                ProjectionStagingWriter writer) {
+        this.consumedAddresses = consumed == null ? ConsumedOutputAddresses.NONE : consumed;
+        try {
+            contributeBlock(event, writer);
+        } finally {
+            this.consumedAddresses = ConsumedOutputAddresses.NONE;
+        }
+    }
+
+    @Override
+    public void contributeBlock(BlockAppliedEvent event, ProjectionStagingWriter writer) {
+        if (!enabled || event.block() == null) return;
+        contribute(context(event.blockNumber(), event.slot(), event.blockHash(), event.block()),
+                ProjectionBlockKind.SHELLEY_PLUS, writer);
+    }
+
+    @Override
+    public void contributeByronBlock(ByronBlockProjectionEvent event, ProjectionStagingWriter writer) {
+        if (!enabled) return;
+        byte[] blockHash = HexUtil.decodeHexString(event.blockHash());
+
+        if (event.isEpochBoundary()) {
+            // An EBB carries no transactions but occupies a block number. It contributes an
+            // empty envelope and advances every required contributor, so the sink's greatest
+            // contiguous coordinate can move past it instead of stopping there forever.
+            Block normalized = ByronBlockNormalizer.normalizeEpochBoundary(
+                    event.epochBoundaryBlock(), event.blockNumber(), blockHash);
+            var context = context(event.blockNumber(), event.slot(), event.blockHash(), normalized);
+            outbox.putBlockIdentity(writer, header(context, ProjectionBlockKind.BYRON_EBB));
+            for (ProjectionSectionType type : identity.requiredSections()) {
+                outbox.advanceContributor(writer, type, event.blockNumber());
+            }
+            return;
+        }
+
+        Block normalized = ByronBlockNormalizer.normalizeMain(
+                event.mainBlock(), event.blockNumber(), blockHash);
+        contribute(context(event.blockNumber(), event.slot(), event.blockHash(), normalized),
+                ProjectionBlockKind.BYRON_MAIN, writer);
+    }
+
+    @Override
+    public void rollbackFrom(long fromBlockNumber) {
+        outbox.rollbackFrom(fromBlockNumber, identity.requiredSections());
+    }
+
+    /**
+     * Roll back by canonical slot. Preferred at an event boundary, where the surviving
+     * block number is not reliably readable at listener time.
+     *
+     * @return the number of envelopes removed
+     */
+    public long rollbackToSlot(long rollbackSlot) {
+        return outbox.rollbackToSlot(rollbackSlot, identity.requiredSections());
+    }
+
+    // ---------------------------------------------------------------- internals
+
+    private void contribute(BlockSourceContext<Block> context, ProjectionBlockKind kind,
+                            ProjectionStagingWriter writer) {
+        outbox.putBlockIdentity(writer, header(context, kind));
+
+        for (ProjectionSectionType type : identity.requiredSections()) {
+            // Every required section is buildable: the constructor rejected any that is not.
+            outbox.putSection(writer, context.blockNumber(), buildSection(type, context));
+        }
+    }
+
+    private ProjectionSection buildSection(ProjectionSectionType type, BlockSourceContext<Block> context) {
+        return switch (type) {
+            case TRANSACTION -> {
+                var facts = blockFacts.project(context).block().transactions();
+                yield section(type, ProjectionFactCodec.encodeTransactions(facts), facts.size());
+            }
+            case UTXO_HISTORY -> {
+                // Resolve pointer stake references here, while the authoritative mapping is
+                // current for this block. The sink then needs no resolver state at all.
+                var fact = ProjectionPointerResolution.resolve(
+                        utxoFacts.project(context).block(), context.slot(), pointerSource);
+                long rows = (long) fact.outputs().size() + fact.assets().size() + fact.inputs().size()
+                        + fact.transactionDatums().size() + fact.transactionRedeemers().size();
+                yield section(type, ProjectionFactCodec.encodeUtxoHistory(fact), rows);
+            }
+            case ACCOUNT_EVENT -> {
+                // Certificates are a pure function of the block body: no ledger state, no
+                // resolution, nothing to capture that is not already in front of us.
+                var facts = blockFacts.project(context).block().accountEvents();
+                yield section(type, ProjectionFactCodec.encodeAccountEvents(facts), facts.size());
+            }
+            // ADDRESS_TRANSACTION still needs input-address resolution at capture time, the way
+            // pointer addresses did: UtxoHistoryFact.Input carries the consumed outpoint but not
+            // the address it belonged to. Unreachable: the constructor rejects an identity that
+            // requires a section this collector cannot build.
+            case ADDRESS_TRANSACTION -> {
+                // Consumed inputs were resolved during apply, while the outputs they spend were
+                // still current; outputs are parsed here with the same parser the live path
+                // uses. The sink therefore needs neither the block nor the UTXO set.
+                var fact = ProjectionAddressParticipation.resolve(context.block(), context.slot(),
+                        consumedAddresses, ADDRESS_KEYS, pointerSource);
+                long rows = fact.transactions().stream()
+                        .mapToLong(tx -> tx.participations().size()).sum();
+                yield section(type, ProjectionFactCodec.encodeAddressParticipations(fact), rows);
+            }
+        };
+    }
+
+    private ProjectionSection section(ProjectionSectionType type, byte[] payload, long rowCount) {
+        return new ProjectionSection(type, type.version(), ProjectionChunking.split(payload, chunkBytes), rowCount);
+    }
+
+    private ProjectionEnvelopeHeader header(BlockSourceContext<Block> context, ProjectionBlockKind kind) {
+        return new ProjectionEnvelopeHeader(network, kind, context.blockNumber(), context.blockHash(),
+                context.parentHash(), context.slot(), (int) context.epoch(),
+                context.blockTime().getEpochSecond(), identity.canonicalProjectionVersion(), List.of(), List.of());
+    }
+
+    private BlockSourceContext<Block> context(long blockNumber, long slot, String blockHash, Block block) {
+        var header = block.getHeader() == null ? null : block.getHeader().getHeaderBody();
+        String prevHash = header == null ? null : header.getPrevHash();
+        byte[] parent = prevHash == null || prevHash.isBlank() ? new byte[0] : HexUtil.decodeHexString(prevHash);
+        return new BlockSourceContext<>(blockNumber, slot, slotToEpoch.applyAsLong(slot),
+                Instant.ofEpochSecond(slotToUnixTime.applyAsLong(slot)), HexUtil.decodeHexString(blockHash),
+                parent, block);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/PointerHistoryCleanupPolicy.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/PointerHistoryCleanupPolicy.java
@@ -1,0 +1,134 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.OptionalLong;
+
+/**
+ * Decides whether the derived as-of pointer index may be reclaimed (ADR-039).
+ *
+ * <p>Pointer addresses exist only pre-Conway, so the index eventually has no readers. But
+ * "the tip is in Conway" is nowhere near sufficient to delete it, and treating it as
+ * sufficient is the obvious mistake this class exists to prevent: a rollback, a lagging
+ * contributor, or a replay of a retained pre-Conway body would all still need resolution
+ * that is no longer possible.
+ *
+ * <p>Every gate must hold. They are evaluated in order and the first failure is reported, so
+ * an operator sees which condition is holding cleanup back rather than an opaque "not yet".
+ */
+/**
+ * <strong>NOT YET WIRED.</strong> This policy is implemented and tested but has no production
+ * caller, deliberately: the pointer index measures <strong>0.68 MiB on a full preprod
+ * chainstate</strong> (17,036 entries at 42 bytes), so there is nothing worth reclaiming and
+ * running cleanup would add risk for no benefit.
+ *
+ * <p>It exists now rather than later because the gates are the hard part and they were specified
+ * with the index design; deriving them again under pressure, when an index has actually grown,
+ * is how a cleanup deletes something a pointer still needs. Wire it when a real network shows the
+ * index growing enough to matter, and only with the completeness state it depends on.
+ */
+public final class PointerHistoryCleanupPolicy {
+
+    /** Everything the decision depends on, gathered by the caller. */
+    public record Observation(
+            /** Final pre-Conway block, empty until the chain has crossed the boundary. */
+            OptionalLong finalPreConwayBlock,
+            /** Slot of that block. */
+            OptionalLong finalPreConwaySlot,
+            /** Greatest block eligible under archive finality, i.e. tip - archiveFinalityBlocks. */
+            long archiveEligibleThroughBlock,
+            /** Greatest block every required contributor has durably completed. */
+            long contributorsCompleteThroughBlock,
+            /** Oldest block any incomplete contributor could still replay; -1 when none. */
+            long oldestReplayableBlock,
+            /** Runtime common rollback floor slot; 0 means unbounded retention. */
+            long commonRollbackFloorSlot,
+            /** Active artifact leases or reconciliation markers requiring pointer history. */
+            int activePointerRetentionHolds,
+            /** Whether pre-Conway envelopes are durable in the outbox or acknowledged. */
+            boolean preConwaySectionsDurable) {
+
+        public Observation {
+            Objects.requireNonNull(finalPreConwayBlock, "finalPreConwayBlock");
+            Objects.requireNonNull(finalPreConwaySlot, "finalPreConwaySlot");
+        }
+    }
+
+    /** Cleanup authorisation, with the reason when it is withheld. */
+    public record Decision(boolean allowed, Optional<String> reason, OptionalLong throughSlot) {
+        public Decision {
+            Objects.requireNonNull(reason, "reason");
+            Objects.requireNonNull(throughSlot, "throughSlot");
+        }
+
+        static Decision deny(String reason) {
+            return new Decision(false, Optional.of(reason), OptionalLong.empty());
+        }
+
+        static Decision allow(long throughSlot) {
+            return new Decision(true, Optional.empty(), OptionalLong.of(throughSlot));
+        }
+    }
+
+    private PointerHistoryCleanupPolicy() {}
+
+    public static Decision evaluate(Observation o) {
+        Objects.requireNonNull(o, "observation");
+
+        // 1. The chain must actually have crossed Conway, and that crossing must itself be
+        //    archive-finality safe. A boundary inside the rollback window can still be undone.
+        if (o.finalPreConwayBlock().isEmpty() || o.finalPreConwaySlot().isEmpty()) {
+            return Decision.deny("the chain has not crossed the Conway boundary");
+        }
+        long finalPreConwayBlock = o.finalPreConwayBlock().getAsLong();
+        if (o.archiveEligibleThroughBlock() < finalPreConwayBlock) {
+            return Decision.deny("the Conway boundary at block " + finalPreConwayBlock
+                    + " is not yet archive-finality safe (eligible through "
+                    + o.archiveEligibleThroughBlock() + ")");
+        }
+
+        // 2. Every required contributor must have durably produced sections through the last
+        //    block that could contain a pointer address.
+        if (o.contributorsCompleteThroughBlock() < finalPreConwayBlock) {
+            return Decision.deny("contributors have only completed through block "
+                    + o.contributorsCompleteThroughBlock() + ", short of the final pre-Conway block "
+                    + finalPreConwayBlock);
+        }
+
+        // 3. No contributor may still be able to replay a pre-Conway body, because that replay
+        //    would need resolution the index no longer provides.
+        long oldestReplayable = o.oldestReplayableBlock();
+        if (oldestReplayable >= 0 && oldestReplayable <= finalPreConwayBlock) {
+            return Decision.deny("a contributor can still replay pre-Conway block " + oldestReplayable);
+        }
+
+        // 4. The rollback floor must be past the boundary; otherwise a rollback could return the
+        //    chain to a range that needs pointer resolution. Floor 0 means unbounded retention,
+        //    which by definition includes pre-Conway.
+        long floor = o.commonRollbackFloorSlot();
+        long finalPreConwaySlot = o.finalPreConwaySlot().getAsLong();
+        if (floor == 0) {
+            return Decision.deny("rollback retention is unbounded, so pre-Conway blocks remain reachable");
+        }
+        if (floor <= finalPreConwaySlot) {
+            return Decision.deny("the common rollback floor " + floor
+                    + " is not past the final pre-Conway slot " + finalPreConwaySlot);
+        }
+
+        // 5. Nothing may still be holding pointer history open.
+        if (o.activePointerRetentionHolds() > 0) {
+            return Decision.deny(o.activePointerRetentionHolds()
+                    + " active retention hold(s) still require pointer history");
+        }
+
+        // 6. The resolved outcomes must already be durable in their sections. The sink receipt
+        //    is deliberately NOT required: the resolved value is recorded in the outbox
+        //    envelope, so durability there is sufficient and waiting on a lagging sink would
+        //    retain the index far longer than correctness needs.
+        if (!o.preConwaySectionsDurable()) {
+            return Decision.deny("pre-Conway projection sections are not yet durable");
+        }
+
+        return Decision.allow(finalPreConwaySlot);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionActivationException.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionActivationException.java
@@ -1,0 +1,14 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+/**
+ * Projection history cannot start with the state it was pointed at.
+ *
+ * <p>Every case this covers is a refusal to adopt data whose completeness cannot be
+ * proven. It is deliberately not recoverable at runtime: the operator chooses a fresh
+ * sync, an older release, or a separately designed offline migration (ADR-039 §1).
+ */
+public class ProjectionActivationException extends RuntimeException {
+    public ProjectionActivationException(String message) {
+        super(message);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionAddressParticipation.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionAddressParticipation.java
@@ -1,0 +1,111 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.TransactionBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionOutput;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.archive.ConsumedOutputAddresses;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource;
+import com.bloxbean.cardano.yano.archive.core.address.AddressKeyCodec;
+import com.bloxbean.cardano.yano.archive.core.dataset.AddressParticipationFact;
+import com.bloxbean.cardano.yano.archive.core.dataset.AddressSubjectRows;
+import com.bloxbean.cardano.yano.archive.core.dataset.AddressTransactionDataset;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Resolves a block's address participations at capture time.
+ *
+ * <p>Consumed inputs are the only part that needs live state: the output being spent was
+ * created by an earlier block and is gone from the UTXO set by the time any sink reads the
+ * envelope. It is resolved here, from addresses the UTXO subsystem captured while deleting
+ * those outputs — the same reasoning that puts pointer-address resolution in canonical apply.
+ *
+ * <p>Outputs are parsed here too, with the <em>same</em> parser the live path uses, so the two
+ * cannot disagree about what an address decomposes into.
+ *
+ * <p>Validity follows the existing rule exactly: a valid transaction contributes its inputs and
+ * outputs, an invalid one contributes its collateral inputs and collateral return.
+ */
+final class ProjectionAddressParticipation {
+
+    private ProjectionAddressParticipation() {}
+
+    /**
+     * @param consumed addresses of the outputs this block spent, captured during apply
+     * @throws IllegalStateException if an input cannot be resolved — a silent skip would drop
+     *                               address history for a real spend, which no later pass could
+     *                               detect, so this fails closed
+     */
+    static AddressParticipationFact resolve(Block block, long blockSlot,
+                                            ConsumedOutputAddresses consumed,
+                                            AddressKeyCodec addressKeys,
+                                            PointerCredentialSource pointerSource) {
+        AddressTransactionDataset.PointerLookup pointers = coordinate -> {
+            var credential = ProjectionPointerResolution.resolveCoordinate(
+                    new PointerCredentialSource.PointerCoordinate(coordinate.slot(),
+                            coordinate.txIndex(), coordinate.certIndex()),
+                    blockSlot, pointerSource);
+            return credential == null ? null
+                    : new com.bloxbean.cardano.yano.archive.core.address.SequentialPointerResolver
+                            .ResolvedStakeCredential(
+                            ProjectionPointerResolution.credentialTypeNameOf(credential),
+                            ProjectionPointerResolution.credentialHashOf(credential));
+        };
+        List<TransactionBody> transactions = block.getTransactionBodies() == null
+                ? List.of() : block.getTransactionBodies();
+        Set<Integer> invalid = block.getInvalidTransactions() == null
+                ? Set.of() : Set.copyOf(block.getInvalidTransactions());
+        int era = block.getEra() == null ? Era.Conway.getValue() : block.getEra().getValue();
+
+        List<AddressParticipationFact.Transaction> result = new ArrayList<>(transactions.size());
+        for (int txIndex = 0; txIndex < transactions.size(); txIndex++) {
+            TransactionBody tx = transactions.get(txIndex);
+            boolean valid = !invalid.contains(txIndex);
+            List<AddressParticipationFact.Participation> participations = new ArrayList<>();
+
+            var spent = valid ? tx.getInputs() : tx.getCollateralInputs();
+            if (spent != null) {
+                for (var input : spent) {
+                    String address = consumed.addressOf(input.getTransactionId(), input.getIndex());
+                    if (address == null) {
+                        throw new IllegalStateException("address-transaction projection could not resolve"
+                                + " consumed output " + input.getTransactionId() + '#' + input.getIndex()
+                                + "; the address of a spent output must be captured during apply");
+                    }
+                    participations.add(new AddressParticipationFact.Participation(
+                            (valid ? AddressSubjectRows.Role.INPUT
+                                    : AddressSubjectRows.Role.COLLATERAL_INPUT).name(),
+                            participant(address, era, addressKeys, pointers)));
+                }
+            }
+
+            if (valid && tx.getOutputs() != null) {
+                for (TransactionOutput output : tx.getOutputs()) {
+                    participations.add(new AddressParticipationFact.Participation(
+                            AddressSubjectRows.Role.OUTPUT.name(),
+                            participant(output.getAddress(), era, addressKeys, pointers)));
+                }
+            } else if (!valid && tx.getCollateralReturn() != null) {
+                participations.add(new AddressParticipationFact.Participation(
+                        AddressSubjectRows.Role.COLLATERAL_RETURN.name(),
+                        participant(tx.getCollateralReturn().getAddress(), era, addressKeys, pointers)));
+            }
+
+            result.add(new AddressParticipationFact.Transaction(
+                    HexUtil.decodeHexString(tx.getTxHash()), txIndex, participations));
+        }
+        return new AddressParticipationFact(result);
+    }
+
+    private static AddressSubjectRows.Participant participant(String address, int era,
+                                                              AddressKeyCodec addressKeys,
+                                                              AddressTransactionDataset.PointerLookup pointers) {
+        var parts = AddressTransactionDataset.parse(address, era, addressKeys, pointers);
+        return new AddressSubjectRows.Participant(parts.addressKey(), parts.displayAddress(),
+                parts.paymentCredential(), parts.stakeCredentialType(), parts.stakeCredential());
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBackpressure.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBackpressure.java
@@ -1,0 +1,60 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Backlog pressure derived from outbox size (ADR-039 §9).
+ *
+ * <p>At the hard limit canonical ingestion pauses <em>visibly</em>. It never satisfies
+ * a limit by discarding projection data or by pruning an unacknowledged source: losing
+ * history silently is the one outcome the whole design exists to prevent.
+ */
+public record ProjectionBackpressure(Level level, Optional<String> reason) {
+
+    public enum Level {
+        /** Normal operation. */
+        NORMAL,
+        /** Soft bound crossed: health degraded, metrics exposed, ingestion continues. */
+        DEGRADED,
+        /** Hard bound crossed: canonical ingestion pauses until the sink drains. */
+        PAUSE_INGEST
+    }
+
+    public ProjectionBackpressure {
+        Objects.requireNonNull(level, "level");
+        Objects.requireNonNull(reason, "reason");
+    }
+
+    public static ProjectionBackpressure evaluate(ProjectionOutboxStats stats, ProjectionConsumerBounds bounds) {
+        if (stats.pendingBlocks() >= bounds.hardBacklogBlocks()) {
+            return pause("outbox backlog of " + stats.pendingBlocks() + " blocks reached the hard bound "
+                    + bounds.hardBacklogBlocks());
+        }
+        if (stats.pendingBytes() >= bounds.hardBacklogBytes()) {
+            return pause("outbox backlog of " + stats.pendingBytes() + " bytes reached the hard bound "
+                    + bounds.hardBacklogBytes());
+        }
+        if (stats.pendingBlocks() >= bounds.softBacklogBlocks()) {
+            return degraded("outbox backlog of " + stats.pendingBlocks() + " blocks crossed the soft bound "
+                    + bounds.softBacklogBlocks());
+        }
+        if (stats.pendingBytes() >= bounds.softBacklogBytes()) {
+            return degraded("outbox backlog of " + stats.pendingBytes() + " bytes crossed the soft bound "
+                    + bounds.softBacklogBytes());
+        }
+        return new ProjectionBackpressure(Level.NORMAL, Optional.empty());
+    }
+
+    private static ProjectionBackpressure degraded(String reason) {
+        return new ProjectionBackpressure(Level.DEGRADED, Optional.of(reason));
+    }
+
+    private static ProjectionBackpressure pause(String reason) {
+        return new ProjectionBackpressure(Level.PAUSE_INGEST, Optional.of(reason));
+    }
+
+    public boolean pausesIngest() {
+        return level == Level.PAUSE_INGEST;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchAccumulator.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchAccumulator.java
@@ -1,0 +1,284 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionManifest;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Accumulates eligible envelopes until the batch policy says commit.
+ *
+ * <p>The important property is that every safety bound is evaluated <strong>before</strong>
+ * rows are materialised. Row counts come from the section manifests already stored in the
+ * outbox, so the accumulator knows exactly how many {@code ArchiveRow} objects a batch would
+ * produce without building any of them. Bounding after materialisation would be too late:
+ * the allocation that must be prevented would already have happened.
+ *
+ * <p>Envelopes are added one at a time and the accumulator refuses one that would breach a
+ * ceiling, leaving it for the next batch. A single envelope larger than a ceiling is still
+ * accepted when the batch is empty, so an oversized block makes progress rather than
+ * deadlocking the consumer.
+ */
+public final class ProjectionBatchAccumulator {
+
+    private final ProjectionBatchPolicy policy;
+    private final List<ProjectionEnvelope> envelopes = new ArrayList<>();
+
+    private long rows;
+    private long encodedBytes;
+    private Instant openedAt;
+
+    /**
+     * Set when an offer was refused for space. The batch cannot grow further, so it must
+     * commit even if neither the block target nor the freshness deadline has been reached;
+     * otherwise the coordinator would spin re-offering an envelope that can never fit.
+     */
+    private ProjectionBatchDecision.Reason saturatedBy;
+
+    // --- observability, accumulated across the accumulator's lifetime -----------
+    private long largestEnvelopeBytes;
+    private long largestEnvelopeRows;
+    private long oversizedSingletons;
+    private long singletonHighWatermarkBytes;
+    private long largestRejectedSingletonBytes;
+    private final java.util.EnumMap<ProjectionBatchDecision.Reason, Long> flushReasons =
+            new java.util.EnumMap<>(ProjectionBatchDecision.Reason.class);
+
+    public ProjectionBatchAccumulator(ProjectionBatchPolicy policy) {
+        this.policy = Objects.requireNonNull(policy, "policy");
+    }
+
+    public boolean isEmpty() {
+        return envelopes.isEmpty();
+    }
+
+    public int size() {
+        return envelopes.size();
+    }
+
+    /** First block held, or -1 when empty. */
+    public long firstBlock() {
+        return envelopes.isEmpty() ? -1 : envelopes.get(0).header().blockNumber();
+    }
+
+    /**
+     * When the oldest buffered envelope entered the batch, or null when empty.
+     *
+     * <p>This is the clock the freshness deadline runs on, and the basis for reporting how
+     * long a finality-eligible envelope has waited before reaching the sink.
+     */
+    public Instant openedAt() {
+        return envelopes.isEmpty() ? null : openedAt;
+    }
+
+    /** Last block held, or -1 when empty. */
+    public long lastBlock() {
+        return envelopes.isEmpty() ? -1 : envelopes.get(envelopes.size() - 1).header().blockNumber();
+    }
+
+    public List<ProjectionEnvelope> envelopes() {
+        return List.copyOf(envelopes);
+    }
+
+    public long rows() {
+        return rows;
+    }
+
+    public long encodedBytes() {
+        return encodedBytes;
+    }
+
+    public long estimatedHeapBytes() {
+        return rows * policy.estimatedHeapBytesPerRow();
+    }
+
+    /** Outcome of offering an envelope to the batch. */
+    public enum Offer {
+        /** Added to the batch. */
+        ACCEPTED,
+        /** Would breach a ceiling; flush the batch and offer it again. */
+        REJECTED_FULL,
+        /**
+         * Alone, this envelope exceeds the absolute singleton safety guard. Processing it
+         * would risk an OOM, and skipping it would lose projection data, so the coordinator
+         * must pause visibly with diagnostics.
+         */
+        REJECTED_UNSAFE
+    }
+
+    /**
+     * Offer an envelope.
+     *
+     * <p>A single envelope larger than a normal ceiling is still accepted when the batch is
+     * empty, so a dense block makes progress rather than deadlocking the consumer — but only
+     * up to the absolute safety guard.
+     */
+    public Offer offer(ProjectionEnvelope envelope, Instant now) {
+        long envelopeRows = rowsOf(envelope);
+        long envelopeBytes = bytesOf(envelope);
+
+        if (envelopes.isEmpty()) {
+            if (!policy.singletonWithinSafetyGuard(envelopeBytes, envelopeRows)) {
+                largestRejectedSingletonBytes = Math.max(largestRejectedSingletonBytes, envelopeBytes);
+                return Offer.REJECTED_UNSAFE;
+            }
+            if (envelopeBytes > policy.maxEncodedBytes() || envelopeRows > policy.effectiveMaxRows()) {
+                oversizedSingletons++;
+                singletonHighWatermarkBytes = Math.max(singletonHighWatermarkBytes,
+                        envelopeRows * policy.estimatedHeapBytesPerRow());
+            }
+        } else {
+            if (envelopes.size() + 1 > policy.maxBlocks()) return saturate(ProjectionBatchDecision.Reason.MAX_BLOCKS);
+            if (encodedBytes + envelopeBytes > policy.maxEncodedBytes()) {
+                return saturate(ProjectionBatchDecision.Reason.MAX_BYTES);
+            }
+            if (rows + envelopeRows > policy.effectiveMaxRows()) {
+                return saturate(ProjectionBatchDecision.Reason.MAX_ROWS);
+            }
+        }
+
+        if (envelopes.isEmpty()) openedAt = now;
+        envelopes.add(envelope);
+        rows += envelopeRows;
+        encodedBytes += envelopeBytes;
+
+        largestEnvelopeBytes = Math.max(largestEnvelopeBytes, envelopeBytes);
+        largestEnvelopeRows = Math.max(largestEnvelopeRows, envelopeRows);
+        return Offer.ACCEPTED;
+    }
+
+    private Offer saturate(ProjectionBatchDecision.Reason reason) {
+        saturatedBy = reason;
+        return Offer.REJECTED_FULL;
+    }
+
+    /**
+     * Decide whether to commit what has accumulated.
+     *
+     * @param nearTip        whether the producer is at the chain tip, selecting the regime
+     * @param moreAvailable  whether more eligible envelopes are waiting. Reported for metrics
+     *                       and retained in the signature, but deliberately not a flush
+     *                       trigger: an intermittent gap in arrivals is normal near tip and
+     *                       must not cause a commit
+     */
+    public ProjectionBatchDecision decide(boolean nearTip, boolean moreAvailable, Instant now) {
+        int blocks = envelopes.size();
+        long heap = estimatedHeapBytes();
+        if (blocks == 0) return ProjectionBatchDecision.accumulate(0, 0, 0, 0);
+
+        if (blocks >= policy.maxBlocks()) {
+            return ProjectionBatchDecision.flush(ProjectionBatchDecision.Reason.MAX_BLOCKS,
+                    blocks, rows, encodedBytes, heap);
+        }
+        if (encodedBytes >= policy.maxEncodedBytes()) {
+            return ProjectionBatchDecision.flush(ProjectionBatchDecision.Reason.MAX_BYTES,
+                    blocks, rows, encodedBytes, heap);
+        }
+        if (rows >= policy.maxRows()) {
+            return ProjectionBatchDecision.flush(ProjectionBatchDecision.Reason.MAX_ROWS,
+                    blocks, rows, encodedBytes, heap);
+        }
+        if (heap >= policy.maxEstimatedHeapBytes()) {
+            return ProjectionBatchDecision.flush(ProjectionBatchDecision.Reason.MAX_HEAP,
+                    blocks, rows, encodedBytes, heap);
+        }
+        // A refused offer means no further envelope fits. Commit rather than wait for a
+        // target that can no longer be reached by growing.
+        if (saturatedBy != null) {
+            return ProjectionBatchDecision.flush(saturatedBy, blocks, rows, encodedBytes, heap);
+        }
+        if (blocks >= policy.minBlocks(nearTip)) {
+            return ProjectionBatchDecision.flush(ProjectionBatchDecision.Reason.MIN_BLOCKS,
+                    blocks, rows, encodedBytes, heap);
+        }
+
+        Duration waited = Duration.between(openedAt, now);
+        if (waited.compareTo(policy.maxLinger(nearTip)) >= 0) {
+            return ProjectionBatchDecision.flush(ProjectionBatchDecision.Reason.LINGER_EXPIRED,
+                    blocks, rows, encodedBytes, heap);
+        }
+
+        // "Nothing more is eligible right now" is deliberately NOT a flush reason near tip.
+        // Blocks arrive intermittently, so treating a momentary gap as a reason to commit
+        // would flush on almost every arrival and recreate the tiny-file problem. The batch
+        // stays durably in the outbox until the target or the freshness deadline says commit.
+        return ProjectionBatchDecision.accumulate(blocks, rows, encodedBytes, heap);
+    }
+
+    /**
+     * Flush regardless of thresholds, for an explicit operational action.
+     *
+     * <p>Deliberately <strong>not</strong> used on shutdown. Accumulated envelopes are still
+     * durable and unacknowledged in the outbox, so a restart simply re-reads them; writing a
+     * small Parquet file purely to empty an in-memory list would create exactly the fragment
+     * this policy exists to avoid, for no durability benefit.
+     */
+    public ProjectionBatchDecision forceFlush() {
+        return ProjectionBatchDecision.flush(ProjectionBatchDecision.Reason.FORCED,
+                envelopes.size(), rows, encodedBytes, estimatedHeapBytes());
+    }
+
+    /**
+     * Observability for the memory invariant.
+     *
+     * @param largestEnvelopeEncodedBytes  largest single encoded envelope seen
+     * @param largestEnvelopeRows          largest single envelope row count seen
+     * @param oversizedSingletons          envelopes accepted alone because they exceeded a
+     *                                     normal batch ceiling
+     * @param singletonHighWatermarkBytes  estimated working set of the largest such singleton
+     * @param largestRejectedSingletonBytes largest envelope refused by the absolute guard;
+     *                                     non-zero means the node paused rather than risking OOM
+     */
+    public record Stats(long largestEnvelopeEncodedBytes, long largestEnvelopeRows,
+                        long oversizedSingletons, long singletonHighWatermarkBytes,
+                        long largestRejectedSingletonBytes,
+                        java.util.Map<ProjectionBatchDecision.Reason, Long> flushReasons) { }
+
+    public synchronized Stats stats() {
+        return new Stats(largestEnvelopeBytes, largestEnvelopeRows, oversizedSingletons,
+                singletonHighWatermarkBytes, largestRejectedSingletonBytes,
+                java.util.Map.copyOf(flushReasons));
+    }
+
+    /**
+     * Record why a batch actually flushed.
+     *
+     * <p>Batch-size distribution is uninterpretable without this: a run dominated by
+     * {@code LINGER_EXPIRED} is behaving as designed near tip, while one dominated by
+     * {@code MAX_ROWS} or {@code MAX_HEAP} means the bounds are mis-sized for the chain.
+     */
+    public synchronized void recordFlush(ProjectionBatchDecision decision) {
+        if (decision.flush()) flushReasons.merge(decision.reason(), 1L, Long::sum);
+    }
+
+    /** Effective row ceiling after the heap bound is applied; exposed for tests. */
+    long effectiveMaxRowsForTest() {
+        return policy.effectiveMaxRows();
+    }
+
+    public void reset() {
+        envelopes.clear();
+        rows = 0;
+        encodedBytes = 0;
+        openedAt = null;
+        saturatedBy = null;
+    }
+
+    /** Row count from the stored manifests; no materialisation required. */
+    static long rowsOf(ProjectionEnvelope envelope) {
+        long total = 0;
+        for (ProjectionSectionManifest manifest : envelope.header().sections()) total += manifest.rowCount();
+        return total;
+    }
+
+    static long bytesOf(ProjectionEnvelope envelope) {
+        long total = 0;
+        for (ProjectionSection section : envelope.sections()) total += section.byteCount();
+        return total;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchDecision.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchDecision.java
@@ -1,0 +1,47 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.Objects;
+
+/**
+ * Whether an accumulated batch should be committed now, and what forced it.
+ *
+ * <p>The reason is carried rather than discarded because batch-size distribution is only
+ * interpretable alongside <em>why</em> each batch flushed. A run dominated by
+ * {@link Reason#MAX_ROWS} means something very different from one dominated by
+ * {@link Reason#LINGER_EXPIRED}, and the difference decides whether the bounds are tuned
+ * correctly.
+ */
+public record ProjectionBatchDecision(boolean flush, Reason reason, int blocks, long rows,
+                                      long encodedBytes, long estimatedHeapBytes) {
+
+    public enum Reason {
+        /** Not enough work yet, and the linger window has not expired. */
+        ACCUMULATING,
+        /** The regime's minimum block count was reached. */
+        MIN_BLOCKS,
+        /** The linger window expired; commit what is available. */
+        LINGER_EXPIRED,
+        /** Hard block ceiling. */
+        MAX_BLOCKS,
+        /** Encoded outbox payload ceiling. */
+        MAX_BYTES,
+        /** Materialised row ceiling. */
+        MAX_ROWS,
+        /** Estimated materialised heap ceiling. */
+        MAX_HEAP,
+        /** Shutdown or an explicit flush request. */
+        FORCED
+    }
+
+    public ProjectionBatchDecision {
+        Objects.requireNonNull(reason, "reason");
+    }
+
+    static ProjectionBatchDecision accumulate(int blocks, long rows, long bytes, long heap) {
+        return new ProjectionBatchDecision(false, Reason.ACCUMULATING, blocks, rows, bytes, heap);
+    }
+
+    static ProjectionBatchDecision flush(Reason reason, int blocks, long rows, long bytes, long heap) {
+        return new ProjectionBatchDecision(true, reason, blocks, rows, bytes, heap);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchPolicy.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchPolicy.java
@@ -1,0 +1,158 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.time.Duration;
+import java.util.Objects;
+
+/**
+ * Adaptive commit batching (ADR-039).
+ *
+ * <p>Small Parquet files are prevented at their source rather than merged afterwards. The
+ * first preprod sync committed whatever was eligible the instant it became eligible, which —
+ * because the sink outpaces the producer — meant a few hundred blocks per commit and 67,603
+ * files averaging 56 KB. Waiting costs nothing: the outbox is durable, so a batch that
+ * lingers is not a batch at risk.
+ *
+ * <p>Two regimes with opposite constraints:
+ *
+ * <ul>
+ *   <li><strong>bootstrap</strong> — blocks arrive in the thousands per second, so a block
+ *       count governs and a large one costs almost no latency;</li>
+ *   <li><strong>near tip</strong> — blocks arrive at the chain rate, so a block count would
+ *       stall for days and a freshness interval must govern instead.</li>
+ * </ul>
+ *
+ * <p>Every bound is a <em>ceiling</em> that forces an early flush; only {@code minBlocks} and
+ * {@code maxLinger} decide when a batch is worth committing at all. That asymmetry matters:
+ * a safety bound must never be able to make a batch larger.
+ *
+ * <p>Physical file granularity is deliberately not a commit interval. Logical visibility is
+ * governed here; Parquet file size is governed by compaction.
+ *
+ * <h2>Memory invariant</h2>
+ *
+ * <p>Stated precisely, because it is <strong>not</strong> a fully configurable hard heap
+ * bound and should not be described as one:
+ *
+ * <ul>
+ *   <li>the <strong>encoded outbox payload</strong> retained for a selected batch is bounded
+ *       by {@link #maxEncodedBytes()}. The selected {@code ProjectionEnvelope} objects and
+ *       their encoded chunks do occupy memory up to that bound;</li>
+ *   <li>transaction decoding and row emission are <strong>streaming</strong>: facts are
+ *       decoded and released one at a time, and chunks are never concatenated;</li>
+ *   <li><strong>derived rows are not retained for the whole batch</strong> — batch size no
+ *       longer contributes to decoded-fact or derived-row retention;</li>
+ *   <li>UTXO decoding retains at most <strong>one block's</strong> decoded fact graph, because
+ *       row derivation resolves each output's address through a map built from that section's
+ *       address list;</li>
+ *   <li>a <strong>singleton</strong> envelope may exceed the normal batch estimate. It stays
+ *       bounded by one valid Cardano block and that block's deterministic projection
+ *       expansion, not by configuration — and beyond
+ *       {@link #singletonWithinSafetyGuard(long, long)} the node pauses visibly rather than
+ *       risking an OOM.</li>
+ * </ul>
+ *
+ * <p>Existing evidence: a production preprod sync observed ~2.96 MB as the largest retained
+ * working set. That is an observation on one chain, not a protocol maximum.
+ */
+public record ProjectionBatchPolicy(int minBlocksBootstrap,
+                                    int minBlocksNearTip,
+                                    int maxBlocks,
+                                    Duration maxLingerBootstrap,
+                                    Duration maxLingerNearTip,
+                                    long maxEncodedBytes,
+                                    long maxRows,
+                                    long maxEstimatedHeapBytes,
+                                    int estimatedHeapBytesPerRow,
+                                    long maxSingletonEncodedBytes,
+                                    long maxSingletonRows) {
+
+    public ProjectionBatchPolicy {
+        Objects.requireNonNull(maxLingerBootstrap, "maxLingerBootstrap");
+        Objects.requireNonNull(maxLingerNearTip, "maxLingerNearTip");
+        if (minBlocksBootstrap < 1 || minBlocksNearTip < 1) {
+            throw new IllegalArgumentException("minimum block counts must be positive");
+        }
+        if (maxBlocks < minBlocksBootstrap || maxBlocks < minBlocksNearTip) {
+            throw new IllegalArgumentException("maxBlocks must be at least every minimum");
+        }
+        if (maxEncodedBytes < 1 || maxRows < 1 || maxEstimatedHeapBytes < 1) {
+            throw new IllegalArgumentException("safety bounds must be positive");
+        }
+        if (estimatedHeapBytesPerRow < 1) {
+            throw new IllegalArgumentException("estimatedHeapBytesPerRow must be positive");
+        }
+        if (maxSingletonEncodedBytes < 1 || maxSingletonRows < 1) {
+            throw new IllegalArgumentException("singleton safety guards must be positive");
+        }
+        if (maxLingerBootstrap.isNegative() || maxLingerNearTip.isNegative()) {
+            throw new IllegalArgumentException("linger must not be negative");
+        }
+    }
+
+    /**
+     * Defaults chosen from the first preprod sync, and deliberately not presented as
+     * universally safe — the bootstrap minimum in particular is a starting point to measure,
+     * not a proven constant.
+     *
+     * <p>10,000 bootstrap blocks accrue in ~8 s at the measured 1,193 blocks/s, giving ~20x
+     * fewer commits.
+     *
+     * <p>Near tip the block count is a <strong>preferred target</strong> (50 envelopes), not a
+     * freshness requirement, and the 15-minute deadline is the hard bound. At normal Cardano
+     * production the deadline typically fires first, around 40-50 blocks; that is the expected
+     * outcome rather than a miss. A near-tip minimum of 1 would flush every eligible block on
+     * arrival and recreate the tiny-file problem this policy exists to prevent, and against an
+     * archive already ~24 h behind by finality the added latency is immaterial.
+     *
+     * <p>{@code estimatedHeapBytesPerRow} is intentionally conservative: measured output is
+     * ~709 bytes/block as Parquet but rows carry uncompressed {@code byte[]} hashes,
+     * addresses and CBOR in heap.
+     */
+    public static ProjectionBatchPolicy defaults() {
+        return new ProjectionBatchPolicy(
+                10_000, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15),
+                256L << 20,          // encoded outbox bytes
+                2_000_000,           // materialised rows
+                512L << 20,          // estimated materialised heap
+                600,                 // conservative bytes per row
+                64L << 20,           // singleton guard: encoded bytes for ONE envelope
+                4_000_000);          // singleton guard: rows for ONE envelope
+    }
+
+    public int minBlocks(boolean nearTip) {
+        return nearTip ? minBlocksNearTip : minBlocksBootstrap;
+    }
+
+    public Duration maxLinger(boolean nearTip) {
+        return nearTip ? maxLingerNearTip : maxLingerBootstrap;
+    }
+
+    /** Rows that fit the heap bound at the configured per-row estimate. */
+    public long heapBoundedRows() {
+        return Math.max(1, maxEstimatedHeapBytes / estimatedHeapBytesPerRow);
+    }
+
+    /** The effective row ceiling: the tighter of the explicit row bound and the heap bound. */
+    public long effectiveMaxRows() {
+        return Math.min(maxRows, heapBoundedRows());
+    }
+
+    /**
+     * Whether a single envelope is safe to process on its own.
+     *
+     * <p>An envelope larger than a normal batch ceiling is still accepted alone, so an
+     * unusually dense block makes progress rather than deadlocking the consumer. But
+     * "unusually dense" has a limit: a section derives from one valid Cardano block, and a
+     * projection of one block cannot legitimately reach tens of millions of rows. Something
+     * that does indicates corruption or a format change, and materialising it would risk an
+     * OOM that takes the node down.
+     *
+     * <p>These guards are set well above any plausible block so they never fire in normal
+     * operation, and are configurable because a protocol upgrade may legitimately raise block
+     * limits.
+     */
+    public boolean singletonWithinSafetyGuard(long encodedBytes, long rows) {
+        return encodedBytes <= maxSingletonEncodedBytes && rows <= maxSingletonRows;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionChunkedInput.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionChunkedInput.java
@@ -1,0 +1,69 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Reads an ordered chunk list as one continuous stream, without concatenating it.
+ *
+ * <p>{@code ProjectionChunking.join} allocated a second copy of the entire section payload
+ * before decoding could start, so a section's bytes were live twice at peak. Chunk boundaries
+ * are a transport artefact — a logical fact may straddle two of them — so chunks cannot be
+ * decoded independently. Presenting them as a single stream lets a framed decoder read across
+ * boundaries while never holding more than the chunk it is currently positioned in.
+ *
+ * <p>Deliberately not thread-safe: one instance belongs to one decode pass.
+ */
+final class ProjectionChunkedInput extends InputStream {
+
+    private final List<byte[]> chunks;
+    private int chunkIndex;
+    private int offset;
+
+    ProjectionChunkedInput(List<byte[]> chunks) {
+        this.chunks = Objects.requireNonNull(chunks, "chunks");
+    }
+
+    @Override
+    public int read() {
+        while (chunkIndex < chunks.size()) {
+            byte[] chunk = chunks.get(chunkIndex);
+            if (offset < chunk.length) return chunk[offset++] & 0xFF;
+            chunkIndex++;
+            offset = 0;
+        }
+        return -1;
+    }
+
+    @Override
+    public int read(byte[] destination, int destinationOffset, int length) {
+        Objects.checkFromIndexSize(destinationOffset, length, destination.length);
+        if (length == 0) return 0;
+        int written = 0;
+        while (written < length && chunkIndex < chunks.size()) {
+            byte[] chunk = chunks.get(chunkIndex);
+            int available = chunk.length - offset;
+            if (available <= 0) {
+                chunkIndex++;
+                offset = 0;
+                continue;
+            }
+            int take = Math.min(available, length - written);
+            System.arraycopy(chunk, offset, destination, destinationOffset + written, take);
+            offset += take;
+            written += take;
+        }
+        return written == 0 ? -1 : written;
+    }
+
+    @Override
+    public int available() {
+        long remaining = 0;
+        for (int i = chunkIndex; i < chunks.size(); i++) {
+            remaining += chunks.get(i).length - (i == chunkIndex ? offset : 0);
+        }
+        return (int) Math.min(Integer.MAX_VALUE, remaining);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionChunking.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionChunking.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Deterministic fixed-size splitting of an encoded section.
+ *
+ * <p>ADR-039 §2 requires that no physical value grow without a configured bound. Splitting
+ * is deterministic — the same payload and chunk size always produce the same chunks — so
+ * the digest over the chunk list is reproducible on replay.
+ */
+public final class ProjectionChunking {
+    /** Default physical value bound. Keeps individual RocksDB values well clear of pathological sizes. */
+    public static final int DEFAULT_CHUNK_BYTES = 1 << 20;
+
+    private ProjectionChunking() {}
+
+    public static List<byte[]> split(byte[] payload, int chunkBytes) {
+        if (chunkBytes < 1) throw new IllegalArgumentException("chunkBytes must be positive");
+        if (payload.length == 0) return List.of();
+        List<byte[]> chunks = new ArrayList<>((payload.length + chunkBytes - 1) / chunkBytes);
+        for (int offset = 0; offset < payload.length; offset += chunkBytes) {
+            chunks.add(Arrays.copyOfRange(payload, offset, Math.min(offset + chunkBytes, payload.length)));
+        }
+        return List.copyOf(chunks);
+    }
+
+    public static byte[] join(List<byte[]> chunks) {
+        int total = 0;
+        for (byte[] chunk : chunks) total += chunk.length;
+        byte[] joined = new byte[total];
+        int offset = 0;
+        for (byte[] chunk : chunks) {
+            System.arraycopy(chunk, 0, joined, offset, chunk.length);
+            offset += chunk.length;
+        }
+        return joined;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionConsumerBounds.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionConsumerBounds.java
@@ -1,0 +1,22 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+/** Bounds on one sink batch and on total retained backlog (ADR-039 §9). */
+public record ProjectionConsumerBounds(int maxBlocksPerBatch, long maxBytesPerBatch,
+                                       long softBacklogBlocks, long hardBacklogBlocks,
+                                       long softBacklogBytes, long hardBacklogBytes) {
+    public ProjectionConsumerBounds {
+        if (maxBlocksPerBatch < 1) throw new IllegalArgumentException("maxBlocksPerBatch must be positive");
+        if (maxBytesPerBatch < 1) throw new IllegalArgumentException("maxBytesPerBatch must be positive");
+        if (softBacklogBlocks < 1 || hardBacklogBlocks < softBacklogBlocks) {
+            throw new IllegalArgumentException("hard block backlog bound must be at least the soft bound");
+        }
+        if (softBacklogBytes < 1 || hardBacklogBytes < softBacklogBytes) {
+            throw new IllegalArgumentException("hard byte backlog bound must be at least the soft bound");
+        }
+    }
+
+    public static ProjectionConsumerBounds defaults() {
+        return new ProjectionConsumerBounds(2_000, 64L << 20,
+                500_000, 2_000_000, 8L << 30, 32L << 30);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionConsumerResult.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionConsumerResult.java
@@ -1,0 +1,58 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/** Outcome of one consumer pass. */
+public record ProjectionConsumerResult(Outcome outcome, long firstBlock, long lastBlock,
+                                       Optional<String> detail, boolean workPending) {
+
+    /** Legacy shape: work is pending exactly when the pass committed something. */
+    public ProjectionConsumerResult(Outcome outcome, long firstBlock, long lastBlock, Optional<String> detail) {
+        this(outcome, firstBlock, lastBlock, detail,
+                outcome == Outcome.COMMITTED || outcome == Outcome.REPLAYED);
+    }
+
+    public enum Outcome {
+        /** Nothing complete, eligible and unacknowledged was available. */
+        IDLE,
+        /** A batch was committed by the sink and acknowledged. */
+        COMMITTED,
+        /** A durable receipt already covered this batch; it was acknowledged without re-writing. */
+        REPLAYED,
+        /** Retention health failed; the consumer paused rather than narrowing eligibility. */
+        PAUSED,
+        /**
+         * Envelopes were consumed into the pending batch but no ceiling, block target or
+         * freshness deadline said commit yet. Nothing was written and nothing was
+         * acknowledged; the envelopes remain durable in the outbox.
+         */
+        ACCUMULATING
+    }
+
+    public ProjectionConsumerResult {
+        Objects.requireNonNull(outcome, "outcome");
+        Objects.requireNonNull(detail, "detail");
+    }
+
+    static ProjectionConsumerResult idle() {
+        return new ProjectionConsumerResult(Outcome.IDLE, -1, -1, Optional.empty());
+    }
+
+    /**
+     * @param workPending whether more eligible envelopes are already waiting, which tells the
+     *                    coordinator to keep draining instead of backing off
+     */
+    static ProjectionConsumerResult accumulating(long firstBlock, long lastBlock, boolean workPending) {
+        return new ProjectionConsumerResult(Outcome.ACCUMULATING, firstBlock, lastBlock,
+                Optional.empty(), workPending);
+    }
+
+    static ProjectionConsumerResult paused(String reason) {
+        return new ProjectionConsumerResult(Outcome.PAUSED, -1, -1, Optional.of(reason));
+    }
+
+    public boolean madeProgress() {
+        return outcome == Outcome.COMMITTED || outcome == Outcome.REPLAYED;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionContributorHealth.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionContributorHealth.java
@@ -1,0 +1,111 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.TreeMap;
+
+/**
+ * Distinguishes a contributor that is merely behind from one that has stopped.
+ *
+ * <p>The outbox itself cannot tell these apart: a block missing a required section
+ * reads as "no envelope yet" whether the contributor is a second behind or has been
+ * dead for an hour, and in both cases the consumer correctly goes idle. Without this,
+ * a permanently stuck contributor would present as a quiet, healthy, idle archive —
+ * the failure mode is silence, which is the worst possible shape for it.
+ *
+ * <p>The discriminator is the ADR-039 operational model's "oldest pending envelope
+ * age": how long the slowest required contributor has been holding the same block.
+ */
+public record ProjectionContributorHealth(Status status,
+                                          long completeThroughBlock,
+                                          long identityCursor,
+                                          Map<String, Long> contributorCursors,
+                                          Optional<ProjectionSectionType> slowestContributor,
+                                          Duration stalledFor,
+                                          Optional<String> detail) {
+
+    public enum Status {
+        /** Every required contributor is keeping up. */
+        HEALTHY,
+        /** A contributor is behind but still advancing. */
+        LAGGING,
+        /** A contributor has not advanced within its threshold: a fault, not backlog. */
+        STALLED
+    }
+
+    public ProjectionContributorHealth {
+        Objects.requireNonNull(status, "status");
+        contributorCursors = Map.copyOf(Objects.requireNonNull(contributorCursors, "contributorCursors"));
+        Objects.requireNonNull(slowestContributor, "slowestContributor");
+        Objects.requireNonNull(stalledFor, "stalledFor");
+        Objects.requireNonNull(detail, "detail");
+    }
+
+    public boolean isStalled() {
+        return status == Status.STALLED;
+    }
+
+    /**
+     * Tracks the slowest required contributor over time and reports a stall when it has
+     * failed to advance for longer than {@code stallThreshold} while canonical identity
+     * has moved on.
+     */
+    public static final class Monitor {
+        private final Duration stallThreshold;
+        private long lastCompleteThrough = Long.MIN_VALUE;
+        private Instant lastAdvance;
+
+        public Monitor(Duration stallThreshold) {
+            this.stallThreshold = Objects.requireNonNull(stallThreshold, "stallThreshold");
+        }
+
+        public ProjectionContributorHealth evaluate(ProjectionOutboxStore store,
+                                                    java.util.Set<ProjectionSectionType> requiredSections,
+                                                    Instant now) {
+            long complete = store.completeThrough(requiredSections);
+            long identityCursor = store.identityCursor();
+
+            Map<String, Long> cursors = new TreeMap<>();
+            ProjectionSectionType slowest = null;
+            long slowestCursor = Long.MAX_VALUE;
+            for (ProjectionSectionType type : requiredSections) {
+                long cursor = store.contributorCursor(type);
+                cursors.put(type.wireName(), cursor);
+                if (cursor < slowestCursor) {
+                    slowestCursor = cursor;
+                    slowest = type;
+                }
+            }
+
+            if (complete != lastCompleteThrough) {
+                lastCompleteThrough = complete;
+                lastAdvance = now;
+            } else if (lastAdvance == null) {
+                lastAdvance = now;
+            }
+
+            Duration stalledFor = Duration.between(lastAdvance, now);
+            boolean behind = identityCursor > complete;
+
+            if (!behind) {
+                return new ProjectionContributorHealth(Status.HEALTHY, complete, identityCursor, cursors,
+                        Optional.ofNullable(slowest), Duration.ZERO, Optional.empty());
+            }
+            if (stalledFor.compareTo(stallThreshold) >= 0) {
+                String name = slowest == null ? "unknown" : slowest.wireName();
+                return new ProjectionContributorHealth(Status.STALLED, complete, identityCursor, cursors,
+                        Optional.ofNullable(slowest), stalledFor,
+                        Optional.of("contributor " + name + " has not advanced past block " + slowestCursor
+                                + " for " + stalledFor.toSeconds() + "s while canonical identity reached "
+                                + identityCursor + "; this is a stalled contributor, not archive backlog"));
+            }
+            return new ProjectionContributorHealth(Status.LAGGING, complete, identityCursor, cursors,
+                    Optional.ofNullable(slowest), stalledFor, Optional.empty());
+        }
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionEnvelopeCodec.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionEnvelopeCodec.java
@@ -1,0 +1,157 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRepresentation;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionManifest;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.OptionalLong;
+
+/**
+ * Deterministic encoding of an envelope header.
+ *
+ * <p>Encoding is stable and byte-exact for a given header so that golden fixtures can
+ * detect an accidental format change. Enums are written by their stable wire name or
+ * an explicit code rather than by {@code ordinal()}, so reordering a Java enum cannot
+ * silently reinterpret already-persisted outbox records.
+ *
+ * <p>Section chunk payloads are stored as opaque bytes under their own keys and are
+ * not part of this encoding; the header's manifest is what binds them together.
+ */
+public final class ProjectionEnvelopeCodec {
+    private static final byte[] MAGIC = {'Y', 'P', 'E', 'H'};
+    static final int FORMAT_VERSION = 1;
+
+    private ProjectionEnvelopeCodec() {}
+
+    public static byte[] encodeHeader(ProjectionEnvelopeHeader header) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            out.write(MAGIC);
+            out.writeByte(FORMAT_VERSION);
+            out.writeInt(header.networkIdentity().networkMagic());
+            out.writeUTF(header.networkIdentity().genesisHash());
+            out.writeUTF(header.blockKind().name());
+            out.writeLong(header.blockNumber());
+            out.writeLong(header.slot());
+            out.writeInt(header.epoch());
+            out.writeLong(header.blockTime());
+            out.writeInt(header.canonicalProjectionVersion());
+            writeBytes(out, header.blockHash());
+            writeBytes(out, header.parentHash());
+
+            out.writeInt(header.sections().size());
+            for (ProjectionSectionManifest section : header.sections()) {
+                out.writeUTF(section.type().wireName());
+                out.writeInt(section.version());
+                out.writeInt(section.chunkCount());
+                out.writeLong(section.rowCount());
+                out.writeLong(section.byteCount());
+                out.writeUTF(section.digest());
+            }
+
+            out.writeInt(header.artifacts().size());
+            for (ProjectionArtifactRef artifact : header.artifacts()) {
+                out.writeUTF(artifact.dataset().name());
+                out.writeInt(artifact.semanticEpoch());
+                out.writeLong(artifact.producingBlockNumber());
+                out.writeLong(artifact.producingSlot());
+                out.writeUTF(artifact.representation().name());
+                out.writeUTF(artifact.sourceGeneration());
+                out.writeInt(artifact.sourceCodecVersion());
+                out.writeUTF(artifact.sourceStateVersion());
+                out.writeBoolean(artifact.expectedRowCount().isPresent());
+                out.writeLong(artifact.expectedRowCount().orElse(0L));
+                out.writeUTF(artifact.contentDigest());
+                out.writeLong(artifact.oldestRequiredSlot());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode projection envelope header", e);
+        }
+        return bytes.toByteArray();
+    }
+
+    public static ProjectionEnvelopeHeader decodeHeader(byte[] encoded) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(encoded))) {
+            byte[] magic = in.readNBytes(MAGIC.length);
+            if (!java.util.Arrays.equals(magic, MAGIC)) {
+                throw new IllegalArgumentException("not a projection envelope header record");
+            }
+            int format = in.readUnsignedByte();
+            if (format != FORMAT_VERSION) {
+                throw new IllegalArgumentException("unsupported envelope header format version " + format);
+            }
+            int networkMagic = in.readInt();
+            String genesisHash = in.readUTF();
+            ProjectionBlockKind blockKind = ProjectionBlockKind.valueOf(in.readUTF());
+            long blockNumber = in.readLong();
+            long slot = in.readLong();
+            int epoch = in.readInt();
+            long blockTime = in.readLong();
+            int projectionVersion = in.readInt();
+            byte[] blockHash = readBytes(in);
+            byte[] parentHash = readBytes(in);
+
+            int sectionCount = in.readInt();
+            List<ProjectionSectionManifest> sections = new ArrayList<>(Math.max(0, sectionCount));
+            for (int i = 0; i < sectionCount; i++) {
+                ProjectionSectionType type = ProjectionSectionType.fromWireName(in.readUTF());
+                sections.add(new ProjectionSectionManifest(type, in.readInt(), in.readInt(),
+                        in.readLong(), in.readLong(), in.readUTF()));
+            }
+
+            int artifactCount = in.readInt();
+            List<ProjectionArtifactRef> artifacts = new ArrayList<>(Math.max(0, artifactCount));
+            for (int i = 0; i < artifactCount; i++) {
+                ArchiveDatasetId dataset = ArchiveDatasetId.valueOf(in.readUTF());
+                int semanticEpoch = in.readInt();
+                long producingBlock = in.readLong();
+                long producingSlot = in.readLong();
+                ProjectionArtifactRepresentation representation =
+                        ProjectionArtifactRepresentation.valueOf(in.readUTF());
+                String generation = in.readUTF();
+                int codecVersion = in.readInt();
+                String stateVersion = in.readUTF();
+                boolean hasRowCount = in.readBoolean();
+                long rowCount = in.readLong();
+                String digest = in.readUTF();
+                long oldestRequiredSlot = in.readLong();
+                artifacts.add(new ProjectionArtifactRef(dataset, semanticEpoch, producingBlock, producingSlot,
+                        representation, generation, codecVersion, stateVersion,
+                        hasRowCount ? OptionalLong.of(rowCount) : OptionalLong.empty(), digest, oldestRequiredSlot));
+            }
+
+            if (in.available() != 0) {
+                throw new IllegalArgumentException("trailing bytes after projection envelope header");
+            }
+            return new ProjectionEnvelopeHeader(new ArchiveNetworkIdentity(networkMagic, genesisHash), blockKind,
+                    blockNumber, blockHash, parentHash, slot, epoch, blockTime, projectionVersion,
+                    sections, artifacts);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode projection envelope header", e);
+        }
+    }
+
+    private static void writeBytes(DataOutputStream out, byte[] value) throws IOException {
+        out.writeInt(value.length);
+        out.write(value);
+    }
+
+    private static byte[] readBytes(DataInputStream in) throws IOException {
+        int length = in.readInt();
+        if (length < 0 || length > 1 << 20) throw new IllegalArgumentException("implausible byte length " + length);
+        return in.readNBytes(length);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionFactCodec.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionFactCodec.java
@@ -1,0 +1,557 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.core.dataset.AccountEventFact;
+import com.bloxbean.cardano.yano.archive.core.dataset.AddressParticipationFact;
+import com.bloxbean.cardano.yano.archive.core.dataset.AddressSubjectRows;
+import com.bloxbean.cardano.yano.archive.core.dataset.TransactionFact;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Deterministic encoding of the projection facts carried by a section payload.
+ *
+ * <p>The facts encoded here are the same {@code TransactionFact} and
+ * {@code UtxoHistoryFact} types the existing archive datasets already consume. That is
+ * the point: the sink rebuilds rows with the very same
+ * {@code BlockArchiveDataset.derive} code the replay workers use, so ADR-039 changes
+ * <em>when and how often</em> facts are produced without changing <em>what</em> they
+ * are. Differential parity is then a property of the transport, not of a second
+ * hand-written row builder that would have to be kept in step.
+ */
+public final class ProjectionFactCodec {
+    static final int TRANSACTION_FORMAT = 1;
+    static final int UTXO_HISTORY_FORMAT = 1;
+    static final int ACCOUNT_EVENT_FORMAT = 1;
+    static final int ADDRESS_TRANSACTION_FORMAT = 1;
+
+    private ProjectionFactCodec() {}
+
+    // ------------------------------------------------------------- transaction
+
+    public static byte[] encodeTransactions(List<TransactionFact> facts) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            out.writeByte(TRANSACTION_FORMAT);
+            out.writeInt(facts.size());
+            for (TransactionFact fact : facts) {
+                writeBytes(out, fact.txHash());
+                out.writeInt(fact.txIndex());
+                out.writeBoolean(fact.valid());
+                writeNullableLong(out, fact.fee());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode transaction facts", e);
+        }
+        return bytes.toByteArray();
+    }
+
+    public static List<TransactionFact> decodeTransactions(byte[] payload) {
+        if (payload.length == 0) return List.of();
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload))) {
+            expectFormat(in.readUnsignedByte(), TRANSACTION_FORMAT, "transaction");
+            int count = in.readInt();
+            List<TransactionFact> facts = new ArrayList<>(Math.max(0, count));
+            for (int i = 0; i < count; i++) {
+                facts.add(new TransactionFact(readBytes(in), in.readInt(), in.readBoolean(), readNullableLong(in)));
+            }
+            requireExhausted(in, "transaction");
+            return List.copyOf(facts);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode transaction facts", e);
+        }
+    }
+
+    /**
+     * Decode transaction facts one at a time from a chunk-backed stream.
+     *
+     * <p>Neither the encoded section nor the decoded list is ever held whole: the reader stays
+     * positioned in one chunk, and each fact is handed to {@code consumer} and released before
+     * the next is read. Facts that straddle a chunk boundary are handled by the stream, since
+     * chunk boundaries carry no semantic meaning.
+     *
+     * @return the number of facts decoded, for receipt accounting without a second pass
+     */
+    public static long streamTransactions(java.util.List<byte[]> chunks,
+                                          java.util.function.Consumer<TransactionFact> consumer) {
+        long decoded = 0;
+        try (DataInputStream in = new DataInputStream(new ProjectionChunkedInput(chunks))) {
+            if (in.available() == 0) return 0;
+            expectFormat(in.readUnsignedByte(), TRANSACTION_FORMAT, "transaction");
+            int count = in.readInt();
+            for (int i = 0; i < count; i++) {
+                consumer.accept(new TransactionFact(readBytes(in), in.readInt(), in.readBoolean(),
+                        readNullableLong(in)));
+                decoded++;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to stream transaction facts", e);
+        }
+        return decoded;
+    }
+
+    // -------------------------------------------------------- address transactions
+
+    public static byte[] encodeAddressParticipations(AddressParticipationFact fact) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            out.writeByte(ADDRESS_TRANSACTION_FORMAT);
+            out.writeInt(fact.transactions().size());
+            for (var tx : fact.transactions()) {
+                writeBytes(out, tx.txHash());
+                out.writeInt(tx.txIndex());
+                out.writeInt(tx.participations().size());
+                for (var participation : tx.participations()) {
+                    writeNullableString(out, participation.role());
+                    var p = participation.participant();
+                    writeNullableBytes(out, p.addressKey());
+                    writeNullableString(out, p.address());
+                    writeNullableBytes(out, p.paymentCredential());
+                    writeNullableString(out, p.stakeCredentialType());
+                    writeNullableBytes(out, p.stakeCredential());
+                }
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode address participation facts", e);
+        }
+        return bytes.toByteArray();
+    }
+
+    public static AddressParticipationFact decodeAddressParticipations(byte[] payload) {
+        if (payload.length == 0) return new AddressParticipationFact(List.of());
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload))) {
+            var fact = readAddressParticipations(in);
+            requireExhausted(in, "address-transaction");
+            return fact;
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode address participation facts", e);
+        }
+    }
+
+    /**
+     * Decode address participations one transaction at a time from a chunk-backed stream.
+     *
+     * <p>Streamed at transaction granularity rather than fact granularity: a transaction's
+     * participations must be seen together, because row emission groups by subject across the
+     * whole transaction. One transaction is the natural unit and is protocol-bounded.
+     *
+     * @return the number of rows-worth of participations decoded, for receipt accounting
+     */
+    public static long streamAddressParticipations(java.util.List<byte[]> chunks,
+                                                   java.util.function.Consumer<
+                                                           AddressParticipationFact.Transaction> consumer) {
+        long decoded = 0;
+        try (DataInputStream in = new DataInputStream(new ProjectionChunkedInput(chunks))) {
+            if (in.available() == 0) return 0;
+            expectFormat(in.readUnsignedByte(), ADDRESS_TRANSACTION_FORMAT, "address-transaction");
+            int count = in.readInt();
+            for (int i = 0; i < count; i++) {
+                var tx = readAddressTransaction(in);
+                consumer.accept(tx);
+                decoded += tx.participations().size();
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to stream address participation facts", e);
+        }
+        return decoded;
+    }
+
+    private static AddressParticipationFact readAddressParticipations(DataInputStream in) throws IOException {
+        expectFormat(in.readUnsignedByte(), ADDRESS_TRANSACTION_FORMAT, "address-transaction");
+        int count = in.readInt();
+        List<AddressParticipationFact.Transaction> transactions = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) transactions.add(readAddressTransaction(in));
+        return new AddressParticipationFact(transactions);
+    }
+
+    private static AddressParticipationFact.Transaction readAddressTransaction(DataInputStream in)
+            throws IOException {
+        byte[] txHash = readBytes(in);
+        int txIndex = in.readInt();
+        int participationCount = in.readInt();
+        List<AddressParticipationFact.Participation> participations =
+                new ArrayList<>(Math.max(0, participationCount));
+        for (int i = 0; i < participationCount; i++) {
+            String role = readNullableString(in);
+            participations.add(new AddressParticipationFact.Participation(role,
+                    new AddressSubjectRows.Participant(readNullableBytes(in), readNullableString(in),
+                            readNullableBytes(in), readNullableString(in), readNullableBytes(in))));
+        }
+        return new AddressParticipationFact.Transaction(txHash, txIndex, participations);
+    }
+
+    // ------------------------------------------------------------- account events
+
+    public static byte[] encodeAccountEvents(List<AccountEventFact> facts) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            out.writeByte(ACCOUNT_EVENT_FORMAT);
+            out.writeInt(facts.size());
+            for (AccountEventFact fact : facts) writeAccountEvent(out, fact);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode account event facts", e);
+        }
+        return bytes.toByteArray();
+    }
+
+    public static List<AccountEventFact> decodeAccountEvents(byte[] payload) {
+        if (payload.length == 0) return List.of();
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload))) {
+            expectFormat(in.readUnsignedByte(), ACCOUNT_EVENT_FORMAT, "account-event");
+            int count = in.readInt();
+            List<AccountEventFact> facts = new ArrayList<>(Math.max(0, count));
+            for (int i = 0; i < count; i++) facts.add(readAccountEvent(in));
+            requireExhausted(in, "account-event");
+            return List.copyOf(facts);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode account event facts", e);
+        }
+    }
+
+    /**
+     * Decode account events one at a time from a chunk-backed stream.
+     *
+     * <p>Streamed for the same reason transactions are: certificates are independent of one
+     * another, so no fact needs any other fact to be materialised. Nothing is held whole.
+     *
+     * @return the number of facts decoded, for receipt accounting without a second pass
+     */
+    public static long streamAccountEvents(java.util.List<byte[]> chunks,
+                                           java.util.function.Consumer<AccountEventFact> consumer) {
+        long decoded = 0;
+        try (DataInputStream in = new DataInputStream(new ProjectionChunkedInput(chunks))) {
+            if (in.available() == 0) return 0;
+            expectFormat(in.readUnsignedByte(), ACCOUNT_EVENT_FORMAT, "account-event");
+            int count = in.readInt();
+            for (int i = 0; i < count; i++) {
+                consumer.accept(readAccountEvent(in));
+                decoded++;
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to stream account event facts", e);
+        }
+        return decoded;
+    }
+
+    private static void writeAccountEvent(DataOutputStream out, AccountEventFact fact) throws IOException {
+        writeBytes(out, fact.stakeCredential());
+        writeNullableString(out, fact.credentialType());
+        writeNullableString(out, fact.eventType());
+        writeBytes(out, fact.txHash());
+        out.writeInt(fact.txIndex());
+        out.writeLong(fact.eventIndex());
+        writeNullableBytes(out, fact.poolHash());
+        writeNullableString(out, fact.drepType());
+        writeNullableBytes(out, fact.drepCredential());
+        writeNullableLong(out, fact.amount());
+    }
+
+    private static AccountEventFact readAccountEvent(DataInputStream in) throws IOException {
+        return new AccountEventFact(readBytes(in), readNullableString(in), readNullableString(in),
+                readBytes(in), in.readInt(), in.readLong(), readNullableBytes(in),
+                readNullableString(in), readNullableBytes(in), readNullableLong(in));
+    }
+
+    /**
+     * Decode a utxo-history fact from a chunk-backed stream, without concatenating the chunks.
+     *
+     * <p>This one is decoded whole rather than streamed, and the reason is a real constraint
+     * rather than convenience: row derivation resolves each output's address through a map
+     * built from the section's address list, so outputs cannot be emitted before the addresses
+     * are known. The retained size is nonetheless bounded by the protocol — a section derives
+     * from a single block, and Cardano caps block body size — so peak heap is one block's
+     * decoded facts, not one batch's.
+     */
+    public static UtxoHistoryFact decodeUtxoHistory(java.util.List<byte[]> chunks) {
+        try (DataInputStream in = new DataInputStream(new ProjectionChunkedInput(chunks))) {
+            if (in.available() == 0) {
+                return new UtxoHistoryFact(0, java.util.List.of(), java.util.List.of(), java.util.List.of(),
+                        java.util.List.of(), java.util.List.of(), java.util.List.of(), java.util.List.of(),
+                        java.util.List.of());
+            }
+            return readUtxoHistory(in);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode utxo-history facts", e);
+        }
+    }
+
+    // ------------------------------------------------------------ utxo history
+
+    public static byte[] encodeUtxoHistory(UtxoHistoryFact fact) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            out.writeByte(UTXO_HISTORY_FORMAT);
+            out.writeInt(fact.era());
+
+            out.writeInt(fact.pointerRegistrations().size());
+            for (var r : fact.pointerRegistrations()) {
+                out.writeLong(r.slot());
+                out.writeInt(r.txIndex());
+                out.writeInt(r.certIndex());
+                writeNullableString(out, r.credentialType());
+                writeNullableBytes(out, r.credential());
+            }
+
+            out.writeInt(fact.pointerDeregistrations().size());
+            for (var d : fact.pointerDeregistrations()) {
+                out.writeInt(d.txIndex());
+                out.writeInt(d.certIndex());
+                writeNullableString(out, d.credentialType());
+                writeNullableBytes(out, d.credential());
+            }
+
+            out.writeInt(fact.newAddresses().size());
+            for (var a : fact.newAddresses()) {
+                writeNullableBytes(out, a.addressKey());
+                writeNullableBytes(out, a.rawAddress());
+                writeNullableString(out, a.displayAddress());
+                writeNullableInt(out, a.networkId());
+                writeNullableString(out, a.addressType());
+                writeNullableString(out, a.paymentCredentialType());
+                writeNullableBytes(out, a.paymentCredential());
+                writeNullableString(out, a.stakeReferenceType());
+                writeNullableString(out, a.stakeCredentialType());
+                writeNullableBytes(out, a.stakeCredential());
+                writeNullableLong(out, a.pointerSlot());
+                writeNullableInt(out, a.pointerTxIndex());
+                writeNullableInt(out, a.pointerCertIndex());
+            }
+
+            out.writeInt(fact.outputs().size());
+            for (var o : fact.outputs()) {
+                writeBytes(out, o.txHash());
+                out.writeInt(o.outputIndex());
+                out.writeInt(o.txIndex());
+                writeNullableString(out, o.originType());
+                writeNullableBytes(out, o.addressKey());
+                writeNullableBytes(out, o.paymentCredential());
+                writeNullableBytes(out, o.stakeCredential());
+                out.writeLong(o.lovelace());
+                writeNullableString(out, o.datumKind());
+                writeNullableBytes(out, o.datumHash());
+                writeNullableBytes(out, o.inlineDatumCbor());
+                writeNullableBytes(out, o.referenceScriptHash());
+                writeNullableString(out, o.referenceScriptType());
+                writeNullableBytes(out, o.referenceScriptCbor());
+                out.writeBoolean(o.collateralReturn());
+            }
+
+            out.writeInt(fact.assets().size());
+            for (var a : fact.assets()) {
+                writeBytes(out, a.txHash());
+                out.writeInt(a.outputIndex());
+                writeNullableBytes(out, a.policyId());
+                writeNullableBytes(out, a.assetName());
+                writeBigInteger(out, a.quantity());
+            }
+
+            out.writeInt(fact.inputs().size());
+            for (var i : fact.inputs()) {
+                writeBytes(out, i.spendingTxHash());
+                out.writeInt(i.spendingTxIndex());
+                out.writeInt(i.inputIndex());
+                writeNullableString(out, i.inputRole());
+                writeNullableBytes(out, i.referencedTxHash());
+                out.writeInt(i.referencedOutputIndex());
+                out.writeBoolean(i.consumesOutput());
+            }
+
+            out.writeInt(fact.transactionDatums().size());
+            for (var d : fact.transactionDatums()) {
+                writeBytes(out, d.txHash());
+                out.writeInt(d.txIndex());
+                writeNullableBytes(out, d.datumHash());
+                writeNullableBytes(out, d.datumCbor());
+            }
+
+            out.writeInt(fact.transactionRedeemers().size());
+            for (var r : fact.transactionRedeemers()) {
+                writeBytes(out, r.txHash());
+                out.writeInt(r.txIndex());
+                writeNullableString(out, r.purpose());
+                out.writeInt(r.redeemerIndex());
+                writeNullableBytes(out, r.redeemerCbor());
+                writeNullableBytes(out, r.redeemerDataHash());
+                writeBigInteger(out, r.executionMem());
+                writeBigInteger(out, r.executionSteps());
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode utxo-history facts", e);
+        }
+        return bytes.toByteArray();
+    }
+
+    /** Legacy byte[] entry point, retained for tests and golden fixtures. */
+    public static UtxoHistoryFact decodeUtxoHistory(byte[] payload) {
+        if (payload.length == 0) {
+            return new UtxoHistoryFact(0, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(),
+                    List.of(), List.of());
+        }
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(payload))) {
+            UtxoHistoryFact fact = readUtxoHistory(in);
+            requireExhausted(in, "utxo-history");
+            return fact;
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode utxo-history facts", e);
+        }
+    }
+
+    /** Shared reader, so the streaming and byte[] paths cannot diverge. */
+    private static UtxoHistoryFact readUtxoHistory(DataInputStream in) throws IOException {
+        expectFormat(in.readUnsignedByte(), UTXO_HISTORY_FORMAT, "utxo-history");
+        int era = in.readInt();
+
+        int count = in.readInt();
+        List<UtxoHistoryFact.PointerRegistration> registrations = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            registrations.add(new UtxoHistoryFact.PointerRegistration(in.readLong(), in.readInt(), in.readInt(),
+                    readNullableString(in), readNullableBytes(in)));
+        }
+
+        count = in.readInt();
+        List<UtxoHistoryFact.PointerDeregistration> deregistrations = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            deregistrations.add(new UtxoHistoryFact.PointerDeregistration(in.readInt(), in.readInt(),
+                    readNullableString(in), readNullableBytes(in)));
+        }
+
+        count = in.readInt();
+        List<UtxoHistoryFact.Address> addresses = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            addresses.add(new UtxoHistoryFact.Address(readNullableBytes(in), readNullableBytes(in),
+                    readNullableString(in), readNullableInt(in), readNullableString(in), readNullableString(in),
+                    readNullableBytes(in), readNullableString(in), readNullableString(in), readNullableBytes(in),
+                    readNullableLong(in), readNullableInt(in), readNullableInt(in)));
+        }
+
+        count = in.readInt();
+        List<UtxoHistoryFact.Output> outputs = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            outputs.add(new UtxoHistoryFact.Output(readBytes(in), in.readInt(), in.readInt(),
+                    readNullableString(in), readNullableBytes(in), readNullableBytes(in), readNullableBytes(in),
+                    in.readLong(), readNullableString(in), readNullableBytes(in), readNullableBytes(in),
+                    readNullableBytes(in), readNullableString(in), readNullableBytes(in), in.readBoolean()));
+        }
+
+        count = in.readInt();
+        List<UtxoHistoryFact.Asset> assets = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            assets.add(new UtxoHistoryFact.Asset(readBytes(in), in.readInt(), readNullableBytes(in),
+                    readNullableBytes(in), readBigInteger(in)));
+        }
+
+        count = in.readInt();
+        List<UtxoHistoryFact.Input> inputs = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            inputs.add(new UtxoHistoryFact.Input(readBytes(in), in.readInt(), in.readInt(),
+                    readNullableString(in), readNullableBytes(in), in.readInt(), in.readBoolean()));
+        }
+
+        count = in.readInt();
+        List<UtxoHistoryFact.TransactionDatum> datums = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            datums.add(new UtxoHistoryFact.TransactionDatum(readBytes(in), in.readInt(),
+                    readNullableBytes(in), readNullableBytes(in)));
+        }
+
+        count = in.readInt();
+        List<UtxoHistoryFact.TransactionRedeemer> redeemers = new ArrayList<>(Math.max(0, count));
+        for (int i = 0; i < count; i++) {
+            redeemers.add(new UtxoHistoryFact.TransactionRedeemer(readBytes(in), in.readInt(),
+                    readNullableString(in), in.readInt(), readNullableBytes(in), readNullableBytes(in),
+                    readBigInteger(in), readBigInteger(in)));
+        }
+
+        return new UtxoHistoryFact(era, registrations, deregistrations, addresses, outputs, assets, inputs,
+                datums, redeemers);
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static void expectFormat(int actual, int expected, String what) {
+        if (actual != expected) {
+            throw new IllegalArgumentException("unsupported " + what + " fact format " + actual);
+        }
+    }
+
+    private static void requireExhausted(DataInputStream in, String what) throws IOException {
+        if (in.available() != 0) {
+            throw new IllegalArgumentException("trailing bytes after " + what + " facts");
+        }
+    }
+
+    private static void writeBytes(DataOutputStream out, byte[] value) throws IOException {
+        if (value == null) throw new IllegalArgumentException("required byte field was null");
+        out.writeInt(value.length);
+        out.write(value);
+    }
+
+    private static byte[] readBytes(DataInputStream in) throws IOException {
+        int length = in.readInt();
+        if (length < 0) throw new IllegalArgumentException("negative byte length");
+        return in.readNBytes(length);
+    }
+
+    private static void writeNullableBytes(DataOutputStream out, byte[] value) throws IOException {
+        if (value == null) {
+            out.writeInt(-1);
+        } else {
+            out.writeInt(value.length);
+            out.write(value);
+        }
+    }
+
+    private static byte[] readNullableBytes(DataInputStream in) throws IOException {
+        int length = in.readInt();
+        if (length < 0) return null;
+        return in.readNBytes(length);
+    }
+
+    private static void writeNullableString(DataOutputStream out, String value) throws IOException {
+        out.writeBoolean(value != null);
+        if (value != null) out.writeUTF(value);
+    }
+
+    private static String readNullableString(DataInputStream in) throws IOException {
+        return in.readBoolean() ? in.readUTF() : null;
+    }
+
+    private static void writeNullableLong(DataOutputStream out, Long value) throws IOException {
+        out.writeBoolean(value != null);
+        out.writeLong(value == null ? 0L : value);
+    }
+
+    private static Long readNullableLong(DataInputStream in) throws IOException {
+        boolean present = in.readBoolean();
+        long value = in.readLong();
+        return present ? value : null;
+    }
+
+    private static void writeNullableInt(DataOutputStream out, Integer value) throws IOException {
+        out.writeBoolean(value != null);
+        out.writeInt(value == null ? 0 : value);
+    }
+
+    private static Integer readNullableInt(DataInputStream in) throws IOException {
+        boolean present = in.readBoolean();
+        int value = in.readInt();
+        return present ? value : null;
+    }
+
+    private static void writeBigInteger(DataOutputStream out, BigInteger value) throws IOException {
+        writeNullableBytes(out, value == null ? null : value.toByteArray());
+    }
+
+    private static BigInteger readBigInteger(DataInputStream in) throws IOException {
+        byte[] bytes = readNullableBytes(in);
+        return bytes == null ? null : new BigInteger(bytes);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionFinalityGate.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionFinalityGate.java
@@ -1,0 +1,41 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveSafetyWindows;
+
+import java.util.Objects;
+
+/**
+ * Greatest block the archive may ingest (ADR-039 §6).
+ *
+ * <p>This deliberately reuses {@link ArchiveSafetyWindows} rather than defining a
+ * second archive-only finality calculation. Because {@code resolve} already enforces
+ * {@code archiveFinalityBlocks >= rollbackRetentionBlocks >= securityParam}, the
+ * combined depth {@code tip - max(archiveFinality, rollbackRetention)} reduces to
+ * {@code tip - archiveFinalityBlocks}, so the simple form is used.
+ *
+ * <p>The runtime common rollback floor is deliberately <em>not</em> a term here. It is a
+ * lower bound on what must remain reachable, not an upper bound on what may be
+ * archived; combining them in a {@code min()} would make the archive most restricted
+ * exactly when retention is best, and would stall at slot 0 under unbounded retention.
+ * Retention health is asserted separately by {@link ProjectionRetentionHealth}.
+ */
+public final class ProjectionFinalityGate {
+
+    private final ArchiveSafetyWindows windows;
+
+    public ProjectionFinalityGate(ArchiveSafetyWindows windows) {
+        this.windows = Objects.requireNonNull(windows, "windows");
+    }
+
+    /** Greatest rollback-safe block number, or -1 when the chain is still too short. */
+    public long eligibleThrough(long tipBlockNumber) {
+        if (tipBlockNumber < 0) return -1;
+        long depth = Math.max(windows.archiveFinalityBlocks(), windows.rollbackRetentionBlocks());
+        long eligible = tipBlockNumber - depth;
+        return Math.max(eligible, -1);
+    }
+
+    public ArchiveSafetyWindows windows() {
+        return windows;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceSchedule.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceSchedule.java
@@ -1,0 +1,97 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Objects;
+
+/**
+ * Decides when the coordinator should run maintenance, and which kind.
+ *
+ * <p>Housekeeping and compaction are scheduled on <strong>different</strong> conditions, not
+ * merely budgeted separately:
+ *
+ * <ul>
+ *   <li><strong>Housekeeping</strong> — expiring snapshots and deleting obsolete and orphaned
+ *       files — becomes due on a wall-clock interval and may run during bootstrap. A mainnet
+ *       bootstrap or a sink recovery can easily outlast the snapshot and file retention
+ *       windows, and an archive that waits for tip before ever cleaning up would accumulate
+ *       obsolete files for the entire sync.</li>
+ *   <li><strong>Compaction</strong> — only once the producer is at tip, the sink is caught up
+ *       to the finality boundary, and no eligible drain backlog remains. During bootstrap it
+ *       would contend with the sink for the same bounded bulk pool and re-merge the same
+ *       neighbourhood as the sink keeps appending.</li>
+ * </ul>
+ *
+ * <p>Housekeeping therefore never waits for tip, and compaction never pre-empts it.
+ */
+public final class ProjectionMaintenanceSchedule {
+
+    private final Duration housekeepingInterval;
+    private final Duration compactionInterval;
+
+    private Instant lastHousekeeping;
+    private Instant lastCompaction;
+
+    public ProjectionMaintenanceSchedule(Duration housekeepingInterval, Duration compactionInterval) {
+        this.housekeepingInterval = Objects.requireNonNull(housekeepingInterval, "housekeepingInterval");
+        this.compactionInterval = Objects.requireNonNull(compactionInterval, "compactionInterval");
+    }
+
+    public static ProjectionMaintenanceSchedule defaults() {
+        return new ProjectionMaintenanceSchedule(Duration.ofMinutes(30), Duration.ofHours(6));
+    }
+
+    /** What, if anything, should run now. */
+    public enum Action {
+        /** Nothing is due. */
+        NONE,
+        /** Housekeeping only: due on the interval, or due while bootstrap continues. */
+        HOUSEKEEPING,
+        /** Housekeeping followed by bounded compaction. */
+        HOUSEKEEPING_AND_COMPACTION
+    }
+
+    /**
+     * @param appendActive   whether the coordinator is mid-append; maintenance never competes
+     *                       with an in-flight sink transaction
+     * @param nearTip        whether the producer has reached the chain tip
+     * @param drainBacklog   whether eligible envelopes are still waiting to be drained
+     */
+    public Action decide(boolean appendActive, boolean nearTip, boolean drainBacklog, Instant now) {
+        if (appendActive) return Action.NONE;
+
+        boolean housekeepingDue = lastHousekeeping == null
+                || Duration.between(lastHousekeeping, now).compareTo(housekeepingInterval) >= 0;
+
+        boolean compactionEligible = nearTip && !drainBacklog;
+        boolean compactionDue = compactionEligible && (lastCompaction == null
+                || Duration.between(lastCompaction, now).compareTo(compactionInterval) >= 0);
+
+        if (compactionDue) return Action.HOUSEKEEPING_AND_COMPACTION;
+        if (housekeepingDue) return Action.HOUSEKEEPING;
+        return Action.NONE;
+    }
+
+    /** Record that a pass ran, so the next becomes due on schedule. */
+    public void recordRun(Action action, Instant now) {
+        if (action == Action.NONE) return;
+        lastHousekeeping = now;
+        if (action == Action.HOUSEKEEPING_AND_COMPACTION) lastCompaction = now;
+    }
+
+    /**
+     * Record that compaction was due but the executor withheld it.
+     *
+     * <p>A backstop against the executor and this schedule disagreeing about eligibility.
+     * Without it, a withheld compaction never advances {@code lastCompaction}, so compaction
+     * stays permanently due and a maintenance pass is attempted on every tick. Spacing the
+     * retry by the housekeeping interval bounds the cost of any such disagreement to one pass
+     * per interval instead of one per tick.
+     */
+    public void recordWithheldCompaction(Instant now) {
+        Instant retryFloor = now.minus(compactionInterval).plus(housekeepingInterval);
+        // Never stamp into the future: with a housekeeping interval longer than the compaction
+        // interval that would defer compaction by more than its own interval.
+        lastCompaction = retryFloor.isAfter(now) ? now : retryFloor;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumer.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumer.java
@@ -1,0 +1,346 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ArchiveArtifactReader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceipt;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceiptMismatchException;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSink;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.function.LongSupplier;
+
+/**
+ * Ordered, finality-gated consumption of the projection outbox (ADR-039 §9, §10).
+ *
+ * <p>There is no {@code CATCHING_UP -> LIVE} lifecycle here. A small backlog simply
+ * means a near-live archive and a large backlog means the archive is catching up; the
+ * consumer's behaviour is identical in both cases, which is what removes the separate
+ * per-dataset catch-up/live state machines the old workers needed.
+ *
+ * <p>The commit order is deliberate and is what makes at-least-once delivery produce
+ * exactly-once effect:
+ *
+ * <pre>
+ * read contiguous eligible envelopes
+ *   -&gt; sink writes rows + durable receipt atomically
+ *   -&gt; acknowledge the outbox range
+ *   -&gt; delete acknowledged chunks
+ * </pre>
+ *
+ * A crash between the sink commit and acknowledgement replays the same deterministic
+ * batch; the existing receipt is found, matched, and the range is acknowledged without
+ * writing anything twice.
+ */
+public final class ProjectionOutboxConsumer {
+
+    private final ProjectionOutboxStore store;
+    private final ProjectionSink sink;
+    private final ProjectionIdentity identity;
+    private final ProjectionFinalityGate finalityGate;
+    private final ProjectionConsumerBounds bounds;
+    private final ArchiveArtifactReader artifacts;
+    private final LongSupplier tipBlockNumber;
+    private final LongSupplier commonRollbackFloorSlot;
+    private final ProjectionBatchPolicy batchPolicy;
+    private final ProjectionBatchAccumulator accumulator;
+    private volatile ProjectionBatchDecision lastDecision;
+    private final java.util.concurrent.atomic.AtomicBoolean discardPending =
+            new java.util.concurrent.atomic.AtomicBoolean();
+
+    public ProjectionOutboxConsumer(ProjectionOutboxStore store, ProjectionSink sink, ProjectionIdentity identity,
+                                    ProjectionFinalityGate finalityGate, ProjectionConsumerBounds bounds,
+                                    ArchiveArtifactReader artifacts, LongSupplier tipBlockNumber,
+                                    LongSupplier commonRollbackFloorSlot) {
+        this.store = Objects.requireNonNull(store, "store");
+        this.sink = Objects.requireNonNull(sink, "sink");
+        this.identity = Objects.requireNonNull(identity, "identity");
+        this.finalityGate = Objects.requireNonNull(finalityGate, "finalityGate");
+        this.bounds = Objects.requireNonNull(bounds, "bounds");
+        this.artifacts = Objects.requireNonNull(artifacts, "artifacts");
+        this.tipBlockNumber = Objects.requireNonNull(tipBlockNumber, "tipBlockNumber");
+        this.commonRollbackFloorSlot = Objects.requireNonNull(commonRollbackFloorSlot, "commonRollbackFloorSlot");
+        this.batchPolicy = ProjectionBatchPolicy.defaults();
+        this.accumulator = new ProjectionBatchAccumulator(batchPolicy);
+    }
+
+    public ProjectionOutboxConsumer(ProjectionOutboxStore store, ProjectionSink sink, ProjectionIdentity identity,
+                                    ProjectionFinalityGate finalityGate, ProjectionConsumerBounds bounds,
+                                    ArchiveArtifactReader artifacts, LongSupplier tipBlockNumber,
+                                    LongSupplier commonRollbackFloorSlot, ProjectionBatchPolicy batchPolicy) {
+        this.store = Objects.requireNonNull(store, "store");
+        this.sink = Objects.requireNonNull(sink, "sink");
+        this.identity = Objects.requireNonNull(identity, "identity");
+        this.finalityGate = Objects.requireNonNull(finalityGate, "finalityGate");
+        this.bounds = Objects.requireNonNull(bounds, "bounds");
+        this.artifacts = Objects.requireNonNull(artifacts, "artifacts");
+        this.tipBlockNumber = Objects.requireNonNull(tipBlockNumber, "tipBlockNumber");
+        this.commonRollbackFloorSlot = Objects.requireNonNull(commonRollbackFloorSlot, "commonRollbackFloorSlot");
+        this.batchPolicy = Objects.requireNonNull(batchPolicy, "batchPolicy");
+        this.accumulator = new ProjectionBatchAccumulator(batchPolicy);
+    }
+
+    /** Why the most recent batch was committed; null until one has been. */
+    public ProjectionBatchDecision lastBatchDecision() {
+        return lastDecision;
+    }
+
+    /**
+     * Run one bounded maintenance pass on the sink.
+     *
+     * <p>Invoked by the same coordinator that drains, never by a separate worker, and only
+     * when it has nothing eligible to drain. Compaction is offered only when the producer is
+     * at tip and the outbox holds no eligible backlog; during bootstrap the budget carries
+     * housekeeping alone, so cleanup still reclaims space without compaction competing with
+     * the sink for the bulk pool.
+     */
+    public MaintenancePass maintain(java.time.Duration housekeeping,
+                                    java.time.Duration compaction, long maxBytesToRewrite) {
+        long from = store.acknowledgedThrough() + 1;
+        long eligible = Math.min(store.completeThrough(identity.requiredSections()),
+                finalityGate.eligibleThrough(tipBlockNumber.getAsLong()));
+        boolean idle = eligible < from && accumulator.isEmpty();
+        boolean allowCompaction = nearTip() && idle;
+        var budget = allowCompaction
+                ? ProjectionMaintenance.Budget.full(housekeeping, compaction, maxBytesToRewrite)
+                : ProjectionMaintenance.Budget.housekeepingOnly(housekeeping);
+        return new MaintenancePass(sink.maintain(budget), allowCompaction);
+    }
+
+    /**
+     * What a maintenance pass was actually permitted to do, alongside what it did.
+     *
+     * <p>The scheduler asks for compaction on an interval, but the consumer withholds it when
+     * the sink is not idle. Without this the caller would record a compaction that never ran
+     * and defer the next one by a full interval.
+     *
+     * @param compactionOffered whether the budget actually carried compaction
+     */
+    public record MaintenancePass(ProjectionMaintenance.Result result, boolean compactionOffered) { }
+
+    /** Run one bounded pass. Safe to call repeatedly; never partially acknowledges a batch. */
+    public ProjectionConsumerResult drainOnce() {
+        return drainOnce(java.time.Instant.now());
+    }
+
+    /**
+     * Run one bounded pass against an explicit clock.
+     *
+     * <p>Structure matters here: a pass with <em>no</em> new envelopes must still evaluate the
+     * pending batch, because "arrivals stopped" is precisely the situation the freshness
+     * deadline exists for. Returning early on an empty read would make the deadline
+     * unreachable.
+     */
+    ProjectionConsumerResult drainOnce(java.time.Instant now) {
+        // A rollback removed envelopes from the outbox. Anything buffered may describe a
+        // discarded fork, so it is dropped and re-read from durable state on the next pass.
+        if (discardPending.compareAndSet(true, false)) {
+            accumulator.reset();
+            return ProjectionConsumerResult.idle();
+        }
+
+        long acknowledged = store.acknowledgedThrough();
+        long complete = store.completeThrough(identity.requiredSections());
+        long eligible = Math.min(complete, finalityGate.eligibleThrough(tipBlockNumber.getAsLong()));
+
+        // The batching regime is derived from the drain backlog, not from a separate sync
+        // signal. A sink that falls far behind while the node sits at tip still gets the
+        // bootstrap regime, and the regime returns to near-tip on its own once it catches up.
+        boolean nearTip = eligible - acknowledged < batchPolicy.minBlocks(false);
+
+
+        long from = accumulator.isEmpty() ? acknowledged + 1 : accumulator.lastBlock() + 1;
+        if (eligible >= from) {
+            List<ProjectionEnvelope> arrivals = store.readRange(from, eligible, identity.requiredSections(),
+                    bounds.maxBlocksPerBatch(), bounds.maxBytesPerBatch());
+            for (ProjectionEnvelope envelope : arrivals) {
+                ProjectionBatchAccumulator.Offer offer = accumulator.offer(envelope, now);
+                if (offer == ProjectionBatchAccumulator.Offer.REJECTED_FULL) break;
+                if (offer == ProjectionBatchAccumulator.Offer.REJECTED_UNSAFE) {
+                    return ProjectionConsumerResult.paused("envelope at block "
+                            + envelope.header().blockNumber() + " exceeds the absolute batch safety guard ("
+                            + ProjectionBatchAccumulator.bytesOf(envelope) + " bytes, "
+                            + ProjectionBatchAccumulator.rowsOf(envelope) + " rows)");
+                }
+            }
+        }
+
+        if (accumulator.isEmpty()) return ProjectionConsumerResult.idle();
+
+        boolean moreAvailable = eligible > accumulator.lastBlock();
+        ProjectionBatchDecision decision = accumulator.decide(nearTip, moreAvailable, now);
+        if (!decision.flush()) {
+            return ProjectionConsumerResult.accumulating(
+                    accumulator.firstBlock(), accumulator.lastBlock(), moreAvailable);
+        }
+
+        // Re-check immediately before committing: a rollback that landed while this pass was
+        // assembling must not be written to the sink.
+        if (discardPending.compareAndSet(true, false)) {
+            accumulator.reset();
+            return ProjectionConsumerResult.idle();
+        }
+
+        ProjectionBatch batch = new ProjectionBatch(identity, accumulator.envelopes());
+        verifyContiguity(batch, acknowledged);
+
+        // Retention health is checked against what this batch actually requires, before
+        // any sink work. A violation pauses; it never narrows eligibility or skips work.
+        long oldestRequired = oldestRequiredSlot(batch);
+        ProjectionRetentionHealth health =
+                ProjectionRetentionHealth.evaluate(commonRollbackFloorSlot.getAsLong(), oldestRequired);
+        if (!health.allowsProgress()) {
+            return ProjectionConsumerResult.paused(health.detail().orElse("retention health violated"));
+        }
+
+        Optional<ProjectionReceipt> existing = sink.receiptFor(batch.firstBlock());
+        boolean replayed = false;
+        if (existing.isPresent()) {
+            // Receipt identity is checked against the encoded batch, so an already-committed
+            // range is recognised without decoding a single section. That keeps crash
+            // recovery cheap, and it keeps a replay from re-running row derivation that the
+            // committed batch already proved succeeds.
+            if (!existing.get().matches(batch)) {
+                throw new ProjectionReceiptMismatchException("a durable receipt already covers block "
+                        + batch.firstBlock() + " but describes a different job; refusing to reconcile"
+                        + " (stored range " + existing.get().firstBlock() + ".." + existing.get().lastBlock()
+                        + ", offered range " + batch.firstBlock() + ".." + batch.lastBlock() + ")");
+            }
+            replayed = true;
+        } else {
+            // Materialise once, in shared code, so every backend sees the same rows.
+            ProjectionReceipt receipt = sink.append(ProjectionRowBuilder.materialise(batch), artifacts);
+            if (!receipt.matches(batch)) {
+                throw new ProjectionReceiptMismatchException(
+                        "sink returned a receipt that does not describe the committed batch at block "
+                                + batch.firstBlock());
+            }
+        }
+
+        // Only now is removal authorised, and only for exactly this verified range.
+        store.acknowledgeThrough(batch.lastBlock());
+        for (var artifact : batch.artifacts()) {
+            artifacts.acknowledge(artifact);
+        }
+        accumulator.recordFlush(decision);
+        lastDecision = decision;
+        accumulator.reset();
+
+        return new ProjectionConsumerResult(
+                replayed ? ProjectionConsumerResult.Outcome.REPLAYED : ProjectionConsumerResult.Outcome.COMMITTED,
+                batch.firstBlock(), batch.lastBlock(), Optional.empty(),
+                eligible > batch.lastBlock());
+    }
+
+    /**
+     * A buffered batch must still start exactly where the acknowledged range ends and must
+     * cover every block in between. A duplicate would be caught downstream by the receipt
+     * check; a <em>gap</em> would not, so it is made loud here.
+     */
+    private static void verifyContiguity(ProjectionBatch batch, long acknowledged) {
+        if (batch.firstBlock() != acknowledged + 1) {
+            throw new IllegalStateException("pending projection batch starts at block " + batch.firstBlock()
+                    + " but the acknowledged range ends at " + acknowledged
+                    + "; refusing to commit a batch that would leave a coverage gap");
+        }
+        long expected = batch.firstBlock();
+        for (ProjectionEnvelope envelope : batch.envelopes()) {
+            if (envelope.header().blockNumber() != expected) {
+                throw new IllegalStateException("pending projection batch is not contiguous: expected block "
+                        + expected + " but found " + envelope.header().blockNumber());
+            }
+            expected++;
+        }
+    }
+
+    /**
+     * Discard whatever is buffered, because the outbox beneath it changed.
+     *
+     * <p>Called from the rollback path, which runs on the event-bus thread. It deliberately
+     * takes no lock the drain thread could be holding across a sink commit: the flag is
+     * observed by the drain thread at its next safe point.
+     */
+    public void discardPendingBatch() {
+        discardPending.set(true);
+    }
+
+    /**
+     * Whether the sink is close enough to the producer to use the near-tip regime.
+     *
+     * <p>Derived from the eligible drain backlog rather than a separate sync signal, so a
+     * sink that falls behind at tip is treated as bootstrapping until it catches up.
+     */
+    public boolean nearTip() {
+        return Math.min(store.completeThrough(identity.requiredSections()),
+                finalityGate.eligibleThrough(tipBlockNumber.getAsLong()))
+                - store.acknowledgedThrough() < batchPolicy.minBlocks(false);
+    }
+
+    /**
+     * Whether any drain work is in flight — either eligible envelopes waiting or a batch
+     * already buffered.
+     *
+     * <p>This is deliberately the exact negation of the idle test {@link #maintain} uses to
+     * decide whether compaction may be offered. If the scheduler and the consumer disagreed,
+     * the scheduler would keep reporting compaction due while the consumer kept withholding
+     * it, and — because nothing would ever record a compaction as having run — a maintenance
+     * pass would be attempted on every drain tick, acquiring a bulk lease each time.
+     */
+    public boolean hasDrainBacklog() {
+        if (!accumulator.isEmpty()) return true;
+        return Math.min(store.completeThrough(identity.requiredSections()),
+                finalityGate.eligibleThrough(tipBlockNumber.getAsLong())) > store.acknowledgedThrough();
+    }
+
+    /** Blocks currently buffered but not yet committed; zero when nothing is pending. */
+    public int pendingBatchBlocks() {
+        return accumulator.size();
+    }
+
+    /**
+     * How long the oldest finality-eligible envelope has waited without reaching the sink,
+     * in seconds; -1 when nothing is buffered.
+     *
+     * <p>This is the staleness the historical API must cover from live storage: it bounds the
+     * window in which a block is final and durable in the outbox but not yet queryable in the
+     * primary sink.
+     */
+    public long pendingBatchAgeSeconds(java.time.Instant now) {
+        java.time.Instant openedAt = accumulator.openedAt();
+        return openedAt == null ? -1 : java.time.Duration.between(openedAt, now).toSeconds();
+    }
+
+    /** Oldest block buffered but not yet committed; -1 when nothing is pending. */
+    public long pendingBatchOldestBlock() {
+        return accumulator.firstBlock();
+    }
+
+    /** Observability for the batching policy actually in force. */
+    public ProjectionBatchPolicy batchPolicy() {
+        return batchPolicy;
+    }
+
+    public ProjectionBatchAccumulator.Stats batchStats() {
+        return accumulator.stats();
+    }
+
+    /** Oldest slot this batch still requires; -1 when it requires nothing retained. */
+    private static long oldestRequiredSlot(ProjectionBatch batch) {
+        return batch.artifacts().stream()
+                .mapToLong(ref -> ref.oldestRequiredSlot())
+                .min()
+                .orElse(-1L);
+    }
+
+    public ProjectionBackpressure backpressure() {
+        return ProjectionBackpressure.evaluate(store.stats(identity.requiredSections()), bounds);
+    }
+
+    public ProjectionOutboxStats stats() {
+        return store.stats(identity.requiredSections());
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumer.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumer.java
@@ -221,11 +221,23 @@ public final class ProjectionOutboxConsumer {
             }
         }
 
-        // Only now is removal authorised, and only for exactly this verified range.
-        store.acknowledgeThrough(batch.lastBlock());
+        // Order matters here, and the obvious order is wrong.
+        //
+        // acknowledgeThrough() deletes the outbox's artifact references along with the range.
+        // Acknowledging the range first would therefore destroy the only record of which
+        // artifacts still need releasing: a crash in the gap leaves their sources pinned
+        // forever, with nothing left to reconcile from. Startup cannot repair it either,
+        // because the reference it would repair from is exactly what was deleted.
+        //
+        // So artifact acknowledgement completes first, against a verified durable receipt.
+        // Acknowledging an artifact twice is harmless - the reader's contract is idempotent -
+        // whereas losing the reference is not, so a crash between the two steps costs a repeat
+        // rather than a leak.
         for (var artifact : batch.artifacts()) {
             artifacts.acknowledge(artifact);
         }
+        // Only now is removal authorised, and only for exactly this verified range.
+        store.acknowledgeThrough(batch.lastBlock());
         accumulator.recordFlush(decision);
         lastDecision = decision;
         accumulator.reset();

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxException.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxException.java
@@ -1,0 +1,12 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+/** Outbox storage failure; never interpreted as an empty or complete envelope. */
+public class ProjectionOutboxException extends RuntimeException {
+    public ProjectionOutboxException(String message) {
+        super(message);
+    }
+
+    public ProjectionOutboxException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxKeys.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxKeys.java
@@ -1,0 +1,68 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+
+/**
+ * Key encoding for the projection outbox column families.
+ *
+ * <p>Block numbers are big-endian so RocksDB's byte order is canonical block order and
+ * an ordered scan is a sequential read. Section records sort as
+ * {@code block, section, manifest-before-chunks}, so assembling one envelope is a
+ * single forward scan rather than a series of point lookups.
+ */
+final class ProjectionOutboxKeys {
+    static final byte KIND_MANIFEST = 0;
+    static final byte KIND_CHUNK = 1;
+
+    static final byte[] META_IDENTITY = "identity".getBytes(StandardCharsets.UTF_8);
+    static final byte[] META_ACK = "ack".getBytes(StandardCharsets.UTF_8);
+    private static final String CURSOR_PREFIX = "cursor/";
+
+    /** Cursor for the contributor that writes canonical block identity. */
+    static final byte[] META_CURSOR_IDENTITY = (CURSOR_PREFIX + "identity").getBytes(StandardCharsets.UTF_8);
+
+    private ProjectionOutboxKeys() {}
+
+    static byte[] blockKey(long blockNumber) {
+        return ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(blockNumber).array();
+    }
+
+    static long blockFromKey(byte[] key) {
+        return ByteBuffer.wrap(key, 0, 8).order(ByteOrder.BIG_ENDIAN).getLong();
+    }
+
+    static byte[] sectionManifestKey(long blockNumber, ProjectionSectionType type) {
+        return sectionKey(blockNumber, type, KIND_MANIFEST, 0);
+    }
+
+    static byte[] sectionChunkKey(long blockNumber, ProjectionSectionType type, int chunkIndex) {
+        return sectionKey(blockNumber, type, KIND_CHUNK, chunkIndex);
+    }
+
+    static byte[] sectionKey(long blockNumber, ProjectionSectionType type, byte kind, int chunkIndex) {
+        return ByteBuffer.allocate(14).order(ByteOrder.BIG_ENDIAN)
+                .putLong(blockNumber).put((byte) type.code()).put(kind).putInt(chunkIndex).array();
+    }
+
+    static byte[] cursorKey(ProjectionSectionType type) {
+        return (CURSOR_PREFIX + type.wireName()).getBytes(StandardCharsets.UTF_8);
+    }
+
+    static byte[] artifactKey(long blockNumber, String dataset, int semanticEpoch) {
+        byte[] name = dataset.getBytes(StandardCharsets.UTF_8);
+        return ByteBuffer.allocate(12 + name.length).order(ByteOrder.BIG_ENDIAN)
+                .putLong(blockNumber).putInt(semanticEpoch).put(name).array();
+    }
+
+    static byte[] encodeLong(long value) {
+        return blockKey(value);
+    }
+
+    static long decodeLong(byte[] value) {
+        return ByteBuffer.wrap(value).order(ByteOrder.BIG_ENDIAN).getLong();
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxStats.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxStats.java
@@ -1,0 +1,10 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+/** Bounded view of outbox backlog, exposed for health, metrics and backpressure. */
+public record ProjectionOutboxStats(long pendingBlocks, long pendingBytes, long pendingRows,
+                                    long oldestPendingBlock, long completeThroughBlock,
+                                    long acknowledgedThroughBlock) {
+    public boolean isEmpty() {
+        return pendingBlocks == 0;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxStore.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxStore.java
@@ -1,0 +1,428 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
+import com.bloxbean.cardano.yano.api.archive.ProjectionStagingWriter;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionManifest;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.ReadOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
+import org.rocksdb.RocksIterator;
+import org.rocksdb.Slice;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import java.util.ArrayList;
+import java.util.EnumMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Durable RocksDB outbox for canonical projection envelopes (ADR-039 §2, §8).
+ *
+ * <p>Writes are contributed into a caller-supplied {@link WriteBatch}. That is the
+ * whole point: a contributor commits its section, its per-section manifest, and its
+ * own cursor in the same batch as the state those facts were derived from, so a
+ * section can never be durable without its state or vice versa. There is deliberately
+ * no batch spanning chain, UTXO and ledger.
+ *
+ * <p>Reads are performed only after commit. Nothing here reads back a key the caller
+ * has merely staged in a batch, because RocksDB point reads cannot observe an
+ * uncommitted batch and a store that depended on that would silently lose same-block
+ * writes.
+ */
+public final class ProjectionOutboxStore {
+
+    private final RocksDB db;
+    private final ColumnFamilyHandle headerCf;
+    private final ColumnFamilyHandle sectionCf;
+    private final ColumnFamilyHandle metaCf;
+    private final ColumnFamilyHandle artifactCf;
+
+    public ProjectionOutboxStore(RocksDB db, ColumnFamilyHandle headerCf, ColumnFamilyHandle sectionCf,
+                                 ColumnFamilyHandle metaCf, ColumnFamilyHandle artifactCf) {
+        this.db = Objects.requireNonNull(db, "db");
+        this.headerCf = Objects.requireNonNull(headerCf, "headerCf");
+        this.sectionCf = Objects.requireNonNull(sectionCf, "sectionCf");
+        this.metaCf = Objects.requireNonNull(metaCf, "metaCf");
+        this.artifactCf = Objects.requireNonNull(artifactCf, "artifactCf");
+    }
+
+    // ------------------------------------------------------------------ identity
+
+    public void putIdentity(ProjectionIdentity identity) {
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions().setSync(true)) {
+            batch.put(metaCf, ProjectionOutboxKeys.META_IDENTITY,
+                    identity.fingerprint().getBytes(java.nio.charset.StandardCharsets.UTF_8));
+            db.write(options, batch);
+        } catch (RocksDBException e) {
+            throw new ProjectionOutboxException("failed to persist projection identity", e);
+        }
+    }
+
+    public Optional<String> identityFingerprint() {
+        return get(metaCf, ProjectionOutboxKeys.META_IDENTITY)
+                .map(value -> new String(value, java.nio.charset.StandardCharsets.UTF_8));
+    }
+
+    // ------------------------------------------------------------------- writing
+
+    /**
+     * Record canonical block identity for {@code header}. Sections and artifacts are
+     * written by their own contributors; the manifest a sink later verifies is derived
+     * from what is actually stored rather than from a promise made here.
+     */
+    public void putBlockIdentity(ProjectionStagingWriter writer, ProjectionEnvelopeHeader header) {
+        ProjectionEnvelopeHeader identityOnly = new ProjectionEnvelopeHeader(header.networkIdentity(),
+                header.blockKind(), header.blockNumber(), header.blockHash(), header.parentHash(),
+                header.slot(), header.epoch(), header.blockTime(), header.canonicalProjectionVersion(),
+                List.of(), List.of());
+        writer.put(ProjectionCfNames.PROJ_HEADER, ProjectionOutboxKeys.blockKey(header.blockNumber()),
+                ProjectionEnvelopeCodec.encodeHeader(identityOnly));
+        writer.put(ProjectionCfNames.PROJ_META, ProjectionOutboxKeys.META_CURSOR_IDENTITY,
+                ProjectionOutboxKeys.encodeLong(header.blockNumber()));
+    }
+
+    /** Stage one contributor's section plus its cursor. Both land in the caller's batch. */
+    public void putSection(ProjectionStagingWriter writer, long blockNumber, ProjectionSection section) {
+        ProjectionSectionManifest manifest = section.manifest();
+        writer.put(ProjectionCfNames.PROJ_SECTION,
+                ProjectionOutboxKeys.sectionManifestKey(blockNumber, section.type()),
+                ProjectionSectionCodec.encodeManifest(manifest));
+        List<byte[]> chunks = section.chunks();
+        for (int i = 0; i < chunks.size(); i++) {
+            writer.put(ProjectionCfNames.PROJ_SECTION,
+                    ProjectionOutboxKeys.sectionChunkKey(blockNumber, section.type(), i), chunks.get(i));
+        }
+        writer.put(ProjectionCfNames.PROJ_META, ProjectionOutboxKeys.cursorKey(section.type()),
+                ProjectionOutboxKeys.encodeLong(blockNumber));
+    }
+
+    /**
+     * Advance a contributor's cursor without writing a section. A block that legitimately
+     * produces no rows for a dataset must still advance, or the envelope would wait
+     * forever on a contributor that has nothing to say.
+     */
+    public void advanceContributor(ProjectionStagingWriter writer, ProjectionSectionType type, long blockNumber) {
+        writer.put(ProjectionCfNames.PROJ_META, ProjectionOutboxKeys.cursorKey(type),
+                ProjectionOutboxKeys.encodeLong(blockNumber));
+    }
+
+    /** Stage an epoch-artifact reference alongside its producing block. */
+    public void putArtifact(ProjectionStagingWriter writer, long blockNumber,
+                            com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef ref) {
+        writer.put(ProjectionCfNames.PROJ_ARTIFACT,
+                ProjectionOutboxKeys.artifactKey(blockNumber, ref.dataset().name(), ref.semanticEpoch()),
+                ProjectionSectionCodec.encodeArtifact(ref));
+    }
+
+    /**
+     * Adapter binding a RocksDB {@link WriteBatch} to the opaque staging contract, so the
+     * same store code serves the runtime hook and direct callers.
+     */
+    public static ProjectionStagingWriter batchWriter(WriteBatch batch,
+                                                      java.util.function.Function<String, ColumnFamilyHandle> handles) {
+        return (columnFamily, key, value) -> {
+            try {
+                batch.put(handles.apply(columnFamily), key, value);
+            } catch (RocksDBException e) {
+                throw new ProjectionOutboxException("failed to stage projection record", e);
+            }
+        };
+    }
+
+    /**
+     * Run {@code work} in the store's own atomic batch.
+     *
+     * <p>Used by contributors that have no other subsystem batch to join — notably Byron,
+     * which the live UTXO path never applies. The section and its cursor still commit
+     * atomically with each other, and the durable replay intent remains the retained
+     * canonical body plus that cursor.
+     */
+    public void commit(java.util.function.Consumer<ProjectionStagingWriter> work) {
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions().setSync(true)) {
+            work.accept(batchWriter(batch, handles()));
+            db.write(options, batch);
+        } catch (RocksDBException e) {
+            throw new ProjectionOutboxException("failed to commit projection batch", e);
+        }
+    }
+
+    /** Column-family handle lookup for {@link #batchWriter}. */
+    public java.util.function.Function<String, ColumnFamilyHandle> handles() {
+        return name -> switch (name) {
+            case ProjectionCfNames.PROJ_HEADER -> headerCf;
+            case ProjectionCfNames.PROJ_SECTION -> sectionCf;
+            case ProjectionCfNames.PROJ_META -> metaCf;
+            case ProjectionCfNames.PROJ_ARTIFACT -> artifactCf;
+            default -> throw new ProjectionOutboxException("unknown projection column family: " + name);
+        };
+    }
+
+    // ------------------------------------------------------------------- cursors
+
+    public long contributorCursor(ProjectionSectionType type) {
+        return get(metaCf, ProjectionOutboxKeys.cursorKey(type))
+                .map(ProjectionOutboxKeys::decodeLong).orElse(-1L);
+    }
+
+    public long identityCursor() {
+        return get(metaCf, ProjectionOutboxKeys.META_CURSOR_IDENTITY)
+                .map(ProjectionOutboxKeys::decodeLong).orElse(-1L);
+    }
+
+    public long acknowledgedThrough() {
+        return get(metaCf, ProjectionOutboxKeys.META_ACK)
+                .map(ProjectionOutboxKeys::decodeLong).orElse(-1L);
+    }
+
+    /**
+     * Greatest block for which every required contributor is durably done.
+     *
+     * <p>This is the completion rule of ADR-039 §8: canonical progress may lead a
+     * contributor, and the envelope is eligible only when the slowest required
+     * contributor has reached it.
+     */
+    public long completeThrough(Set<ProjectionSectionType> requiredSections) {
+        long complete = identityCursor();
+        for (ProjectionSectionType type : requiredSections) {
+            complete = Math.min(complete, contributorCursor(type));
+        }
+        return complete;
+    }
+
+    // ------------------------------------------------------------------- reading
+
+    public Optional<ProjectionEnvelope> readEnvelope(long blockNumber, Set<ProjectionSectionType> requiredSections) {
+        Optional<byte[]> identity = get(headerCf, ProjectionOutboxKeys.blockKey(blockNumber));
+        if (identity.isEmpty()) return Optional.empty();
+        ProjectionEnvelopeHeader identityHeader = ProjectionEnvelopeCodec.decodeHeader(identity.get());
+
+        Map<ProjectionSectionType, ProjectionSectionManifest> manifests = new EnumMap<>(ProjectionSectionType.class);
+        Map<ProjectionSectionType, List<byte[]>> chunks = new EnumMap<>(ProjectionSectionType.class);
+        scanSections(blockNumber, manifests, chunks);
+
+        List<ProjectionSection> sections = new ArrayList<>(manifests.size());
+        List<ProjectionSectionManifest> orderedManifests = new ArrayList<>(manifests.size());
+        for (Map.Entry<ProjectionSectionType, ProjectionSectionManifest> entry : manifests.entrySet()) {
+            ProjectionSectionManifest manifest = entry.getValue();
+            List<byte[]> payload = chunks.getOrDefault(entry.getKey(), List.of());
+            if (payload.size() != manifest.chunkCount()) {
+                throw new ProjectionOutboxException("section " + manifest.type().wireName() + " at block "
+                        + blockNumber + " has " + payload.size() + " chunks but its manifest declares "
+                        + manifest.chunkCount());
+            }
+            ProjectionSection section = new ProjectionSection(manifest.type(), manifest.version(), payload,
+                    manifest.rowCount());
+            sections.add(section);
+            orderedManifests.add(manifest);
+        }
+
+        for (ProjectionSectionType required : requiredSections) {
+            if (!manifests.containsKey(required) && !identityHeader.blockKind().allowsEmptyEnvelope()) {
+                return Optional.empty();
+            }
+        }
+
+        ProjectionEnvelopeHeader header = new ProjectionEnvelopeHeader(identityHeader.networkIdentity(),
+                identityHeader.blockKind(), identityHeader.blockNumber(), identityHeader.blockHash(),
+                identityHeader.parentHash(), identityHeader.slot(), identityHeader.epoch(),
+                identityHeader.blockTime(), identityHeader.canonicalProjectionVersion(),
+                orderedManifests, readArtifacts(blockNumber));
+        return Optional.of(new ProjectionEnvelope(header, sections));
+    }
+
+    private void scanSections(long blockNumber, Map<ProjectionSectionType, ProjectionSectionManifest> manifests,
+                              Map<ProjectionSectionType, List<byte[]>> chunks) {
+        byte[] lower = ProjectionOutboxKeys.blockKey(blockNumber);
+        byte[] upper = ProjectionOutboxKeys.blockKey(blockNumber + 1);
+        try (Slice upperSlice = new Slice(upper);
+             ReadOptions options = new ReadOptions().setIterateUpperBound(upperSlice);
+             RocksIterator it = db.newIterator(sectionCf, options)) {
+            for (it.seek(lower); it.isValid(); it.next()) {
+                byte[] key = it.key();
+                if (key.length != 14) continue;
+                ProjectionSectionType type = ProjectionSectionType.fromCode(key[8]);
+                if (key[9] == ProjectionOutboxKeys.KIND_MANIFEST) {
+                    manifests.put(type, ProjectionSectionCodec.decodeManifest(it.value()));
+                } else {
+                    chunks.computeIfAbsent(type, k -> new ArrayList<>()).add(it.value());
+                }
+            }
+        }
+    }
+
+    private List<com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef> readArtifacts(long blockNumber) {
+        List<com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef> refs = new ArrayList<>();
+        byte[] lower = ProjectionOutboxKeys.blockKey(blockNumber);
+        byte[] upper = ProjectionOutboxKeys.blockKey(blockNumber + 1);
+        try (Slice upperSlice = new Slice(upper);
+             ReadOptions options = new ReadOptions().setIterateUpperBound(upperSlice);
+             RocksIterator it = db.newIterator(artifactCf, options)) {
+            for (it.seek(lower); it.isValid(); it.next()) {
+                refs.add(ProjectionSectionCodec.decodeArtifact(it.value()));
+            }
+        }
+        return refs;
+    }
+
+    /**
+     * Read a contiguous, complete, eligible run starting at {@code fromBlock}.
+     *
+     * <p>Stops at the first block whose envelope is not yet assembled, so a batch never
+     * spans a gap. Bounds are applied after at least one envelope so a single oversized
+     * envelope still makes progress rather than deadlocking the consumer.
+     */
+    public List<ProjectionEnvelope> readRange(long fromBlock, long throughBlock,
+                                              Set<ProjectionSectionType> requiredSections,
+                                              int maxBlocks, long maxBytes) {
+        List<ProjectionEnvelope> envelopes = new ArrayList<>();
+        long bytes = 0;
+        for (long block = fromBlock; block <= throughBlock && envelopes.size() < maxBlocks; block++) {
+            Optional<ProjectionEnvelope> envelope = readEnvelope(block, requiredSections);
+            if (envelope.isEmpty()) break;
+            long size = envelope.get().sections().stream().mapToLong(ProjectionSection::byteCount).sum();
+            if (!envelopes.isEmpty() && bytes + size > maxBytes) break;
+            bytes += size;
+            envelopes.add(envelope.get());
+        }
+        return envelopes;
+    }
+
+    // -------------------------------------------------------------- cleanup
+
+    /**
+     * Delete everything through {@code throughBlock} and record acknowledgement.
+     *
+     * <p>Acknowledgement is recorded in the same batch as the deletion, so a crash
+     * cannot leave the outbox claiming data it has already removed. Re-running with the
+     * same argument is harmless.
+     */
+    public void acknowledgeThrough(long throughBlock) {
+        byte[] upper = ProjectionOutboxKeys.blockKey(throughBlock + 1);
+        byte[] lower = ProjectionOutboxKeys.blockKey(0);
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions().setSync(true)) {
+            batch.deleteRange(headerCf, lower, upper);
+            batch.deleteRange(sectionCf, lower, upper);
+            batch.deleteRange(artifactCf, lower, upper);
+            batch.put(metaCf, ProjectionOutboxKeys.META_ACK, ProjectionOutboxKeys.encodeLong(throughBlock));
+            db.write(options, batch);
+        } catch (RocksDBException e) {
+            throw new ProjectionOutboxException("failed to acknowledge projection range", e);
+        }
+    }
+
+    /**
+     * Roll back every pending envelope newer than {@code rollbackSlot}.
+     *
+     * <p>Preferred over {@link #rollbackFrom} at the event boundary. Deriving the cutoff
+     * from a live chain tip read inside a rollback listener is racy: the listener's order
+     * relative to chain-state rollback is unspecified, so a tip read too early leaves
+     * stale envelopes above the surviving tip — precisely the "replacement block at the
+     * same height" case that must not survive. The envelope's own recorded slot is
+     * authoritative and needs no cross-subsystem timing assumption.
+     *
+     * <p>Scans backwards from the newest header and stops at the first envelope at or
+     * below the rollback slot, so the cost is proportional to the rolled-back suffix
+     * rather than to the whole backlog.
+     *
+     * @return the number of envelopes removed
+     */
+    public long rollbackToSlot(long rollbackSlot, Set<ProjectionSectionType> requiredSections) {
+        long firstRemoved = -1;
+        try (RocksIterator it = db.newIterator(headerCf)) {
+            for (it.seekToLast(); it.isValid(); it.prev()) {
+                ProjectionEnvelopeHeader header = ProjectionEnvelopeCodec.decodeHeader(it.value());
+                if (header.slot() <= rollbackSlot) break;
+                firstRemoved = header.blockNumber();
+            }
+        }
+        if (firstRemoved < 0) return 0;
+        long lastBlock = identityCursor();
+        rollbackFrom(firstRemoved, requiredSections);
+        return Math.max(0, lastBlock - firstRemoved + 1);
+    }
+
+    /**
+     * Remove pending envelopes at or above {@code fromBlock} after a rollback, and pull
+     * every contributor cursor back with them.
+     *
+     * <p>Cursors must move back too. Leaving one ahead of the deleted data would make
+     * the outbox believe a block it no longer holds was already contributed, and the
+     * replaced block at that height would never be projected.
+     */
+    public void rollbackFrom(long fromBlock, Set<ProjectionSectionType> requiredSections) {
+        byte[] lower = ProjectionOutboxKeys.blockKey(fromBlock);
+        byte[] upper = ProjectionOutboxKeys.blockKey(Long.MAX_VALUE);
+        long rewound = fromBlock - 1;
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions().setSync(true)) {
+            batch.deleteRange(headerCf, lower, upper);
+            batch.deleteRange(sectionCf, lower, upper);
+            batch.deleteRange(artifactCf, lower, upper);
+            if (identityCursor() > rewound) {
+                batch.put(metaCf, ProjectionOutboxKeys.META_CURSOR_IDENTITY,
+                        ProjectionOutboxKeys.encodeLong(rewound));
+            }
+            for (ProjectionSectionType type : requiredSections) {
+                if (contributorCursor(type) > rewound) {
+                    batch.put(metaCf, ProjectionOutboxKeys.cursorKey(type), ProjectionOutboxKeys.encodeLong(rewound));
+                }
+            }
+            db.write(options, batch);
+        } catch (RocksDBException e) {
+            throw new ProjectionOutboxException("failed to roll back pending projection envelopes", e);
+        }
+    }
+
+    // ------------------------------------------------------------------- metrics
+
+    public ProjectionOutboxStats stats(Set<ProjectionSectionType> requiredSections) {
+        long pendingBlocks = 0;
+        long oldest = -1;
+        try (RocksIterator it = db.newIterator(headerCf)) {
+            for (it.seekToFirst(); it.isValid(); it.next()) {
+                if (oldest < 0) oldest = ProjectionOutboxKeys.blockFromKey(it.key());
+                pendingBlocks++;
+            }
+        }
+        long bytes = 0;
+        long rows = 0;
+        try (RocksIterator it = db.newIterator(sectionCf)) {
+            for (it.seekToFirst(); it.isValid(); it.next()) {
+                byte[] key = it.key();
+                if (key.length == 14 && key[9] == ProjectionOutboxKeys.KIND_MANIFEST) {
+                    ProjectionSectionManifest manifest = ProjectionSectionCodec.decodeManifest(it.value());
+                    rows += manifest.rowCount();
+                } else {
+                    bytes += it.value().length;
+                }
+            }
+        }
+        return new ProjectionOutboxStats(pendingBlocks, bytes, rows, oldest,
+                completeThrough(requiredSections), acknowledgedThrough());
+    }
+
+    public ProjectionCoordinate coordinateOf(ProjectionBatch batch) {
+        var envelopes = batch.envelopes();
+        return ProjectionCoordinate.of(envelopes.get(envelopes.size() - 1).header());
+    }
+
+    private Optional<byte[]> get(ColumnFamilyHandle cf, byte[] key) {
+        try {
+            return Optional.ofNullable(db.get(cf, key));
+        } catch (RocksDBException e) {
+            throw new ProjectionOutboxException("failed to read projection outbox key", e);
+        }
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionPointerResolution.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionPointerResolution.java
@@ -1,0 +1,228 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCoordinate;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCredential;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Resolves pointer-address stake references at <em>capture</em> time, as of the block being
+ * projected, so the sink needs no resolver state and can never fail for lack of it.
+ *
+ * <p>A pointer is valid at block B only if its registration coordinate R still has an active
+ * credential there. The Shelley ledger drops a credential's {@code ptrs} entries when it is
+ * deregistered, so the deciding interval is:
+ *
+ * <pre>R  &lt;  deregistration coordinate  &lt;=  end of block B</pre>
+ *
+ * <p>Two sources are consulted, and the order matters:
+ *
+ * <ol>
+ *   <li>an <strong>in-block overlay</strong> of this block's own certificates, because the
+ *       authoritative store may not have applied them yet when this contributor runs —
+ *       depending on listener order would be fragile;</li>
+ *   <li>the authoritative append-only records, for everything from earlier blocks.</li>
+ * </ol>
+ *
+ * <p>Critically, the overlay is consulted for <em>deregistrations</em> even when the
+ * registration came from the authoritative source. Otherwise a coordinate registered in an
+ * earlier block and deregistered in <em>this</em> one would fall through and wrongly resolve.
+ *
+ * <p>Resolution never consults a coordinate newer than the block being projected. A pointer
+ * address can encode arbitrary numbers, and without that bound a coordinate registered later
+ * in the chain would resolve on replay while being unresolvable on the first pass.
+ */
+public final class ProjectionPointerResolution {
+
+    private static final int CONWAY_ERA = com.bloxbean.cardano.yaci.core.model.Era.Conway.getValue();
+
+    static final String POINTER = "pointer";
+    static final String RESOLVED = "pointer_resolved";
+    static final String UNRESOLVED = "pointer_unresolved";
+    static final String NOT_EFFECTIVE = "pointer_not_effective";
+
+    private ProjectionPointerResolution() {}
+
+    /** One block's certificates, ordered, ready to answer registration and deregistration. */
+    private record Overlay(Map<PointerCoordinate, PointerCredential> registrations,
+                           List<Deregistration> deregistrations) {
+        boolean deregisteredWithin(PointerCredential credential, PointerCoordinate after,
+                                   PointerCoordinate through) {
+            for (Deregistration d : deregistrations) {
+                if (!d.credential().equals(credential)) continue;
+                if (d.at().compareTo(after) > 0 && d.at().compareTo(through) <= 0) return true;
+            }
+            return false;
+        }
+    }
+
+    private record Deregistration(PointerCoordinate at, PointerCredential credential) { }
+
+    public static UtxoHistoryFact resolve(UtxoHistoryFact fact, long blockSlot,
+                                          PointerCredentialSource source) {
+        Objects.requireNonNull(fact, "fact");
+        Objects.requireNonNull(source, "source");
+
+        boolean anyPointer = fact.newAddresses().stream()
+                .anyMatch(address -> POINTER.equals(address.stakeReferenceType()));
+        if (!anyPointer) return fact;
+
+        Overlay overlay = buildOverlay(fact);
+        PointerCoordinate blockEnd = PointerCoordinate.endOfBlock(blockSlot);
+
+        List<UtxoHistoryFact.Address> resolved = new ArrayList<>(fact.newAddresses().size());
+        for (UtxoHistoryFact.Address address : fact.newAddresses()) {
+            resolved.add(resolveAddress(address, fact.era(), blockSlot, blockEnd, overlay, source));
+        }
+        return new UtxoHistoryFact(fact.era(), fact.pointerRegistrations(), fact.pointerDeregistrations(),
+                resolved, fact.outputs(), fact.assets(), fact.inputs(), fact.transactionDatums(),
+                fact.transactionRedeemers());
+    }
+
+    /**
+     * Collect this block's certificates in canonical order.
+     *
+     * <p>Registrations are kept by coordinate and deregistrations as an ordered list rather
+     * than being collapsed. Collapsing would lose the ordering needed for
+     * register / deregister / re-register within one block, where the later registration must
+     * produce a <em>new</em> valid coordinate while the earlier one stays dead.
+     */
+    private static Overlay buildOverlay(UtxoHistoryFact fact) {
+        record Event(int txIndex, int certIndex, UtxoHistoryFact.PointerRegistration registration,
+                     UtxoHistoryFact.PointerDeregistration deregistration) { }
+        List<Event> events = new ArrayList<>();
+        fact.pointerRegistrations().forEach(r -> events.add(new Event(r.txIndex(), r.certIndex(), r, null)));
+        fact.pointerDeregistrations().forEach(d -> events.add(new Event(d.txIndex(), d.certIndex(), null, d)));
+        events.sort(Comparator.comparingInt(Event::txIndex).thenComparingInt(Event::certIndex));
+
+        Map<PointerCoordinate, PointerCredential> registrations = new HashMap<>();
+        List<Deregistration> deregistrations = new ArrayList<>();
+        for (Event event : events) {
+            if (event.registration() != null) {
+                var r = event.registration();
+                registrations.put(new PointerCoordinate(r.slot(), r.txIndex(), r.certIndex()),
+                        credential(r.credentialType(), r.credential()));
+            } else {
+                var d = event.deregistration();
+                // A deregistration's own slot is this block's slot; only tx/cert order distinguishes
+                // it from other events here, and the fact model carries exactly those.
+                deregistrations.add(new Deregistration(
+                        new PointerCoordinate(slotOf(fact), d.txIndex(), d.certIndex()),
+                        credential(d.credentialType(), d.credential())));
+            }
+        }
+        return new Overlay(registrations, deregistrations);
+    }
+
+    /** Deregistration facts carry no slot; every certificate in a block shares the block's slot. */
+    private static long slotOf(UtxoHistoryFact fact) {
+        return fact.pointerRegistrations().isEmpty() ? 0 : fact.pointerRegistrations().get(0).slot();
+    }
+
+    private static UtxoHistoryFact.Address resolveAddress(
+            UtxoHistoryFact.Address address, int era, long blockSlot, PointerCoordinate blockEnd,
+            Overlay overlay, PointerCredentialSource source) {
+
+        if (!POINTER.equals(address.stakeReferenceType())) return address;
+        if (era >= CONWAY_ERA) return copy(address, NOT_EFFECTIVE, null, null);
+
+        Long slot = address.pointerSlot();
+        Integer txIndex = address.pointerTxIndex();
+        Integer certIndex = address.pointerCertIndex();
+        if (slot == null || txIndex == null || certIndex == null) {
+            return copy(address, UNRESOLVED, null, null);
+        }
+        PointerCoordinate registration = new PointerCoordinate(slot, txIndex, certIndex);
+
+        // A coordinate newer than this block can never be its pointer's target.
+        if (registration.compareTo(blockEnd) > 0) return copy(address, UNRESOLVED, null, null);
+
+        PointerCredential credential = overlay.registrations().get(registration);
+        if (credential == null) {
+            credential = source.registrationAt(registration).orElse(null);
+        }
+        if (credential == null) return copy(address, UNRESOLVED, null, null);
+
+        // Deregistration invalidates every older coordinate for that credential. Both sources
+        // are checked: the overlay covers this block, the index covers earlier ones. A
+        // previous-block coordinate deregistered in this block is caught by the overlay and
+        // must not fall through to the append-only registration record.
+        if (overlay.deregisteredWithin(credential, registration, blockEnd)
+                || source.deregisteredWithin(credential, registration, blockEnd)) {
+            return copy(address, UNRESOLVED, null, null);
+        }
+
+        return copy(address, RESOLVED, credentialTypeName(credential.credentialType()),
+                hexToBytes(credential.credentialHash()));
+    }
+
+    /**
+     * Coordinate-level pointer lookup with the same as-of rule the UTXO path uses.
+     *
+     * <p>Exposed so the address-transaction projection resolves pointer stake references
+     * identically rather than growing a second interpretation of the same ledger rule. There is
+     * no in-block overlay here: address participations are resolved per block against
+     * registrations that already exist, and a pointer registered in the very block that spends
+     * to it is not resolvable by the live path either.
+     *
+     * @return the credential, or null when the pointer resolves to nothing — a coordinate newer
+     *         than this block, an unknown registration, or one deregistered by this block
+     */
+    static PointerCredential resolveCoordinate(PointerCoordinate registration, long blockSlot,
+                                               PointerCredentialSource source) {
+        PointerCoordinate blockEnd = PointerCoordinate.endOfBlock(blockSlot);
+        if (registration.compareTo(blockEnd) > 0) return null;
+        PointerCredential credential = source.registrationAt(registration).orElse(null);
+        if (credential == null) return null;
+        if (source.deregisteredWithin(credential, registration, blockEnd)) return null;
+        return credential;
+    }
+
+    /** {@code "key"} / {@code "script"} for a resolved credential; the archive's vocabulary. */
+    static String credentialTypeNameOf(PointerCredential credential) {
+        return credentialTypeName(credential.credentialType());
+    }
+
+    /** Raw credential hash bytes for a resolved credential. */
+    static byte[] credentialHashOf(PointerCredential credential) {
+        return hexToBytes(credential.credentialHash());
+    }
+
+    private static PointerCredential credential(String type, byte[] hash) {
+        return new PointerCredential(credentialTypeCode(type),
+                hash == null ? "" : com.bloxbean.cardano.yaci.core.util.HexUtil.encodeHexString(hash));
+    }
+
+    /**
+     * The account-state store encodes 0 = key hash, 1 = script hash. The projection vocabulary
+     * is {@code "key"}/{@code "script"} — the strings the shipped decoder emits and
+     * {@code StakeAddressCodec} accepts — not the yaci enum names.
+     */
+    private static int credentialTypeCode(String type) {
+        return "script".equalsIgnoreCase(type) || "SCRIPTHASH".equalsIgnoreCase(type) ? 1 : 0;
+    }
+
+    private static String credentialTypeName(int code) {
+        return code == 1 ? "script" : "key";
+    }
+
+    private static byte[] hexToBytes(String hex) {
+        return hex == null || hex.isEmpty() ? null
+                : com.bloxbean.cardano.yaci.core.util.HexUtil.decodeHexString(hex);
+    }
+
+    private static UtxoHistoryFact.Address copy(UtxoHistoryFact.Address source, String referenceType,
+                                                String credentialType, byte[] credential) {
+        return new UtxoHistoryFact.Address(source.addressKey(), source.rawAddress(), source.displayAddress(),
+                source.networkId(), source.addressType(), source.paymentCredentialType(),
+                source.paymentCredential(), referenceType, credentialType, credential,
+                source.pointerSlot(), source.pointerTxIndex(), source.pointerCertIndex());
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionRetentionHealth.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionRetentionHealth.java
@@ -1,0 +1,64 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Retention-health assertion of ADR-039 §6 and invariant 14:
+ *
+ * <pre>runtime common rollback floor &lt;= oldest active required slot</pre>
+ *
+ * <p>A <em>lower</em> floor means <em>more</em> replay capability, so this is a
+ * precondition rather than a term in eligibility. Equality is an exhaustion warning;
+ * a greater floor means required replay data was already lost, and the correct
+ * response is a visible fail-closed pause — never narrowing archive eligibility,
+ * skipping the affected work, or pruning the required source.
+ */
+public record ProjectionRetentionHealth(Status status, long commonRollbackFloorSlot,
+                                        long oldestActiveRequiredSlot, Optional<String> detail) {
+
+    public enum Status {
+        /** Floor is safely below every active requirement. */
+        HEALTHY,
+        /** Floor has reached the oldest requirement; the next prune would cross it. */
+        EXHAUSTED,
+        /** Floor has passed a requirement: replay data required by pending work is gone. */
+        VIOLATED
+    }
+
+    public ProjectionRetentionHealth {
+        Objects.requireNonNull(status, "status");
+        Objects.requireNonNull(detail, "detail");
+    }
+
+    /**
+     * @param commonRollbackFloorSlot max of {@code RollbackCapableStore.getRollbackFloorSlot()};
+     *                                0 means unbounded retention
+     * @param oldestActiveRequiredSlot oldest slot any pending envelope, artifact reference or
+     *                                 recomputation input closure still requires, or -1 when
+     *                                 nothing is pending
+     */
+    public static ProjectionRetentionHealth evaluate(long commonRollbackFloorSlot, long oldestActiveRequiredSlot) {
+        if (oldestActiveRequiredSlot < 0) {
+            return new ProjectionRetentionHealth(Status.HEALTHY, commonRollbackFloorSlot,
+                    oldestActiveRequiredSlot, Optional.empty());
+        }
+        if (commonRollbackFloorSlot < oldestActiveRequiredSlot) {
+            return new ProjectionRetentionHealth(Status.HEALTHY, commonRollbackFloorSlot,
+                    oldestActiveRequiredSlot, Optional.empty());
+        }
+        if (commonRollbackFloorSlot == oldestActiveRequiredSlot) {
+            return new ProjectionRetentionHealth(Status.EXHAUSTED, commonRollbackFloorSlot, oldestActiveRequiredSlot,
+                    Optional.of("retention margin exhausted at slot " + oldestActiveRequiredSlot
+                            + "; the next prune would remove data pending projection work still requires"));
+        }
+        return new ProjectionRetentionHealth(Status.VIOLATED, commonRollbackFloorSlot, oldestActiveRequiredSlot,
+                Optional.of("common rollback floor " + commonRollbackFloorSlot
+                        + " has passed the oldest active required slot " + oldestActiveRequiredSlot
+                        + "; required replay data was lost under a lagging sink"));
+    }
+
+    public boolean allowsProgress() {
+        return status != Status.VIOLATED;
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionRowBuilder.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionRowBuilder.java
@@ -1,0 +1,201 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.ArchiveJob;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRangeAnchor;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.BlockRange;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionRowBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.core.dataset.ArchiveBlockFacts;
+import com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext;
+import com.bloxbean.cardano.yano.archive.core.dataset.StandardBlockDatasets;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryDataset;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Materialises a projection batch into archive rows, once, for every backend.
+ *
+ * <p>Rows are derived through the same {@code BlockArchiveDataset} implementations the
+ * existing archive path uses. Keeping one derivation is what makes the differential
+ * parity gate meaningful: DuckLake and SQLite cannot disagree about what a block means,
+ * because neither of them decides.
+ */
+public final class ProjectionRowBuilder {
+
+    private ProjectionRowBuilder() {}
+
+    /**
+     * Present a batch as a lazily materialised row stream.
+     *
+     * <p>Rows for one envelope are derived, handed to the consumer, and discarded before the
+     * next envelope is touched. Peak heap is therefore bounded by the largest single block,
+     * not by batch size — which is what makes the configured memory ceiling a real bound
+     * rather than a nominal one, and lets an oversized single envelope be processed instead
+     * of either deadlocking the consumer or blowing the heap.
+     */
+    public static ProjectionRowBatch materialise(ProjectionBatch batch) {
+        Iterable<ArchiveRow> rows = new SingleUseRowSource(batch.envelopes());
+        return new ProjectionRowBatch(batch.identity(), batch.firstBlock(), batch.lastBlock(),
+                batch.blockCount(), batch.firstEnvelopeId(), batch.lastEnvelopeId(),
+                batch.orderedDigest(), rows, batch.artifacts());
+    }
+
+    /**
+     * Walks envelopes in canonical order, holding at most one envelope's rows at a time.
+     *
+     * <p><strong>Single-use.</strong> A sink iterates exactly once and accumulates its receipt
+     * row counts during that pass. A second {@code iterator()} call throws rather than
+     * silently replaying: a partially consumed source would otherwise yield a short or
+     * duplicated second pass that looks like valid data. After a failure the caller
+     * re-materialises from the still-unacknowledged outbox batch, which is durable, so a fresh
+     * stream is always obtainable without reusing a spent one.
+     */
+    /** Enforces single use; see {@link #materialise}. */
+    private static final class SingleUseRowSource implements Iterable<ArchiveRow> {
+        private final List<ProjectionEnvelope> envelopes;
+        private final java.util.concurrent.atomic.AtomicBoolean consumed =
+                new java.util.concurrent.atomic.AtomicBoolean();
+
+        SingleUseRowSource(List<ProjectionEnvelope> envelopes) {
+            this.envelopes = envelopes;
+        }
+
+        @Override
+        public java.util.Iterator<ArchiveRow> iterator() {
+            if (!consumed.compareAndSet(false, true)) {
+                throw new IllegalStateException("projection row stream is single-use; re-materialise the"
+                        + " batch from the outbox instead of iterating a partially consumed source");
+            }
+            return new StreamingRowIterator(envelopes);
+        }
+    }
+
+    private static final class StreamingRowIterator implements java.util.Iterator<ArchiveRow> {
+        private final List<ProjectionEnvelope> envelopes;
+        private int nextEnvelope;
+        private List<ArchiveRow> buffer = List.of();
+        private int nextRow;
+
+        StreamingRowIterator(List<ProjectionEnvelope> envelopes) {
+            this.envelopes = envelopes;
+        }
+
+        @Override
+        public boolean hasNext() {
+            while (nextRow >= buffer.size()) {
+                if (nextEnvelope >= envelopes.size()) return false;
+                List<ArchiveRow> next = new ArrayList<>();
+                appendRows(envelopes.get(nextEnvelope++), next);
+                buffer = next;
+                nextRow = 0;
+            }
+            return true;
+        }
+
+        @Override
+        public ArchiveRow next() {
+            if (!hasNext()) throw new java.util.NoSuchElementException();
+            return buffer.get(nextRow++);
+        }
+    }
+
+    /**
+     * Derive one envelope's rows.
+     *
+     * <p>Section payloads are read through {@link ProjectionChunkedInput}, so the encoded bytes
+     * are never concatenated into a second copy. Transaction facts are streamed and released
+     * one at a time. The utxo-history fact is decoded whole because row derivation resolves
+     * each output's address through a map built from the section's address list — outputs
+     * cannot be emitted before the addresses are known.
+     *
+     * <p>That retained size is bounded by the protocol rather than by configuration: a section
+     * derives from exactly one block, and Cardano caps block body size, so peak heap here is
+     * one block's decoded facts. Batch size no longer contributes, which is what makes the
+     * configured memory ceiling a real bound and lets an oversized single envelope be
+     * processed rather than deadlocking the consumer.
+     */
+    private static void appendRows(ProjectionEnvelope envelope, List<ArchiveRow> rows) {
+        var header = envelope.header();
+        long blockNumber = header.blockNumber();
+        byte[] blockHash = header.blockHash();
+        byte[] parentHash = header.parentHash();
+        Instant blockTime = Instant.ofEpochSecond(header.blockTime());
+
+        envelope.section(ProjectionSectionType.TRANSACTION).ifPresent(section -> {
+            List<com.bloxbean.cardano.yano.archive.core.dataset.TransactionFact> facts = new ArrayList<>();
+            ProjectionFactCodec.streamTransactions(section.chunks(), facts::add);
+            StandardBlockDatasets.transactions().derive(
+                    job(ArchiveDatasetId.TRANSACTION, envelope),
+                    new BlockSourceContext<>(blockNumber, header.slot(), header.epoch(), blockTime,
+                            blockHash, parentHash, new ArchiveBlockFacts(facts, List.of())),
+                    rows::add);
+        });
+
+        envelope.section(ProjectionSectionType.ACCOUNT_EVENT).ifPresent(section -> {
+            List<com.bloxbean.cardano.yano.archive.core.dataset.AccountEventFact> facts = new ArrayList<>();
+            ProjectionFactCodec.streamAccountEvents(section.chunks(), facts::add);
+            StandardBlockDatasets.accountEvents().derive(
+                    job(ArchiveDatasetId.ACCOUNT_EVENT, envelope),
+                    new BlockSourceContext<>(blockNumber, header.slot(), header.epoch(), blockTime,
+                            blockHash, parentHash, new ArchiveBlockFacts(List.of(), facts)),
+                    rows::add);
+        });
+
+        envelope.section(ProjectionSectionType.ADDRESS_TRANSACTION).ifPresent(section -> {
+            // One transaction at a time: row emission groups by subject across a whole
+            // transaction, so that is the smallest unit that can be materialised, and it is
+            // protocol-bounded. Rows come from the same accumulator the live path uses.
+            var job = job(ArchiveDatasetId.ADDRESS_TRANSACTION, envelope);
+            ProjectionFactCodec.streamAddressParticipations(section.chunks(), tx -> {
+                var accumulator = new com.bloxbean.cardano.yano.archive.core.dataset.AddressSubjectRows(
+                        com.bloxbean.cardano.yano.archive.core.dataset.AddressTransactionSubjects.all(),
+                        header.networkIdentity().networkMagic());
+                for (var participation : tx.participations()) {
+                    accumulator.add(participation.participant(),
+                            com.bloxbean.cardano.yano.archive.core.dataset.AddressSubjectRows.Role
+                                    .valueOf(participation.role()));
+                }
+                accumulator.emit(tx.txHash(), tx.txIndex(), blockHash, blockNumber, header.slot(),
+                        header.epoch(), header.blockTime(), job.jobId(), rows::add);
+            });
+        });
+
+        envelope.section(ProjectionSectionType.UTXO_HISTORY).ifPresent(section -> {
+            UtxoHistoryFact fact = ProjectionFactCodec.decodeUtxoHistory(section.chunks());
+            new UtxoHistoryDataset().derive(
+                    job(ArchiveDatasetId.UTXO_HISTORY, envelope),
+                    new BlockSourceContext<>(blockNumber, header.slot(), header.epoch(), blockTime,
+                            blockHash, parentHash, fact),
+                    rows::add);
+        });
+    }
+
+    /**
+     * Deterministic per-envelope job identity. The archive_job_id column therefore stays
+     * reproducible on replay: the same canonical block always yields the same job.
+     */
+    private static ArchiveJob job(ArchiveDatasetId dataset, ProjectionEnvelope envelope) {
+        var header = envelope.header();
+        long blockNumber = header.blockNumber();
+        return ArchiveJob.deterministic(header.networkIdentity(), dataset,
+                header.canonicalProjectionVersion(), new BlockRange(blockNumber, blockNumber),
+                new ArchiveRangeAnchor(header.slot(), header.blockHash(), header.slot(), header.blockHash()),
+                "projection-v" + header.canonicalProjectionVersion());
+    }
+
+    /** Total bytes of section payload in a batch, for bounds and metrics. */
+    public static long payloadBytes(ProjectionBatch batch) {
+        return batch.envelopes().stream()
+                .flatMap(e -> e.sections().stream())
+                .mapToLong(ProjectionSection::byteCount)
+                .sum();
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionSectionCodec.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionSectionCodec.java
@@ -1,0 +1,101 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRepresentation;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionManifest;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.OptionalLong;
+
+/** Deterministic encoding for per-section manifests and artifact references. */
+final class ProjectionSectionCodec {
+    private static final int MANIFEST_FORMAT = 1;
+    private static final int ARTIFACT_FORMAT = 1;
+
+    private ProjectionSectionCodec() {}
+
+    static byte[] encodeManifest(ProjectionSectionManifest manifest) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            out.writeByte(MANIFEST_FORMAT);
+            out.writeByte(manifest.type().code());
+            out.writeInt(manifest.version());
+            out.writeInt(manifest.chunkCount());
+            out.writeLong(manifest.rowCount());
+            out.writeLong(manifest.byteCount());
+            out.writeUTF(manifest.digest());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode section manifest", e);
+        }
+        return bytes.toByteArray();
+    }
+
+    static ProjectionSectionManifest decodeManifest(byte[] encoded) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(encoded))) {
+            int format = in.readUnsignedByte();
+            if (format != MANIFEST_FORMAT) {
+                throw new IllegalArgumentException("unsupported section manifest format " + format);
+            }
+            ProjectionSectionType type = ProjectionSectionType.fromCode(in.readUnsignedByte());
+            return new ProjectionSectionManifest(type, in.readInt(), in.readInt(), in.readLong(),
+                    in.readLong(), in.readUTF());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode section manifest", e);
+        }
+    }
+
+    static byte[] encodeArtifact(ProjectionArtifactRef ref) {
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+        try (DataOutputStream out = new DataOutputStream(bytes)) {
+            out.writeByte(ARTIFACT_FORMAT);
+            out.writeUTF(ref.dataset().name());
+            out.writeInt(ref.semanticEpoch());
+            out.writeLong(ref.producingBlockNumber());
+            out.writeLong(ref.producingSlot());
+            out.writeUTF(ref.representation().name());
+            out.writeUTF(ref.sourceGeneration());
+            out.writeInt(ref.sourceCodecVersion());
+            out.writeUTF(ref.sourceStateVersion());
+            out.writeBoolean(ref.expectedRowCount().isPresent());
+            out.writeLong(ref.expectedRowCount().orElse(0L));
+            out.writeUTF(ref.contentDigest());
+            out.writeLong(ref.oldestRequiredSlot());
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to encode artifact reference", e);
+        }
+        return bytes.toByteArray();
+    }
+
+    static ProjectionArtifactRef decodeArtifact(byte[] encoded) {
+        try (DataInputStream in = new DataInputStream(new ByteArrayInputStream(encoded))) {
+            int format = in.readUnsignedByte();
+            if (format != ARTIFACT_FORMAT) {
+                throw new IllegalArgumentException("unsupported artifact reference format " + format);
+            }
+            ArchiveDatasetId dataset = ArchiveDatasetId.valueOf(in.readUTF());
+            int semanticEpoch = in.readInt();
+            long producingBlock = in.readLong();
+            long producingSlot = in.readLong();
+            ProjectionArtifactRepresentation representation = ProjectionArtifactRepresentation.valueOf(in.readUTF());
+            String generation = in.readUTF();
+            int codecVersion = in.readInt();
+            String stateVersion = in.readUTF();
+            boolean hasRowCount = in.readBoolean();
+            long rowCount = in.readLong();
+            String digest = in.readUTF();
+            long oldestRequiredSlot = in.readLong();
+            return new ProjectionArtifactRef(dataset, semanticEpoch, producingBlock, producingSlot,
+                    representation, generation, codecVersion, stateVersion,
+                    hasRowCount ? OptionalLong.of(rowCount) : OptionalLong.empty(), digest, oldestRequiredSlot);
+        } catch (IOException e) {
+            throw new UncheckedIOException("failed to decode artifact reference", e);
+        }
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionSinkLifecycle.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionSinkLifecycle.java
@@ -1,0 +1,97 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSink;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Function;
+
+/**
+ * Guarantees a sink is never closed while it is being used.
+ *
+ * <p>The obvious shutdown - stop the loop, interrupt the thread, close the sink - is wrong in a
+ * way that is easy to miss and hard to reproduce: interrupting does not abort a JDBC call, so the
+ * close can land while a commit is still in flight and tear the connection down mid transaction.
+ * Waiting first and then closing anyway is <em>also</em> wrong; it narrows the race without
+ * removing it, and a log line saying the wait expired is not a substitute for not doing it.
+ *
+ * <p>So the sink is only ever touched while this lock is held, and shutdown closes it only if it
+ * can take that same lock. If it cannot, the sink stays open and the process exits with it open,
+ * which the operating system reclaims. An incomplete shutdown is a visible, recoverable event -
+ * the outbox is durable and an unacknowledged commit replays - whereas concurrent close is
+ * undefined behaviour inside the database driver.
+ *
+ * <p><strong>The wait will sometimes expire, by design.</strong> A bounded maintenance pass may
+ * legitimately run for the housekeeping budget plus the compaction budget - 30 s + 300 s at the
+ * defaults - which is far longer than any sensible shutdown wait. Shutdown does not try to
+ * outlast it; it declines to close instead.
+ */
+public final class ProjectionSinkLifecycle implements AutoCloseable {
+
+    private final ProjectionSink sink;
+    private final ReentrantLock inUse = new ReentrantLock();
+    private volatile boolean closed;
+
+    public ProjectionSinkLifecycle(ProjectionSink sink) {
+        this.sink = Objects.requireNonNull(sink, "sink");
+    }
+
+    /**
+     * Run one operation against the sink, holding the lock for its duration.
+     *
+     * @throws IllegalStateException if the sink has already been closed, which would otherwise
+     *                               surface as a driver-level error at an arbitrary later point
+     */
+    public <T> T use(Function<ProjectionSink, T> operation) {
+        inUse.lock();
+        try {
+            if (closed) throw new IllegalStateException("projection sink is closed");
+            return operation.apply(sink);
+        } finally {
+            inUse.unlock();
+        }
+    }
+
+    /** Whether an operation is in flight; for diagnostics and tests, never for control flow. */
+    public boolean busy() {
+        return inUse.isLocked();
+    }
+
+    public boolean isClosed() {
+        return closed;
+    }
+
+    /**
+     * Close the sink, but only once nothing is using it.
+     *
+     * @param wait how long to wait for the in-flight operation to finish
+     * @return true if the sink was closed; false if it is still in use and was deliberately left
+     *         open, which the caller should report as an incomplete shutdown
+     */
+    public boolean closeWhenIdle(Duration wait) {
+        boolean acquired = false;
+        try {
+            acquired = inUse.tryLock(wait.toMillis(), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        if (!acquired) return false;
+        try {
+            if (!closed) {
+                closed = true;
+                sink.close();
+            }
+            return true;
+        } finally {
+            inUse.unlock();
+        }
+    }
+
+    /** Unconditional close, for callers that already know nothing is using the sink. */
+    @Override
+    public void close() {
+        closeWhenIdle(Duration.ZERO);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuard.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuard.java
@@ -23,13 +23,30 @@ import java.util.stream.Collectors;
 public final class ProjectionStartupGuard {
 
     /** Observed state of the node and its configured sink at startup. */
+    /**
+     * @param outboxAcknowledgedThrough the highest block the outbox has already handed to a sink
+     *                                  and pruned, or -1 when nothing has been acknowledged. This
+     *                                  is the number that makes an empty sink dangerous: the
+     *                                  outbox no longer holds those blocks, so if the sink does
+     *                                  not either, they exist nowhere.
+     */
     public record Observed(long canonicalTipBlockNumber,
                            boolean outboxHasProjectionIdentity,
                            Optional<ProjectionIdentity> outboxIdentity,
                            boolean sinkEmpty,
                            Optional<ProjectionIdentity> sinkIdentity,
                            ProjectionCoordinate sinkCoordinate,
-                           Set<ProjectionSectionType> sinkReadableSections) {
+                           Set<ProjectionSectionType> sinkReadableSections,
+                           long outboxAcknowledgedThrough) {
+
+        /** Legacy shape for callers with nothing acknowledged yet. */
+        public Observed(long canonicalTipBlockNumber, boolean outboxHasProjectionIdentity,
+                        Optional<ProjectionIdentity> outboxIdentity, boolean sinkEmpty,
+                        Optional<ProjectionIdentity> sinkIdentity, ProjectionCoordinate sinkCoordinate,
+                        Set<ProjectionSectionType> sinkReadableSections) {
+            this(canonicalTipBlockNumber, outboxHasProjectionIdentity, outboxIdentity, sinkEmpty,
+                    sinkIdentity, sinkCoordinate, sinkReadableSections, -1L);
+        }
         public Observed {
             Objects.requireNonNull(outboxIdentity, "outboxIdentity");
             Objects.requireNonNull(sinkIdentity, "sinkIdentity");
@@ -79,6 +96,21 @@ public final class ProjectionStartupGuard {
         }
 
         if (observed.sinkEmpty()) {
+            // The case that silently loses history: the outbox has already acknowledged blocks
+            // and pruned them, so an empty sink means those blocks exist nowhere. It happens
+            // when the history directory is deleted or repointed while the chainstate is kept -
+            // draining would resume after the acknowledged point and every earlier block would
+            // be permanently missing, with the archive reporting itself healthy.
+            if (observed.outboxAcknowledgedThrough() >= 0) {
+                throw new ProjectionActivationException(
+                        "the outbox has acknowledged blocks through " + observed.outboxAcknowledgedThrough()
+                                + " but the configured sink is empty. Those blocks have been pruned from"
+                                + " the outbox, so resuming would leave 0.."
+                                + observed.outboxAcknowledgedThrough() + " permanently missing from the"
+                                + " archive. This usually means the history directory was deleted or"
+                                + " repointed while the chainstate was kept: restore the archive it"
+                                + " belongs to, or start a fresh sync with a fresh chainstate.");
+            }
             if (observed.sinkCoordinate().isPresent()) {
                 throw new ProjectionActivationException(
                         "configured sink reports itself empty but exposes a committed coordinate at block "
@@ -98,6 +130,18 @@ public final class ProjectionStartupGuard {
             throw new ProjectionActivationException("archive identity mismatch: node is configured for "
                     + expected.fingerprint() + " but the archive was written by " + sink.fingerprint());
         }
+        // A sink behind the acknowledgement has lost committed data, or is a different archive.
+        // Either way the gap between them cannot be refilled: the outbox pruned those blocks when
+        // it acknowledged them.
+        if (observed.outboxAcknowledgedThrough() >= 0 && observed.sinkCoordinate().isPresent()
+                && observed.sinkCoordinate().blockNumber() < observed.outboxAcknowledgedThrough()) {
+            throw new ProjectionActivationException(
+                    "the sink is at block " + observed.sinkCoordinate().blockNumber()
+                            + " but the outbox acknowledged through " + observed.outboxAcknowledgedThrough()
+                            + "; the blocks between them were pruned on acknowledgement and cannot be"
+                            + " replayed. The sink and the chainstate are not from the same archive.");
+        }
+
         if (freshChain && observed.sinkCoordinate().isPresent()) {
             throw new ProjectionActivationException(
                     "a fresh chainstate cannot adopt an archive that already covers blocks through "

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuard.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuard.java
@@ -1,0 +1,107 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+/**
+ * Enforces the fresh-sync identity invariant before any projection work is accepted
+ * (ADR-039 §1, invariant 12).
+ *
+ * <p>The rule this encodes is that partial history must never be presented as complete
+ * history. Enabling history on a chainstate that has already advanced would produce an
+ * archive whose coverage begins mid-chain while its metadata claims genesis, and no
+ * later check could distinguish that from a legitimately complete archive. Refusing at
+ * startup is the only point where the difference is still visible.
+ */
+public final class ProjectionStartupGuard {
+
+    /** Observed state of the node and its configured sink at startup. */
+    public record Observed(long canonicalTipBlockNumber,
+                           boolean outboxHasProjectionIdentity,
+                           Optional<ProjectionIdentity> outboxIdentity,
+                           boolean sinkEmpty,
+                           Optional<ProjectionIdentity> sinkIdentity,
+                           ProjectionCoordinate sinkCoordinate,
+                           Set<ProjectionSectionType> sinkReadableSections) {
+        public Observed {
+            Objects.requireNonNull(outboxIdentity, "outboxIdentity");
+            Objects.requireNonNull(sinkIdentity, "sinkIdentity");
+            Objects.requireNonNull(sinkCoordinate, "sinkCoordinate");
+            sinkReadableSections = Set.copyOf(Objects.requireNonNull(sinkReadableSections, "sinkReadableSections"));
+        }
+    }
+
+    private ProjectionStartupGuard() {}
+
+    /**
+     * @param expected the identity this node is configured to produce
+     * @param observed what the chainstate, outbox and sink actually contain
+     * @throws ProjectionActivationException on any unsupported or mismatched start
+     */
+    public static void verify(ProjectionIdentity expected, Observed observed) {
+        Objects.requireNonNull(expected, "expected");
+        Objects.requireNonNull(observed, "observed");
+
+        // A required section the sink cannot write is a startup error, never a silent
+        // omission: the alternative is acknowledging envelopes that drop it.
+        Set<ProjectionSectionType> missing = expected.requiredSections().stream()
+                .filter(section -> !observed.sinkReadableSections().contains(section))
+                .collect(Collectors.toCollection(TreeSet::new));
+        if (!missing.isEmpty()) {
+            throw new ProjectionActivationException("configured sink cannot serve required projection section(s): "
+                    + missing.stream().map(ProjectionSectionType::wireName).collect(Collectors.joining(", ")));
+        }
+
+        boolean freshChain = observed.canonicalTipBlockNumber() <= 0;
+
+        if (observed.outboxHasProjectionIdentity()) {
+            ProjectionIdentity stored = observed.outboxIdentity().orElseThrow(() ->
+                    new ProjectionActivationException("outbox reports a projection identity but none could be read"));
+            if (!expected.matches(stored)) {
+                throw new ProjectionActivationException("projection identity mismatch: node is configured for "
+                        + expected.fingerprint() + " but the outbox was written by " + stored.fingerprint());
+            }
+        } else if (!freshChain) {
+            // Chain has advanced with no projection identity recorded: this is exactly
+            // mid-chain activation, and the blocks already applied have no envelopes.
+            throw new ProjectionActivationException(
+                    "history cannot be enabled mid-chain: canonical tip is at block "
+                            + observed.canonicalTipBlockNumber()
+                            + " but no projection identity exists. Projection history must be enabled from genesis;"
+                            + " start a fresh sync or use a coordinated snapshot that includes projection metadata");
+        }
+
+        if (observed.sinkEmpty()) {
+            if (observed.sinkCoordinate().isPresent()) {
+                throw new ProjectionActivationException(
+                        "configured sink reports itself empty but exposes a committed coordinate at block "
+                                + observed.sinkCoordinate().blockNumber());
+            }
+            if (!freshChain && !observed.outboxHasProjectionIdentity()) {
+                throw new ProjectionActivationException(
+                        "an existing chainstate cannot adopt an empty archive: canonical tip is at block "
+                                + observed.canonicalTipBlockNumber());
+            }
+            return;
+        }
+
+        ProjectionIdentity sink = observed.sinkIdentity().orElseThrow(() ->
+                new ProjectionActivationException("configured sink is non-empty but exposes no projection identity"));
+        if (!expected.matches(sink)) {
+            throw new ProjectionActivationException("archive identity mismatch: node is configured for "
+                    + expected.fingerprint() + " but the archive was written by " + sink.fingerprint());
+        }
+        if (freshChain && observed.sinkCoordinate().isPresent()) {
+            throw new ProjectionActivationException(
+                    "a fresh chainstate cannot adopt an archive that already covers blocks through "
+                            + observed.sinkCoordinate().blockNumber());
+        }
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/BoundedDecodeCache.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/BoundedDecodeCache.java
@@ -1,0 +1,79 @@
+package com.bloxbean.cardano.yano.archive.core.source;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Bounded memoisation for one block's address decoding.
+ *
+ * <p>Three properties matter, and each is a deliberate choice rather than a default:
+ *
+ * <ul>
+ *   <li><strong>Bounded.</strong> Entries stop being admitted once {@code maxEntries} is
+ *       reached. A block with pathologically many distinct addresses degrades to the
+ *       uncached path instead of growing without limit.</li>
+ *   <li><strong>No eviction.</strong> Admission simply stops; nothing is ever evicted. That
+ *       removes eviction order as a variable entirely, so the decoded output cannot depend
+ *       on which entries a policy happened to keep. A cache that evicted could, in
+ *       principle, produce different work orders; this one cannot.</li>
+ *   <li><strong>Thread-confined.</strong> One instance belongs to one decode call on one
+ *       thread and is discarded with it. It is deliberately not synchronised: sharing an
+ *       instance across threads is a programming error, not a supported mode, and one
+ *       decoder object may legitimately serve two worker threads with separate caches.</li>
+ * </ul>
+ *
+ * <p>Memoisation cannot change results: it returns the value the same pure function would
+ * have computed. Counters exist so that claim is observable rather than assumed.
+ */
+final class BoundedDecodeCache<V> {
+
+    /** Distinct addresses per block are normally in the low hundreds; this is headroom. */
+    static final int DEFAULT_MAX_ENTRIES = 4_096;
+
+    private final int maxEntries;
+    private final Map<String, V> entries;
+
+    private long hits;
+    private long misses;
+    private long admissionsSkipped;
+
+    BoundedDecodeCache(int maxEntries) {
+        if (maxEntries < 0) throw new IllegalArgumentException("maxEntries must not be negative");
+        this.maxEntries = maxEntries;
+        this.entries = maxEntries == 0 ? Map.of() : new HashMap<>(Math.min(maxEntries, 256));
+    }
+
+    V get(String key) {
+        if (maxEntries == 0) {
+            misses++;
+            return null;
+        }
+        V value = entries.get(key);
+        if (value == null) misses++;
+        else hits++;
+        return value;
+    }
+
+    void put(String key, V value) {
+        if (maxEntries == 0) return;
+        if (entries.size() >= maxEntries) {
+            admissionsSkipped++;
+            return;
+        }
+        entries.put(key, value);
+    }
+
+    long hits() { return hits; }
+
+    long misses() { return misses; }
+
+    /** Lookups that could not be admitted because the bound was reached. */
+    long admissionsSkipped() { return admissionsSkipped; }
+
+    int size() { return entries.size(); }
+
+    /** A cache with no capacity: every lookup misses. Used to prove caching changes nothing. */
+    static <V> BoundedDecodeCache<V> disabled() {
+        return new BoundedDecodeCache<>(0);
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/ByronBlockNormalizer.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/ByronBlockNormalizer.java
@@ -1,0 +1,83 @@
+package com.bloxbean.cardano.yano.archive.core.source;
+
+import com.bloxbean.cardano.yaci.core.model.Amount;
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.BlockHeader;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.HeaderBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionInput;
+import com.bloxbean.cardano.yaci.core.model.TransactionOutput;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlock;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronMainBlock;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+
+import java.util.LinkedHashSet;
+import java.util.List;
+
+/**
+ * Maps a decoded Byron block into the Shelley {@link Block} model the projection code
+ * expects.
+ *
+ * <p>This is the normalizer ADR-039 requires be <em>retained</em> rather than deleted
+ * with the replay workers: it is the only path by which roughly a third of mainnet
+ * becomes projectable, and under ADR-039 it runs against an already-decoded block from
+ * the projection carrier instead of re-parsing stored CBOR.
+ *
+ * <p>The mapping is deliberately lossy in exactly the ways Byron is a strict subset:
+ *
+ * <ul>
+ *   <li>no fee is set, so {@code chain_transaction.fee} is {@code NULL} — Byron's
+ *       transaction body genuinely does not carry one, and the column is nullable;</li>
+ *   <li>addresses keep their raw base58 representation;</li>
+ *   <li>there are no invalid transactions, collateral, reference inputs, datums,
+ *       redeemers, multi-asset values, or pointer addresses;</li>
+ *   <li>an epoch-boundary block normalises to zero transactions while keeping its block
+ *       number and parent, which is what lets it emit an empty envelope.</li>
+ * </ul>
+ */
+public final class ByronBlockNormalizer {
+
+    private ByronBlockNormalizer() {}
+
+    public static Block normalizeMain(ByronMainBlock byron, long blockNumber, byte[] blockHash) {
+        List<TransactionBody> transactions =
+                byron.getBody() == null || byron.getBody().getTxPayload() == null
+                        ? List.of()
+                        : byron.getBody().getTxPayload().stream().map(payload -> {
+                            var tx = payload.getTransaction();
+                            var inputs = tx.getInputs() == null ? List.<TransactionInput>of()
+                                    : tx.getInputs().stream().map(input -> TransactionInput.builder()
+                                            .transactionId(input.getTxId()).index(input.getIndex()).build()).toList();
+                            var outputs = tx.getOutputs() == null ? List.<TransactionOutput>of()
+                                    : tx.getOutputs().stream().map(output -> TransactionOutput.builder()
+                                            .address(output.getAddress().getBase58Raw())
+                                            .amounts(List.of(Amount.builder()
+                                                    .unit("lovelace").quantity(output.getAmount()).build()))
+                                            .build()).toList();
+                            return TransactionBody.builder()
+                                    .txHash(tx.getTxHash())
+                                    .inputs(new LinkedHashSet<>(inputs))
+                                    .outputs(outputs)
+                                    .build();
+                        }).toList();
+        return block(blockNumber, byron.getHeader().getConsensusData().getAbsoluteSlot(),
+                byron.getHeader().getPrevBlock(), blockHash, transactions);
+    }
+
+    public static Block normalizeEpochBoundary(ByronEbBlock ebb, long blockNumber, byte[] blockHash) {
+        return block(blockNumber, ebb.getHeader().getConsensusData().getAbsoluteSlot(),
+                ebb.getHeader().getPrevBlock(), blockHash, List.of());
+    }
+
+    static Block block(long blockNumber, long slot, String parentHash, byte[] blockHash,
+                       List<TransactionBody> transactions) {
+        var header = BlockHeader.builder()
+                .headerBody(HeaderBody.builder()
+                        .blockNumber(blockNumber).slot(slot).prevHash(parentHash)
+                        .blockHash(HexUtil.encodeHexString(blockHash)).build())
+                .build();
+        return Block.builder().era(Era.Byron).header(header).transactionBodies(transactions)
+                .transactionWitness(List.of()).invalidTransactions(List.of()).build();
+    }
+}

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/YaciBlockDecoder.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/YaciBlockDecoder.java
@@ -56,47 +56,18 @@ public final class YaciBlockDecoder implements CanonicalBlockDecoder<Block> {
         }
     }
 
+    /**
+     * Decodes stored Byron CBOR. The mapping itself lives in {@link ByronBlockNormalizer}
+     * so the replay path and the ADR-039 projection carrier share one definition of what
+     * a normalized Byron block is, and cannot drift apart.
+     */
     private Block decodeByron(byte[] body, long blockNumber, CanonicalBlockReference reference) {
         try {
             var byron = ByronBlockSerializer.INSTANCE.deserialize(body);
-            List<com.bloxbean.cardano.yaci.core.model.TransactionBody> transactions =
-                    byron.getBody() == null || byron.getBody().getTxPayload() == null
-                    ? List.<com.bloxbean.cardano.yaci.core.model.TransactionBody>of()
-                    : byron.getBody().getTxPayload().stream().map(payload -> {
-                        var tx = payload.getTransaction();
-                        var inputs = tx.getInputs() == null ? List.<com.bloxbean.cardano.yaci.core.model.TransactionInput>of()
-                                : tx.getInputs().stream().map(input ->
-                                com.bloxbean.cardano.yaci.core.model.TransactionInput.builder()
-                                        .transactionId(input.getTxId()).index(input.getIndex()).build()).toList();
-                        var outputs = tx.getOutputs() == null ? List.<com.bloxbean.cardano.yaci.core.model.TransactionOutput>of()
-                                : tx.getOutputs().stream().map(output ->
-                                com.bloxbean.cardano.yaci.core.model.TransactionOutput.builder()
-                                        .address(output.getAddress().getBase58Raw())
-                                        .amounts(List.of(com.bloxbean.cardano.yaci.core.model.Amount.builder()
-                                                .unit("lovelace").quantity(output.getAmount()).build()))
-                                        .build()).toList();
-                        return com.bloxbean.cardano.yaci.core.model.TransactionBody.builder()
-                                .txHash(tx.getTxHash()).inputs(new java.util.LinkedHashSet<>(inputs))
-                                .outputs(outputs).build();
-                    }).toList();
-            long slot = byron.getHeader().getConsensusData().getAbsoluteSlot();
-            return byronBlock(blockNumber, slot, byron.getHeader().getPrevBlock(), reference, transactions);
+            return ByronBlockNormalizer.normalizeMain(byron, blockNumber, reference.blockHash());
         } catch (Exception notMainBlock) {
             var ebb = ByronEbBlockSerializer.INSTANCE.deserialize(body);
-            long slot = ebb.getHeader().getConsensusData().getAbsoluteSlot();
-            return byronBlock(blockNumber, slot, ebb.getHeader().getPrevBlock(), reference, List.of());
+            return ByronBlockNormalizer.normalizeEpochBoundary(ebb, blockNumber, reference.blockHash());
         }
-    }
-
-    private Block byronBlock(long blockNumber, long slot, String parent,
-                             CanonicalBlockReference reference,
-                             List<com.bloxbean.cardano.yaci.core.model.TransactionBody> transactions) {
-        var header = com.bloxbean.cardano.yaci.core.model.BlockHeader.builder()
-                .headerBody(com.bloxbean.cardano.yaci.core.model.HeaderBody.builder()
-                        .blockNumber(blockNumber).slot(slot).prevHash(parent)
-                        .blockHash(HexUtil.encodeHexString(reference.blockHash())).build())
-                .build();
-        return Block.builder().era(Era.Byron).header(header).transactionBodies(transactions)
-                .transactionWitness(List.of()).invalidTransactions(List.of()).build();
     }
 }

--- a/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/YaciUtxoHistoryDecoder.java
+++ b/archive-modules/archive-core/src/main/java/com/bloxbean/cardano/yano/archive/core/source/YaciUtxoHistoryDecoder.java
@@ -31,6 +31,11 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
     private final List<GenesisOutput> genesisOutputs;
     private final long genesisBlockNumber;
     private final UtxoHistoryProjection projection;
+    /** Per-block address memoisation bound; 0 disables caching entirely. */
+    private volatile int addressCacheMaxEntries = BoundedDecodeCache.DEFAULT_MAX_ENTRIES;
+    private final java.util.concurrent.atomic.LongAdder addressCacheHits = new java.util.concurrent.atomic.LongAdder();
+    private final java.util.concurrent.atomic.LongAdder addressCacheMisses = new java.util.concurrent.atomic.LongAdder();
+    private final java.util.concurrent.atomic.LongAdder addressCacheSkipped = new java.util.concurrent.atomic.LongAdder();
 
     public YaciUtxoHistoryDecoder(LongUnaryOperator slotToEpoch, LongUnaryOperator slotToUnixTime) {
         this.blockDecoder = new YaciBlockDecoder(slotToEpoch, slotToUnixTime);
@@ -109,6 +114,15 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
         List<UtxoHistoryFact.TransactionDatum> transactionDatums = new ArrayList<>();
         List<UtxoHistoryFact.TransactionRedeemer> transactionRedeemers = new ArrayList<>();
         Set<String> seenAddresses = new HashSet<>();
+        // Per-block memoisation of address decoding. Profiling attributed ~82% of the
+        // ADR-039 projection cost to fact derivation, and nearly all of that to decoding the
+        // same output addresses repeatedly: each call parses the address, extracts payment
+        // and delegation credentials, hashes a key, and re-encodes the whole thing back to
+        // bech32. Addresses repeat heavily within a block, and the decode is a pure function
+        // of the display string, so caching is semantics-preserving. Scoped to one block, so
+        // it is inherently bounded and needs no eviction policy; passed as a parameter rather
+        // than held as a field because one decoder instance may serve two worker threads.
+        BoundedDecodeCache<AddressInfo> addressCache = new BoundedDecodeCache<>(addressCacheMaxEntries);
         Set<Integer> invalid = block.getInvalidTransactions() == null ? Set.of() : Set.copyOf(block.getInvalidTransactions());
         List<TransactionBody> bodies = block.getTransactionBodies() == null ? List.of() : block.getTransactionBodies();
 
@@ -121,7 +135,7 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
         if (includeGenesis && includeOutputs) {
             LinkedHashMap<String, GenesisOutput> unique = new LinkedHashMap<>();
             for (GenesisOutput genesis : genesisOutputs) {
-                AddressInfo address = address(genesis.address());
+                AddressInfo address = address(genesis.address(), addressCache);
                 String outpoint = HexUtil.encodeHexString(Blake2bUtil.blake2bHash256(address.fact().rawAddress()));
                 GenesisOutput previous = unique.get(outpoint);
                 if (previous == null) unique.put(outpoint, genesis);
@@ -131,7 +145,7 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
                         previous.amount().add(genesis.amount()), previous.originType()));
             }
             for (GenesisOutput genesis : unique.values()) {
-                AddressInfo address = address(genesis.address());
+                AddressInfo address = address(genesis.address(), addressCache);
                 String addressId = HexUtil.encodeHexString(address.key());
                 if (seenAddresses.add(addressId)) addresses.add(address.fact());
                 if (includeOutputs) outputs.add(new UtxoHistoryFact.Output(
@@ -178,14 +192,14 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
             }
             if (includeOutputs && valid && tx.getOutputs() != null) {
                 for (int outputIndex = 0; outputIndex < tx.getOutputs().size(); outputIndex++) {
-                    addOutput(addresses, outputs, assets, seenAddresses, txHash, txIndex,
+                    addOutput(addresses, outputs, assets, seenAddresses, addressCache, txHash, txIndex,
                             outputIndex, "regular", false, tx.getOutputs().get(outputIndex),
                             includeOutputs, includeAssets);
                 }
             }
             if (includeOutputs && !valid && tx.getCollateralReturn() != null) {
                 int outputIndex = tx.getOutputs() == null ? 0 : tx.getOutputs().size();
-                addOutput(addresses, outputs, assets, seenAddresses, txHash, txIndex,
+                addOutput(addresses, outputs, assets, seenAddresses, addressCache, txHash, txIndex,
                         outputIndex, "collateral_return", true, tx.getCollateralReturn(),
                         includeOutputs, includeAssets);
             }
@@ -194,6 +208,10 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
                         includeDatums, includeRedeemers);
             }
         }
+        addressCacheHits.add(addressCache.hits());
+        addressCacheMisses.add(addressCache.misses());
+        addressCacheSkipped.add(addressCache.admissionsSkipped());
+
         return new UtxoHistoryFact(era, pointerRegistrations, pointerDeregistrations,
                 addresses, outputs, assets, inputs,
                 transactionDatums, transactionRedeemers);
@@ -201,10 +219,11 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
 
     private void addOutput(List<UtxoHistoryFact.Address> addresses, List<UtxoHistoryFact.Output> outputs,
                            List<UtxoHistoryFact.Asset> assets, Set<String> seenAddresses,
+                           BoundedDecodeCache<AddressInfo> addressCache,
                            byte[] txHash, int txIndex, int outputIndex, String originType,
                            boolean collateralReturn, TransactionOutput output,
                            boolean includeOutputs, boolean includeAssets) {
-        AddressInfo address = address(output.getAddress());
+        AddressInfo address = address(output.getAddress(), addressCache);
         String addressId = HexUtil.encodeHexString(address.key());
         if (includeOutputs && seenAddresses.add(addressId)) addresses.add(address.fact());
         BigInteger lovelace = BigInteger.ZERO;
@@ -305,7 +324,47 @@ public final class YaciUtxoHistoryDecoder implements CanonicalBlockDecoder<UtxoH
         };
     }
 
-    private AddressInfo address(String display) {
+    /**
+     * Bound on per-block address memoisation. Zero disables caching, which must produce
+     * byte-identical output — that equivalence is asserted by
+     * {@code AddressCacheEquivalenceTest}.
+     */
+    public void setAddressCacheMaxEntries(int maxEntries) {
+        if (maxEntries < 0) throw new IllegalArgumentException("maxEntries must not be negative");
+        this.addressCacheMaxEntries = maxEntries;
+    }
+
+    public int addressCacheMaxEntries() {
+        return addressCacheMaxEntries;
+    }
+
+    /** Cumulative memoisation counters across every block this decoder has processed. */
+    public AddressCacheStats addressCacheStats() {
+        return new AddressCacheStats(addressCacheHits.sum(), addressCacheMisses.sum(),
+                addressCacheSkipped.sum(), addressCacheMaxEntries);
+    }
+
+    /**
+     * @param admissionsSkipped lookups that could not be admitted because the per-block bound
+     *                          was reached; a persistently non-zero value means the bound is
+     *                          too small for this chain's blocks, not that anything is wrong
+     */
+    public record AddressCacheStats(long hits, long misses, long admissionsSkipped, int maxEntries) {
+        public double hitRate() {
+            long total = hits + misses;
+            return total == 0 ? 0.0 : (double) hits / total;
+        }
+    }
+
+    private AddressInfo address(String display, BoundedDecodeCache<AddressInfo> cache) {
+        AddressInfo cached = cache.get(display);
+        if (cached != null) return cached;
+        AddressInfo decoded = decodeAddress(display);
+        cache.put(display, decoded);
+        return decoded;
+    }
+
+    private AddressInfo decodeAddress(String display) {
         try {
             byte[] raw;
             try { raw = AddressUtil.addressToBytes(display); }

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/AddressCacheEquivalenceTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/AddressCacheEquivalenceTest.java
@@ -1,0 +1,195 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Amount;
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.BlockHeader;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.HeaderBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionInput;
+import com.bloxbean.cardano.yaci.core.model.TransactionOutput;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionDigest;
+import com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext;
+import com.bloxbean.cardano.yano.archive.core.source.YaciUtxoHistoryDecoder;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * The memoisation added to speed up projection must be an optimisation and nothing else.
+ *
+ * <p>These tests exist because a cache is exactly the kind of change that can silently alter
+ * output — through eviction order, aliasing of mutable values, or cross-thread sharing — and
+ * the projection's whole contract rests on deterministic, digest-verified bytes.
+ */
+class AddressCacheEquivalenceTest {
+
+    private static String hex(int b, int len) {
+        return String.format("%02x", b).repeat(len);
+    }
+
+    private static String shelleyAddress(int paymentFill, int stakeFill) {
+        byte[] address = new byte[57];
+        address[0] = 0;
+        Arrays.fill(address, 1, 29, (byte) paymentFill);
+        Arrays.fill(address, 29, 57, (byte) stakeFill);
+        return HexUtil.encodeHexString(address);
+    }
+
+    /** Many outputs over a mixture of repeated and distinct addresses. */
+    private static Block block(int transactions, int distinctAddresses) {
+        List<TransactionBody> txs = new ArrayList<>();
+        for (int i = 0; i < transactions; i++) {
+            var out = TransactionOutput.builder()
+                    .address(shelleyAddress(i % distinctAddresses + 1, i % 7 + 1))
+                    .amounts(List.of(
+                            Amount.builder().unit("lovelace").quantity(BigInteger.valueOf(2_000_000 + i)).build(),
+                            Amount.builder().unit(hex(0xaa, 28) + "01").policyId(hex(0xaa, 28))
+                                    .assetName("01").assetNameBytes(new byte[]{1})
+                                    .quantity(BigInteger.valueOf(7)).build()))
+                    .build();
+            txs.add(TransactionBody.builder().txHash(hex(i % 200, 32)).fee(BigInteger.valueOf(170_000 + i))
+                    .inputs(new LinkedHashSet<>(List.of(
+                            TransactionInput.builder().transactionId(hex((i + 5) % 200, 32)).index(0).build())))
+                    .outputs(List.of(out, out)).build());
+        }
+        return Block.builder().era(Era.Babbage)
+                .header(BlockHeader.builder().headerBody(HeaderBody.builder()
+                        .blockNumber(100).slot(2000).prevHash(hex(0x0a, 32)).blockHash(hex(0x0b, 32)).build()).build())
+                .transactionBodies(txs).transactionWitness(List.of()).invalidTransactions(List.of()).build();
+    }
+
+    private static BlockSourceContext<Block> context(Block block) {
+        return new BlockSourceContext<>(100, 2000, 20, Instant.ofEpochSecond(1_600_002_000L),
+                HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)), block);
+    }
+
+    private static String digestWithCache(Block block, int maxEntries) {
+        var decoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        decoder.setAddressCacheMaxEntries(maxEntries);
+        byte[] encoded = ProjectionFactCodec.encodeUtxoHistory(decoder.project(context(block)).block());
+        return ProjectionDigest.ofChunks(List.of(encoded));
+    }
+
+    // ------------------------------------------------------------- equivalence
+
+    @Test
+    void cacheEnabledAndDisabledProduceIdenticalDigests() {
+        Block dense = block(60, 12);
+        String disabled = digestWithCache(dense, 0);
+        String enabled = digestWithCache(dense, 4096);
+        assertThat(enabled).isEqualTo(disabled);
+    }
+
+    @Test
+    void everyCacheBoundProducesTheSameDigestIncludingBoundsThatForceSkips() {
+        Block dense = block(60, 40);
+        // A bound of 1 admits one entry and skips the rest: the uncached path must still be
+        // taken for everything else, with identical output.
+        String reference = digestWithCache(dense, 0);
+        for (int bound : new int[]{0, 1, 2, 5, 39, 40, 41, 4096}) {
+            assertThat(digestWithCache(dense, bound))
+                    .as("cache bound %d", bound)
+                    .isEqualTo(reference);
+        }
+    }
+
+    @Test
+    void repeatedDecodesWithAWarmDecoderStayIdentical() {
+        Block dense = block(40, 10);
+        var decoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        String first = ProjectionDigest.ofChunks(List.of(
+                ProjectionFactCodec.encodeUtxoHistory(decoder.project(context(dense)).block())));
+        for (int i = 0; i < 20; i++) {
+            assertThat(ProjectionDigest.ofChunks(List.of(
+                    ProjectionFactCodec.encodeUtxoHistory(decoder.project(context(dense)).block()))))
+                    .isEqualTo(first);
+        }
+    }
+
+    // ------------------------------------------------------------- boundedness
+
+    @Test
+    void theCacheIsBoundedAndReportsSkippedAdmissions() {
+        Block dense = block(60, 40);
+        var decoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        decoder.setAddressCacheMaxEntries(3);
+        decoder.project(context(dense));
+
+        var stats = decoder.addressCacheStats();
+        assertThat(stats.maxEntries()).isEqualTo(3);
+        assertThat(stats.admissionsSkipped())
+                .as("a 3-entry bound over 40 distinct addresses must skip admissions")
+                .isPositive();
+    }
+
+    @Test
+    void aGenerousBoundSkipsNothingAndHitsOften() {
+        Block dense = block(60, 8);
+        var decoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        decoder.project(context(dense));
+
+        var stats = decoder.addressCacheStats();
+        assertThat(stats.admissionsSkipped()).isZero();
+        assertThat(stats.hits()).isPositive();
+        assertThat(stats.hitRate()).isGreaterThan(0.5);
+    }
+
+    @Test
+    void countersAccumulateAcrossBlocks() {
+        var decoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        decoder.project(context(block(20, 5)));
+        long afterOne = decoder.addressCacheStats().hits() + decoder.addressCacheStats().misses();
+        decoder.project(context(block(20, 5)));
+        long afterTwo = decoder.addressCacheStats().hits() + decoder.addressCacheStats().misses();
+        assertThat(afterTwo).isGreaterThan(afterOne);
+    }
+
+    @Test
+    void aNegativeBoundIsRejected() {
+        var decoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        assertThatThrownBy(() -> decoder.setAddressCacheMaxEntries(-1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    // ------------------------------------------------------------ thread safety
+
+    @Test
+    void oneDecoderServingConcurrentThreadsProducesIdenticalDigests() throws Exception {
+        // The cache is per-decode-call and thread-confined, so a single decoder instance may
+        // legitimately serve several worker threads. This asserts that arrangement is safe
+        // and that no thread observes another's partial state.
+        Block dense = block(50, 15);
+        var decoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        String expected = ProjectionDigest.ofChunks(List.of(
+                ProjectionFactCodec.encodeUtxoHistory(decoder.project(context(dense)).block())));
+
+        int threads = 8;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        try {
+            List<Callable<String>> work = new ArrayList<>();
+            for (int i = 0; i < threads * 8; i++) {
+                work.add(() -> ProjectionDigest.ofChunks(List.of(
+                        ProjectionFactCodec.encodeUtxoHistory(decoder.project(context(dense)).block()))));
+            }
+            for (Future<String> result : pool.invokeAll(work)) {
+                assertThat(result.get()).isEqualTo(expected);
+            }
+        } finally {
+            pool.shutdownNow();
+        }
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/AddressTransactionProjectionParityTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/AddressTransactionProjectionParityTest.java
@@ -1,0 +1,430 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Amount;
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.BlockHeader;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.HeaderBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionInput;
+import com.bloxbean.cardano.yaci.core.model.TransactionOutput;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.archive.ConsumedOutputAddresses;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.core.address.AddressKeyCodec;
+import com.bloxbean.cardano.yano.archive.core.dataset.AddressSubjectRows;
+import com.bloxbean.cardano.yano.archive.core.dataset.AddressTransactionSubjects;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Address-transaction projection: capture, encode, decode, derive.
+ *
+ * <p>Row-shape parity with the live path is guaranteed structurally rather than by comparison —
+ * both call {@link AddressSubjectRows}, and both decompose addresses through the one shared
+ * parser. What still needs testing is everything around that: which addresses participate in
+ * which role, that the encoding round-trips, and that an unresolvable input fails loudly rather
+ * than silently dropping address history.
+ */
+class AddressTransactionProjectionParityTest {
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(1, "fixture");
+    private static final AddressKeyCodec KEYS = new AddressKeyCodec();
+
+    private static String hex(int b, int len) {
+        return String.format("%02x", b).repeat(len);
+    }
+
+    /** A Shelley address with distinct payment and stake parts, so all three subjects appear. */
+    private static String address(int paymentFill, int stakeFill) {
+        byte[] raw = new byte[57];
+        raw[0] = 0;
+        Arrays.fill(raw, 1, 29, (byte) paymentFill);
+        Arrays.fill(raw, 29, 57, (byte) stakeFill);
+        return HexUtil.encodeHexString(raw);
+    }
+
+    private static TransactionOutput out(String address, long lovelace) {
+        return TransactionOutput.builder().address(address)
+                .amounts(List.of(Amount.builder().unit("lovelace")
+                        .quantity(BigInteger.valueOf(lovelace)).build()))
+                .build();
+    }
+
+    private static TransactionInput in(int fill, int index) {
+        return TransactionInput.builder().transactionId(hex(fill, 32)).index(index).build();
+    }
+
+    private static Block block(Era era, List<TransactionBody> txs, List<Integer> invalid) {
+        return Block.builder().era(era)
+                .header(BlockHeader.builder().headerBody(HeaderBody.builder()
+                        .blockNumber(100).slot(2000).prevHash(hex(0x0a, 32))
+                        .blockHash(hex(0x0b, 32)).build()).build())
+                .transactionBodies(txs).transactionWitness(List.of()).invalidTransactions(invalid)
+                .build();
+    }
+
+    private static ConsumedOutputAddresses consumed(Map<String, String> map) {
+        return (txHash, index) -> map.get(txHash + '#' + index);
+    }
+
+    /** Rows the projection path produces, end to end through the encoding. */
+    private List<ArchiveRow> projectedRows(Block block, ConsumedOutputAddresses consumed) {
+        var fact = ProjectionAddressParticipation.resolve(block, 2000, consumed, KEYS,
+                PointerCredentialSource.NONE);
+        var decoded = ProjectionFactCodec.decodeAddressParticipations(
+                ProjectionFactCodec.encodeAddressParticipations(fact));
+
+        List<ArchiveRow> rows = new ArrayList<>();
+        UUID jobId = UUID.nameUUIDFromBytes("fixture".getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        for (var tx : decoded.transactions()) {
+            var accumulator = new AddressSubjectRows(AddressTransactionSubjects.all(),
+                    NETWORK.networkMagic());
+            for (var participation : tx.participations()) {
+                accumulator.add(participation.participant(),
+                        AddressSubjectRows.Role.valueOf(participation.role()));
+            }
+            accumulator.emit(tx.txHash(), tx.txIndex(), HexUtil.decodeHexString(hex(0x0b, 32)),
+                    100, 2000, 20, 1_600_002_000L, jobId, rows::add);
+        }
+        return rows;
+    }
+
+    private static String render(List<ArchiveRow> rows) {
+        return rows.stream().map(row -> row.table() + "(" + row.values().stream()
+                .map(v -> v instanceof byte[] b ? HexUtil.encodeHexString(b) : String.valueOf(v))
+                .collect(Collectors.joining(",")) + ")").collect(Collectors.joining("\n"));
+    }
+
+    // ------------------------------------------------------------------ cases
+
+    @Test
+    void aValidTransactionContributesItsInputsAndOutputs() {
+        var tx = TransactionBody.builder().txHash(hex(0x20, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(in(0x30, 0))))
+                .outputs(List.of(out(address(0x11, 0x12), 1_000_000L)))
+                .fee(BigInteger.valueOf(170_000L)).build();
+
+        var rows = projectedRows(block(Era.Babbage, List.of(tx), List.of()),
+                consumed(Map.of(hex(0x30, 32) + "#0", address(0x21, 0x22))));
+
+        // Two distinct addresses x three subject types.
+        assertThat(rows).hasSize(6);
+        assertThat(render(rows)).contains("address_transactions(");
+        // The spent address is recorded as an input, the created one as an output.
+        long inputRows = rows.stream().filter(r -> (Integer) r.values().get(11) == 1).count();
+        long outputRows = rows.stream().filter(r -> (Integer) r.values().get(12) == 1).count();
+        assertThat(inputRows).isEqualTo(3);
+        assertThat(outputRows).isEqualTo(3);
+    }
+
+    @Test
+    void oneAddressOnBothSidesIsASingleSubjectWithBothRoles() {
+        // Change back to the same address: the archive must not emit it twice.
+        String same = address(0x11, 0x12);
+        var tx = TransactionBody.builder().txHash(hex(0x21, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(in(0x31, 0))))
+                .outputs(List.of(out(same, 900_000L)))
+                .fee(BigInteger.valueOf(170_000L)).build();
+
+        var rows = projectedRows(block(Era.Babbage, List.of(tx), List.of()),
+                consumed(Map.of(hex(0x31, 32) + "#0", same)));
+
+        assertThat(rows).hasSize(3);
+        for (ArchiveRow row : rows) {
+            assertThat((Integer) row.values().get(11)).as("input count").isEqualTo(1);
+            assertThat((Integer) row.values().get(12)).as("output count").isEqualTo(1);
+        }
+    }
+
+    @Test
+    void anInvalidTransactionContributesCollateralRatherThanInputsAndOutputs() {
+        var tx = TransactionBody.builder().txHash(hex(0x22, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(in(0x32, 0))))
+                .collateralInputs(new java.util.LinkedHashSet<>(List.of(in(0x33, 1))))
+                .outputs(List.of(out(address(0x41, 0x42), 1_000_000L)))
+                .collateralReturn(out(address(0x51, 0x52), 500_000L))
+                .fee(BigInteger.valueOf(170_000L)).build();
+
+        var rows = projectedRows(block(Era.Babbage, List.of(tx), List.of(0)),
+                consumed(Map.of(hex(0x33, 32) + "#1", address(0x61, 0x62))));
+
+        // Collateral input address plus collateral return address; the ordinary input and the
+        // ordinary outputs take no part in a failed transaction.
+        assertThat(rows).hasSize(6);
+        long collateralInputs = rows.stream().filter(r -> (Integer) r.values().get(13) == 1).count();
+        long collateralReturns = rows.stream().filter(r -> (Integer) r.values().get(14) == 1).count();
+        assertThat(collateralInputs).isEqualTo(3);
+        assertThat(collateralReturns).isEqualTo(3);
+        assertThat(rows.stream().filter(r -> (Integer) r.values().get(11) == 1)).isEmpty();
+        assertThat(rows.stream().filter(r -> (Integer) r.values().get(12) == 1)).isEmpty();
+    }
+
+    @Test
+    void anUnresolvableInputFailsLoudlyRatherThanDroppingAddressHistory() {
+        // A skipped input would silently lose a real spend from address history, and no later
+        // pass could detect it. Failing closed is the only safe behaviour.
+        var tx = TransactionBody.builder().txHash(hex(0x23, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(in(0x34, 0))))
+                .outputs(List.of(out(address(0x11, 0x12), 1_000_000L)))
+                .fee(BigInteger.valueOf(170_000L)).build();
+
+        assertThatThrownBy(() -> projectedRows(block(Era.Babbage, List.of(tx), List.of()),
+                ConsumedOutputAddresses.NONE))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("could not resolve")
+                .hasMessageContaining(hex(0x34, 32));
+    }
+
+    @Test
+    void theEncodingRoundTripsEveryParticipationField() {
+        var tx = TransactionBody.builder().txHash(hex(0x24, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(in(0x35, 7))))
+                .outputs(List.of(out(address(0x71, 0x72), 1_000_000L),
+                        out(address(0x73, 0x74), 2_000_000L)))
+                .fee(BigInteger.valueOf(170_000L)).build();
+        var original = ProjectionAddressParticipation.resolve(
+                block(Era.Babbage, List.of(tx), List.of()), 2000,
+                consumed(Map.of(hex(0x35, 32) + "#7", address(0x75, 0x76))), KEYS,
+                PointerCredentialSource.NONE);
+
+        var encoded = ProjectionFactCodec.encodeAddressParticipations(original);
+        var decoded = ProjectionFactCodec.decodeAddressParticipations(encoded);
+
+        assertThat(decoded.transactions()).hasSize(1);
+        var before = original.transactions().get(0);
+        var after = decoded.transactions().get(0);
+        assertThat(after.txIndex()).isEqualTo(before.txIndex());
+        assertThat(after.txHash()).isEqualTo(before.txHash());
+        assertThat(after.participations()).hasSameSizeAs(before.participations());
+        for (int i = 0; i < before.participations().size(); i++) {
+            var b = before.participations().get(i);
+            var a = after.participations().get(i);
+            assertThat(a.role()).isEqualTo(b.role());
+            assertThat(a.participant().addressKey()).isEqualTo(b.participant().addressKey());
+            assertThat(a.participant().address()).isEqualTo(b.participant().address());
+            assertThat(a.participant().paymentCredential()).isEqualTo(b.participant().paymentCredential());
+            assertThat(a.participant().stakeCredentialType()).isEqualTo(b.participant().stakeCredentialType());
+            assertThat(a.participant().stakeCredential()).isEqualTo(b.participant().stakeCredential());
+        }
+    }
+
+    @Test
+    void streamingYieldsTheSameTransactionsAsDecodingWhole() {
+        var txs = new ArrayList<TransactionBody>();
+        var map = new LinkedHashMap<String, String>();
+        for (int i = 0; i < 40; i++) {
+            txs.add(TransactionBody.builder().txHash(hex(0x80 + (i % 60), 32))
+                    .inputs(new java.util.LinkedHashSet<>(List.of(in(0x90, i))))
+                    .outputs(List.of(out(address(0xa0, 0xa1), 1_000_000L + i)))
+                    .fee(BigInteger.valueOf(170_000L)).build());
+            map.put(hex(0x90, 32) + '#' + i, address(0xb0, 0xb1));
+        }
+        var fact = ProjectionAddressParticipation.resolve(block(Era.Babbage, txs, List.of()), 2000,
+                consumed(map), KEYS, PointerCredentialSource.NONE);
+        byte[] encoded = ProjectionFactCodec.encodeAddressParticipations(fact);
+
+        // Split small, so transactions straddle chunk boundaries.
+        var chunks = ProjectionChunking.split(encoded, 64);
+        assertThat(chunks.size()).isGreaterThan(1);
+        List<Integer> streamed = new ArrayList<>();
+        long participations = ProjectionFactCodec.streamAddressParticipations(chunks,
+                tx -> streamed.add(tx.txIndex()));
+
+        assertThat(streamed).hasSize(40);
+        assertThat(streamed).isEqualTo(fact.transactions().stream()
+                .map(t -> t.txIndex()).collect(Collectors.toList()));
+        assertThat(participations).isEqualTo(fact.transactions().stream()
+                .mapToLong(t -> t.participations().size()).sum());
+    }
+
+    // ------------------------------- side by side against the live dataset
+
+    @org.junit.jupiter.api.io.TempDir
+    java.nio.file.Path temp;
+
+    /**
+     * Both paths, same two blocks, same rows.
+     *
+     * <p>Block 1 creates outputs; block 2 spends them. The live dataset resolves those inputs
+     * through its own resolver, populated by block 1. The projection resolves them from the
+     * addresses the UTXO subsystem would have captured while deleting the same outputs. Row
+     * shape is already identical by construction — both call {@link AddressSubjectRows} — so
+     * what this actually tests is that the two <em>resolutions</em> agree, which sharing code
+     * cannot guarantee.
+     */
+    @Test
+    void theProjectionAndTheLiveDatasetAgreeOnTheSameSpend() throws Exception {
+        String fundedA = address(0xc1, 0xc2);
+        String fundedB = address(0xc3, 0xc4);
+        String createdA = address(0xd1, 0xd2);
+
+        var funding = TransactionBody.builder().txHash(hex(0xe0, 32))
+                .inputs(new java.util.LinkedHashSet<>())
+                .outputs(List.of(out(fundedA, 5_000_000L), out(fundedB, 6_000_000L)))
+                .fee(BigInteger.valueOf(170_000L)).build();
+        var spending = TransactionBody.builder().txHash(hex(0xe1, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0xe0, 32)).index(0).build(),
+                        TransactionInput.builder().transactionId(hex(0xe0, 32)).index(1).build())))
+                .outputs(List.of(out(createdA, 10_000_000L), out(fundedA, 500_000L)))
+                .fee(BigInteger.valueOf(170_000L)).build();
+
+        var blockOne = Block.builder().era(Era.Babbage)
+                .header(BlockHeader.builder().headerBody(HeaderBody.builder()
+                        .blockNumber(99).slot(1980).prevHash(hex(0x09, 32))
+                        .blockHash(hex(0x0a, 32)).build()).build())
+                .transactionBodies(List.of(funding)).transactionWitness(List.of())
+                .invalidTransactions(List.of()).build();
+        var blockTwo = block(Era.Babbage, List.of(spending), List.of());
+
+        // --- the live path -------------------------------------------------
+        List<ArchiveRow> live = new ArrayList<>();
+        UUID jobId;
+        try (var state = new com.bloxbean.cardano.yano.archive.core.hot.RocksDbHotHistoryStore(
+                temp.resolve("side-by-side"))) {
+            var dataset = new com.bloxbean.cardano.yano.archive.core.dataset.AddressTransactionDataset(
+                    state, KEYS);
+            dataset.seedGenesis(List.of());
+
+            var contextOne = new com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext<>(
+                    99L, 1980L, 19L, java.time.Instant.ofEpochSecond(1_600_001_980L),
+                    HexUtil.decodeHexString(hex(0x0a, 32)), HexUtil.decodeHexString(hex(0x09, 32)),
+                    blockOne);
+            var contextTwo = new com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext<>(
+                    100L, 2000L, 20L, java.time.Instant.ofEpochSecond(1_600_002_000L),
+                    HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)),
+                    blockTwo);
+
+            var job = com.bloxbean.cardano.yano.archive.api.ArchiveJob.deterministic(NETWORK,
+                    com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId.ADDRESS_TRANSACTION, 3,
+                    new com.bloxbean.cardano.yano.archive.api.BlockRange(99, 100),
+                    new com.bloxbean.cardano.yano.archive.api.ArchiveRangeAnchor(1980,
+                            HexUtil.decodeHexString(hex(0x0a, 32)), 2000,
+                            HexUtil.decodeHexString(hex(0x0b, 32))), "v3");
+            jobId = job.jobId();
+            dataset.beginBatch(job, List.of(contextOne, contextTwo));
+            dataset.derive(job, contextOne, row -> { });      // block 1 only populates the resolver
+            dataset.derive(job, contextTwo, live::add);
+            dataset.abortBatch();
+        }
+
+        // --- the projection path -------------------------------------------
+        var consumedFromBlockOne = new LinkedHashMap<String, String>();
+        consumedFromBlockOne.put(hex(0xe0, 32) + "#0", fundedA);
+        consumedFromBlockOne.put(hex(0xe0, 32) + "#1", fundedB);
+
+        var fact = ProjectionAddressParticipation.resolve(blockTwo, 2000,
+                consumed(consumedFromBlockOne), KEYS, PointerCredentialSource.NONE);
+        var decoded = ProjectionFactCodec.decodeAddressParticipations(
+                ProjectionFactCodec.encodeAddressParticipations(fact));
+        List<ArchiveRow> projected = new ArrayList<>();
+        for (var tx : decoded.transactions()) {
+            var accumulator = new AddressSubjectRows(AddressTransactionSubjects.all(),
+                    NETWORK.networkMagic());
+            for (var participation : tx.participations()) {
+                accumulator.add(participation.participant(),
+                        AddressSubjectRows.Role.valueOf(participation.role()));
+            }
+            accumulator.emit(tx.txHash(), tx.txIndex(), HexUtil.decodeHexString(hex(0x0b, 32)),
+                    100, 2000, 20, 1_600_002_000L, jobId, projected::add);
+        }
+
+        assertThat(projected).isNotEmpty();
+        assertThat(render(projected))
+                .as("the projection must reproduce the live path's rows exactly")
+                .isEqualTo(render(live));
+    }
+
+    @Test
+    void theSectionsEncodedCostIsMeasuredRatherThanAssumed() {
+        // The address-transaction section carries output addresses that utxo-history already
+        // carries, so enabling all four datasets costs more than the sum of their row counts
+        // suggests. Measure it rather than assume it is small.
+        var txs = new ArrayList<TransactionBody>();
+        var map = new LinkedHashMap<String, String>();
+        for (int i = 0; i < 30; i++) {
+            var inputs = new java.util.LinkedHashSet<TransactionInput>();
+            for (int k = 0; k < 2; k++) {
+                inputs.add(in(0xf0, i * 2 + k));
+                map.put(hex(0xf0, 32) + '#' + (i * 2 + k), address(0x90 + (i % 40), 0x91));
+            }
+            var outputs = new ArrayList<TransactionOutput>();
+            for (int k = 0; k < 3; k++) outputs.add(out(address(0xa0 + (i % 40), 0xa1 + k), 1_000_000L + k));
+            txs.add(TransactionBody.builder().txHash(hex(0x10 + (i % 200), 32))
+                    .inputs(inputs).outputs(outputs).fee(BigInteger.valueOf(170_000L)).build());
+        }
+        var blk = block(Era.Babbage, txs, List.of());
+
+        var fact = ProjectionAddressParticipation.resolve(blk, 2000, consumed(map), KEYS,
+                PointerCredentialSource.NONE);
+        byte[] encoded = ProjectionFactCodec.encodeAddressParticipations(fact);
+        long participations = fact.transactions().stream()
+                .mapToLong(t -> t.participations().size()).sum();
+
+        System.out.printf("ADR-039 address-transaction section: %d txs, %d participations,"
+                        + " %d bytes (%d B/participation)%n",
+                fact.transactions().size(), participations, encoded.length,
+                encoded.length / Math.max(1, participations));
+
+        // 30 transactions x (2 inputs + 3 outputs).
+        assertThat(participations).isEqualTo(150);
+        // A guard rather than a target: the encoding carries an address key, a display address
+        // and two credentials per participation, so a few hundred bytes each is expected. A
+        // large jump means a field was added without anyone noticing the size cost.
+        assertThat(encoded.length / participations).isLessThan(400L);
+    }
+
+    @Test
+    void anOutputCreatedAndSpentInsideOneBlockResolves() {
+        // Preprod block 1,809,762: an invalid transaction's collateral return (output #1) is
+        // consumed later in the same block. The consuming transaction's input never appears on
+        // the UTXO store's spend path as a stored read - the output was created in the same
+        // uncommitted batch - so capturing only on spend leaves it unresolvable and the
+        // fail-closed guard halts the node. Addresses are therefore captured on creation too.
+        String collateralReturnAddress = address(0xb1, 0xb2);
+        String laterOutput = address(0xb3, 0xb4);
+
+        var invalidTx = TransactionBody.builder().txHash(hex(0x50, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(in(0x51, 0))))
+                .collateralInputs(new java.util.LinkedHashSet<>(List.of(in(0x52, 0))))
+                .outputs(List.of(out(address(0xb5, 0xb6), 1_000_000L)))
+                .collateralReturn(out(collateralReturnAddress, 7_000_000L))
+                .fee(BigInteger.valueOf(170_000L)).build();
+        // Spends the collateral return created by the transaction above, in this same block.
+        var spender = TransactionBody.builder().txHash(hex(0x53, 32))
+                .inputs(new java.util.LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0x50, 32)).index(1).build())))
+                .outputs(List.of(out(laterOutput, 6_500_000L)))
+                .fee(BigInteger.valueOf(170_000L)).build();
+
+        // What the UTXO subsystem captures: the spent collateral input, plus every output it
+        // creates — including the collateral return, which is the entry that matters here.
+        var captured = new LinkedHashMap<String, String>();
+        captured.put(hex(0x52, 32) + "#0", address(0xb7, 0xb8));   // collateral input, spend path
+        captured.put(hex(0x50, 32) + "#1", collateralReturnAddress); // collateral return, creation path
+
+        var rows = projectedRows(block(Era.Babbage, List.of(invalidTx, spender), List.of(0)),
+                consumed(captured));
+
+        assertThat(rows).isNotEmpty();
+        String rendered = render(rows);
+        assertThat(rendered)
+                .as("the collateral return must appear as the spender's input")
+                .contains(HexUtil.encodeHexString(
+                        KEYS.key(HexUtil.decodeHexString(collateralReturnAddress))));
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveIngestGateTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ArchiveIngestGateTest.java
@@ -1,0 +1,128 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ADR-039 disk backpressure: canonical sync stays asynchronous until the node would run out
+ * of the disk it was given.
+ */
+class ArchiveIngestGateTest {
+
+    private static final long GB = 1L << 30;
+
+    private static ArchiveDiskLimits limits() {
+        // soft 8 GiB, hard 32 GiB, resume under 4 GiB, keep 16 GiB free
+        return new ArchiveDiskLimits(8 * GB, 32 * GB, 4 * GB, 16 * GB);
+    }
+
+    private static ArchiveRetainedFootprint used(long logicalOutbox, long staged, long pinned, long free) {
+        return new ArchiveRetainedFootprint(logicalOutbox, staged, pinned, 1.4, free);
+    }
+
+    @Test
+    void coreRunsAheadOfTheSinkByDefault() {
+        var gate = new ArchiveIngestGate(limits());
+        // A large backlog is normal during bootstrap and must not pause anything.
+        var decision = gate.evaluate(used(3 * GB, 0, 0, 500 * GB));
+        assertThat(decision.state()).isEqualTo(ArchiveIngestGate.Decision.State.RUNNING);
+        assertThat(decision.pausesIngest()).isFalse();
+    }
+
+    @Test
+    void theSoftBoundDegradesHealthWithoutPausing() {
+        var gate = new ArchiveIngestGate(limits());
+        var decision = gate.evaluate(used(7 * GB, 0, 0, 500 * GB)); // 7 * 1.4 = 9.8 GiB
+        assertThat(decision.state()).isEqualTo(ArchiveIngestGate.Decision.State.DEGRADED);
+        assertThat(decision.pausesIngest()).isFalse();
+        assertThat(decision.reason()).isPresent();
+    }
+
+    @Test
+    void theAggregateBudgetCountsStagedFilesAndPinnedGenerationsNotJustTheOutbox() {
+        var gate = new ArchiveIngestGate(limits());
+        // Outbox alone is well under the hard limit; the obligation is not.
+        var outboxOnly = gate.evaluate(used(2 * GB, 0, 0, 500 * GB));
+        assertThat(outboxOnly.pausesIngest()).isFalse();
+
+        var withArtifacts = gate.evaluate(used(2 * GB, 12 * GB, 18 * GB, 500 * GB));
+        assertThat(withArtifacts.state()).isEqualTo(ArchiveIngestGate.Decision.State.PAUSED);
+        assertThat(withArtifacts.reason()).get().asString().contains("hard limit");
+    }
+
+    @Test
+    void amplificationIsCountedSoTheBudgetReflectsRealDisk() {
+        var gate = new ArchiveIngestGate(limits());
+        // 24 GiB logical is under the 32 GiB hard limit, but 1.4x amplification is not.
+        assertThat(gate.evaluate(used(24 * GB, 0, 0, 500 * GB)).pausesIngest()).isTrue();
+    }
+
+    @Test
+    void freeSpaceReservePausesEvenWhenTheBudgetIsUntouched() {
+        var gate = new ArchiveIngestGate(limits());
+        var decision = gate.evaluate(used(1 * GB, 0, 0, 8 * GB)); // plenty of budget, no disk
+        assertThat(decision.state()).isEqualTo(ArchiveIngestGate.Decision.State.PAUSED);
+        assertThat(decision.reason()).get().asString().contains("safety reserve");
+    }
+
+    // ------------------------------------------------------ hysteresis / resume
+
+    @Test
+    void aPauseHoldsUntilCleanupReachesTheLowWaterMarkRatherThanOscillating() {
+        var gate = new ArchiveIngestGate(limits());
+        assertThat(gate.evaluate(used(24 * GB, 0, 0, 500 * GB)).pausesIngest()).isTrue();
+
+        // Dipping just under the hard limit is not enough: resuming here would immediately
+        // re-cross it and thrash.
+        assertThat(gate.evaluate(used(22 * GB, 0, 0, 500 * GB)).pausesIngest()).isTrue();
+        assertThat(gate.evaluate(used(7 * GB, 0, 0, 500 * GB)).pausesIngest()).isTrue();
+
+        // Below the low-water mark, ingestion resumes automatically.
+        var resumed = gate.evaluate(used(2 * GB, 0, 0, 500 * GB)); // 2 * 1.4 = 2.8 GiB
+        assertThat(resumed.state()).isEqualTo(ArchiveIngestGate.Decision.State.RUNNING);
+    }
+
+    @Test
+    void resumeAlsoRequiresFreeSpaceToHaveRecovered() {
+        var gate = new ArchiveIngestGate(limits());
+        assertThat(gate.evaluate(used(1 * GB, 0, 0, 8 * GB)).pausesIngest()).isTrue();
+        // Usage is tiny, but the filesystem is still under its reserve.
+        assertThat(gate.evaluate(used(1 * GB, 0, 0, 10 * GB)).pausesIngest()).isTrue();
+        assertThat(gate.evaluate(used(1 * GB, 0, 0, 500 * GB)).pausesIngest()).isFalse();
+    }
+
+    @Test
+    void thePauseReasonNamesUsageThresholdAndRequiredProgress() {
+        var gate = new ArchiveIngestGate(limits());
+        gate.evaluate(used(24 * GB, 0, 0, 500 * GB));
+        var stillPaused = gate.evaluate(used(20 * GB, 0, 0, 500 * GB));
+        assertThat(stillPaused.reason()).get().asString()
+                .contains("waiting for archive cleanup")
+                .contains("resuming below");
+        assertThat(stillPaused.observedBytes()).isPositive();
+        assertThat(stillPaused.limitBytes()).isEqualTo(4 * GB);
+    }
+
+    // ----------------------------------------------------------- configuration
+
+    @Test
+    void limitsMustBeCoherent() {
+        assertThatThrownBy(() -> new ArchiveDiskLimits(8 * GB, 4 * GB, 2 * GB, 0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> new ArchiveDiskLimits(8 * GB, 32 * GB, 9 * GB, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("lowWaterBytes");
+        assertThatThrownBy(() -> new ArchiveRetainedFootprint(0, 0, 0, 0.5, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("amplification");
+    }
+
+    @Test
+    void defaultsAreCoherent() {
+        var defaults = ArchiveDiskLimits.defaults();
+        assertThat(defaults.lowWaterBytes()).isLessThanOrEqualTo(defaults.softBytes());
+        assertThat(defaults.hardBytes()).isGreaterThanOrEqualTo(defaults.softBytes());
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ByronProjectionCarrierTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ByronProjectionCarrierTest.java
@@ -1,0 +1,310 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Epoch;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronAddress;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronBlockBody;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronBlockCons;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronBlockHead;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlock;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlockCons;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronEbHead;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronMainBlock;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronTx;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronTxIn;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronTxOut;
+import com.bloxbean.cardano.yaci.core.model.byron.payload.ByronTxPayload;
+import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
+import com.bloxbean.cardano.yano.api.events.ByronBlockProjectionEvent;
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.ArchiveJob;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRangeAnchor;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.BlockRange;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.core.dataset.ArchiveBlockFacts;
+import com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext;
+import com.bloxbean.cardano.yano.archive.core.dataset.StandardBlockDatasets;
+import com.bloxbean.cardano.yano.archive.core.source.ByronBlockNormalizer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Drives genuine {@link ByronMainBlock} and {@link ByronEbBlock} values through the
+ * dedicated ADR-039 projection carrier.
+ *
+ * <p>Byron is roughly a third of mainnet and has no live-path source at all: the UTXO
+ * store returns immediately on the {@code block() == null} sentinel and never applies a
+ * Byron transaction. So this path is the only way those blocks become projectable, and
+ * the EBB case is what keeps the archive's contiguous coordinate from stopping dead at
+ * the first epoch boundary.
+ */
+class ByronProjectionCarrierTest {
+    static { RocksDB.loadLibrary(); }
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(764824073, "5f20df93");
+    private static final Set<ProjectionSectionType> REQUIRED =
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY);
+    private static final ProjectionIdentity IDENTITY =
+            new ProjectionIdentity(NETWORK, "synthetic", 1, REQUIRED);
+
+    private static final String BASE58 = "Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi";
+
+    @TempDir Path directory;
+
+    private RocksDB db;
+    private DBOptions dbOptions;
+    private List<ColumnFamilyHandle> handles;
+    private ProjectionOutboxStore store;
+    private CanonicalProjectionCollector collector;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbOptions = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+        List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+        for (String name : ProjectionCfNames.ALL) {
+            descriptors.add(new ColumnFamilyDescriptor(name.getBytes(StandardCharsets.UTF_8)));
+        }
+        handles = new ArrayList<>();
+        db = RocksDB.open(dbOptions, directory.resolve("db").toString(), descriptors, handles);
+        store = new ProjectionOutboxStore(db, handles.get(1), handles.get(2), handles.get(3), handles.get(4));
+        collector = new CanonicalProjectionCollector(store, IDENTITY, slot -> slot / 21600,
+                slot -> 1_506_203_091L + slot * 20);
+    }
+
+    @AfterEach
+    void tearDown() {
+        handles.forEach(ColumnFamilyHandle::close);
+        db.close();
+        dbOptions.close();
+    }
+
+    // ---------------------------------------------------------------- fixtures
+
+    private static String hex(int b, int len) {
+        return String.format("%02x", b).repeat(len);
+    }
+
+    private static ByronMainBlock mainBlock(long slot, String prevBlock, List<ByronTx> transactions) {
+        var payloads = transactions.stream()
+                .map(tx -> ByronTxPayload.builder().transaction(tx).witnesses(List.of()).build())
+                .toList();
+        return ByronMainBlock.builder()
+                .header(ByronBlockHead.builder()
+                        .protocolMagic(764824073L)
+                        .prevBlock(prevBlock)
+                        .consensusData(ByronBlockCons.builder()
+                                .slotId(Epoch.builder().epoch(slot / 21600).slot(slot % 21600).build())
+                                .difficulty(BigInteger.ONE)
+                                .build())
+                        .build())
+                .body(ByronBlockBody.builder().txPayload(payloads).build())
+                .build();
+    }
+
+    private static ByronTx transaction(String txHash, String inputTxId, int inputIndex, long amount) {
+        return ByronTx.builder()
+                .txHash(txHash)
+                .inputs(List.of(ByronTxIn.builder().txId(inputTxId).index(inputIndex).build()))
+                .outputs(List.of(ByronTxOut.builder()
+                        .address(ByronAddress.builder().base58Raw(BASE58).build())
+                        .amount(BigInteger.valueOf(amount)).build()))
+                .build();
+    }
+
+    private static ByronEbBlock epochBoundaryBlock(long slot, String prevBlock) {
+        return ByronEbBlock.builder()
+                .header(ByronEbHead.builder()
+                        .protocolMagic(764824073L)
+                        .prevBlock(prevBlock)
+                        .consensusData(ByronEbBlockCons.builder()
+                                .epoch(slot / 21600).difficulty(BigInteger.ONE).build())
+                        .build())
+                .build();
+    }
+
+    private void contribute(ByronBlockProjectionEvent event) {
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            collector.contributeByronBlock(event, ProjectionOutboxStore.batchWriter(batch, store.handles()));
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    // ----------------------------------------------------------------- the cases
+
+    @Test
+    void aGenuineByronMainBlockProducesAProjectableEnvelope() {
+        var byron = mainBlock(43200, hex(0x0a, 32),
+                List.of(transaction(hex(0x11, 32), hex(0x22, 32), 0, 1_000_000)));
+        contribute(ByronBlockProjectionEvent.main(43200, 500, hex(0x0b, 32), hex(0x0a, 32), byron));
+
+        var envelope = store.readEnvelope(500, REQUIRED).orElseThrow();
+        assertThat(envelope.header().blockKind()).isEqualTo(ProjectionBlockKind.BYRON_MAIN);
+        assertThat(envelope.sections()).hasSize(2);
+
+        var txFacts = ProjectionFactCodec.decodeTransactions(ProjectionChunking.join(
+                envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow().chunks()));
+        assertThat(txFacts).hasSize(1);
+        assertThat(txFacts.get(0).txIndex()).isZero();
+        assertThat(txFacts.get(0).valid()).isTrue();
+    }
+
+    @Test
+    void byronTransactionFeeIsNullBecauseByronCarriesNone() {
+        var byron = mainBlock(43200, hex(0x0a, 32),
+                List.of(transaction(hex(0x11, 32), hex(0x22, 32), 0, 1_000_000)));
+        contribute(ByronBlockProjectionEvent.main(43200, 500, hex(0x0b, 32), hex(0x0a, 32), byron));
+
+        var envelope = store.readEnvelope(500, REQUIRED).orElseThrow();
+        var facts = ProjectionFactCodec.decodeTransactions(ProjectionChunking.join(
+                envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow().chunks()));
+        assertThat(facts.get(0).fee()).isNull();
+
+        // And the fee reaches chain_transaction as a genuine SQL NULL, not a zero.
+        List<ArchiveRow> rows = new ArrayList<>();
+        StandardBlockDatasets.transactions().derive(
+                ArchiveJob.deterministic(NETWORK, ArchiveDatasetId.TRANSACTION, 1, new BlockRange(500, 500),
+                        new ArchiveRangeAnchor(43200, new byte[]{1}, 43200, new byte[]{1}), "v1"),
+                new BlockSourceContext<>(500, 43200, 2, Instant.EPOCH, new byte[]{1}, new byte[]{0},
+                        new ArchiveBlockFacts(facts, List.of())),
+                rows::add);
+        assertThat(rows).singleElement().satisfies(row -> assertThat(row.values().get(8)).isNull());
+    }
+
+    @Test
+    void byronOutputsKeepTheirRawBase58Address() {
+        var byron = mainBlock(43200, hex(0x0a, 32),
+                List.of(transaction(hex(0x11, 32), hex(0x22, 32), 0, 1_000_000)));
+        contribute(ByronBlockProjectionEvent.main(43200, 500, hex(0x0b, 32), hex(0x0a, 32), byron));
+
+        var envelope = store.readEnvelope(500, REQUIRED).orElseThrow();
+        var fact = ProjectionFactCodec.decodeUtxoHistory(ProjectionChunking.join(
+                envelope.section(ProjectionSectionType.UTXO_HISTORY).orElseThrow().chunks()));
+        assertThat(fact.outputs()).hasSize(1);
+        assertThat(fact.newAddresses()).anySatisfy(address ->
+                assertThat(address.displayAddress()).isEqualTo(BASE58));
+    }
+
+    @Test
+    void byronHasNoCollateralReferenceInputsDatumsOrRedeemers() {
+        var byron = mainBlock(43200, hex(0x0a, 32),
+                List.of(transaction(hex(0x11, 32), hex(0x22, 32), 0, 1_000_000)));
+        contribute(ByronBlockProjectionEvent.main(43200, 500, hex(0x0b, 32), hex(0x0a, 32), byron));
+
+        var fact = ProjectionFactCodec.decodeUtxoHistory(ProjectionChunking.join(
+                store.readEnvelope(500, REQUIRED).orElseThrow()
+                        .section(ProjectionSectionType.UTXO_HISTORY).orElseThrow().chunks()));
+        assertThat(fact.transactionDatums()).isEmpty();
+        assertThat(fact.transactionRedeemers()).isEmpty();
+        assertThat(fact.assets()).isEmpty();
+        assertThat(fact.pointerRegistrations()).isEmpty();
+        assertThat(fact.inputs()).allSatisfy(input -> assertThat(input.inputRole()).isEqualTo("input"));
+    }
+
+    @Test
+    void anEpochBoundaryBlockEmitsAnEmptyEnvelopeAndAdvancesEveryContributor() {
+        contribute(ByronBlockProjectionEvent.epochBoundary(21600, 499, hex(0x0c, 32), hex(0x09, 32),
+                epochBoundaryBlock(21600, hex(0x09, 32))));
+
+        var envelope = store.readEnvelope(499, REQUIRED).orElseThrow();
+        assertThat(envelope.sections()).isEmpty();
+        assertThat(envelope.header().blockKind()).isEqualTo(ProjectionBlockKind.BYRON_EBB);
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(499);
+    }
+
+    @Test
+    void anEbbBetweenTwoMainBlocksKeepsTheCoordinateContiguous() {
+        contribute(ByronBlockProjectionEvent.main(21580, 498, hex(0x0d, 32), hex(0x08, 32),
+                mainBlock(21580, hex(0x08, 32), List.of(transaction(hex(0x31, 32), hex(0x32, 32), 0, 5)))));
+        contribute(ByronBlockProjectionEvent.epochBoundary(21600, 499, hex(0x0c, 32), hex(0x0d, 32),
+                epochBoundaryBlock(21600, hex(0x0d, 32))));
+        contribute(ByronBlockProjectionEvent.main(21620, 500, hex(0x0b, 32), hex(0x0c, 32),
+                mainBlock(21620, hex(0x0c, 32), List.of(transaction(hex(0x33, 32), hex(0x34, 32), 0, 6)))));
+
+        // No hole: every block in 498..500 has a readable envelope.
+        for (long block = 498; block <= 500; block++) {
+            assertThat(store.readEnvelope(block, REQUIRED)).as("block %d", block).isPresent();
+        }
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(500);
+    }
+
+    @Test
+    void theByronParentBridgeIsPreservedThroughTheEnvelopeHeader() {
+        contribute(ByronBlockProjectionEvent.epochBoundary(21600, 499, hex(0x0c, 32), hex(0x0d, 32),
+                epochBoundaryBlock(21600, hex(0x0d, 32))));
+        var envelope = store.readEnvelope(499, REQUIRED).orElseThrow();
+        assertThat(envelope.header().parentHash())
+                .isEqualTo(com.bloxbean.cardano.yaci.core.util.HexUtil.decodeHexString(hex(0x0d, 32)));
+    }
+
+    @Test
+    void anEmptyByronMainBlockStillProducesAnEnvelope() {
+        contribute(ByronBlockProjectionEvent.main(43200, 501, hex(0x0e, 32), hex(0x0b, 32),
+                mainBlock(43200, hex(0x0b, 32), List.of())));
+        var envelope = store.readEnvelope(501, REQUIRED).orElseThrow();
+        assertThat(envelope.header().blockKind()).isEqualTo(ProjectionBlockKind.BYRON_MAIN);
+        assertThat(ProjectionFactCodec.decodeTransactions(ProjectionChunking.join(
+                envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow().chunks()))).isEmpty();
+    }
+
+    @Test
+    void theNormalizerAgreesWithTheCarrierPath() {
+        // The retained normalizer is the single definition of a normalized Byron block;
+        // replay and the projection carrier must not drift apart.
+        var byron = mainBlock(43200, hex(0x0a, 32),
+                List.of(transaction(hex(0x11, 32), hex(0x22, 32), 0, 1_000_000)));
+        var normalized = ByronBlockNormalizer.normalizeMain(byron, 500,
+                com.bloxbean.cardano.yaci.core.util.HexUtil.decodeHexString(hex(0x0b, 32)));
+
+        assertThat(normalized.getEra()).isEqualTo(com.bloxbean.cardano.yaci.core.model.Era.Byron);
+        assertThat(normalized.getTransactionBodies()).hasSize(1);
+        assertThat(normalized.getTransactionBodies().get(0).getFee()).isNull();
+        assertThat(normalized.getInvalidTransactions()).isEmpty();
+        assertThat(normalized.getHeader().getHeaderBody().getPrevHash()).isEqualTo(hex(0x0a, 32));
+    }
+
+    @Test
+    void everyShippedSectionIsBuildable() {
+        // Phase 4b's exit condition. The collector fails closed on a required section it cannot
+        // build, because advancing the cursor with no section would stall every envelope
+        // forever - so "all four are accepted" is the statement that the four datasets are
+        // actually covered, not merely declared.
+        var all = new ProjectionIdentity(NETWORK, "synthetic", 1,
+                java.util.Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY,
+                        ProjectionSectionType.ACCOUNT_EVENT, ProjectionSectionType.ADDRESS_TRANSACTION));
+        new CanonicalProjectionCollector(store, all, slot -> 0, slot -> 0);
+
+        // And the fail-closed guard itself still works, for any section added in future before
+        // its contributor exists.
+        org.assertj.core.api.Assertions.assertThatThrownBy(() ->
+                        new CanonicalProjectionCollector(store, all, slot -> 0, slot -> 0,
+                                1 << 20, true, com.bloxbean.cardano.yano.api.archive
+                                        .PointerCredentialSource.NONE,
+                                java.util.Set.of(ProjectionSectionType.TRANSACTION)))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("cannot");
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/PointerHistoryCleanupPolicyTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/PointerHistoryCleanupPolicyTest.java
@@ -1,0 +1,150 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.OptionalLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * The pointer index may only be reclaimed when every ADR-039 gate holds. These tests exist
+ * mainly to prove the <em>denials</em>: deleting the index early is silent and irreversible,
+ * and "the tip is in Conway" is the tempting wrong answer.
+ */
+class PointerHistoryCleanupPolicyTest {
+
+    private static final long PRE_CONWAY_BLOCK = 1_000_000;
+    private static final long PRE_CONWAY_SLOT = 50_000_000;
+
+    /** Every gate satisfied; individual tests weaken exactly one. */
+    private static PointerHistoryCleanupPolicy.Observation allGatesPass() {
+        return new PointerHistoryCleanupPolicy.Observation(
+                OptionalLong.of(PRE_CONWAY_BLOCK), OptionalLong.of(PRE_CONWAY_SLOT),
+                PRE_CONWAY_BLOCK + 5_000,   // archive-finality safe
+                PRE_CONWAY_BLOCK + 10_000,  // contributors well past
+                -1,                          // nothing replayable
+                PRE_CONWAY_SLOT + 1_000,     // rollback floor past the boundary
+                0,                           // no holds
+                true);                       // sections durable
+    }
+
+    @Test
+    void cleanupIsAllowedWhenEveryGatePasses() {
+        var decision = PointerHistoryCleanupPolicy.evaluate(allGatesPass());
+        assertThat(decision.allowed()).isTrue();
+        assertThat(decision.throughSlot()).hasValue(PRE_CONWAY_SLOT);
+        assertThat(decision.reason()).isEmpty();
+    }
+
+    @Test
+    void gate1_noCleanupBeforeTheChainCrossesConway() {
+        var o = new PointerHistoryCleanupPolicy.Observation(
+                OptionalLong.empty(), OptionalLong.empty(), 9_999_999, 9_999_999, -1,
+                PRE_CONWAY_SLOT + 1, 0, true);
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("has not crossed the Conway boundary");
+    }
+
+    @Test
+    void gate1_noCleanupWhileTheBoundaryIsStillInsideTheFinalityWindow() {
+        var base = allGatesPass();
+        var o = new PointerHistoryCleanupPolicy.Observation(base.finalPreConwayBlock(),
+                base.finalPreConwaySlot(), PRE_CONWAY_BLOCK - 1, base.contributorsCompleteThroughBlock(),
+                base.oldestReplayableBlock(), base.commonRollbackFloorSlot(),
+                base.activePointerRetentionHolds(), base.preConwaySectionsDurable());
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("not yet archive-finality safe");
+    }
+
+    @Test
+    void gate2_noCleanupWhileAContributorIsBehindTheBoundary() {
+        var base = allGatesPass();
+        var o = new PointerHistoryCleanupPolicy.Observation(base.finalPreConwayBlock(),
+                base.finalPreConwaySlot(), base.archiveEligibleThroughBlock(), PRE_CONWAY_BLOCK - 1,
+                base.oldestReplayableBlock(), base.commonRollbackFloorSlot(),
+                base.activePointerRetentionHolds(), base.preConwaySectionsDurable());
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("short of the final pre-Conway block");
+    }
+
+    @Test
+    void gate3_noCleanupWhileAPreConwayBlockRemainsReplayable() {
+        var base = allGatesPass();
+        var o = new PointerHistoryCleanupPolicy.Observation(base.finalPreConwayBlock(),
+                base.finalPreConwaySlot(), base.archiveEligibleThroughBlock(),
+                base.contributorsCompleteThroughBlock(), PRE_CONWAY_BLOCK - 500,
+                base.commonRollbackFloorSlot(), base.activePointerRetentionHolds(),
+                base.preConwaySectionsDurable());
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("can still replay pre-Conway block");
+    }
+
+    @Test
+    void gate4_noCleanupWhileTheRollbackFloorIsAtOrBeforeTheBoundary() {
+        var base = allGatesPass();
+        var o = new PointerHistoryCleanupPolicy.Observation(base.finalPreConwayBlock(),
+                base.finalPreConwaySlot(), base.archiveEligibleThroughBlock(),
+                base.contributorsCompleteThroughBlock(), base.oldestReplayableBlock(),
+                PRE_CONWAY_SLOT, base.activePointerRetentionHolds(), base.preConwaySectionsDurable());
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("not past the final pre-Conway slot");
+    }
+
+    @Test
+    void gate4_unboundedRetentionBlocksCleanupEntirely() {
+        // Floor 0 means "can roll back anywhere", which includes pre-Conway.
+        var base = allGatesPass();
+        var o = new PointerHistoryCleanupPolicy.Observation(base.finalPreConwayBlock(),
+                base.finalPreConwaySlot(), base.archiveEligibleThroughBlock(),
+                base.contributorsCompleteThroughBlock(), base.oldestReplayableBlock(),
+                0, base.activePointerRetentionHolds(), base.preConwaySectionsDurable());
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("unbounded");
+    }
+
+    @Test
+    void gate5_noCleanupWhileARetentionHoldExists() {
+        var base = allGatesPass();
+        var o = new PointerHistoryCleanupPolicy.Observation(base.finalPreConwayBlock(),
+                base.finalPreConwaySlot(), base.archiveEligibleThroughBlock(),
+                base.contributorsCompleteThroughBlock(), base.oldestReplayableBlock(),
+                base.commonRollbackFloorSlot(), 2, base.preConwaySectionsDurable());
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("retention hold");
+    }
+
+    @Test
+    void gate6_noCleanupWhilePreConwaySectionsAreNotDurable() {
+        var base = allGatesPass();
+        var o = new PointerHistoryCleanupPolicy.Observation(base.finalPreConwayBlock(),
+                base.finalPreConwaySlot(), base.archiveEligibleThroughBlock(),
+                base.contributorsCompleteThroughBlock(), base.oldestReplayableBlock(),
+                base.commonRollbackFloorSlot(), base.activePointerRetentionHolds(), false);
+        var decision = PointerHistoryCleanupPolicy.evaluate(o);
+        assertThat(decision.allowed()).isFalse();
+        assertThat(decision.reason()).get().asString().contains("not yet durable");
+    }
+
+    @Test
+    void aConwayTipAloneIsNotSufficient() {
+        // The specific mistake this policy exists to prevent: everything else unmet.
+        var o = new PointerHistoryCleanupPolicy.Observation(
+                OptionalLong.of(PRE_CONWAY_BLOCK), OptionalLong.of(PRE_CONWAY_SLOT),
+                PRE_CONWAY_BLOCK - 1, 0, 0, 0, 3, false);
+        assertThat(PointerHistoryCleanupPolicy.evaluate(o).allowed()).isFalse();
+    }
+
+    @Test
+    void aSinkReceiptIsDeliberatelyNotRequired() {
+        // The resolved pointer outcome is already durable in the outbox envelope, so waiting
+        // on a lagging sink would retain the index far longer than correctness needs.
+        assertThat(PointerHistoryCleanupPolicy.evaluate(allGatesPass()).allowed()).isTrue();
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/PointerResolutionDifferentialTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/PointerResolutionDifferentialTest.java
@@ -1,0 +1,358 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCoordinate;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCredential;
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.ArchiveJob;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRangeAnchor;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.BlockRange;
+import com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryDataset;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact;
+import com.bloxbean.cardano.yano.archive.core.hot.RocksDbHotHistoryStore;
+import com.bloxbean.cardano.yano.archive.core.worker.ArchiveTrack;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Differential and semantic tests for ADR-039 as-of pointer resolution.
+ *
+ * <p>The oracle is the **real** shipped sequential archive resolver, backed by a live
+ * {@code RocksDbHotHistoryStore}. Comparing two resolver-less paths would be tautological for
+ * pointer addresses, which is how the original crash-on-pointer defect survived a full parity
+ * suite.
+ *
+ * <p>The subject is capture-time resolution against the authoritative registration mapping and
+ * the derived deregistration index, evaluated as of the block being projected.
+ */
+class PointerResolutionDifferentialTest {
+    @TempDir Path temp;
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(1, "fixture-genesis");
+    private static final String CRED_A = "77".repeat(28);
+    private static final String CRED_B = "88".repeat(28);
+
+    /**
+     * Models the account-state store: an append-only registration map plus a coordinate-keyed
+     * deregistration index. Deliberately mirrors the real key semantics rather than the real
+     * storage, so the interval logic is what is under test.
+     */
+    static final class FakeAuthoritativeSource implements PointerCredentialSource {
+        private final TreeMap<PointerCoordinate, PointerCredential> registrations = new TreeMap<>();
+        private final List<Object[]> deregistrations = new ArrayList<>(); // [credential, coordinate]
+        private IndexCompleteness completeness = IndexCompleteness.COMPLETE;
+
+        FakeAuthoritativeSource register(long slot, int tx, int cert, String hash) {
+            registrations.put(new PointerCoordinate(slot, tx, cert), new PointerCredential(0, hash));
+            return this;
+        }
+
+        FakeAuthoritativeSource deregister(long slot, int tx, int cert, String hash) {
+            deregistrations.add(new Object[]{new PointerCredential(0, hash),
+                    new PointerCoordinate(slot, tx, cert)});
+            return this;
+        }
+
+        FakeAuthoritativeSource completeness(IndexCompleteness value) {
+            this.completeness = value;
+            return this;
+        }
+
+        @Override public Optional<PointerCredential> registrationAt(PointerCoordinate coordinate) {
+            return Optional.ofNullable(registrations.get(coordinate));
+        }
+
+        @Override public boolean deregisteredWithin(PointerCredential credential, PointerCoordinate after,
+                                                    PointerCoordinate through) {
+            return deregistrations.stream().anyMatch(entry ->
+                    entry[0].equals(credential)
+                            && ((PointerCoordinate) entry[1]).compareTo(after) > 0
+                            && ((PointerCoordinate) entry[1]).compareTo(through) <= 0);
+        }
+
+        @Override public IndexCompleteness completeness() {
+            return completeness;
+        }
+    }
+
+    // ------------------------------------------------------------------ fixtures
+
+    private static UtxoHistoryFact.Address pointerAddress(long slot, int tx, int cert) {
+        return new UtxoHistoryFact.Address(new byte[]{1, 2, 3}, new byte[]{4}, "addr_test_pointer",
+                0, "ptr", "key", new byte[]{9}, "pointer", null, null, slot, tx, cert);
+    }
+
+    private static UtxoHistoryFact.Output output() {
+        return new UtxoHistoryFact.Output(new byte[]{0x11}, 0, 0, "output", new byte[]{1, 2, 3},
+                new byte[]{9}, null, 1_000_000L, "none", null, null, null, null, null, false);
+    }
+
+    private static UtxoHistoryFact.PointerRegistration registration(long slot, int tx, int cert, String hash) {
+        return new UtxoHistoryFact.PointerRegistration(slot, tx, cert, "key", HexUtil.decodeHexString(hash));
+    }
+
+    private static UtxoHistoryFact.PointerDeregistration deregistration(int tx, int cert, String hash) {
+        return new UtxoHistoryFact.PointerDeregistration(tx, cert, "key", HexUtil.decodeHexString(hash));
+    }
+
+    private static UtxoHistoryFact fact(int era, List<UtxoHistoryFact.PointerRegistration> regs,
+                                        List<UtxoHistoryFact.PointerDeregistration> deregs,
+                                        UtxoHistoryFact.Address address) {
+        return new UtxoHistoryFact(era, regs, deregs, List.of(address), List.of(output()),
+                List.of(), List.of(), List.of(), List.of());
+    }
+
+    private static ArchiveJob job() {
+        return ArchiveJob.deterministic(NETWORK, ArchiveDatasetId.UTXO_HISTORY, 5, new BlockRange(1, 1),
+                new ArchiveRangeAnchor(100, new byte[]{1}, 100, new byte[]{1}), "v1");
+    }
+
+    private static BlockSourceContext<UtxoHistoryFact> ctx(UtxoHistoryFact fact, long block, long slot) {
+        return new BlockSourceContext<>(block, slot, 0, Instant.EPOCH, new byte[]{(byte) block},
+                new byte[]{(byte) (block - 1)}, fact);
+    }
+
+    private static List<String> render(List<ArchiveRow> rows) {
+        return rows.stream().filter(r -> r.table().equals("transaction_outputs"))
+                .map(r -> r.values().stream()
+                        .map(v -> v instanceof byte[] b ? HexUtil.encodeHexString(b) : String.valueOf(v))
+                        .collect(Collectors.joining(",")))
+                .toList();
+    }
+
+    /** Subject: resolve as of the block, then derive rows with no resolver at all. */
+    private static List<String> subject(UtxoHistoryFact fact, long block, long slot,
+                                        PointerCredentialSource source) {
+        var resolved = ProjectionPointerResolution.resolve(fact, slot, source);
+        List<ArchiveRow> rows = new ArrayList<>();
+        new UtxoHistoryDataset().derive(job(), ctx(resolved, block, slot), rows::add);
+        return render(rows);
+    }
+
+    /** Oracle: the shipped sequential resolver over an ordered sequence of blocks. */
+    private List<String> oracleLastBlock(String store, List<BlockSourceContext<UtxoHistoryFact>> blocks) {
+        try (var state = new RocksDbHotHistoryStore(temp.resolve(store))) {
+            var dataset = new UtxoHistoryDataset(state, ArchiveTrack.BACKFILL);
+            dataset.beginBatch(job(), blocks);
+            List<ArchiveRow> last = null;
+            for (BlockSourceContext<UtxoHistoryFact> block : blocks) {
+                List<ArchiveRow> rows = new ArrayList<>();
+                dataset.derive(job(), block, rows::add);
+                last = rows;
+            }
+            return render(last);
+        }
+    }
+
+    private static boolean resolvedTo(List<String> rows, String hash) {
+        return rows.size() == 1 && rows.get(0).contains(hash);
+    }
+
+    // ------------------------------------------------- core as-of semantics
+
+    @Test
+    void registrationThenLaterDeregistrationThenUseIsUnresolved() {
+        // The divergence that motivated this work: the ledger drops the pointer on
+        // deregistration, so a later use must not resolve.
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A).deregister(75, 0, 0, CRED_A);
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+
+        var oracle = oracleLastBlock("dereg-then-use", List.of(
+                ctx(fact(Era.Babbage.getValue(), List.of(registration(50, 0, 0, CRED_A)), List.of(),
+                        pointerAddress(50, 0, 0)), 1, 50),
+                ctx(new UtxoHistoryFact(Era.Babbage.getValue(), List.of(),
+                        List.of(deregistration(0, 0, CRED_A)), List.of(), List.of(), List.of(), List.of(),
+                        List.of(), List.of()), 2, 75),
+                ctx(using, 3, 100)));
+
+        assertThat(subject(using, 3, 100, source)).isEqualTo(oracle);
+        assertThat(resolvedTo(subject(using, 3, 100, source), CRED_A)).isFalse();
+    }
+
+    @Test
+    void useBeforeDeregistrationIsResolved() {
+        // Same chain, but projected at a block before the deregistration coordinate.
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A).deregister(75, 0, 0, CRED_A);
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        assertThat(resolvedTo(subject(using, 2, 60, source), CRED_A)).isTrue();
+    }
+
+    @Test
+    void aPreviousBlockCoordinateDeregisteredInThisBlockDoesNotFallThrough() {
+        // The registration comes from the authoritative source; the deregistration is only in
+        // this block's overlay. Resolving the former without consulting the latter would
+        // wrongly resolve.
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A);
+        var thisBlock = fact(Era.Babbage.getValue(),
+                List.of(registration(100, 9, 9, CRED_B)),   // supplies this block's slot
+                List.of(deregistration(0, 0, CRED_A)),
+                pointerAddress(50, 0, 0));
+        assertThat(resolvedTo(subject(thisBlock, 3, 100, source), CRED_A)).isFalse();
+    }
+
+    @Test
+    void registrationThenDeregistrationInOneBlock() {
+        var source = new FakeAuthoritativeSource();
+        var block = fact(Era.Babbage.getValue(),
+                List.of(registration(100, 0, 0, CRED_A)),
+                List.of(deregistration(1, 0, CRED_A)),
+                pointerAddress(100, 0, 0));
+        var oracle = oracleLastBlock("reg-dereg-one-block", List.of(ctx(block, 1, 100)));
+        assertThat(subject(block, 1, 100, source)).isEqualTo(oracle);
+        assertThat(resolvedTo(subject(block, 1, 100, source), CRED_A)).isFalse();
+    }
+
+    @Test
+    void deregistrationThenReRegistrationInOneBlockLeavesTheOldCoordinateDead() {
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A);
+        var block = fact(Era.Babbage.getValue(),
+                List.of(registration(100, 2, 0, CRED_A)),      // re-registration, new coordinate
+                List.of(deregistration(1, 0, CRED_A)),
+                pointerAddress(50, 0, 0));                      // the OLD coordinate
+        assertThat(resolvedTo(subject(block, 3, 100, source), CRED_A))
+                .as("re-registration must never reactivate an older coordinate")
+                .isFalse();
+    }
+
+    @Test
+    void theNewCoordinateFromAReRegistrationResolves() {
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A);
+        var block = fact(Era.Babbage.getValue(),
+                List.of(registration(100, 2, 0, CRED_A)),
+                List.of(deregistration(1, 0, CRED_A)),
+                pointerAddress(100, 2, 0));                     // the NEW coordinate
+        assertThat(resolvedTo(subject(block, 3, 100, source), CRED_A)).isTrue();
+    }
+
+    @Test
+    void anOldCoordinateStaysUnresolvedAfterCrossBlockReRegistration() {
+        var source = new FakeAuthoritativeSource()
+                .register(50, 0, 0, CRED_A)
+                .deregister(75, 0, 0, CRED_A)
+                .register(90, 0, 0, CRED_A);
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        assertThat(resolvedTo(subject(using, 5, 200, source), CRED_A)).isFalse();
+
+        var usingNew = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(90, 0, 0));
+        assertThat(resolvedTo(subject(usingNew, 5, 200, source), CRED_A)).isTrue();
+    }
+
+    @Test
+    void multipleEventsForOneCredentialInTheSameSlotDoNotCollide() {
+        // Two deregistrations in one slot, different transactions. A slot-only key would keep
+        // one and lose the other; the full coordinate distinguishes them.
+        var source = new FakeAuthoritativeSource()
+                .register(50, 0, 0, CRED_A)
+                .deregister(75, 0, 0, CRED_A)
+                .deregister(75, 4, 0, CRED_A);
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        assertThat(resolvedTo(subject(using, 5, 100, source), CRED_A)).isFalse();
+
+        // A coordinate registered between the two same-slot deregistrations is killed by the
+        // later one only.
+        var between = new FakeAuthoritativeSource()
+                .register(75, 2, 0, CRED_A)
+                .deregister(75, 0, 0, CRED_A)
+                .deregister(75, 4, 0, CRED_A);
+        var usingBetween = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(75, 2, 0));
+        assertThat(resolvedTo(subject(usingBetween, 5, 100, between), CRED_A)).isFalse();
+    }
+
+    @Test
+    void anUnrelatedCredentialsDeregistrationDoesNotInvalidate() {
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A).deregister(75, 0, 0, CRED_B);
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        assertThat(resolvedTo(subject(using, 5, 100, source), CRED_A)).isTrue();
+    }
+
+    @Test
+    void aMissingMappingIsUnresolvedRatherThanThrowing() {
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(10, 0, 0));
+        var rows = subject(using, 3, 100, new FakeAuthoritativeSource());
+        assertThat(rows).hasSize(1);
+        assertThat(rows.get(0)).contains("null");
+    }
+
+    @Test
+    void conwayPointerReferencesAreNotEffective() {
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A);
+        var using = fact(Era.Conway.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        var oracle = oracleLastBlock("conway", List.of(ctx(using, 1, 100)));
+        assertThat(subject(using, 1, 100, source)).isEqualTo(oracle);
+        assertThat(resolvedTo(subject(using, 1, 100, source), CRED_A)).isFalse();
+    }
+
+    // ------------------------------------------------------ replay determinism
+
+    @Test
+    void aFutureCoordinateStaysUnresolved() {
+        var source = new FakeAuthoritativeSource().register(9_000, 0, 0, CRED_A);
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(9_000, 0, 0));
+        assertThat(resolvedTo(subject(using, 3, 100, source), CRED_A)).isFalse();
+    }
+
+    @Test
+    void replayAgainstAdvancedCoreStateReproducesTheFirstPass() {
+        // At capture, only the registration existed. Later the chain deregistered and
+        // re-registered. Replaying the same block must give the capture-time answer.
+        var atCapture = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A);
+        var advanced = new FakeAuthoritativeSource()
+                .register(50, 0, 0, CRED_A)
+                .deregister(5_000, 0, 0, CRED_A)
+                .register(6_000, 0, 0, CRED_A)
+                .deregister(7_000, 1, 1, CRED_B);
+
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        assertThat(subject(using, 3, 100, advanced)).isEqualTo(subject(using, 3, 100, atCapture));
+        assertThat(resolvedTo(subject(using, 3, 100, advanced), CRED_A)).isTrue();
+    }
+
+    @Test
+    void replayIsDeterministicAcrossRepeatedResolution() {
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A).deregister(75, 0, 0, CRED_A);
+        var using = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        var first = subject(using, 3, 100, source);
+        for (int i = 0; i < 10; i++) {
+            assertThat(subject(using, 3, 100, source)).isEqualTo(first);
+        }
+    }
+
+    @Test
+    void resolutionIsIdempotent() {
+        var source = new FakeAuthoritativeSource().register(50, 0, 0, CRED_A);
+        var f = fact(Era.Babbage.getValue(), List.of(), List.of(), pointerAddress(50, 0, 0));
+        var once = ProjectionPointerResolution.resolve(f, 100, source);
+        var twice = ProjectionPointerResolution.resolve(once, 100, source);
+
+        List<ArchiveRow> a = new ArrayList<>();
+        List<ArchiveRow> b = new ArrayList<>();
+        new UtxoHistoryDataset().derive(job(), ctx(once, 3, 100), a::add);
+        new UtxoHistoryDataset().derive(job(), ctx(twice, 3, 100), b::add);
+        assertThat(render(b)).isEqualTo(render(a));
+    }
+
+    @Test
+    void nonPointerAddressesAreUntouched() {
+        var plain = new UtxoHistoryFact.Address(new byte[]{1, 2, 3}, new byte[]{4}, "addr_test_plain",
+                0, "base", "key", new byte[]{9}, "credential", "key",
+                HexUtil.decodeHexString(CRED_A), null, null, null);
+        var f = new UtxoHistoryFact(Era.Babbage.getValue(), List.of(), List.of(), List.of(plain),
+                List.of(output()), List.of(), List.of(), List.of(), List.of());
+        assertThat(ProjectionPointerResolution.resolve(f, 100, new FakeAuthoritativeSource())).isSameAs(f);
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchAccumulatorTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionBatchAccumulatorTest.java
@@ -1,0 +1,405 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Batching decides how many Parquet files the archive ends up with, so every bound needs a
+ * test that shows which one fired. The first preprod sync produced 67,603 files at 56 KB
+ * because the drain loop committed whatever was eligible immediately; these assert the
+ * replacement behaves per regime and never exceeds a safety ceiling.
+ */
+class ProjectionBatchAccumulatorTest {
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(1, "fixture");
+    private static final Instant T0 = Instant.EPOCH;
+
+    private static ProjectionEnvelope envelope(long block, long rows, int payloadBytes) {
+        var section = new ProjectionSection(ProjectionSectionType.TRANSACTION,
+                ProjectionSectionType.TRANSACTION.version(), List.of(new byte[payloadBytes]), rows);
+        var header = new ProjectionEnvelopeHeader(NETWORK, ProjectionBlockKind.SHELLEY_PLUS, block,
+                new byte[]{(byte) block}, new byte[]{(byte) (block - 1)}, block * 20, 1, 1L, 1,
+                List.of(section.manifest()), List.of());
+        return new ProjectionEnvelope(header, List.of(section));
+    }
+
+    private static ProjectionBatchPolicy policy(int minBootstrap, int minTip, int maxBlocks,
+                                                long maxBytes, long maxRows, long maxHeap) {
+        return new ProjectionBatchPolicy(minBootstrap, minTip, maxBlocks,
+                Duration.ofSeconds(30), Duration.ofMinutes(5), maxBytes, maxRows, maxHeap, 600,
+                64L << 20, 4_000_000);
+    }
+
+    // ------------------------------------------------------------- bootstrap
+
+    @Test
+    void bootstrapAccumulatesUntilTheMinimumBlockCount() {
+        var acc = new ProjectionBatchAccumulator(policy(100, 1, 1000, 1 << 30, 1_000_000, 1L << 30));
+        for (long b = 0; b < 99; b++) acc.offer(envelope(b, 1, 10), T0);
+        assertThat(acc.decide(false, true, T0).flush()).isFalse();
+
+        acc.offer(envelope(99, 1, 10), T0);
+        var decision = acc.decide(false, true, T0);
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.MIN_BLOCKS);
+        assertThat(decision.blocks()).isEqualTo(100);
+    }
+
+    @Test
+    void bootstrapFlushesWhenTheLingerWindowExpiresEvenBelowMinimum() {
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 1 << 30, 1_000_000, 1L << 30));
+        acc.offer(envelope(0, 1, 10), T0);
+        assertThat(acc.decide(false, true, T0.plusSeconds(29)).flush()).isFalse();
+
+        var decision = acc.decide(false, true, T0.plusSeconds(30));
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.LINGER_EXPIRED);
+    }
+
+    // ------------------------------------------------------------- near tip
+
+    @Test
+    void nearTipUsesItsOwnBlockTargetNotTheBootstrapOne() {
+        // A bootstrap-sized floor at tip would stall for days; the tip target governs instead.
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 5, 20_000, 1 << 30, 1_000_000, 1L << 30));
+        for (long b = 0; b < 4; b++) acc.offer(envelope(b, 1, 10), T0);
+        assertThat(acc.decide(true, true, T0).flush()).isFalse();
+
+        acc.offer(envelope(4, 1, 10), T0);
+        var decision = acc.decide(true, true, T0);
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.MIN_BLOCKS);
+    }
+
+    /**
+     * The correction that matters most at tip: a single eligible block must NOT commit on
+     * arrival. Blocks arrive intermittently, so treating "nothing more right now" as a flush
+     * reason would commit on almost every arrival and rebuild the tiny-file problem.
+     */
+    @Test
+    void oneEligibleBlockDoesNotCommitImmediatelyAndCommitsWhenFreshnessExpires() {
+        var policy = new ProjectionBatchPolicy(10_000, 15, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(5), 1L << 30, 1_000_000, 1L << 30, 600,
+                64L << 20, 4_000_000);
+        var acc = new ProjectionBatchAccumulator(policy);
+        acc.offer(envelope(0, 1, 10), T0);
+
+        // deterministic clock: nothing else arrives for the whole freshness window
+        assertThat(acc.decide(true, false, T0).flush()).isFalse();
+        assertThat(acc.decide(true, false, T0.plusSeconds(60)).flush()).isFalse();
+        assertThat(acc.decide(true, false, T0.plusSeconds(299)).flush()).isFalse();
+
+        var decision = acc.decide(true, false, T0.plusSeconds(300));
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.LINGER_EXPIRED);
+        assertThat(decision.blocks()).isEqualTo(1);
+    }
+
+    // --------------------------------------------------------- safety bounds
+
+    @Test
+    void theRowCeilingIsEnforcedBeforeMaterialisation() {
+        // Rows come from stored manifests, so the bound is applied without building any
+        // ArchiveRow objects - which is the entire point of bounding here.
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 1L << 30, 1_000, 1L << 30));
+        for (long b = 0; b < 10; b++) assertThat(acc.offer(envelope(b, 100, 10), T0)).isEqualTo(ProjectionBatchAccumulator.Offer.ACCEPTED);
+        assertThat(acc.rows()).isEqualTo(1_000);
+
+        assertThat(acc.offer(envelope(10, 100, 10), T0)).as("accepting this would breach the row ceiling")
+                .isEqualTo(ProjectionBatchAccumulator.Offer.REJECTED_FULL);
+        assertThat(acc.decide(false, true, T0).reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MAX_ROWS);
+    }
+
+    @Test
+    void theHeapCeilingCanBindBeforeTheExplicitRowCeiling() {
+        // 600 bytes/row estimate x 1,000 rows = 600 KB; a 300 KB heap bound must bind first.
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 1L << 30, 1_000_000, 300_000));
+        assertThat(acc.effectiveMaxRowsForTest()).isLessThan(1_000_000L);
+        for (long b = 0; b < 600; b++) acc.offer(envelope(b, 1, 10), T0);
+        var decision = acc.decide(false, true, T0);
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.MAX_HEAP);
+        assertThat(decision.estimatedHeapBytes()).isGreaterThanOrEqualTo(300_000);
+    }
+
+    @Test
+    void theEncodedByteCeilingIsEnforced() {
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 10_000, 1_000_000, 1L << 30));
+        for (long b = 0; b < 10; b++) acc.offer(envelope(b, 1, 1_000), T0);
+        assertThat(acc.encodedBytes()).isEqualTo(10_000);
+        assertThat(acc.offer(envelope(10, 1, 1_000), T0)).isEqualTo(ProjectionBatchAccumulator.Offer.REJECTED_FULL);
+        assertThat(acc.decide(false, true, T0).reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MAX_BYTES);
+    }
+
+    @Test
+    void theBlockCeilingIsEnforced() {
+        // maxBlocks must be at least every minimum, so the bootstrap minimum is set below it.
+        var acc = new ProjectionBatchAccumulator(policy(2, 1, 5, 1L << 30, 1_000_000, 1L << 30));
+        for (long b = 0; b < 5; b++) acc.offer(envelope(b, 1, 10), T0);
+        assertThat(acc.offer(envelope(5, 1, 10), T0)).isEqualTo(ProjectionBatchAccumulator.Offer.REJECTED_FULL);
+        assertThat(acc.decide(false, true, T0).reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MAX_BLOCKS);
+    }
+
+    @Test
+    void anOversizedSingleEnvelopeIsStillAcceptedWhenTheBatchIsEmpty() {
+        // Otherwise one dense block larger than a ceiling would deadlock the consumer forever.
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 100, 10, 1_000));
+        assertThat(acc.offer(envelope(0, 10_000, 1_000_000), T0)).isEqualTo(ProjectionBatchAccumulator.Offer.ACCEPTED);
+        assertThat(acc.decide(false, true, T0).flush()).isTrue();
+    }
+
+    // ------------------------------------------------------------ lifecycle
+
+    @Test
+    void forceFlushCommitsWhateverIsHeldForShutdown() {
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 1L << 30, 1_000_000, 1L << 30));
+        acc.offer(envelope(0, 1, 10), T0);
+        var decision = acc.forceFlush();
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.FORCED);
+        assertThat(decision.blocks()).isEqualTo(1);
+    }
+
+    @Test
+    void resetClearsAccountingSoTheNextBatchStartsClean() {
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 1L << 30, 1_000_000, 1L << 30));
+        acc.offer(envelope(0, 5, 100), T0);
+        acc.reset();
+        assertThat(acc.isEmpty()).isTrue();
+        assertThat(acc.rows()).isZero();
+        assertThat(acc.encodedBytes()).isZero();
+        assertThat(acc.decide(false, true, T0).flush()).isFalse();
+    }
+
+    @Test
+    void anEmptyAccumulatorNeverFlushes() {
+        var acc = new ProjectionBatchAccumulator(policy(1, 1, 10, 1L << 30, 1_000_000, 1L << 30));
+        assertThat(acc.decide(false, false, T0.plusSeconds(3600)).flush()).isFalse();
+    }
+
+    // -------------------------------------------------------------- policy
+
+    @Test
+    void defaultsAreCoherentAndRegimeAware() {
+        var d = ProjectionBatchPolicy.defaults();
+        assertThat(d.minBlocks(false)).isEqualTo(10_000);
+        assertThat(d.minBlocks(true))
+                .as("a near-tip minimum of 1 would flush every block on arrival")
+                .isGreaterThan(1);
+        assertThat(d.maxLinger(true)).isGreaterThan(d.maxLinger(false));
+        assertThat(d.effectiveMaxRows()).isLessThanOrEqualTo(d.maxRows());
+    }
+
+    /**
+     * The near-tip block count is a <em>preferred</em> target; the freshness window is the hard
+     * bound. Under slow production the target is never reached, and the linger must still fire.
+     */
+    @Test
+    void underSlowProductionTheFreshnessWindowGovernsNotTheBlockTarget() {
+        var policy = nearTipDefaults();
+        var acc = new ProjectionBatchAccumulator(policy);
+
+        // one block per minute: only 5 arrive within the freshness window, well under 15
+        for (int minute = 0; minute < 5; minute++) {
+            acc.offer(envelope(minute, 1, 10), T0.plusSeconds(minute * 60L));
+            assertThat(acc.decide(true, true, T0.plusSeconds(minute * 60L)).flush())
+                    .as("only %d blocks; the target of 15 is not reached", minute + 1)
+                    .isFalse();
+        }
+
+        assertThat(acc.decide(true, true, T0.plusSeconds(899)).flush())
+                .as("one second before the deadline")
+                .isFalse();
+
+        var decision = acc.decide(true, true, T0.plusSeconds(900));
+        assertThat(decision.flush()).as("flushes at exactly the linger deadline").isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.LINGER_EXPIRED);
+        assertThat(decision.blocks()).isEqualTo(5);
+    }
+
+    /** The companion: with fast production the target fires well before the window. */
+    @Test
+    void reachingTheTargetFlushesEarlierWithMinBlocks() {
+        var acc = new ProjectionBatchAccumulator(nearTipDefaults());
+        for (int i = 0; i < 50; i++) acc.offer(envelope(i, 1, 10), T0.plusSeconds(i));
+
+        var decision = acc.decide(true, true, T0.plusSeconds(50));
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.MIN_BLOCKS);
+        assertThat(decision.blocks()).isEqualTo(50);
+    }
+
+    /** Conversely, when blocks arrive quickly the target fires before the window. */
+    @Test
+    void underFastProductionTheBlockTargetFiresBeforeTheFreshnessWindow() {
+        var policy = new ProjectionBatchPolicy(10_000, 15, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(5), 1L << 30, 1_000_000, 1L << 30, 600,
+                64L << 20, 4_000_000);
+        var acc = new ProjectionBatchAccumulator(policy);
+        for (int i = 0; i < 15; i++) acc.offer(envelope(i, 1, 10), T0.plusSeconds(i));
+
+        var decision = acc.decide(true, true, T0.plusSeconds(15));
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.MIN_BLOCKS);
+    }
+
+    // ------------------------------------------------ singleton safety guard
+
+    @Test
+    void anEnvelopeBeyondTheAbsoluteGuardIsRefusedRatherThanRiskingOom() {
+        // Guards set implausibly low so the case is reachable; in production they sit far
+        // above any valid Cardano block, so this never fires in normal operation.
+        var policy = new ProjectionBatchPolicy(2, 1, 10, Duration.ofSeconds(30), Duration.ofMinutes(5),
+                1L << 30, 1_000_000, 1L << 30, 600, /*singleton bytes*/ 1_000, /*singleton rows*/ 10);
+        var acc = new ProjectionBatchAccumulator(policy);
+
+        assertThat(acc.offer(envelope(0, 5_000, 10), T0))
+                .as("a projection this large from one block indicates corruption, not density")
+                .isEqualTo(ProjectionBatchAccumulator.Offer.REJECTED_UNSAFE);
+        assertThat(acc.isEmpty()).isTrue();
+        assertThat(acc.stats().largestRejectedSingletonBytes()).isPositive();
+    }
+
+    @Test
+    void anOversizedButSafeSingletonIsAcceptedAndCounted() {
+        var policy = new ProjectionBatchPolicy(2, 1, 10, Duration.ofSeconds(30), Duration.ofMinutes(5),
+                /*maxEncodedBytes*/ 100, 10, 1L << 30, 600, 64L << 20, 4_000_000);
+        var acc = new ProjectionBatchAccumulator(policy);
+
+        assertThat(acc.offer(envelope(0, 50, 5_000), T0))
+                .isEqualTo(ProjectionBatchAccumulator.Offer.ACCEPTED);
+        var stats = acc.stats();
+        assertThat(stats.oversizedSingletons()).isEqualTo(1);
+        assertThat(stats.singletonHighWatermarkBytes()).isPositive();
+    }
+
+    // ------------------------------------------------------- observability
+
+    @Test
+    void statsReportLargestEnvelopeBytesAndRows() {
+        var acc = new ProjectionBatchAccumulator(policy(10_000, 1, 20_000, 1L << 30, 1_000_000, 1L << 30));
+        acc.offer(envelope(0, 10, 100), T0);
+        acc.offer(envelope(1, 250, 4_000), T0);
+        acc.offer(envelope(2, 5, 50), T0);
+
+        var stats = acc.stats();
+        assertThat(stats.largestEnvelopeRows()).isEqualTo(250);
+        assertThat(stats.largestEnvelopeEncodedBytes()).isEqualTo(4_000);
+        assertThat(stats.oversizedSingletons()).isZero();
+    }
+
+    // ------------------------------- near-tip defaults: 50 blocks OR 15 minutes
+
+    /** Production near-tip policy: preferred target 50 envelopes, hard bound 15 minutes. */
+    private static ProjectionBatchPolicy nearTipDefaults() {
+        return new ProjectionBatchPolicy(10_000, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15), 1L << 30, 1_000_000, 1L << 30, 600,
+                64L << 20, 4_000_000);
+    }
+
+    @Test
+    void fortyNineEnvelopesDoNotFlushBeforeTheDeadline() {
+        var acc = new ProjectionBatchAccumulator(nearTipDefaults());
+        for (int i = 0; i < 49; i++) {
+            // arrival spacing kept inside the 15-minute window so only the block target is in play
+            acc.offer(envelope(i, 1, 10), T0.plusSeconds(i * 10L));
+            assertThat(acc.decide(true, true, T0.plusSeconds(i * 10L)).flush())
+                    .as("%d envelopes, target is 50", i + 1)
+                    .isFalse();
+        }
+        // still short of both the target and the 15-minute deadline
+        assertThat(acc.decide(true, true, T0.plusSeconds(880)).flush()).isFalse();
+    }
+
+    @Test
+    void theFiftiethEnvelopeFlushesWithMinBlocks() {
+        var acc = new ProjectionBatchAccumulator(nearTipDefaults());
+        for (int i = 0; i < 49; i++) acc.offer(envelope(i, 1, 10), T0.plusSeconds(i));
+        assertThat(acc.decide(true, true, T0.plusSeconds(49)).flush()).isFalse();
+
+        acc.offer(envelope(49, 1, 10), T0.plusSeconds(50));
+        var decision = acc.decide(true, true, T0.plusSeconds(50));
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.MIN_BLOCKS);
+        assertThat(decision.blocks()).isEqualTo(50);
+    }
+
+    @Test
+    void aPartialBatchFlushesAtExactlyFifteenMinutes() {
+        // At 20 s slots the deadline typically fires around 40-50 blocks; that is the expected
+        // steady-state outcome, not a missed target.
+        var acc = new ProjectionBatchAccumulator(nearTipDefaults());
+        for (int i = 0; i < 45; i++) acc.offer(envelope(i, 1, 10), T0.plusSeconds(i * 20L));
+
+        assertThat(acc.decide(true, true, T0.plusSeconds(899)).flush()).isFalse();
+        var decision = acc.decide(true, true, T0.plusSeconds(900));
+        assertThat(decision.flush()).isTrue();
+        assertThat(decision.reason()).isEqualTo(ProjectionBatchDecision.Reason.LINGER_EXPIRED);
+        assertThat(decision.blocks()).isEqualTo(45);
+    }
+
+    @Test
+    void safetyGuardsOverrideBothNearTipTargets() {
+        // Byte ceiling fires well before 50 envelopes and well before 15 minutes.
+        var bytes = new ProjectionBatchAccumulator(new ProjectionBatchPolicy(10_000, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15), 5_000, 1_000_000, 1L << 30, 600,
+                64L << 20, 4_000_000));
+        for (int i = 0; i < 5; i++) bytes.offer(envelope(i, 1, 1_000), T0);
+        assertThat(bytes.decide(true, true, T0).reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MAX_BYTES);
+
+        // Row ceiling.
+        var rows = new ProjectionBatchAccumulator(new ProjectionBatchPolicy(10_000, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15), 1L << 30, 100, 1L << 30, 600,
+                64L << 20, 4_000_000));
+        for (int i = 0; i < 10; i++) rows.offer(envelope(i, 10, 10), T0);
+        assertThat(rows.decide(true, true, T0).reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MAX_ROWS);
+
+        // Heap ceiling.
+        var heap = new ProjectionBatchAccumulator(new ProjectionBatchPolicy(10_000, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15), 1L << 30, 1_000_000, 6_000, 600,
+                64L << 20, 4_000_000));
+        for (int i = 0; i < 10; i++) heap.offer(envelope(i, 1, 10), T0);
+        assertThat(heap.decide(true, true, T0).reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MAX_HEAP);
+
+        // Singleton guard refuses rather than flushing.
+        var guard = new ProjectionBatchAccumulator(new ProjectionBatchPolicy(10_000, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15), 1L << 30, 1_000_000, 1L << 30, 600,
+                1_000, 10));
+        assertThat(guard.offer(envelope(0, 5_000, 10), T0))
+                .isEqualTo(ProjectionBatchAccumulator.Offer.REJECTED_UNSAFE);
+    }
+
+    @Test
+    void flushReasonDistributionIsRecordedForMetrics() {
+        var acc = new ProjectionBatchAccumulator(nearTipDefaults());
+        for (int i = 0; i < 50; i++) acc.offer(envelope(i, 1, 10), T0);
+        var byTarget = acc.decide(true, true, T0);
+        acc.recordFlush(byTarget);
+        acc.reset();
+
+        acc.offer(envelope(100, 1, 10), T0);
+        var byLinger = acc.decide(true, true, T0.plusSeconds(900));
+        acc.recordFlush(byLinger);
+
+        var reasons = acc.stats().flushReasons();
+        assertThat(reasons).containsEntry(ProjectionBatchDecision.Reason.MIN_BLOCKS, 1L);
+        assertThat(reasons).containsEntry(ProjectionBatchDecision.Reason.LINGER_EXPIRED, 1L);
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionDifferentialParityTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionDifferentialParityTest.java
@@ -1,0 +1,546 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Amount;
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.BlockHeader;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.HeaderBody;
+import com.bloxbean.cardano.yaci.core.model.Redeemer;
+import com.bloxbean.cardano.yaci.core.model.RedeemerTag;
+import com.bloxbean.cardano.yaci.core.model.TransactionBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionInput;
+import com.bloxbean.cardano.yaci.core.model.TransactionOutput;
+import com.bloxbean.cardano.yaci.core.model.Witnesses;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
+import com.bloxbean.cardano.yano.api.archive.ProjectionStagingWriter;
+import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.ArchiveJob;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRangeAnchor;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.BlockRange;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext;
+import com.bloxbean.cardano.yano.archive.core.dataset.StandardBlockDatasets;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryDataset;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact;
+import com.bloxbean.cardano.yano.archive.core.source.YaciBlockArchiveDecoder;
+import com.bloxbean.cardano.yano.archive.core.source.YaciUtxoHistoryDecoder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ADR-039 Phase 3 exit criterion: the projection outbox must produce byte-identical
+ * archive rows to the existing decode-and-derive path over the same canonical block.
+ *
+ * <p>The old path is the differential oracle. Both paths deliberately end in the same
+ * {@code BlockArchiveDataset.derive} implementations, so any divergence is a transport
+ * defect — a lossy encoding, a reordering, a dropped nullable — rather than two
+ * independent interpretations of the chain drifting apart. That is precisely the class
+ * of bug this test exists to catch, and it is the evidence Phase 7 needs before the
+ * replay workers can be deleted.
+ */
+class ProjectionDifferentialParityTest {
+    static { RocksDB.loadLibrary(); }
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(1, "162d29c4");
+    private static final Set<ProjectionSectionType> REQUIRED =
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY,
+                    ProjectionSectionType.ACCOUNT_EVENT);
+    private static final ProjectionIdentity IDENTITY =
+            new ProjectionIdentity(NETWORK, "synthetic", 1, REQUIRED);
+
+    @TempDir Path directory;
+
+    private RocksDB db;
+    private DBOptions dbOptions;
+    private List<ColumnFamilyHandle> handles;
+    private ProjectionOutboxStore store;
+    private CanonicalProjectionCollector collector;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        dbOptions = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+        List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
+        descriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+        for (String name : ProjectionCfNames.ALL) {
+            descriptors.add(new ColumnFamilyDescriptor(name.getBytes(StandardCharsets.UTF_8)));
+        }
+        handles = new ArrayList<>();
+        db = RocksDB.open(dbOptions, directory.resolve("db").toString(), descriptors, handles);
+        store = new ProjectionOutboxStore(db, handles.get(1), handles.get(2), handles.get(3), handles.get(4));
+        collector = new CanonicalProjectionCollector(store, IDENTITY, slot -> slot / 100, slot -> 1_600_000_000L + slot);
+    }
+
+    @AfterEach
+    void tearDown() {
+        handles.forEach(ColumnFamilyHandle::close);
+        db.close();
+        dbOptions.close();
+    }
+
+    // ---------------------------------------------------------------- fixtures
+
+    private static String hex(int b, int len) {
+        return String.format("%02x", b).repeat(len);
+    }
+
+    private static TransactionOutput output(String address, long lovelace, Amount... extra) {
+        List<Amount> amounts = new ArrayList<>();
+        amounts.add(Amount.builder().unit("lovelace").quantity(BigInteger.valueOf(lovelace)).build());
+        amounts.addAll(Arrays.asList(extra));
+        return TransactionOutput.builder().address(address).amounts(amounts).build();
+    }
+
+    private static String shelleyAddress(int paymentFill, int stakeFill) {
+        byte[] address = new byte[57];
+        address[0] = 0;
+        Arrays.fill(address, 1, 29, (byte) paymentFill);
+        Arrays.fill(address, 29, 57, (byte) stakeFill);
+        return HexUtil.encodeHexString(address);
+    }
+
+    private static Block block(Era era, List<TransactionBody> txs, List<Integer> invalid, List<Witnesses> witnesses) {
+        return Block.builder().era(era)
+                .header(BlockHeader.builder().headerBody(HeaderBody.builder()
+                        .blockNumber(100).slot(2000).prevHash(hex(0x0a, 32)).blockHash(hex(0x0b, 32)).build()).build())
+                .transactionBodies(txs)
+                .transactionWitness(witnesses == null ? List.of() : witnesses)
+                .invalidTransactions(invalid)
+                .build();
+    }
+
+    // ------------------------------------------------------- parity machinery
+
+    private static String render(List<ArchiveRow> rows) {
+        return rows.stream().map(row -> row.table() + "(" + row.values().stream()
+                .map(value -> value instanceof byte[] bytes ? HexUtil.encodeHexString(bytes) : String.valueOf(value))
+                .collect(Collectors.joining(",")) + ")").collect(Collectors.joining("\n"));
+    }
+
+    private static ArchiveJob job(ArchiveDatasetId dataset) {
+        return ArchiveJob.deterministic(NETWORK, dataset, 1, new BlockRange(100, 100),
+                new ArchiveRangeAnchor(2000, HexUtil.decodeHexString(hex(0x0b, 32)), 2000,
+                        HexUtil.decodeHexString(hex(0x0b, 32))), "v1");
+    }
+
+    private BlockSourceContext<Block> context(Block block) {
+        return new BlockSourceContext<>(100, 2000, 20, Instant.ofEpochSecond(1_600_002_000L),
+                HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)), block);
+    }
+
+    /** Rows the existing path produces: decode the block, derive directly. */
+    private List<ArchiveRow> oracleRows(Block block) {
+        var ctx = context(block);
+        List<ArchiveRow> rows = new ArrayList<>();
+        var txFacts = new YaciBlockArchiveDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot).project(ctx);
+        StandardBlockDatasets.transactions().derive(job(ArchiveDatasetId.TRANSACTION), txFacts, rows::add);
+
+        StandardBlockDatasets.accountEvents().derive(job(ArchiveDatasetId.ACCOUNT_EVENT), txFacts, rows::add);
+
+        var utxoFacts = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot).project(ctx);
+        new UtxoHistoryDataset().derive(job(ArchiveDatasetId.UTXO_HISTORY), utxoFacts, rows::add);
+        return rows;
+    }
+
+    /** Rows the ADR-039 path produces: collect during apply, read back, derive from carried facts. */
+    private List<ArchiveRow> outboxRows(Block block) {
+        var event = new BlockAppliedEvent(block.getEra(), 2000, 100, hex(0x0b, 32), block);
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            ProjectionStagingWriter writer = ProjectionOutboxStore.batchWriter(batch, store.handles());
+            collector.contributeBlock(event, writer);
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+
+        var envelope = store.readEnvelope(100, REQUIRED).orElseThrow();
+        List<ArchiveRow> rows = new ArrayList<>();
+
+        var txSection = envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow();
+        var txFacts = ProjectionFactCodec.decodeTransactions(ProjectionChunking.join(txSection.chunks()));
+        StandardBlockDatasets.transactions().derive(job(ArchiveDatasetId.TRANSACTION),
+                new BlockSourceContext<>(100, 2000, 20, Instant.ofEpochSecond(1_600_002_000L),
+                        HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)),
+                        new com.bloxbean.cardano.yano.archive.core.dataset.ArchiveBlockFacts(txFacts, List.of())),
+                rows::add);
+
+        var eventSection = envelope.section(ProjectionSectionType.ACCOUNT_EVENT).orElseThrow();
+        var eventFacts = ProjectionFactCodec.decodeAccountEvents(ProjectionChunking.join(eventSection.chunks()));
+        StandardBlockDatasets.accountEvents().derive(job(ArchiveDatasetId.ACCOUNT_EVENT),
+                new BlockSourceContext<>(100, 2000, 20, Instant.ofEpochSecond(1_600_002_000L),
+                        HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)),
+                        new com.bloxbean.cardano.yano.archive.core.dataset.ArchiveBlockFacts(
+                                List.of(), eventFacts)),
+                rows::add);
+
+        var utxoSection = envelope.section(ProjectionSectionType.UTXO_HISTORY).orElseThrow();
+        UtxoHistoryFact utxoFact =
+                ProjectionFactCodec.decodeUtxoHistory(ProjectionChunking.join(utxoSection.chunks()));
+        new UtxoHistoryDataset().derive(job(ArchiveDatasetId.UTXO_HISTORY),
+                new BlockSourceContext<>(100, 2000, 20, Instant.ofEpochSecond(1_600_002_000L),
+                        HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)), utxoFact),
+                rows::add);
+        return rows;
+    }
+
+    private void assertParity(Block block) {
+        String oracle = render(oracleRows(block));
+        String outbox = render(outboxRows(block));
+        assertThat(outbox).isEqualTo(oracle);
+    }
+
+    /**
+     * Parity, plus proof that the fixture actually exercises the dataset.
+     *
+     * <p>Equality between two empty row sets is not evidence of anything. A certificate fixture
+     * that silently produced no account events would pass {@link #assertParity} while testing
+     * nothing at all, so the expected row count is stated rather than assumed.
+     */
+    private void assertAccountEventParity(Block block, int expectedEvents) {
+        List<ArchiveRow> oracle = oracleRows(block);
+        long events = oracle.stream().filter(row -> row.table().equals("account_events")).count();
+        assertThat(events)
+                .as("the fixture must actually produce account events, or parity proves nothing")
+                .isEqualTo(expectedEvents);
+        assertThat(render(outboxRows(block))).isEqualTo(render(oracle));
+    }
+
+    // -------------------------------------------------------------- the cases
+
+    @Test
+    void emptyBlock() {
+        assertParity(block(Era.Babbage, List.of(), List.of(), List.of()));
+    }
+
+    @Test
+    void simpleValidTransaction() {
+        var tx = TransactionBody.builder().txHash(hex(0x11, 32)).fee(BigInteger.valueOf(170_000))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0x22, 32)).index(0).build())))
+                .outputs(List.of(output(shelleyAddress(1, 2), 5_000_000)))
+                .build();
+        assertParity(block(Era.Babbage, List.of(tx), List.of(), List.of()));
+    }
+
+    @Test
+    void invalidTransactionWithCollateralAndCollateralReturn() {
+        var out = output(shelleyAddress(3, 4), 1_000_000);
+        var tx = TransactionBody.builder().txHash(hex(0x33, 32)).fee(BigInteger.valueOf(200_000))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0x44, 32)).index(0).build())))
+                .collateralInputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0x55, 32)).index(1).build())))
+                .referenceInputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0x66, 32)).index(2).build())))
+                .outputs(List.of(out))
+                .collateralReturn(out)
+                .build();
+        assertParity(block(Era.Babbage, List.of(tx), List.of(0), List.of()));
+    }
+
+    @Test
+    void sameBlockParentAndChildPreserveCanonicalOrder() {
+        var parent = TransactionBody.builder().txHash(hex(0x77, 32)).fee(BigInteger.valueOf(100))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0x88, 32)).index(0).build())))
+                .outputs(List.of(output(shelleyAddress(5, 6), 9_000_000)))
+                .build();
+        // Child spends the parent's output created earlier in this same block.
+        var child = TransactionBody.builder().txHash(hex(0x99, 32)).fee(BigInteger.valueOf(120))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0x77, 32)).index(0).build())))
+                .outputs(List.of(output(shelleyAddress(7, 8), 8_000_000)))
+                .build();
+        assertParity(block(Era.Babbage, List.of(parent, child), List.of(), List.of()));
+    }
+
+    @Test
+    void multiAssetOutputs() {
+        var multi = output(shelleyAddress(9, 10), 2_000_000,
+                Amount.builder().unit(hex(0xaa, 28) + "01").policyId(hex(0xaa, 28))
+                        .assetName("01").assetNameBytes(new byte[]{1}).quantity(BigInteger.valueOf(42)).build(),
+                Amount.builder().unit(hex(0xbb, 28) + "02").policyId(hex(0xbb, 28))
+                        .assetName("02").assetNameBytes(new byte[]{2}).quantity(BigInteger.valueOf(7)).build());
+        var tx = TransactionBody.builder().txHash(hex(0xab, 32)).fee(BigInteger.valueOf(180_000))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0xac, 32)).index(0).build())))
+                .outputs(List.of(multi)).build();
+        assertParity(block(Era.Babbage, List.of(tx), List.of(), List.of()));
+    }
+
+    @Test
+    void datumHashInlineDatumAndReferenceScript() {
+        var withDatumHash = TransactionOutput.builder().address(shelleyAddress(11, 12))
+                .amounts(List.of(Amount.builder().unit("lovelace").quantity(BigInteger.valueOf(3_000_000)).build()))
+                .datumHash(hex(0xcc, 32)).build();
+        var withInline = TransactionOutput.builder().address(shelleyAddress(13, 14))
+                .amounts(List.of(Amount.builder().unit("lovelace").quantity(BigInteger.valueOf(4_000_000)).build()))
+                .inlineDatum(hex(0xdd, 16)).build();
+        var tx = TransactionBody.builder().txHash(hex(0xae, 32)).fee(BigInteger.valueOf(190_000))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0xaf, 32)).index(0).build())))
+                .outputs(List.of(withDatumHash, withInline)).build();
+        assertParity(block(Era.Babbage, List.of(tx), List.of(), List.of()));
+    }
+
+    @Test
+    void redeemersAreCarriedIntact() {
+        var redeemer = Redeemer.builder().tag(RedeemerTag.Spend).index(0)
+                .data(com.bloxbean.cardano.yaci.core.model.Datum.builder().cbor(hex(0xef, 8)).build())
+                .exUnits(com.bloxbean.cardano.yaci.core.model.ExUnits.builder()
+                        .mem(BigInteger.valueOf(1000)).steps(BigInteger.valueOf(2000)).build())
+                .cbor(hex(0xee, 8)).build();
+        var witnesses = Witnesses.builder().redeemers(List.of(redeemer)).build();
+        var tx = TransactionBody.builder().txHash(hex(0xba, 32)).fee(BigInteger.valueOf(210_000))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0xbc, 32)).index(0).build())))
+                .outputs(List.of(output(shelleyAddress(15, 16), 1_500_000))).build();
+        assertParity(block(Era.Babbage, List.of(tx), List.of(), List.of(witnesses)));
+    }
+
+    @Test
+    void denseBlockWithManyTransactions() {
+        List<TransactionBody> txs = new ArrayList<>();
+        for (int i = 0; i < 60; i++) {
+            txs.add(TransactionBody.builder().txHash(hex(i % 200, 32)).fee(BigInteger.valueOf(150_000 + i))
+                    .inputs(new LinkedHashSet<>(List.of(
+                            TransactionInput.builder().transactionId(hex((i + 7) % 200, 32)).index(i % 3).build())))
+                    .outputs(List.of(output(shelleyAddress(i % 20 + 1, i % 15 + 1), 1_000_000L + i)))
+                    .build());
+        }
+        assertParity(block(Era.Babbage, txs, List.of(3, 17, 41), List.of()));
+    }
+
+    @Test
+    void byronStyleBlockWithNullFeeAndBase58Addresses() {
+        // Byron normalization yields no fee and raw base58 addresses; both must survive.
+        var tx = TransactionBody.builder().txHash(hex(0xca, 32))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0xcb, 32)).index(0).build())))
+                .outputs(List.of(output("Ae2tdPwUPEZFRbyhz3cpfC2CumGzNkFBN2L42rcUc2yjQpEkxDbkPodpMAi", 10_000_000)))
+                .build();
+        Block byron = Block.builder().era(Era.Byron)
+                .header(BlockHeader.builder().headerBody(HeaderBody.builder()
+                        .blockNumber(100).slot(2000).prevHash(hex(0x0a, 32)).blockHash(hex(0x0b, 32)).build()).build())
+                .transactionBodies(List.of(tx)).transactionWitness(List.of()).invalidTransactions(List.of()).build();
+
+        assertParity(byron);
+
+        // The projection semantic the ADR calls out explicitly: fee is NULL for Byron.
+        assertThat(render(outboxRows(byron))).contains("null");
+    }
+
+    @Test
+    void chunkingDoesNotChangeDerivedRows() {
+        // Force multi-chunk sections; the reassembled payload must derive identical rows.
+        var small = new CanonicalProjectionCollector(store, IDENTITY, slot -> slot / 100,
+                slot -> 1_600_000_000L + slot, 64, true);
+        List<TransactionBody> txs = new ArrayList<>();
+        for (int i = 0; i < 40; i++) {
+            txs.add(TransactionBody.builder().txHash(hex(i % 200, 32)).fee(BigInteger.valueOf(1000 + i))
+                    .inputs(new LinkedHashSet<>(List.of(
+                            TransactionInput.builder().transactionId(hex((i + 3) % 200, 32)).index(0).build())))
+                    .outputs(List.of(output(shelleyAddress(i % 10 + 1, 2), 2_000_000L + i))).build());
+        }
+        Block dense = block(Era.Babbage, txs, List.of(), List.of());
+
+        var event = new BlockAppliedEvent(dense.getEra(), 2000, 100, hex(0x0b, 32), dense);
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            small.contributeBlock(event, ProjectionOutboxStore.batchWriter(batch, store.handles()));
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+
+        var envelope = store.readEnvelope(100, REQUIRED).orElseThrow();
+        assertThat(envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow().chunks().size())
+                .isGreaterThan(1);
+
+        var txFacts = ProjectionFactCodec.decodeTransactions(ProjectionChunking.join(
+                envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow().chunks()));
+        List<ArchiveRow> rows = new ArrayList<>();
+        StandardBlockDatasets.transactions().derive(job(ArchiveDatasetId.TRANSACTION),
+                new BlockSourceContext<>(100, 2000, 20, Instant.ofEpochSecond(1_600_002_000L),
+                        HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)),
+                        new com.bloxbean.cardano.yano.archive.core.dataset.ArchiveBlockFacts(txFacts, List.of())),
+                rows::add);
+
+        List<ArchiveRow> oracle = oracleRows(dense).stream()
+                .filter(r -> r.table().equals("chain_transaction")).toList();
+        assertThat(render(rows)).isEqualTo(render(oracle));
+    }
+
+    // ------------------------------------------------------- pointer addresses
+
+    /**
+     * Pre-Conway pointer addresses used to throw here, because row derivation ran without a
+     * resolver. They are now resolved at <em>capture</em> time against the authoritative
+     * account-state mapping, so the sink needs no resolver state and an unresolvable pointer
+     * is recorded as {@code pointer_unresolved} rather than failing the batch.
+     *
+     * <p>This collector is constructed with {@code PointerCredentialSource.NONE}, so every
+     * pointer is genuinely unresolvable — which is precisely the case that used to crash.
+     * Full agreement with the shipped sequential resolver is covered by
+     * {@code PointerResolutionDifferentialTest}, which uses that resolver as its oracle
+     * instead of comparing two resolver-less paths.
+     */
+    @Test
+    void preConwayPointerAddressesResolveToUnresolvedInsteadOfThrowing() {
+        String pointerAddress = "40" + "66".repeat(28) + "0a0000";
+        var tx = TransactionBody.builder().txHash(hex(0xd1, 32)).fee(BigInteger.valueOf(100))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0xd2, 32)).index(0).build())))
+                .outputs(List.of(TransactionOutput.builder().address(pointerAddress)
+                        .amounts(List.of(Amount.builder().unit("lovelace")
+                                .quantity(BigInteger.valueOf(1_000_000)).build())).build()))
+                .build();
+        Block preConway = block(Era.Babbage, List.of(tx), List.of(), List.of());
+
+        List<ArchiveRow> rows = outboxRows(preConway);
+        assertThat(rows).isNotEmpty();
+        assertThat(render(rows)).contains("transaction_outputs");
+    }
+
+    @Test
+    void conwayPointerAddressesAreProjectedWithoutAResolver() {
+        // From Conway on, a pointer stake reference is recorded as not effective, so the
+        // projection path needs no resolver and parity holds.
+        String pointerAddress = "40" + "66".repeat(28) + "0a0000";
+        var tx = TransactionBody.builder().txHash(hex(0xd3, 32)).fee(BigInteger.valueOf(100))
+                .inputs(new LinkedHashSet<>(List.of(
+                        TransactionInput.builder().transactionId(hex(0xd4, 32)).index(0).build())))
+                .outputs(List.of(TransactionOutput.builder().address(pointerAddress)
+                        .amounts(List.of(Amount.builder().unit("lovelace")
+                                .quantity(BigInteger.valueOf(1_000_000)).build())).build()))
+                .build();
+        assertParity(block(Era.Conway, List.of(tx), List.of(), List.of()));
+    }
+
+    // ------------------------------------------------- account event fixtures
+
+    private static com.bloxbean.cardano.yaci.core.model.certs.StakeCredential stakeKey(int fill) {
+        return com.bloxbean.cardano.yaci.core.model.certs.StakeCredential.fromKeyHash(
+                HexUtil.decodeHexString(hex(fill, 28)));
+    }
+
+    private static com.bloxbean.cardano.yaci.core.model.certs.StakeCredential stakeScript(int fill) {
+        return com.bloxbean.cardano.yaci.core.model.certs.StakeCredential.fromScriptHash(
+                HexUtil.decodeHexString(hex(fill, 28)));
+    }
+
+    private static TransactionBody txWithCertificates(int fill,
+            List<com.bloxbean.cardano.yaci.core.model.certs.Certificate> certificates) {
+        return TransactionBody.builder().txHash(hex(fill, 32))
+                .inputs(java.util.Set.of()).outputs(List.of(output(shelleyAddress(0x11, 0x22), 1_000_000L)))
+                .fee(BigInteger.valueOf(170_000L))
+                .certificates(certificates)
+                .build();
+    }
+
+    @Test
+    void stakeRegistrationAndDeregistrationProjectIdentically() {
+        var tx = txWithCertificates(0x40, List.of(
+                com.bloxbean.cardano.yaci.core.model.certs.StakeRegistration.builder()
+                        .stakeCredential(stakeKey(0x51)).build(),
+                com.bloxbean.cardano.yaci.core.model.certs.StakeDeregistration.builder()
+                        .stakeCredential(stakeKey(0x52)).build()));
+        assertAccountEventParity(block(Era.Babbage, List.of(tx), List.of(), List.of()), 2);
+    }
+
+    @Test
+    void scriptStakeCredentialsKeepTheirCredentialType() {
+        // The credential type reaches the stake-address encoder, so getting it wrong produces
+        // a valid-looking but wrong bech32 address rather than an error.
+        var tx = txWithCertificates(0x41, List.of(
+                com.bloxbean.cardano.yaci.core.model.certs.StakeRegistration.builder()
+                        .stakeCredential(stakeScript(0x53)).build()));
+        assertAccountEventParity(block(Era.Babbage, List.of(tx), List.of(), List.of()), 1);
+    }
+
+    @Test
+    void stakeDelegationCarriesThePoolHash() {
+        var tx = txWithCertificates(0x42, List.of(
+                com.bloxbean.cardano.yaci.core.model.certs.StakeDelegation.builder()
+                        .stakeCredential(stakeKey(0x54))
+                        .stakePoolId(com.bloxbean.cardano.yaci.core.model.certs.StakePoolId.builder()
+                                .poolKeyHash(hex(0x55, 28)).build())
+                        .build()));
+        assertAccountEventParity(block(Era.Babbage, List.of(tx), List.of(), List.of()), 1);
+    }
+
+    @Test
+    void aConwayCertificateThatExpandsIntoSeveralEventsKeepsTheirOrderAndIndices() {
+        // StakeVoteRegDelegCert becomes three events at index<<32, +1 and +2. Their order and
+        // their derived indices are part of the archive contract, not an implementation detail.
+        var tx = txWithCertificates(0x43, List.of(
+                com.bloxbean.cardano.yaci.core.model.certs.StakeVoteRegDelegCert.builder()
+                        .stakeCredential(stakeKey(0x56))
+                        .poolKeyHash(hex(0x57, 28))
+                        .drep(com.bloxbean.cardano.yaci.core.model.governance.Drep
+                                .addrKeyHash(hex(0x58, 28)))
+                        .coin(BigInteger.valueOf(2_000_000L))
+                        .build()));
+        assertAccountEventParity(block(Era.Babbage, List.of(tx), List.of(), List.of()), 3);
+    }
+
+    @Test
+    void withdrawalsProjectAsAccountEvents() {
+        var tx = TransactionBody.builder().txHash(hex(0x44, 32))
+                .inputs(java.util.Set.of()).outputs(List.of(output(shelleyAddress(0x11, 0x22), 1_000_000L)))
+                .fee(BigInteger.valueOf(170_000L))
+                .withdrawals(new java.util.LinkedHashMap<>(java.util.Map.of(
+                        "e1" + hex(0x59, 28), BigInteger.valueOf(4_500_000L))))
+                .build();
+        assertAccountEventParity(block(Era.Babbage, List.of(tx), List.of(), List.of()), 1);
+    }
+
+    @Test
+    void certificatesInAnInvalidTransactionFollowTheSameRuleAsTheExistingPath() {
+        // Whatever the existing archive does with certificates in a failed transaction, the
+        // projection must do the same. Pinning it here means a change in that rule shows up as
+        // a parity failure rather than as a silent divergence between the two paths.
+        var tx = txWithCertificates(0x45, List.of(
+                com.bloxbean.cardano.yaci.core.model.certs.StakeRegistration.builder()
+                        .stakeCredential(stakeKey(0x5a)).build()));
+        // The existing path derives account events only from valid transactions, so the
+        // expected count is zero. Stating it makes the rule explicit rather than incidental.
+        assertAccountEventParity(block(Era.Babbage, List.of(tx), List.of(0), List.of()), 0);
+    }
+
+    @Test
+    void certificatesAcrossSeveralTransactionsKeepBlockOrder() {
+        var first = txWithCertificates(0x46, List.of(
+                com.bloxbean.cardano.yaci.core.model.certs.StakeRegistration.builder()
+                        .stakeCredential(stakeKey(0x5b)).build()));
+        var second = txWithCertificates(0x47, List.of(
+                com.bloxbean.cardano.yaci.core.model.certs.StakeDeregistration.builder()
+                        .stakeCredential(stakeKey(0x5c)).build()));
+        assertAccountEventParity(block(Era.Babbage, List.of(first, second), List.of(), List.of()), 2);
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionEncodingProfileTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionEncodingProfileTest.java
@@ -1,0 +1,172 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yaci.core.model.Amount;
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.BlockHeader;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.model.HeaderBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionBody;
+import com.bloxbean.cardano.yaci.core.model.TransactionInput;
+import com.bloxbean.cardano.yaci.core.model.TransactionOutput;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.core.dataset.BlockSourceContext;
+import com.bloxbean.cardano.yano.archive.core.source.YaciBlockArchiveDecoder;
+import com.bloxbean.cardano.yano.archive.core.source.YaciUtxoHistoryDecoder;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Attributes the projection hot-path cost per stage, so optimisation targets the stage that
+ * actually dominates rather than the one that looks expensive.
+ *
+ * <p>Not a pass/fail gate — it prints a breakdown and asserts only that every stage ran. The
+ * authoritative regression number is the isolated alternating history-off/on node benchmark;
+ * this exists to explain that number and to attribute changes to it.
+ *
+ * <p>Reference point from the isolated benchmark: 2,410 blk/s without history and 2,070 with,
+ * i.e. roughly <strong>68 microseconds per block</strong> of projection cost, against a 5%
+ * budget of about 21 microseconds.
+ */
+class ProjectionEncodingProfileTest {
+
+    private static final int WARMUP = 200;
+    private static final int ITERATIONS = 2_000;
+
+    private static String hex(int b, int len) {
+        return String.format("%02x", b).repeat(len);
+    }
+
+    private static String shelleyAddress(int paymentFill, int stakeFill) {
+        byte[] address = new byte[57];
+        address[0] = 0;
+        Arrays.fill(address, 1, 29, (byte) paymentFill);
+        Arrays.fill(address, 29, 57, (byte) stakeFill);
+        return HexUtil.encodeHexString(address);
+    }
+
+    /** A block shaped like a dense Babbage/Conway block: 40 transactions, multi-asset outputs. */
+    private static Block denseBlock() {
+        List<TransactionBody> txs = new ArrayList<>();
+        for (int i = 0; i < 40; i++) {
+            List<Amount> amounts = new ArrayList<>();
+            amounts.add(Amount.builder().unit("lovelace").quantity(BigInteger.valueOf(2_000_000 + i)).build());
+            amounts.add(Amount.builder().unit(hex(0xaa, 28) + "01").policyId(hex(0xaa, 28))
+                    .assetName("01").assetNameBytes(new byte[]{1}).quantity(BigInteger.valueOf(7)).build());
+            var out = TransactionOutput.builder().address(shelleyAddress(i % 20 + 1, i % 15 + 1))
+                    .amounts(amounts).build();
+            txs.add(TransactionBody.builder().txHash(hex(i % 200, 32)).fee(BigInteger.valueOf(170_000 + i))
+                    .inputs(new LinkedHashSet<>(List.of(
+                            TransactionInput.builder().transactionId(hex((i + 5) % 200, 32)).index(0).build(),
+                            TransactionInput.builder().transactionId(hex((i + 9) % 200, 32)).index(1).build())))
+                    .outputs(List.of(out, out)).build());
+        }
+        return Block.builder().era(Era.Babbage)
+                .header(BlockHeader.builder().headerBody(HeaderBody.builder()
+                        .blockNumber(100).slot(2000).prevHash(hex(0x0a, 32)).blockHash(hex(0x0b, 32)).build()).build())
+                .transactionBodies(txs).transactionWitness(List.of()).invalidTransactions(List.of()).build();
+    }
+
+    private static long timed(int iterations, Runnable work) {
+        long start = System.nanoTime();
+        for (int i = 0; i < iterations; i++) work.run();
+        return (System.nanoTime() - start) / iterations;
+    }
+
+    @Test
+    void attributeProjectionCostPerStage() {
+        Block block = denseBlock();
+        var context = new BlockSourceContext<>(100L, 2000L, 20L, Instant.ofEpochSecond(1_600_002_000L),
+                HexUtil.decodeHexString(hex(0x0b, 32)), HexUtil.decodeHexString(hex(0x0a, 32)), block);
+
+        var txDecoder = new YaciBlockArchiveDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+        var utxoDecoder = new YaciUtxoHistoryDecoder(slot -> slot / 100, slot -> 1_600_000_000L + slot);
+
+        // Warm up every stage together so JIT state is comparable across measurements.
+        for (int i = 0; i < WARMUP; i++) {
+            var t = txDecoder.project(context).block().transactions();
+            var u = utxoDecoder.project(context).block();
+            byte[] te = ProjectionFactCodec.encodeTransactions(t);
+            byte[] ue = ProjectionFactCodec.encodeUtxoHistory(u);
+            new ProjectionSection(ProjectionSectionType.TRANSACTION, 2,
+                    ProjectionChunking.split(te, ProjectionChunking.DEFAULT_CHUNK_BYTES), t.size());
+            new ProjectionSection(ProjectionSectionType.UTXO_HISTORY, 5,
+                    ProjectionChunking.split(ue, ProjectionChunking.DEFAULT_CHUNK_BYTES), 1);
+        }
+
+        long txProject = timed(ITERATIONS, () -> txDecoder.project(context).block().transactions());
+        long utxoProject = timed(ITERATIONS, () -> utxoDecoder.project(context).block());
+
+        var txFacts = txDecoder.project(context).block().transactions();
+        var utxoFact = utxoDecoder.project(context).block();
+
+        long txEncode = timed(ITERATIONS, () -> ProjectionFactCodec.encodeTransactions(txFacts));
+        long utxoEncode = timed(ITERATIONS, () -> ProjectionFactCodec.encodeUtxoHistory(utxoFact));
+
+        byte[] txEncoded = ProjectionFactCodec.encodeTransactions(txFacts);
+        byte[] utxoEncoded = ProjectionFactCodec.encodeUtxoHistory(utxoFact);
+
+        long chunking = timed(ITERATIONS, () -> {
+            ProjectionChunking.split(txEncoded, ProjectionChunking.DEFAULT_CHUNK_BYTES);
+            ProjectionChunking.split(utxoEncoded, ProjectionChunking.DEFAULT_CHUNK_BYTES);
+        });
+
+        var txChunks = ProjectionChunking.split(txEncoded, ProjectionChunking.DEFAULT_CHUNK_BYTES);
+        var utxoChunks = ProjectionChunking.split(utxoEncoded, ProjectionChunking.DEFAULT_CHUNK_BYTES);
+
+        // Section construction copies every chunk defensively.
+        long sectionBuild = timed(ITERATIONS, () -> {
+            new ProjectionSection(ProjectionSectionType.TRANSACTION, 2, txChunks, txFacts.size());
+            new ProjectionSection(ProjectionSectionType.UTXO_HISTORY, 5, utxoChunks, 1);
+        });
+
+        var txSection = new ProjectionSection(ProjectionSectionType.TRANSACTION, 2, txChunks, txFacts.size());
+        var utxoSection = new ProjectionSection(ProjectionSectionType.UTXO_HISTORY, 5, utxoChunks, 1);
+
+        // manifest() digests the payload; the accessor copies it again on the write path.
+        long manifest = timed(ITERATIONS, () -> {
+            txSection.manifest();
+            utxoSection.manifest();
+        });
+        long accessorCopy = timed(ITERATIONS, () -> {
+            txSection.chunks();
+            utxoSection.chunks();
+        });
+
+        long total = txProject + utxoProject + txEncode + utxoEncode + chunking + sectionBuild
+                + manifest + accessorCopy;
+
+        System.out.printf("%n=== ADR-039 projection cost attribution (dense 40-tx block) ===%n");
+        System.out.printf("  payload: transaction=%d B, utxo-history=%d B, total=%d B%n",
+                txEncoded.length, utxoEncoded.length, txEncoded.length + utxoEncoded.length);
+        record Stage(String name, long nanos) { }
+        List<Stage> stages = List.of(
+                new Stage("derive transaction facts", txProject),
+                new Stage("derive utxo-history facts", utxoProject),
+                new Stage("encode transaction", txEncode),
+                new Stage("encode utxo-history", utxoEncode),
+                new Stage("chunk split (copy)", chunking),
+                new Stage("section construct (copy)", sectionBuild),
+                new Stage("manifest + digest", manifest),
+                new Stage("chunks() accessor (copy)", accessorCopy));
+        for (Stage stage : stages) {
+            System.out.printf("  %-28s %8.1f us  %5.1f%%%n", stage.name(),
+                    stage.nanos() / 1000.0, 100.0 * stage.nanos() / total);
+        }
+        System.out.printf("  %-28s %8.1f us%n", "TOTAL", total / 1000.0);
+        System.out.printf("  isolated-benchmark budget:   ~68 us/block observed, ~21 us/block for a 5%% target%n%n");
+
+        assertThat(total).isPositive();
+        assertThat(txEncoded.length).isPositive();
+        assertThat(utxoEncoded.length).isPositive();
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionEnvelopeCodecTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionEnvelopeCodecTest.java
@@ -1,0 +1,150 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRepresentation;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionDigest;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.OptionalLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProjectionEnvelopeCodecTest {
+
+    private static final ArchiveNetworkIdentity PREPROD = new ArchiveNetworkIdentity(1, "162d29c4e1cf6b8a");
+
+    private static ProjectionEnvelopeHeader sampleHeader() {
+        var tx = new ProjectionSection(ProjectionSectionType.TRANSACTION,
+                ProjectionSectionType.TRANSACTION.version(), List.of(new byte[]{1, 2, 3}), 2);
+        var utxo = new ProjectionSection(ProjectionSectionType.UTXO_HISTORY,
+                ProjectionSectionType.UTXO_HISTORY.version(),
+                List.of(new byte[]{4, 5}, new byte[]{6}), 7);
+        var artifact = new ProjectionArtifactRef(ArchiveDatasetId.EPOCH_STAKE, 42, 1000, 20000,
+                ProjectionArtifactRepresentation.IMMUTABLE_GENERATION, "epoch-deleg-snapshot/42", 1,
+                "account-state-v1", OptionalLong.of(1_300_000L), "abcdef01", 19000);
+        return new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, 1000,
+                new byte[]{10, 20, 30}, new byte[]{9, 19, 29}, 20000, 42, 1_700_000_000L, 1,
+                List.of(tx.manifest(), utxo.manifest()), List.of(artifact));
+    }
+
+    @Test
+    void headerRoundTripsExactly() {
+        var header = sampleHeader();
+        var decoded = ProjectionEnvelopeCodec.decodeHeader(ProjectionEnvelopeCodec.encodeHeader(header));
+        assertThat(decoded).isEqualTo(header);
+        assertThat(decoded.envelopeId()).isEqualTo(header.envelopeId());
+        assertThat(decoded.artifacts()).isEqualTo(header.artifacts());
+    }
+
+    @Test
+    void encodingIsStableAcrossCalls() {
+        assertThat(ProjectionEnvelopeCodec.encodeHeader(sampleHeader()))
+                .isEqualTo(ProjectionEnvelopeCodec.encodeHeader(sampleHeader()));
+    }
+
+    /**
+     * Golden fixture. A change to this digest means the persisted outbox format changed;
+     * that requires a format-version bump and a migration decision, not a test update.
+     */
+    @Test
+    void encodedHeaderMatchesItsGoldenDigest() {
+        String digest = ProjectionDigest.ofChunks(List.of(ProjectionEnvelopeCodec.encodeHeader(sampleHeader())));
+        assertThat(digest)
+                .as("projection envelope header wire format v%d", ProjectionEnvelopeCodec.FORMAT_VERSION)
+                .isEqualTo("4d41e29892b91f4c01982d0f4b0c30e6072ea99103cd32b8374e3fd6d824c848");
+    }
+
+    @Test
+    void emptyEbbHeaderRoundTrips() {
+        var ebb = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.BYRON_EBB, 500,
+                new byte[]{5, 0}, new byte[]{4, 9}, 10000, 21, 1_600_000_000L, 1, List.of(), List.of());
+        var decoded = ProjectionEnvelopeCodec.decodeHeader(ProjectionEnvelopeCodec.encodeHeader(ebb));
+        assertThat(decoded).isEqualTo(ebb);
+        assertThat(decoded.sections()).isEmpty();
+        assertThat(decoded.blockKind()).isEqualTo(ProjectionBlockKind.BYRON_EBB);
+    }
+
+    @Test
+    void byronMainHeaderRoundTrips() {
+        var tx = new ProjectionSection(ProjectionSectionType.TRANSACTION,
+                ProjectionSectionType.TRANSACTION.version(), List.of(new byte[]{7}), 1);
+        var byron = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.BYRON_MAIN, 501,
+                new byte[]{5, 1}, new byte[]{5, 0}, 10020, 21, 1_600_000_020L, 1,
+                List.of(tx.manifest()), List.of());
+        assertThat(ProjectionEnvelopeCodec.decodeHeader(ProjectionEnvelopeCodec.encodeHeader(byron)))
+                .isEqualTo(byron);
+    }
+
+    // --- malformed input fails closed -------------------------------------------
+
+    @Test
+    void aForeignRecordIsRejected() {
+        assertThatThrownBy(() -> ProjectionEnvelopeCodec.decodeHeader(new byte[]{'X', 'X', 'X', 'X', 1}))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("not a projection envelope header");
+    }
+
+    @Test
+    void anUnsupportedFormatVersionIsRejected() {
+        byte[] encoded = ProjectionEnvelopeCodec.encodeHeader(sampleHeader());
+        encoded[4] = 99;
+        assertThatThrownBy(() -> ProjectionEnvelopeCodec.decodeHeader(encoded))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unsupported envelope header format version");
+    }
+
+    @Test
+    void aTruncatedRecordIsRejected() {
+        byte[] encoded = ProjectionEnvelopeCodec.encodeHeader(sampleHeader());
+        byte[] truncated = Arrays.copyOf(encoded, encoded.length - 5);
+        assertThatThrownBy(() -> ProjectionEnvelopeCodec.decodeHeader(truncated))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void trailingBytesAreRejected() {
+        byte[] encoded = ProjectionEnvelopeCodec.encodeHeader(sampleHeader());
+        byte[] extended = Arrays.copyOf(encoded, encoded.length + 3);
+        assertThatThrownBy(() -> ProjectionEnvelopeCodec.decodeHeader(extended))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("trailing bytes");
+    }
+
+    @Test
+    void anUnknownSectionWireNameIsRejectedRatherThanSkipped() {
+        var header = sampleHeader();
+        byte[] encoded = ProjectionEnvelopeCodec.encodeHeader(header);
+        String from = ProjectionSectionType.TRANSACTION.wireName();
+        String to = "transaction:v3";
+        byte[] patched = replaceUtf(encoded, from, to);
+        assertThatThrownBy(() -> ProjectionEnvelopeCodec.decodeHeader(patched))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("unknown projection section");
+    }
+
+    /** Replaces a same-length modified UTF string body in an encoded record. */
+    private static byte[] replaceUtf(byte[] encoded, String from, String to) {
+        byte[] fromBytes = from.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        byte[] toBytes = to.getBytes(java.nio.charset.StandardCharsets.UTF_8);
+        if (fromBytes.length != toBytes.length) throw new IllegalArgumentException("test helper needs equal lengths");
+        byte[] copy = encoded.clone();
+        outer:
+        for (int i = 0; i + fromBytes.length <= copy.length; i++) {
+            for (int j = 0; j < fromBytes.length; j++) {
+                if (copy[i + j] != fromBytes[j]) continue outer;
+            }
+            System.arraycopy(toBytes, 0, copy, i, toBytes.length);
+            return copy;
+        }
+        throw new IllegalStateException("pattern not found");
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceBudgetTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceBudgetTest.java
@@ -61,14 +61,15 @@ class ProjectionMaintenanceBudgetTest {
     void unnecessaryReportsFileCountWithoutClaimingWork() {
         var result = ProjectionMaintenance.Result.unnecessary(42);
         assertThat(result.outcome()).isEqualTo(ProjectionMaintenance.Outcome.UNNECESSARY);
-        assertThat(result.filesBefore()).isEqualTo(42);
-        assertThat(result.filesReclaimed()).isZero();
+        assertThat(result.filesBefore()).hasValue(42);
+        assertThat(result.filesReclaimed()).hasValue(0);
     }
 
     @Test
     void filesReclaimedNeverGoesNegative() {
         var grew = new ProjectionMaintenance.Result(ProjectionMaintenance.Outcome.COMPLETED,
-                Duration.ZERO, 10, 12, 0, 0, 0, Duration.ZERO, java.util.Optional.empty());
-        assertThat(grew.filesReclaimed()).isZero();
+                Duration.ZERO, java.util.OptionalLong.of(10), java.util.OptionalLong.of(12),
+                java.util.OptionalLong.of(0), 0, 0, Duration.ZERO, java.util.Optional.empty());
+        assertThat(grew.filesReclaimed()).hasValue(0);
     }
 }

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceBudgetTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceBudgetTest.java
@@ -1,0 +1,74 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Housekeeping reclaims disk; compaction is an optimisation. The budgets are separate so a
+ * large rewrite can never consume the window and skip the cleanup — which is precisely how
+ * the replay-worker path behaves today, and how a lagging archive becomes a full disk.
+ */
+class ProjectionMaintenanceBudgetTest {
+
+    @Test
+    void housekeepingAndCompactionAreBudgetedSeparately() {
+        var budget = ProjectionMaintenance.Budget.full(
+                Duration.ofSeconds(10), Duration.ofSeconds(30), 1L << 30);
+        assertThat(budget.housekeepingTimeLimit()).isEqualTo(Duration.ofSeconds(10));
+        assertThat(budget.compactionTimeLimit()).isEqualTo(Duration.ofSeconds(30));
+        assertThat(budget.compactionAllowed()).isTrue();
+    }
+
+    @Test
+    void housekeepingOnlyWithholdsCompactionButKeepsCleanupFunded() {
+        var budget = ProjectionMaintenance.Budget.housekeepingOnly(Duration.ofSeconds(10));
+        assertThat(budget.compactionAllowed()).isFalse();
+        assertThat(budget.compactionTimeLimit()).isEqualTo(Duration.ZERO);
+        assertThat(budget.maxBytesToRewrite()).isZero();
+        assertThat(budget.housekeepingTimeLimit())
+                .as("cleanup must still be funded when compaction is withheld")
+                .isEqualTo(Duration.ofSeconds(10));
+    }
+
+    @Test
+    void compactingFewerThanTwoFilesIsRejectedAsMeaningless() {
+        assertThatThrownBy(() -> new ProjectionMaintenance.Budget(Duration.ofSeconds(1),
+                Duration.ofSeconds(1), 1024, 1024, 1, 1024, true))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("fewer than two files");
+    }
+
+    @Test
+    void unsupportedIsExplicitRatherThanASilentNoOp() {
+        var result = ProjectionMaintenance.Result.unsupported("this backend stores no files");
+        assertThat(result.outcome()).isEqualTo(ProjectionMaintenance.Outcome.UNSUPPORTED);
+        assertThat(result.detail()).isPresent();
+    }
+
+    @Test
+    void deferralCarriesItsReason() {
+        var result = ProjectionMaintenance.Result.deferred("active reader snapshot");
+        assertThat(result.outcome()).isEqualTo(ProjectionMaintenance.Outcome.DEFERRED);
+        assertThat(result.detail()).get().asString().contains("reader");
+    }
+
+    @Test
+    void unnecessaryReportsFileCountWithoutClaimingWork() {
+        var result = ProjectionMaintenance.Result.unnecessary(42);
+        assertThat(result.outcome()).isEqualTo(ProjectionMaintenance.Outcome.UNNECESSARY);
+        assertThat(result.filesBefore()).isEqualTo(42);
+        assertThat(result.filesReclaimed()).isZero();
+    }
+
+    @Test
+    void filesReclaimedNeverGoesNegative() {
+        var grew = new ProjectionMaintenance.Result(ProjectionMaintenance.Outcome.COMPLETED,
+                Duration.ZERO, 10, 12, 0, 0, 0, Duration.ZERO, java.util.Optional.empty());
+        assertThat(grew.filesReclaimed()).isZero();
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceScheduleTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionMaintenanceScheduleTest.java
@@ -1,0 +1,119 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Housekeeping reclaims disk and must not wait for tip; compaction is an optimisation and must
+ * wait. A mainnet bootstrap can outlast the snapshot and file retention windows, so an archive
+ * that cleaned up only at tip would accumulate obsolete files for the whole sync.
+ */
+class ProjectionMaintenanceScheduleTest {
+
+    private static final Instant T0 = Instant.EPOCH;
+
+    private static ProjectionMaintenanceSchedule schedule() {
+        return new ProjectionMaintenanceSchedule(Duration.ofMinutes(30), Duration.ofHours(6));
+    }
+
+    @Test
+    void housekeepingRunsDuringBootstrapWithoutWaitingForTip() {
+        var s = schedule();
+        var action = s.decide(false, false, true, T0);
+        assertThat(action)
+                .as("bootstrap with a backlog must still clean up")
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING);
+    }
+
+    @Test
+    void compactionIsWithheldDuringBootstrapEvenWhenDue() {
+        var s = schedule();
+        s.recordRun(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING, T0);
+        // long past the compaction interval, but still bootstrapping
+        assertThat(s.decide(false, false, true, T0.plus(Duration.ofDays(2))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING);
+    }
+
+    @Test
+    void compactionIsWithheldAtTipWhileABacklogRemains() {
+        var s = schedule();
+        s.recordRun(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING, T0);
+        assertThat(s.decide(false, true, true, T0.plus(Duration.ofDays(1))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING);
+    }
+
+    @Test
+    void compactionRunsOnlyAtTipWithNoBacklog() {
+        var s = schedule();
+        assertThat(s.decide(false, true, false, T0))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING_AND_COMPACTION);
+    }
+
+    @Test
+    void nothingRunsWhileAnAppendIsActive() {
+        var s = schedule();
+        assertThat(s.decide(true, true, false, T0.plus(Duration.ofDays(1))))
+                .as("maintenance must never compete with an in-flight sink transaction")
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.NONE);
+    }
+
+    @Test
+    void housekeepingBecomesDueAgainOnItsOwnInterval() {
+        var s = schedule();
+        s.recordRun(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING, T0);
+        assertThat(s.decide(false, false, true, T0.plus(Duration.ofMinutes(29))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.NONE);
+        assertThat(s.decide(false, false, true, T0.plus(Duration.ofMinutes(30))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING);
+    }
+
+    @Test
+    void compactionHasItsOwnLongerIntervalAndDoesNotStarveHousekeeping() {
+        var s = schedule();
+        s.recordRun(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING_AND_COMPACTION, T0);
+
+        // 30 minutes later housekeeping is due again; compaction is not.
+        assertThat(s.decide(false, true, false, T0.plus(Duration.ofMinutes(30))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING);
+
+        // after the compaction interval, both.
+        assertThat(s.decide(false, true, false, T0.plus(Duration.ofHours(6))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING_AND_COMPACTION);
+    }
+
+    @Test
+    void aCompactionRunAlsoSatisfiesHousekeeping() {
+        var s = schedule();
+        s.recordRun(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING_AND_COMPACTION, T0);
+        assertThat(s.decide(false, true, false, T0.plus(Duration.ofMinutes(5))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.NONE);
+    }
+
+    @Test
+    void aWithheldCompactionDoesNotStayPermanentlyDueAndRetryOnEveryTick() {
+        // Compaction is due, but the executor withholds it because the sink is busy. Nothing
+        // records a compaction as having run, so without a backstop it stays due forever and a
+        // maintenance pass — which acquires a bulk lease — is attempted on every drain tick.
+        var schedule = new ProjectionMaintenanceSchedule(Duration.ofMinutes(30), Duration.ofHours(6));
+        var t0 = Instant.parse("2026-08-20T00:00:00Z");
+
+        assertThat(schedule.decide(false, true, false, t0))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING_AND_COMPACTION);
+        schedule.recordRun(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING, t0);
+        schedule.recordWithheldCompaction(t0);
+
+        // A quarter of a second later — the drain loop's idle interval — nothing is due.
+        assertThat(schedule.decide(false, true, false, t0.plusMillis(250)))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.NONE);
+        assertThat(schedule.decide(false, true, false, t0.plusSeconds(60)))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.NONE);
+
+        // It retries one housekeeping interval later, not one tick later.
+        assertThat(schedule.decide(false, true, false, t0.plus(Duration.ofMinutes(30))))
+                .isEqualTo(ProjectionMaintenanceSchedule.Action.HOUSEKEEPING_AND_COMPACTION);
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumerTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumerTest.java
@@ -1,0 +1,538 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveSafetyWindows;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceipt;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceiptMismatchException;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/** Covers the outbox-side crash boundaries of ADR-039 §11 using a synthetic sink. */
+class ProjectionOutboxConsumerTest {
+    static { RocksDB.loadLibrary(); }
+
+    private static final ArchiveNetworkIdentity PREPROD = new ArchiveNetworkIdentity(1, "162d29c4");
+    private static final Set<ProjectionSectionType> REQUIRED =
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY);
+    /** k=10 keeps the finality window small enough to reason about in a test. */
+    private static final ArchiveSafetyWindows WINDOWS = ArchiveSafetyWindows.resolve(10, 10L, 10L);
+
+    @TempDir Path directory;
+
+    private RocksDB db;
+    private DBOptions dbOptions;
+    private List<ColumnFamilyHandle> handles;
+    private ProjectionOutboxStore store;
+    private SyntheticProjectionSink sink;
+    private NoopArtifactReader artifacts;
+    private ProjectionIdentity identity;
+    private final AtomicLong tip = new AtomicLong(0);
+    private final AtomicLong rollbackFloor = new AtomicLong(0);
+
+    @BeforeEach
+    void setUp() {
+        openDatabase();
+        sink = new SyntheticProjectionSink();
+        artifacts = new NoopArtifactReader();
+        identity = new ProjectionIdentity(PREPROD, "synthetic", 1, REQUIRED);
+        sink.initialize(identity);
+    }
+
+    private void openDatabase() {
+        try {
+            dbOptions = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+            List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
+            descriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+            for (String name : ProjectionCfNames.ALL) {
+                descriptors.add(new ColumnFamilyDescriptor(name.getBytes(StandardCharsets.UTF_8)));
+            }
+            handles = new ArrayList<>();
+            db = RocksDB.open(dbOptions, directory.resolve("db").toString(), descriptors, handles);
+            store = new ProjectionOutboxStore(db, handles.get(1), handles.get(2), handles.get(3), handles.get(4));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void restartNode() {
+        handles.forEach(ColumnFamilyHandle::close);
+        db.close();
+        dbOptions.close();
+        openDatabase();
+        sink.simulateRestart();
+    }
+
+    @AfterEach
+    void tearDown() {
+        handles.forEach(ColumnFamilyHandle::close);
+        db.close();
+        dbOptions.close();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private ProjectionOutboxConsumer consumer() {
+        return consumer(ProjectionConsumerBounds.defaults());
+    }
+
+    private ProjectionOutboxConsumer consumer(ProjectionConsumerBounds bounds) {
+        return new ProjectionOutboxConsumer(store, sink, identity, new ProjectionFinalityGate(WINDOWS),
+                bounds, artifacts, tip::get, rollbackFloor::get, COMMIT_EVERY_PASS);
+    }
+
+    private ProjectionOutboxConsumer consumer(ProjectionBatchPolicy policy) {
+        return consumer(ProjectionConsumerBounds.defaults(), policy);
+    }
+
+    private ProjectionOutboxConsumer consumer(ProjectionConsumerBounds bounds, ProjectionBatchPolicy policy) {
+        return new ProjectionOutboxConsumer(store, sink, identity, new ProjectionFinalityGate(WINDOWS),
+                bounds, artifacts, tip::get, rollbackFloor::get, policy);
+    }
+
+    /** Production-shaped near-tip policy: preferred target 50 envelopes, hard bound 15 minutes. */
+    private static final ProjectionBatchPolicy NEAR_TIP = new ProjectionBatchPolicy(
+            10_000, 50, 20_000, Duration.ofSeconds(30), Duration.ofMinutes(15),
+            256L << 20, 2_000_000, 512L << 20, 600, 64L << 20, 4_000_000);
+
+    /**
+     * These tests exercise the eligibility gate, receipt identity, retention health and
+     * artifact handshake, not batch sizing. A one-block target commits on every pass so each
+     * of those behaviours is observed directly; batch sizing has its own tests.
+     */
+    private static final ProjectionBatchPolicy COMMIT_EVERY_PASS = new ProjectionBatchPolicy(
+            1, 1, 20_000, Duration.ofSeconds(30), Duration.ofMinutes(15),
+            256L << 20, 2_000_000, 512L << 20, 600, 64L << 20, 4_000_000);
+
+    private void commitBlock(long blockNumber) {
+        var header = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, blockNumber,
+                new byte[]{(byte) (blockNumber >> 8), (byte) blockNumber}, new byte[]{(byte) (blockNumber - 1)},
+                blockNumber * 20, 1, 1L, 1, List.of(), List.of());
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.putBlockIdentity(ProjectionOutboxStore.batchWriter(batch, store.handles()), header);
+            // Real encoded facts: the consumer materialises rows through the fact codec,
+            // so a placeholder payload would (correctly) be rejected as corrupt.
+            store.putSection(ProjectionOutboxStore.batchWriter(batch, store.handles()), blockNumber,
+                    new ProjectionSection(ProjectionSectionType.TRANSACTION,
+                            ProjectionSectionType.TRANSACTION.version(),
+                            List.of(ProjectionFactCodec.encodeTransactions(List.of(
+                                    new com.bloxbean.cardano.yano.archive.core.dataset.TransactionFact(
+                                            new byte[]{(byte) blockNumber}, 0, true, 100L)))), 1));
+            store.putSection(ProjectionOutboxStore.batchWriter(batch, store.handles()), blockNumber,
+                    new ProjectionSection(ProjectionSectionType.UTXO_HISTORY,
+                            ProjectionSectionType.UTXO_HISTORY.version(),
+                            List.of(ProjectionFactCodec.encodeUtxoHistory(
+                                    new com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact(
+                                            6, List.of(), List.of(), List.of(), List.of(), List.of(),
+                                            List.of(), List.of(), List.of()))), 0));
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void commitBlocks(long from, long to) {
+        for (long block = from; block <= to; block++) commitBlock(block);
+    }
+
+    // ---------------------------------------------------------- finality gating
+
+    @Test
+    void nothingIsConsumedUntilBlocksAreRollbackSafe() {
+        commitBlocks(0, 5);
+        tip.set(5);
+        assertThat(consumer().drainOnce().outcome()).isEqualTo(ProjectionConsumerResult.Outcome.IDLE);
+        assertThat(sink.appendCalls()).isZero();
+
+        tip.set(15); // eligible through 15 - 10 = 5
+        var result = consumer().drainOnce();
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(result.lastBlock()).isEqualTo(5);
+    }
+
+    @Test
+    void theGateNeverExceedsTheFinalityDepth() {
+        commitBlocks(0, 20);
+        tip.set(18); // eligible through 8
+        var result = consumer().drainOnce();
+        assertThat(result.lastBlock()).isEqualTo(8);
+        assertThat(sink.committedBlocks()).containsExactly(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L);
+    }
+
+    @Test
+    void anIncompleteEnvelopeStopsTheBatchEvenWhenItIsRollbackSafe() {
+        commitBlocks(0, 3);
+        // Block 4 has identity but no sections.
+        var header = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, 4,
+                new byte[]{4}, new byte[]{3}, 80, 1, 1L, 1, List.of(), List.of());
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.putBlockIdentity(ProjectionOutboxStore.batchWriter(batch, store.handles()), header);
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        commitBlocks(5, 8);
+        tip.set(30);
+
+        var result = consumer().drainOnce();
+        assertThat(result.lastBlock()).isEqualTo(3);
+        assertThat(sink.committedBlocks()).doesNotContain(4L, 5L);
+    }
+
+    // ------------------------------------------------------- receipts and retry
+
+    /** ADR-039 §11 case 7: crash after sink commit but before outbox acknowledgement. */
+    @Test
+    void aCrashBetweenSinkCommitAndAcknowledgementReplaysWithoutDuplicating() {
+        commitBlocks(0, 5);
+        tip.set(15);
+        sink.throwAfterNextCommit();
+
+        assertThatThrownBy(() -> consumer().drainOnce()).isInstanceOf(ProjectionSinkException.class);
+        assertThat(store.acknowledgedThrough()).isEqualTo(-1); // not acknowledged
+        assertThat(sink.committedBlocks()).hasSize(6);         // but durably committed
+
+        restartNode();
+        var result = consumer().drainOnce();
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.REPLAYED);
+        assertThat(store.acknowledgedThrough()).isEqualTo(5);
+        assertThat(sink.appendCalls()).isEqualTo(1); // no second write
+        assertThat(sink.committedBlocks()).hasSize(6);
+    }
+
+    @Test
+    void aDifferentlyShapedRetryForTheSameRangeIsRejected() {
+        commitBlocks(0, 5);
+        tip.set(15);
+        var foreign = new ProjectionReceipt(identity.fingerprint(), 0, 5, "aa", "bb", 6,
+                Map.of(), "deadbeef", Instant.EPOCH);
+        sink.forceReceipt(0, foreign);
+
+        assertThatThrownBy(() -> consumer().drainOnce())
+                .isInstanceOf(ProjectionReceiptMismatchException.class)
+                .hasMessageContaining("describes a different job");
+        assertThat(store.acknowledgedThrough()).isEqualTo(-1);
+    }
+
+    /** ADR-039 §11 case 6: sink commit failure leaves the outbox intact and retryable. */
+    @Test
+    void aSinkFailureBeforeCommitLeavesTheOutboxIntact() {
+        commitBlocks(0, 5);
+        tip.set(15);
+        sink.failNextAppends(1);
+
+        assertThatThrownBy(() -> consumer().drainOnce()).isInstanceOf(ProjectionSinkException.class);
+        assertThat(store.acknowledgedThrough()).isEqualTo(-1);
+        assertThat(sink.committedBlocks()).isEmpty();
+        assertThat(store.stats(REQUIRED).pendingBlocks()).isEqualTo(6);
+
+        var result = consumer().drainOnce();
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(store.acknowledgedThrough()).isEqualTo(5);
+    }
+
+    @Test
+    void repeatedSinkOutageKeepsTheBacklogBoundedAndOrderedOnRecovery() {
+        commitBlocks(0, 20);
+        tip.set(40);
+        sink.failNextAppends(3);
+        for (int attempt = 0; attempt < 3; attempt++) {
+            assertThatThrownBy(() -> consumer().drainOnce()).isInstanceOf(ProjectionSinkException.class);
+        }
+        assertThat(store.acknowledgedThrough()).isEqualTo(-1);
+
+        var result = consumer().drainOnce();
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(sink.committedBlocks()).isSorted();
+        assertThat(sink.committedBlocks()).containsExactlyElementsOf(
+                java.util.stream.LongStream.rangeClosed(0, 20).boxed().toList());
+    }
+
+    // ------------------------------------------------------------ progress loop
+
+    @Test
+    void repeatedDrainsAdvanceContiguouslyAndThenGoIdle() {
+        commitBlocks(0, 100);
+        tip.set(120);
+        var bounds = new ProjectionConsumerBounds(10, 1 << 20, 1000, 5000, 1 << 30, 4L << 30);
+
+        List<Long> lastBlocks = new ArrayList<>();
+        ProjectionConsumerResult result;
+        while ((result = consumer(bounds).drainOnce()).madeProgress()) {
+            lastBlocks.add(result.lastBlock());
+        }
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.IDLE);
+        assertThat(lastBlocks).isSorted();
+        assertThat(store.acknowledgedThrough()).isEqualTo(110 - 10);
+        assertThat(sink.committedBlocks()).containsExactlyElementsOf(
+                java.util.stream.LongStream.rangeClosed(0, 100).boxed().toList());
+        assertThat(store.stats(REQUIRED).pendingBlocks()).isZero();
+    }
+
+    @Test
+    void acknowledgedChunksAreDeletedSoTheOutboxDoesNotGrowWithoutBound() {
+        commitBlocks(0, 50);
+        tip.set(100);
+        consumer().drainOnce();
+        var stats = store.stats(REQUIRED);
+        assertThat(stats.pendingBlocks()).isZero();
+        assertThat(stats.pendingBytes()).isZero();
+    }
+
+    // ------------------------------------------------------------ backpressure
+
+    @Test
+    void softAndHardBacklogBoundsAreReportedRatherThanDiscardingData() {
+        commitBlocks(0, 20);
+        var bounds = new ProjectionConsumerBounds(10, 1 << 20, 10, 15, 1L << 40, 2L << 40);
+        var pressure = consumer(bounds).backpressure();
+        assertThat(pressure.level()).isEqualTo(ProjectionBackpressure.Level.PAUSE_INGEST);
+        assertThat(pressure.pausesIngest()).isTrue();
+        assertThat(pressure.reason()).isPresent();
+        // Nothing was dropped to satisfy the bound.
+        assertThat(store.stats(REQUIRED).pendingBlocks()).isEqualTo(21);
+    }
+
+    @Test
+    void aSmallBacklogIsNormal() {
+        commitBlocks(0, 3);
+        assertThat(consumer().backpressure().level()).isEqualTo(ProjectionBackpressure.Level.NORMAL);
+    }
+
+    // -------------------------------------------------------- retention health
+
+    @Test
+    void retentionViolationPausesRatherThanNarrowingEligibility() {
+        // An artifact requiring slot 500 while the common floor has advanced to 900.
+        var artifact = new com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef(
+                com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId.EPOCH_STAKE, 7, 3, 60,
+                com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRepresentation.IMMUTABLE_GENERATION,
+                "gen/7", 1, "v1", java.util.OptionalLong.empty(), "", 500);
+        var header = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, 0,
+                new byte[]{0}, new byte[]{0}, 0, 0, 1L, 1, List.of(), List.of(artifact));
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.putBlockIdentity(ProjectionOutboxStore.batchWriter(batch, store.handles()), header);
+            store.putSection(ProjectionOutboxStore.batchWriter(batch, store.handles()), 0,
+                    new ProjectionSection(ProjectionSectionType.TRANSACTION,
+                            ProjectionSectionType.TRANSACTION.version(),
+                            List.of(ProjectionFactCodec.encodeTransactions(List.of())), 0));
+            store.putSection(ProjectionOutboxStore.batchWriter(batch, store.handles()), 0,
+                    new ProjectionSection(ProjectionSectionType.UTXO_HISTORY,
+                            ProjectionSectionType.UTXO_HISTORY.version(),
+                            List.of(ProjectionFactCodec.encodeUtxoHistory(
+                                    new com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact(
+                                            6, List.of(), List.of(), List.of(), List.of(), List.of(),
+                                            List.of(), List.of(), List.of()))), 0));
+            batch.put(handles.get(4), ProjectionOutboxKeys.artifactKey(0, "EPOCH_STAKE", 7),
+                    ProjectionSectionCodec.encodeArtifact(artifact));
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        tip.set(20);
+        rollbackFloor.set(900);
+
+        var result = consumer().drainOnce();
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.PAUSED);
+        assertThat(result.detail()).isPresent();
+        assertThat(sink.appendCalls()).isZero();
+        assertThat(store.acknowledgedThrough()).isEqualTo(-1);
+        // The source was not pruned and eligibility was not narrowed.
+        assertThat(store.stats(REQUIRED).pendingBlocks()).isEqualTo(1);
+    }
+
+    @Test
+    void aHealthyRetentionMarginAllowsProgress() {
+        commitBlocks(0, 5);
+        tip.set(20);
+        rollbackFloor.set(0); // unbounded retention must not stall the archive
+        assertThat(consumer().drainOnce().outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+    }
+
+    @Test
+    void artifactAcknowledgementHappensOnlyAfterTheReceiptIsVerified() {
+        commitBlocks(0, 5);
+        tip.set(20);
+        sink.failNextAppends(1);
+        assertThatThrownBy(() -> consumer().drainOnce()).isInstanceOf(ProjectionSinkException.class);
+        assertThat(artifacts.acknowledged()).isEmpty();
+    }
+
+    // --------------------------------------------------- batching inside the drain loop
+
+    @Test
+    void arrivalsBelowTheTargetAccumulateWithoutWritingAnything() {
+        commitBlocks(0, 19);
+        tip.set(200);
+        var consumer = consumer(NEAR_TIP);
+
+        var result = consumer.drainOnce(Instant.EPOCH);
+
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.ACCUMULATING);
+        assertThat(result.workPending()).isFalse();
+        assertThat(consumer.pendingBatchBlocks()).isEqualTo(20);
+        assertThat(sink.appendCalls()).isZero();
+        assertThat(store.acknowledgedThrough()).isEqualTo(-1);
+    }
+
+    @Test
+    void aPassWithNoNewArrivalsStillCommitsWhenTheDeadlineArrives() {
+        // The freshness deadline exists precisely for the case where arrivals stop. A drain
+        // pass that reads nothing must still evaluate the pending batch, or the deadline is
+        // unreachable and the batch lingers forever.
+        commitBlocks(0, 19);
+        tip.set(200);
+        var consumer = consumer(NEAR_TIP);
+
+        assertThat(consumer.drainOnce(Instant.EPOCH).outcome())
+                .isEqualTo(ProjectionConsumerResult.Outcome.ACCUMULATING);
+        // Many passes with no new blocks at all.
+        for (int pass = 1; pass <= 10; pass++) {
+            assertThat(consumer.drainOnce(Instant.EPOCH.plusSeconds(pass)).outcome())
+                    .isEqualTo(ProjectionConsumerResult.Outcome.ACCUMULATING);
+        }
+
+        var result = consumer.drainOnce(Instant.EPOCH.plus(Duration.ofMinutes(15)));
+
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(result.firstBlock()).isEqualTo(0);
+        assertThat(result.lastBlock()).isEqualTo(19);
+        assertThat(consumer.lastBatchDecision().reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.LINGER_EXPIRED);
+        assertThat(store.acknowledgedThrough()).isEqualTo(19);
+    }
+
+    @Test
+    void reachingTheTargetCommitsWithoutWaitingForTheDeadline() {
+        commitBlocks(0, 49);
+        tip.set(200);
+        var consumer = consumer(NEAR_TIP);
+
+        var result = consumer.drainOnce(Instant.EPOCH);
+
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(result.lastBlock()).isEqualTo(49);
+        assertThat(consumer.lastBatchDecision().reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MIN_BLOCKS);
+    }
+
+    @Test
+    void aLargeBacklogUsesTheBootstrapRegimeEvenThoughTheProducerIsAtTip() {
+        commitBlocks(0, 59);
+        tip.set(200);
+        var consumer = consumer(NEAR_TIP);
+        assertThat(consumer.nearTip()).isTrue();
+
+        // A backlog past the bootstrap target switches the regime back, so a sink that falls
+        // behind at tip is not throttled to 50-block commits.
+        var bootstrapPolicy = new ProjectionBatchPolicy(40, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15),
+                256L << 20, 2_000_000, 512L << 20, 600, 64L << 20, 4_000_000);
+        var bootstrapConsumer = consumer(bootstrapPolicy);
+        assertThat(bootstrapConsumer.nearTip()).isFalse();
+
+        var result = bootstrapConsumer.drainOnce(Instant.EPOCH);
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(bootstrapConsumer.lastBatchDecision().reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MIN_BLOCKS);
+        assertThat(result.lastBlock()).isGreaterThanOrEqualTo(40);
+    }
+
+    @Test
+    void aRollbackDiscardsWhateverTheDrainThreadHadBuffered() {
+        commitBlocks(0, 19);
+        tip.set(200);
+        var consumer = consumer(NEAR_TIP);
+        assertThat(consumer.drainOnce(Instant.EPOCH).outcome())
+                .isEqualTo(ProjectionConsumerResult.Outcome.ACCUMULATING);
+        assertThat(consumer.pendingBatchBlocks()).isEqualTo(20);
+
+        // Blocks 16..19 are rolled back; the buffered copies describe a discarded fork.
+        store.rollbackToSlot(15 * 20L, REQUIRED);
+        consumer.discardPendingBatch();
+
+        assertThat(consumer.drainOnce(Instant.EPOCH.plusSeconds(1)).outcome())
+                .as("the pass that observes the rollback drops the buffer and reads nothing")
+                .isEqualTo(ProjectionConsumerResult.Outcome.IDLE);
+        assertThat(consumer.pendingBatchBlocks()).isZero();
+
+        // The surviving chain is re-read from durable state and buffered afresh, so its
+        // freshness deadline runs from the moment it was re-read.
+        Instant reopened = Instant.EPOCH.plusSeconds(2);
+        assertThat(consumer.drainOnce(reopened).outcome())
+                .isEqualTo(ProjectionConsumerResult.Outcome.ACCUMULATING);
+        assertThat(consumer.pendingBatchBlocks()).isEqualTo(16);
+
+        // Nothing above 15 survives from the discarded fork.
+        var reread = consumer.drainOnce(reopened.plus(Duration.ofMinutes(15)));
+        assertThat(reread.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(reread.firstBlock()).isEqualTo(0);
+        assertThat(reread.lastBlock()).isEqualTo(15);
+        assertThat(sink.committedBlocks()).containsExactlyElementsOf(
+                java.util.stream.LongStream.rangeClosed(0, 15).boxed().toList());
+    }
+
+    @Test
+    void aBatchThatCanNoLongerGrowCommitsInsteadOfSpinning() {
+        // A byte ceiling far below the block target: without a saturation trigger the
+        // coordinator would re-offer an envelope that can never fit, forever.
+        commitBlocks(0, 59);
+        tip.set(200);
+        var tinyBytes = new ProjectionBatchPolicy(10_000, 50, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15), 200, 2_000_000, 512L << 20, 600,
+                64L << 20, 4_000_000);
+        var consumer = consumer(tinyBytes);
+
+        var result = consumer.drainOnce(Instant.EPOCH);
+
+        assertThat(result.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(consumer.lastBatchDecision().reason())
+                .isEqualTo(ProjectionBatchDecision.Reason.MAX_BYTES);
+        assertThat(result.lastBlock()).isLessThan(49);
+    }
+
+    @Test
+    void moreEligibleWorkKeepsTheCoordinatorDrainingRatherThanBackingOff() {
+        commitBlocks(0, 59);
+        tip.set(200);
+        var smallBatches = new ProjectionBatchPolicy(10_000, 10, 20_000,
+                Duration.ofSeconds(30), Duration.ofMinutes(15),
+                256L << 20, 2_000_000, 512L << 20, 600, 64L << 20, 4_000_000);
+        // A read bound below the eligible range, so one pass cannot consume everything.
+        var narrowReads = new ProjectionConsumerBounds(10, 1 << 20, 1000, 5000, 1 << 30, 4L << 30);
+        var consumer = consumer(narrowReads, smallBatches);
+
+        var first = consumer.drainOnce(Instant.EPOCH);
+        assertThat(first.outcome()).isEqualTo(ProjectionConsumerResult.Outcome.COMMITTED);
+        assertThat(first.workPending())
+                .as("more eligible envelopes remain, so the loop must not sleep")
+                .isTrue();
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumerTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxConsumerTest.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yano.archive.core.projection;
 import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
 import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
 import com.bloxbean.cardano.yano.archive.api.ArchiveSafetyWindows;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef;
 import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
 import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
 import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
@@ -534,5 +535,85 @@ class ProjectionOutboxConsumerTest {
         assertThat(first.workPending())
                 .as("more eligible envelopes remain, so the loop must not sleep")
                 .isTrue();
+    }
+
+    // ------------------------------- artifact cleanup ordering across crash boundaries
+
+    private static ProjectionArtifactRef artifactAt(long block, int epoch) {
+        return new ProjectionArtifactRef(
+                com.bloxbean.cardano.yano.archive.api.ArchiveDatasetId.EPOCH_STAKE, epoch, block,
+                block * 20, com.bloxbean.cardano.yano.archive.api.projection
+                        .ProjectionArtifactRepresentation.IMMUTABLE_GENERATION,
+                "gen-" + epoch, 1, "state-1", java.util.OptionalLong.of(10), "", block * 20);
+    }
+
+    /** Stage an artifact reference against a block, the way an epoch transition would. */
+    private void commitArtifact(long blockNumber, ProjectionArtifactRef ref) {
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.putArtifact(ProjectionOutboxStore.batchWriter(batch, store.handles()), blockNumber, ref);
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Test
+    void artifactsAreAcknowledgedBeforeTheOutboxDropsTheirReference() {
+        // acknowledgeThrough() deletes the artifact references along with the range, so
+        // acknowledging the range first would destroy the only record of what still needs
+        // releasing. A crash in that gap pins the source forever with nothing to reconcile from.
+        commitBlocks(0, 5);
+        commitArtifact(3, artifactAt(3, 100));
+        tip.set(200);
+
+        var consumer = consumer();
+        // Crash before any artifact is acknowledged: the range must NOT have been acknowledged,
+        // so the reference survives and the next pass can retry.
+        artifacts.failAcknowledgeAfter(0);
+        assertThatThrownBy(() -> consumer.drainOnce(Instant.EPOCH))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("simulated crash");
+
+        assertThat(store.acknowledgedThrough())
+                .as("the range must not be acknowledged while an artifact is unreleased")
+                .isEqualTo(-1);
+        assertThat(artifacts.acknowledged()).isEmpty();
+    }
+
+    @Test
+    void aRetryAfterACrashAcknowledgesIdempotentlyAndThenCompletes() {
+        commitBlocks(0, 5);
+        commitArtifact(3, artifactAt(3, 100));
+        tip.set(200);
+        var consumer = consumer();
+
+        artifacts.failAcknowledgeAfter(0);
+        assertThatThrownBy(() -> consumer.drainOnce(Instant.EPOCH)).isInstanceOf(IllegalStateException.class);
+
+        // The sink already holds a durable receipt for this batch, so the retry recognises it and
+        // does not rewrite rows - but it must still finish releasing the artifact.
+        artifacts.failAcknowledgeAfter(Integer.MAX_VALUE);
+        var result = consumer.drainOnce(Instant.EPOCH.plusSeconds(1));
+
+        assertThat(result.outcome()).isIn(ProjectionConsumerResult.Outcome.COMMITTED,
+                ProjectionConsumerResult.Outcome.REPLAYED);
+        assertThat(artifacts.acknowledged()).hasSize(1);
+        assertThat(store.acknowledgedThrough()).isEqualTo(5);
+        assertThat(sink.appendCalls())
+                .as("the receipt must have prevented a second row write")
+                .isEqualTo(1);
+    }
+
+    @Test
+    void acknowledgingTheSameArtifactTwiceIsHarmless() {
+        // The ordering guarantees a replayed acknowledgement, so the contract must absorb it.
+        var ref = artifactAt(3, 100);
+        artifacts.acknowledge(ref);
+        artifacts.acknowledge(ref);
+
+        assertThat(artifacts.acknowledged()).hasSize(1);
+        assertThat(artifacts.acknowledgeCalls())
+                .as("it really was called twice; the reader absorbed the repeat")
+                .isEqualTo(2);
     }
 }

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxStoreTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionOutboxStoreTest.java
@@ -1,0 +1,526 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.ColumnFamilyDescriptor;
+import org.rocksdb.ColumnFamilyHandle;
+import org.rocksdb.DBOptions;
+import org.rocksdb.RocksDB;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Exercises the outbox against a real RocksDB, including the crash boundaries of
+ * ADR-039 §11 that can be reached without a sink.
+ */
+class ProjectionOutboxStoreTest {
+    static { RocksDB.loadLibrary(); }
+
+    private static final ArchiveNetworkIdentity PREPROD = new ArchiveNetworkIdentity(1, "162d29c4");
+    private static final Set<ProjectionSectionType> REQUIRED =
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY);
+
+    @TempDir
+    Path directory;
+
+    private RocksDB db;
+    private DBOptions dbOptions;
+    private List<ColumnFamilyHandle> handles;
+    private ProjectionOutboxStore store;
+
+    @BeforeEach
+    void open() {
+        openDatabase();
+    }
+
+    private void openDatabase() {
+        try {
+            dbOptions = new DBOptions().setCreateIfMissing(true).setCreateMissingColumnFamilies(true);
+            List<ColumnFamilyDescriptor> descriptors = new ArrayList<>();
+            descriptors.add(new ColumnFamilyDescriptor(RocksDB.DEFAULT_COLUMN_FAMILY));
+            for (String name : ProjectionCfNames.ALL) {
+                descriptors.add(new ColumnFamilyDescriptor(name.getBytes(StandardCharsets.UTF_8)));
+            }
+            handles = new ArrayList<>();
+            db = RocksDB.open(dbOptions, directory.resolve("db").toString(), descriptors, handles);
+            store = new ProjectionOutboxStore(db, handles.get(1), handles.get(2), handles.get(3), handles.get(4));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void closeDatabase() {
+        handles.forEach(ColumnFamilyHandle::close);
+        db.close();
+        dbOptions.close();
+    }
+
+    /** Simulates a process restart: everything committed survives, nothing else does. */
+    private void restart() {
+        closeDatabase();
+        openDatabase();
+    }
+
+    @AfterEach
+    void close() {
+        closeDatabase();
+    }
+
+    // ------------------------------------------------------------------ helpers
+
+    private static ProjectionEnvelopeHeader identity(long blockNumber, ProjectionBlockKind kind) {
+        return new ProjectionEnvelopeHeader(PREPROD, kind, blockNumber,
+                new byte[]{(byte) (blockNumber >> 8), (byte) blockNumber}, new byte[]{(byte) (blockNumber - 1)},
+                blockNumber * 20, (int) (blockNumber / 100), 1_600_000_000L + blockNumber, 1, List.of(), List.of());
+    }
+
+    private static ProjectionSection section(ProjectionSectionType type, long rows, byte[]... chunks) {
+        return new ProjectionSection(type, type.version(), List.of(chunks), rows);
+    }
+
+    /** One contributor commit: its section and its cursor in a single batch. */
+    private void commitSection(long blockNumber, ProjectionSection section) {
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.putSection(ProjectionOutboxStore.batchWriter(batch, store.handles()), blockNumber, section);
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void commitIdentity(long blockNumber, ProjectionBlockKind kind) {
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.putBlockIdentity(ProjectionOutboxStore.batchWriter(batch, store.handles()), identity(blockNumber, kind));
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private void commitCompleteBlock(long blockNumber) {
+        commitIdentity(blockNumber, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(blockNumber, section(ProjectionSectionType.TRANSACTION, 2, new byte[]{1, 2}));
+        commitSection(blockNumber, section(ProjectionSectionType.UTXO_HISTORY, 3, new byte[]{3, 4, 5}));
+    }
+
+    // ------------------------------------------------------- completion gating
+
+    @Test
+    void anEnvelopeIsIncompleteUntilEveryRequiredContributorReachesIt() {
+        commitIdentity(100, ProjectionBlockKind.SHELLEY_PLUS);
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(-1);
+
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(-1);
+
+        commitSection(100, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[]{2}));
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(100);
+    }
+
+    @Test
+    void canonicalProgressMayLeadASlowContributor() {
+        // Core reaches 103, TRANSACTION reaches 102, UTXO_HISTORY only 101.
+        for (long block = 100; block <= 103; block++) commitIdentity(block, ProjectionBlockKind.SHELLEY_PLUS);
+        for (long block = 100; block <= 102; block++) {
+            commitSection(block, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        }
+        for (long block = 100; block <= 101; block++) {
+            commitSection(block, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[]{2}));
+        }
+        assertThat(store.identityCursor()).isEqualTo(103);
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(101);
+    }
+
+    @Test
+    void aBlockWithNoRowsForADatasetStillAdvancesThatContributor() {
+        commitIdentity(100, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 0));
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.advanceContributor(ProjectionOutboxStore.batchWriter(batch, store.handles()), ProjectionSectionType.UTXO_HISTORY, 100);
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(100);
+    }
+
+    // --------------------------------------------------------------- assembly
+
+    @Test
+    void anAssembledEnvelopeMatchesWhatWasContributed() {
+        commitCompleteBlock(100);
+        ProjectionEnvelope envelope = store.readEnvelope(100, REQUIRED).orElseThrow();
+        assertThat(envelope.blockNumber()).isEqualTo(100);
+        assertThat(envelope.sections()).hasSize(2);
+        assertThat(envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow().rowCount()).isEqualTo(2);
+        assertThat(envelope.section(ProjectionSectionType.UTXO_HISTORY).orElseThrow().rowCount()).isEqualTo(3);
+        assertThat(envelope.envelopeId()).isEqualTo(identity(100, ProjectionBlockKind.SHELLEY_PLUS).envelopeId());
+    }
+
+    @Test
+    void multiChunkSectionsReassembleInOrder() {
+        commitIdentity(100, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 3,
+                new byte[]{1}, new byte[]{2}, new byte[]{3}));
+        commitSection(100, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[]{9}));
+        var chunks = store.readEnvelope(100, REQUIRED).orElseThrow()
+                .section(ProjectionSectionType.TRANSACTION).orElseThrow().chunks();
+        assertThat(chunks).hasSize(3);
+        assertThat(chunks.get(0)).containsExactly(1);
+        assertThat(chunks.get(1)).containsExactly(2);
+        assertThat(chunks.get(2)).containsExactly(3);
+    }
+
+    @Test
+    void anEnvelopeMissingARequiredSectionIsNotReadable() {
+        commitIdentity(100, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        assertThat(store.readEnvelope(100, REQUIRED)).isEmpty();
+    }
+
+    @Test
+    void anEbbProducesAReadableEmptyEnvelopeSoCoverageStaysContiguous() {
+        commitIdentity(100, ProjectionBlockKind.BYRON_EBB);
+        ProjectionEnvelope envelope = store.readEnvelope(100, REQUIRED).orElseThrow();
+        assertThat(envelope.sections()).isEmpty();
+        assertThat(envelope.header().blockKind()).isEqualTo(ProjectionBlockKind.BYRON_EBB);
+    }
+
+    // ---------------------------------------------------------- ordered reads
+
+    @Test
+    void aRangeStopsAtTheFirstIncompleteBlockRatherThanSkippingIt() {
+        commitCompleteBlock(100);
+        commitCompleteBlock(101);
+        commitIdentity(102, ProjectionBlockKind.SHELLEY_PLUS); // incomplete
+        commitCompleteBlock(103);
+
+        var envelopes = store.readRange(100, 103, REQUIRED, 100, Long.MAX_VALUE);
+        assertThat(envelopes).extracting(ProjectionEnvelope::blockNumber).containsExactly(100L, 101L);
+    }
+
+    @Test
+    void aRangeHonoursBlockAndByteBounds() {
+        for (long block = 100; block <= 110; block++) commitCompleteBlock(block);
+
+        assertThat(store.readRange(100, 110, REQUIRED, 3, Long.MAX_VALUE)).hasSize(3);
+        // 5 bytes per block; a 12-byte budget fits two whole blocks.
+        assertThat(store.readRange(100, 110, REQUIRED, 100, 12)).hasSize(2);
+    }
+
+    @Test
+    void asingleOversizedEnvelopeStillMakesProgress() {
+        commitIdentity(100, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 1, new byte[4096]));
+        commitSection(100, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[4096]));
+        assertThat(store.readRange(100, 100, REQUIRED, 100, 8)).hasSize(1);
+    }
+
+    // ----------------------------------------------- acknowledgement + cleanup
+
+    @Test
+    void acknowledgementRemovesExactlyTheAcknowledgedRange() {
+        for (long block = 100; block <= 105; block++) commitCompleteBlock(block);
+        store.acknowledgeThrough(102);
+
+        assertThat(store.acknowledgedThrough()).isEqualTo(102);
+        assertThat(store.readEnvelope(100, REQUIRED)).isEmpty();
+        assertThat(store.readEnvelope(102, REQUIRED)).isEmpty();
+        assertThat(store.readEnvelope(103, REQUIRED)).isPresent();
+        assertThat(store.stats(REQUIRED).pendingBlocks()).isEqualTo(3);
+    }
+
+    @Test
+    void acknowledgementIsIdempotent() {
+        for (long block = 100; block <= 105; block++) commitCompleteBlock(block);
+        store.acknowledgeThrough(102);
+        store.acknowledgeThrough(102);
+        assertThat(store.acknowledgedThrough()).isEqualTo(102);
+        assertThat(store.stats(REQUIRED).pendingBlocks()).isEqualTo(3);
+    }
+
+    /** ADR-039 §11 case 8: crash after acknowledgement but during chunk cleanup. */
+    @Test
+    void acknowledgementSurvivesRestartAndDoesNotResurrectCleanedData() {
+        for (long block = 100; block <= 105; block++) commitCompleteBlock(block);
+        store.acknowledgeThrough(103);
+        restart();
+
+        assertThat(store.acknowledgedThrough()).isEqualTo(103);
+        assertThat(store.readEnvelope(103, REQUIRED)).isEmpty();
+        assertThat(store.readEnvelope(104, REQUIRED)).isPresent();
+    }
+
+    // ------------------------------------------------------------- rollback
+
+    @Test
+    void rollbackRemovesPendingEnvelopesAndRewindsEveryCursor() {
+        for (long block = 100; block <= 105; block++) commitCompleteBlock(block);
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(105);
+
+        store.rollbackFrom(103, REQUIRED);
+
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(102);
+        assertThat(store.identityCursor()).isEqualTo(102);
+        assertThat(store.readEnvelope(103, REQUIRED)).isEmpty();
+        assertThat(store.readEnvelope(102, REQUIRED)).isPresent();
+    }
+
+    @Test
+    void aReplacementBlockAfterRollbackGetsADistinctEnvelopeIdentity() {
+        commitCompleteBlock(100);
+        String original = store.readEnvelope(100, REQUIRED).orElseThrow().envelopeId();
+
+        store.rollbackFrom(100, REQUIRED);
+        assertThat(store.readEnvelope(100, REQUIRED)).isEmpty();
+
+        var replacement = new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS, 100,
+                new byte[]{(byte) 0xAA, (byte) 0xBB}, new byte[]{99}, 2000, 1, 1L, 1, List.of(), List.of());
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            store.putBlockIdentity(ProjectionOutboxStore.batchWriter(batch, store.handles()), replacement);
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{7}));
+        commitSection(100, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[]{8}));
+
+        assertThat(store.readEnvelope(100, REQUIRED).orElseThrow().envelopeId()).isNotEqualTo(original);
+    }
+
+    @Test
+    void rollbackDoesNotRewindACursorThatIsAlreadyBehind() {
+        commitCompleteBlock(100);
+        commitIdentity(101, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(101, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        // UTXO_HISTORY is still at 100.
+        store.rollbackFrom(101, REQUIRED);
+        assertThat(store.contributorCursor(ProjectionSectionType.UTXO_HISTORY)).isEqualTo(100);
+        assertThat(store.contributorCursor(ProjectionSectionType.TRANSACTION)).isEqualTo(100);
+    }
+
+    // -------------------------------------------------------------- restart
+
+    /** ADR-039 §11 case 3: crash after a complete durable outbox commit, before the sink runs. */
+    @Test
+    void aCompleteEnvelopeSurvivesRestartIntact() {
+        commitCompleteBlock(100);
+        String before = store.readEnvelope(100, REQUIRED).orElseThrow().envelopeId();
+        restart();
+        ProjectionEnvelope after = store.readEnvelope(100, REQUIRED).orElseThrow();
+        assertThat(after.envelopeId()).isEqualTo(before);
+        assertThat(after.sections()).hasSize(2);
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(100);
+    }
+
+    /** ADR-039 §11 case 2: crash after one contributor commits, before the envelope completes. */
+    @Test
+    void aPartiallyContributedBlockSurvivesRestartAndRemainsIncomplete() {
+        commitIdentity(100, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        restart();
+
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(-1);
+        assertThat(store.readEnvelope(100, REQUIRED)).isEmpty();
+        assertThat(store.contributorCursor(ProjectionSectionType.TRANSACTION)).isEqualTo(100);
+        assertThat(store.contributorCursor(ProjectionSectionType.UTXO_HISTORY)).isEqualTo(-1);
+
+        // The lagging contributor completes after restart and the envelope becomes eligible.
+        commitSection(100, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[]{2}));
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(100);
+        assertThat(store.readEnvelope(100, REQUIRED)).isPresent();
+    }
+
+    @Test
+    void identityRoundTripsAcrossRestart() {
+        var identity = new com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity(
+                PREPROD, "ducklake", 1, REQUIRED);
+        store.putIdentity(identity);
+        restart();
+        assertThat(store.identityFingerprint()).contains(identity.fingerprint());
+    }
+
+    // --------------------------------------------------------- torn records
+
+    @Test
+    void aSectionWithFewerChunksThanItsManifestDeclaresIsRejected() {
+        commitIdentity(100, ProjectionBlockKind.SHELLEY_PLUS);
+        // Write a manifest claiming two chunks but only store one.
+        try (WriteBatch batch = new WriteBatch(); WriteOptions options = new WriteOptions()) {
+            var declared = section(ProjectionSectionType.TRANSACTION, 2, new byte[]{1}, new byte[]{2});
+            batch.put(handles.get(2), ProjectionOutboxKeys.sectionManifestKey(100, ProjectionSectionType.TRANSACTION),
+                    ProjectionSectionCodec.encodeManifest(declared.manifest()));
+            batch.put(handles.get(2), ProjectionOutboxKeys.sectionChunkKey(100, ProjectionSectionType.TRANSACTION, 0),
+                    new byte[]{1});
+            db.write(options, batch);
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+        assertThatThrownBy(() -> store.readEnvelope(100, REQUIRED))
+                .isInstanceOf(ProjectionOutboxException.class)
+                .hasMessageContaining("manifest declares");
+    }
+
+    // -------------------------------------------------------------- metrics
+
+    @Test
+    void statsReportBacklogAndCoordinates() {
+        for (long block = 100; block <= 104; block++) commitCompleteBlock(block);
+        var stats = store.stats(REQUIRED);
+        assertThat(stats.pendingBlocks()).isEqualTo(5);
+        assertThat(stats.oldestPendingBlock()).isEqualTo(100);
+        assertThat(stats.completeThroughBlock()).isEqualTo(104);
+        assertThat(stats.acknowledgedThroughBlock()).isEqualTo(-1);
+        assertThat(stats.pendingRows()).isEqualTo(25);
+        assertThat(stats.pendingBytes()).isEqualTo(25);
+        assertThat(stats.isEmpty()).isFalse();
+    }
+
+    // ------------------------------------------------- stalled vs lagging
+
+    @Test
+    void aLaggingContributorIsNotReportedAsStalled() {
+        var monitor = new ProjectionContributorHealth.Monitor(java.time.Duration.ofSeconds(30));
+        java.time.Instant now = java.time.Instant.EPOCH;
+        for (long block = 100; block <= 103; block++) commitIdentity(block, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        commitSection(100, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[]{2}));
+
+        var health = monitor.evaluate(store, REQUIRED, now);
+        assertThat(health.status()).isEqualTo(ProjectionContributorHealth.Status.LAGGING);
+
+        // It advances a moment later, so the stall timer resets.
+        commitSection(101, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        commitSection(101, section(ProjectionSectionType.UTXO_HISTORY, 1, new byte[]{2}));
+        health = monitor.evaluate(store, REQUIRED, now.plusSeconds(20));
+        assertThat(health.status()).isEqualTo(ProjectionContributorHealth.Status.LAGGING);
+        assertThat(health.stalledFor()).isEqualTo(java.time.Duration.ZERO);
+    }
+
+    @Test
+    void aContributorThatStopsAdvancingIsReportedAsStalledNotSilentlyIdle() {
+        var monitor = new ProjectionContributorHealth.Monitor(java.time.Duration.ofSeconds(30));
+        java.time.Instant now = java.time.Instant.EPOCH;
+        for (long block = 100; block <= 110; block++) commitIdentity(block, ProjectionBlockKind.SHELLEY_PLUS);
+        commitSection(100, section(ProjectionSectionType.TRANSACTION, 1, new byte[]{1}));
+        // UTXO_HISTORY never contributes.
+
+        assertThat(monitor.evaluate(store, REQUIRED, now).status())
+                .isEqualTo(ProjectionContributorHealth.Status.LAGGING);
+
+        var health = monitor.evaluate(store, REQUIRED, now.plusSeconds(31));
+        assertThat(health.status()).isEqualTo(ProjectionContributorHealth.Status.STALLED);
+        assertThat(health.isStalled()).isTrue();
+        assertThat(health.slowestContributor()).contains(ProjectionSectionType.UTXO_HISTORY);
+        assertThat(health.detail()).get().asString().contains("stalled contributor, not archive backlog");
+        assertThat(health.identityCursor()).isEqualTo(110);
+        assertThat(health.completeThroughBlock()).isEqualTo(-1);
+    }
+
+    @Test
+    void aFullyCaughtUpProjectionIsHealthy() {
+        var monitor = new ProjectionContributorHealth.Monitor(java.time.Duration.ofSeconds(30));
+        commitCompleteBlock(100);
+        var health = monitor.evaluate(store, REQUIRED, java.time.Instant.EPOCH.plusSeconds(600));
+        assertThat(health.status()).isEqualTo(ProjectionContributorHealth.Status.HEALTHY);
+        assertThat(health.contributorCursors()).containsEntry("transaction:v2", 100L);
+    }
+
+    // ------------------------------------------------- slot-based rollback
+
+    @Test
+    void rollbackBySlotRemovesExactlyTheEnvelopesNewerThanTheRollbackPoint() {
+        // identity(n) puts block n at slot n*20.
+        for (long block = 100; block <= 105; block++) commitCompleteBlock(block);
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(105);
+
+        long removed = store.rollbackToSlot(102 * 20, REQUIRED);
+
+        assertThat(removed).isEqualTo(3); // blocks 103, 104, 105
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(102);
+        assertThat(store.readEnvelope(102, REQUIRED)).isPresent();
+        assertThat(store.readEnvelope(103, REQUIRED)).isEmpty();
+    }
+
+    @Test
+    void rollbackBySlotIsANoOpWhenNothingIsNewerThanTheRollbackPoint() {
+        for (long block = 100; block <= 103; block++) commitCompleteBlock(block);
+        assertThat(store.rollbackToSlot(103 * 20, REQUIRED)).isZero();
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(103);
+        assertThat(store.readEnvelope(103, REQUIRED)).isPresent();
+    }
+
+    @Test
+    void rollbackBySlotDoesNotDependOnReadingALiveChainTip() {
+        // The whole point: the cutoff is derived from what the outbox itself recorded, so
+        // a listener firing before or after chain-state rollback gets the same answer.
+        for (long block = 100; block <= 110; block++) commitCompleteBlock(block);
+        long first = store.rollbackToSlot(105 * 20, REQUIRED);
+        long second = store.rollbackToSlot(105 * 20, REQUIRED);
+        assertThat(first).isEqualTo(5);
+        assertThat(second).isZero();
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(105);
+    }
+
+    // ------------------------------------- lingering batches are not durable state
+
+    @Test
+    void aRestartWhileEnvelopesAreLingeringLeavesThemUnacknowledgedAndRebuildsTheSameBatch() {
+        // Near tip the accumulator holds envelopes until 50 arrive or 15 minutes elapse. A batch
+        // that is still lingering has no durable footprint, so a restart must lose nothing.
+        var policy = new ProjectionBatchPolicy(10_000, 50, 20_000,
+                java.time.Duration.ofSeconds(30), java.time.Duration.ofMinutes(15),
+                1L << 30, 1_000_000, 1L << 30, 600, 64L << 20, 4_000_000);
+
+        for (long block = 100; block < 130; block++) commitCompleteBlock(block);
+
+        var before = new ProjectionBatchAccumulator(policy);
+        var beforeIds = new ArrayList<String>();
+        for (ProjectionEnvelope envelope : store.readRange(100, store.completeThrough(REQUIRED), REQUIRED, 100, 1L << 30)) {
+            before.offer(envelope, java.time.Instant.EPOCH);
+            beforeIds.add(envelope.header().envelopeId());
+        }
+        assertThat(before.size()).isEqualTo(30);
+        assertThat(before.decide(true, false, java.time.Instant.EPOCH).flush())
+                .as("30 envelopes is short of the 50-envelope target and the 15-minute deadline")
+                .isFalse();
+
+        long acknowledgedBefore = store.acknowledgedThrough();
+        restart();
+
+        assertThat(store.acknowledgedThrough())
+                .as("a lingering batch was never acknowledged")
+                .isEqualTo(acknowledgedBefore);
+        assertThat(store.completeThrough(REQUIRED)).isEqualTo(129);
+
+        var after = new ProjectionBatchAccumulator(policy);
+        var afterIds = new ArrayList<String>();
+        for (ProjectionEnvelope envelope : store.readRange(100, store.completeThrough(REQUIRED), REQUIRED, 100, 1L << 30)) {
+            after.offer(envelope, java.time.Instant.EPOCH);
+            afterIds.add(envelope.header().envelopeId());
+        }
+
+        assertThat(afterIds).containsExactlyElementsOf(beforeIds);
+        assertThat(after.size()).isEqualTo(before.size());
+        assertThat(after.rows()).isEqualTo(before.rows());
+        assertThat(after.encodedBytes()).isEqualTo(before.encodedBytes());
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionPeakRetentionMeasurementTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionPeakRetentionMeasurementTest.java
@@ -1,0 +1,274 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.core.dataset.TransactionFact;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact;
+import org.junit.jupiter.api.Test;
+
+import java.lang.management.ManagementFactory;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Measures — rather than asserts by construction — that the materialisation working set is
+ * bounded by one envelope.
+ *
+ * <p>{@link ProjectionStreamingBoundTest} pins the structural properties (chunks are never
+ * joined, the stream is single-use). This class puts numbers on them: peak retained heap
+ * during streaming, and bytes allocated per row. The interesting property is the
+ * <em>scaling</em>: growing the batch by 20x must grow the working set by roughly nothing,
+ * because only the envelope currently being decoded is live.
+ *
+ * <p>Measurements are printed so a change in encoding cost is visible in CI output even when
+ * the assertions still hold.
+ */
+class ProjectionPeakRetentionMeasurementTest {
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(1, "fixture");
+    private static final ProjectionIdentity IDENTITY = new ProjectionIdentity(NETWORK, "test", 1,
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY));
+
+    /**
+     * Per-envelope density calibrated to the densest genuine preprod blocks observed during
+     * ADR-039 validation: many outputs carrying inline datums, multi-asset bundles and
+     * redeemers, rather than the average block which is far cheaper.
+     */
+    private static final int DENSE_ITEMS = 300;
+
+    private record Measurement(int envelopes, long rows, long peakRetainedBytes,
+                               long allocatedBytes) {
+        long bytesPerRow() {
+            return rows == 0 ? 0 : allocatedBytes / rows;
+        }
+    }
+
+    @Test
+    void theMaterialisationWorkingSetDoesNotGrowWithBatchSize() {
+        Measurement small = measure(5);
+        Measurement large = measure(100);
+
+        System.out.printf("ADR-039 peak retention: %d envelopes -> %d rows, peak %d KiB, %d B/row%n",
+                small.envelopes(), small.rows(), small.peakRetainedBytes() >> 10, small.bytesPerRow());
+        System.out.printf("ADR-039 peak retention: %d envelopes -> %d rows, peak %d KiB, %d B/row%n",
+                large.envelopes(), large.rows(), large.peakRetainedBytes() >> 10, large.bytesPerRow());
+
+        assertThat(large.rows())
+                .as("the larger batch really does carry 20x the rows")
+                .isEqualTo(small.rows() * 20);
+
+        // Allocation scales with total work, as it must: every row is still produced.
+        assertThat(large.allocatedBytes())
+                .as("total allocation tracks total rows")
+                .isGreaterThan(small.allocatedBytes() * 10);
+
+        // Retention does not. A 20x batch may not cost more than 4x the working set; a
+        // materialise-the-whole-batch implementation would show ~20x here.
+        long ceiling = Math.max(small.peakRetainedBytes() * 4, 24L << 20);
+        assertThat(large.peakRetainedBytes())
+                .as("peak retained heap must not scale with batch size (small=%d B, large=%d B)",
+                        small.peakRetainedBytes(), large.peakRetainedBytes())
+                .isLessThanOrEqualTo(ceiling);
+    }
+
+    @Test
+    void oneDenseEnvelopeWorkingSetIsReportedForCapacityPlanning() {
+        Measurement one = measure(1);
+        System.out.printf("ADR-039 densest single envelope: %d rows, peak %d KiB, %d B/row%n",
+                one.rows(), one.peakRetainedBytes() >> 10, one.bytesPerRow());
+
+        // The singleton safety guard is sized in encoded bytes and rows; this records the
+        // heap cost that sizing is protecting against.
+        assertThat(one.rows()).isGreaterThan(1_000);
+        assertThat(one.peakRetainedBytes()).isLessThan(256L << 20);
+    }
+
+    // ------------------------------------------------------------------ measurement
+
+    private static Measurement measure(int envelopeCount) {
+        List<ProjectionEnvelope> envelopes = new ArrayList<>();
+        for (int b = 0; b < envelopeCount; b++) envelopes.add(denseEnvelope(b));
+        var batch = new ProjectionBatch(IDENTITY, envelopes);
+
+        // Baseline is taken with the envelopes already live, so what follows isolates the
+        // cost of materialising rows from the cost of holding the encoded batch.
+        long baseline = usedHeapAfterGc();
+        long allocationBefore = allocatedBytes();
+
+        long rows = 0;
+        long peak = 0;
+        int sampleEvery = Math.max(1, envelopeCount / 4);
+        int envelopeBoundary = 0;
+        long lastBlock = -1;
+        var iterator = ProjectionRowBuilder.materialise(batch).rows().iterator();
+        while (iterator.hasNext()) {
+            ArchiveRow row = iterator.next();
+            rows++;
+            // Sample at a few envelope boundaries rather than every row: a forced GC per row
+            // would dominate the measurement it is trying to take.
+            long block = blockOf(row, lastBlock);
+            if (block != lastBlock) {
+                lastBlock = block;
+                if (envelopeBoundary++ % sampleEvery == 0) {
+                    peak = Math.max(peak, usedHeapAfterGc() - baseline);
+                }
+            }
+        }
+        long allocated = allocatedBytes() - allocationBefore;
+        return new Measurement(envelopeCount, rows, Math.max(peak, 0), allocated);
+    }
+
+    /** Row-order proxy for "a new envelope started"; exact identity is not needed. */
+    private static long blockOf(ArchiveRow row, long fallback) {
+        for (Object value : row.values()) {
+            if (value instanceof Long l && l >= 0 && l < 1_000_000) return l;
+        }
+        return fallback;
+    }
+
+    private static long usedHeapAfterGc() {
+        Runtime runtime = Runtime.getRuntime();
+        for (int i = 0; i < 3; i++) {
+            System.gc();
+            try {
+                Thread.sleep(10);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+                break;
+            }
+        }
+        return runtime.totalMemory() - runtime.freeMemory();
+    }
+
+    private static long allocatedBytes() {
+        var bean = ManagementFactory.getThreadMXBean();
+        if (bean instanceof com.sun.management.ThreadMXBean sun && sun.isThreadAllocatedMemoryEnabled()) {
+            return sun.getThreadAllocatedBytes(Thread.currentThread().threadId());
+        }
+        return 0;
+    }
+
+    // ------------------------------------------------------------------ fixtures
+
+    private static ProjectionEnvelope denseEnvelope(long block) {
+        List<TransactionFact> txs = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            byte[] hash = new byte[32];
+            hash[0] = (byte) i;
+            hash[1] = (byte) block;
+            txs.add(new TransactionFact(hash, i, true, 170_000L + i));
+        }
+        UtxoHistoryFact utxo = denseUtxo(DENSE_ITEMS, block);
+
+        byte[] txEncoded = ProjectionFactCodec.encodeTransactions(txs);
+        byte[] utxoEncoded = ProjectionFactCodec.encodeUtxoHistory(utxo);
+        var txSection = new ProjectionSection(ProjectionSectionType.TRANSACTION,
+                ProjectionSectionType.TRANSACTION.version(),
+                ProjectionChunking.split(txEncoded, 1 << 20), txs.size());
+        long utxoRows = utxo.outputs().size() + utxo.assets().size() + utxo.inputs().size()
+                + utxo.transactionDatums().size() + utxo.transactionRedeemers().size();
+        var utxoSection = new ProjectionSection(ProjectionSectionType.UTXO_HISTORY,
+                ProjectionSectionType.UTXO_HISTORY.version(),
+                ProjectionChunking.split(utxoEncoded, 1 << 20), utxoRows);
+        var eventSection = accountEventSection(block);
+        var addressSection = addressSection(block);
+        var header = new ProjectionEnvelopeHeader(NETWORK, ProjectionBlockKind.SHELLEY_PLUS, block,
+                new byte[]{(byte) block}, new byte[]{(byte) (block - 1)}, block * 20, 1, 1L, 1,
+                List.of(txSection.manifest(), utxoSection.manifest(), eventSection.manifest(),
+                        addressSection.manifest()),
+                List.of());
+        return new ProjectionEnvelope(header,
+                List.of(txSection, utxoSection, eventSection, addressSection));
+    }
+
+    /** Certificates: cheap per row, but they are part of a four-dataset envelope. */
+    private static ProjectionSection accountEventSection(long block) {
+        List<com.bloxbean.cardano.yano.archive.core.dataset.AccountEventFact> events = new ArrayList<>();
+        for (int i = 0; i < 20; i++) {
+            byte[] credential = new byte[28];
+            credential[0] = (byte) i;
+            credential[1] = (byte) block;
+            byte[] hash = new byte[32];
+            hash[0] = (byte) i;
+            events.add(new com.bloxbean.cardano.yano.archive.core.dataset.AccountEventFact(
+                    credential, "key", "registration", hash, i, ((long) i) << 32,
+                    null, null, null, 2_000_000L));
+        }
+        byte[] encoded = ProjectionFactCodec.encodeAccountEvents(events);
+        return new ProjectionSection(ProjectionSectionType.ACCOUNT_EVENT,
+                ProjectionSectionType.ACCOUNT_EVENT.version(),
+                ProjectionChunking.split(encoded, 1 << 20), events.size());
+    }
+
+    /**
+     * The heaviest of the four per row: every participation carries an address key, a display
+     * address and two credentials, measured at ~234 bytes each.
+     */
+    private static ProjectionSection addressSection(long block) {
+        List<com.bloxbean.cardano.yano.archive.core.dataset.AddressParticipationFact.Transaction> txs =
+                new ArrayList<>();
+        long participations = 0;
+        for (int t = 0; t < 20; t++) {
+            List<com.bloxbean.cardano.yano.archive.core.dataset.AddressParticipationFact.Participation> parts =
+                    new ArrayList<>();
+            for (int i = 0; i < DENSE_ITEMS / 4; i++) {
+                byte[] key = new byte[28];
+                key[0] = (byte) i;
+                key[1] = (byte) block;
+                parts.add(new com.bloxbean.cardano.yano.archive.core.dataset
+                        .AddressParticipationFact.Participation(
+                        i % 2 == 0 ? "INPUT" : "OUTPUT",
+                        new com.bloxbean.cardano.yano.archive.core.dataset.AddressSubjectRows.Participant(
+                                key, "addr_test1" + block + "_" + i, key, "key", key)));
+            }
+            byte[] txHash = new byte[32];
+            txHash[0] = (byte) t;
+            txHash[1] = (byte) block;
+            txs.add(new com.bloxbean.cardano.yano.archive.core.dataset
+                    .AddressParticipationFact.Transaction(txHash, t, parts));
+            participations += parts.size();
+        }
+        byte[] encoded = ProjectionFactCodec.encodeAddressParticipations(
+                new com.bloxbean.cardano.yano.archive.core.dataset.AddressParticipationFact(txs));
+        return new ProjectionSection(ProjectionSectionType.ADDRESS_TRANSACTION,
+                ProjectionSectionType.ADDRESS_TRANSACTION.version(),
+                ProjectionChunking.split(encoded, 1 << 20), participations);
+    }
+
+    private static UtxoHistoryFact denseUtxo(int n, long block) {
+        List<UtxoHistoryFact.Address> addresses = new ArrayList<>();
+        List<UtxoHistoryFact.Output> outputs = new ArrayList<>();
+        List<UtxoHistoryFact.Asset> assets = new ArrayList<>();
+        List<UtxoHistoryFact.TransactionDatum> datums = new ArrayList<>();
+        List<UtxoHistoryFact.TransactionRedeemer> redeemers = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            byte[] key = new byte[28];
+            key[0] = (byte) i;
+            key[1] = (byte) block;
+            byte[] hash = new byte[32];
+            hash[0] = (byte) i;
+            hash[1] = (byte) block;
+            addresses.add(new UtxoHistoryFact.Address(key, key, "addr" + block + "_" + i, 0, "base",
+                    "key", key, "none", null, null, null, null, null));
+            outputs.add(new UtxoHistoryFact.Output(hash, i, i, "output", key, key, null, 1_000_000L,
+                    "hash", hash, new byte[512], null, null, null, false));
+            assets.add(new UtxoHistoryFact.Asset(hash, i, key, new byte[]{1}, BigInteger.valueOf(7)));
+            datums.add(new UtxoHistoryFact.TransactionDatum(hash, i, hash, new byte[1024]));
+            redeemers.add(new UtxoHistoryFact.TransactionRedeemer(hash, i, "spend", i, new byte[512],
+                    hash, BigInteger.TEN, BigInteger.TEN));
+        }
+        return new UtxoHistoryFact(6, List.of(), List.of(), addresses, outputs, assets, List.of(),
+                datums, redeemers);
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionSinkLifecycleTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionSinkLifecycleTest.java
@@ -1,0 +1,176 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Shutdown must never close a sink that is in use.
+ *
+ * <p>Interrupting a thread does not abort a JDBC call, so "stop the loop, interrupt, close" can
+ * land a close in the middle of a commit. Waiting and then closing anyway narrows that race
+ * without removing it — a log line saying the wait expired is not the same as not doing it. These
+ * tests pin the difference, with a fake sink that blocks inside a commit until released.
+ */
+class ProjectionSinkLifecycleTest {
+
+    private static final ProjectionIdentity IDENTITY = new ProjectionIdentity(
+            new ArchiveNetworkIdentity(1, "fixture"), "fake", 1,
+            Set.of(ProjectionSectionType.TRANSACTION));
+
+    /** A sink whose commit blocks until released, so the race is deterministic rather than timed. */
+    private static final class BlockingSink implements com.bloxbean.cardano.yano.archive.api.projection.ProjectionSink {
+        private final CountDownLatch entered = new CountDownLatch(1);
+        private final CountDownLatch release = new CountDownLatch(1);
+        private final AtomicInteger closeCalls = new AtomicInteger();
+        private final AtomicBoolean closedWhileBusy = new AtomicBoolean();
+        private volatile boolean inCommit;
+
+        void beginCommit() {
+            inCommit = true;
+            entered.countDown();
+            try {
+                release.await(10, TimeUnit.SECONDS);
+            } catch (InterruptedException e) {
+                Thread.currentThread().interrupt();
+            }
+            inCommit = false;
+        }
+
+        @Override
+        public void close() {
+            if (inCommit) closedWhileBusy.set(true);
+            closeCalls.incrementAndGet();
+        }
+
+        @Override public String engine() { return "fake"; }
+        @Override public void initialize(com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity e) { }
+        @Override public com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate coordinate() {
+            return com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate.NONE;
+        }
+        @Override public java.util.Optional<com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceipt>
+                receiptFor(long firstBlock) { return java.util.Optional.empty(); }
+        @Override public com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceipt append(
+                com.bloxbean.cardano.yano.archive.api.projection.ProjectionRowBatch batch,
+                com.bloxbean.cardano.yano.archive.api.projection.ArchiveArtifactReader artifacts) {
+            throw new UnsupportedOperationException("not used by these tests");
+        }
+        @Override public com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance.Result maintain(
+                com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance.Budget budget) {
+            return com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance.Result
+                    .unsupported("fake");
+        }
+        @Override public com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkHealth health() {
+            return com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkHealth.ready();
+        }
+    }
+
+    @Test
+    void shutdownDoesNotCloseTheSinkWhileACommitIsInFlight() throws Exception {
+        var sink = new BlockingSink();
+        var lifecycle = new ProjectionSinkLifecycle(sink);
+
+        var drain = new Thread(() -> lifecycle.use(s -> { sink.beginCommit(); return null; }), "drain");
+        drain.start();
+        assertThat(sink.entered.await(5, TimeUnit.SECONDS)).as("commit started").isTrue();
+
+        // Shutdown runs concurrently while the commit is blocked.
+        AtomicReference<Boolean> closedIt = new AtomicReference<>();
+        var shutdown = new Thread(() -> closedIt.set(lifecycle.closeWhenIdle(Duration.ofMillis(300))), "shutdown");
+        shutdown.start();
+        shutdown.join(5_000);
+
+        assertThat(closedIt.get()).as("must decline to close a sink that is in use").isFalse();
+        assertThat(sink.closeCalls.get()).as("close must not have been called at all").isZero();
+        assertThat(sink.closedWhileBusy.get()).isFalse();
+        assertThat(lifecycle.isClosed()).isFalse();
+
+        // Release: the commit finishes normally, and only then can the sink close.
+        sink.release.countDown();
+        drain.join(5_000);
+        assertThat(lifecycle.closeWhenIdle(Duration.ofSeconds(5))).isTrue();
+        assertThat(sink.closeCalls.get()).as("closed exactly once").isEqualTo(1);
+        assertThat(sink.closedWhileBusy.get()).as("never closed underneath the commit").isFalse();
+    }
+
+    @Test
+    void theCommitCompletesNormallyDespiteAConcurrentShutdownAttempt() throws Exception {
+        var sink = new BlockingSink();
+        var lifecycle = new ProjectionSinkLifecycle(sink);
+        var completed = new AtomicBoolean();
+
+        var drain = new Thread(() -> lifecycle.use(s -> {
+            sink.beginCommit();
+            completed.set(true);
+            return null;
+        }), "drain");
+        drain.start();
+        assertThat(sink.entered.await(5, TimeUnit.SECONDS)).isTrue();
+
+        var shutdown = new Thread(() -> lifecycle.closeWhenIdle(Duration.ofMillis(200)), "shutdown");
+        shutdown.start();
+        shutdown.join(5_000);
+
+        sink.release.countDown();
+        drain.join(5_000);
+        assertThat(completed.get()).as("the in-flight commit must run to completion").isTrue();
+    }
+
+    @Test
+    void closingTwiceClosesTheSinkOnlyOnce() {
+        var sink = new BlockingSink();
+        var lifecycle = new ProjectionSinkLifecycle(sink);
+
+        assertThat(lifecycle.closeWhenIdle(Duration.ofSeconds(1))).isTrue();
+        assertThat(lifecycle.closeWhenIdle(Duration.ofSeconds(1))).isTrue();
+        assertThat(sink.closeCalls.get()).isEqualTo(1);
+    }
+
+    @Test
+    void useAfterCloseIsRefusedRatherThanReachingTheDriver() {
+        var sink = new BlockingSink();
+        var lifecycle = new ProjectionSinkLifecycle(sink);
+        lifecycle.closeWhenIdle(Duration.ofSeconds(1));
+
+        // Without this the call would reach a closed connection and fail somewhere inside the
+        // driver, at a point with no useful context.
+        assertThatThrownBy(() -> lifecycle.use(s -> null))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("closed");
+    }
+
+    @Test
+    void aLongMaintenancePassOutlastsTheShutdownWaitAndIsStillNotInterruptedByAClose() throws Exception {
+        // The default budgets allow housekeeping (30 s) plus compaction (300 s) in one pass, so a
+        // maintenance pass can legitimately run far longer than any sane shutdown wait. The
+        // shutdown must decline rather than try to outlast it.
+        var sink = new BlockingSink();
+        var lifecycle = new ProjectionSinkLifecycle(sink);
+
+        var maintenance = new Thread(() -> lifecycle.use(s -> { sink.beginCommit(); return null; }), "maintenance");
+        maintenance.start();
+        assertThat(sink.entered.await(5, TimeUnit.SECONDS)).isTrue();
+
+        assertThat(lifecycle.closeWhenIdle(Duration.ofMillis(100)))
+                .as("a short wait against a long pass declines, it does not force")
+                .isFalse();
+        assertThat(sink.closeCalls.get()).isZero();
+        assertThat(lifecycle.busy()).isTrue();
+
+        sink.release.countDown();
+        maintenance.join(5_000);
+        assertThat(sink.closedWhileBusy.get()).isFalse();
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuardTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuardTest.java
@@ -175,4 +175,60 @@ class ProjectionStartupGuardTest {
                 .isInstanceOf(ProjectionActivationException.class)
                 .hasMessageContaining("none could be read");
     }
+
+    // ------------------------------ sink and outbox must describe the same archive
+
+    @Test
+    void anEmptySinkWithAnAcknowledgedOutboxFailsClosed() {
+        // The history directory was deleted or repointed while the chainstate was kept. The
+        // outbox pruned everything it acknowledged, so those blocks are in the sink or nowhere.
+        // Accepting this would create a fresh archive, resume draining after the acknowledged
+        // point, and leave 0..5,000,000 permanently missing while reporting healthy.
+        var observed = new ProjectionStartupGuard.Observed(
+                5_000_100, true, Optional.of(expected()),
+                true, Optional.empty(), ProjectionCoordinate.NONE, REQUIRED,
+                5_000_000);
+
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("acknowledged blocks through 5000000")
+                .hasMessageContaining("permanently missing");
+    }
+
+    @Test
+    void anEmptySinkOnAFreshChainIsStillFine() {
+        // Nothing acknowledged yet, so an empty sink is exactly what a fresh sync looks like.
+        var observed = new ProjectionStartupGuard.Observed(
+                0, false, Optional.empty(),
+                true, Optional.empty(), ProjectionCoordinate.NONE, REQUIRED, -1);
+
+        ProjectionStartupGuard.verify(expected(), observed);
+    }
+
+    @Test
+    void aSinkBehindTheOutboxAcknowledgementFailsClosed() {
+        // The gap cannot be refilled: the outbox pruned those blocks when it acknowledged them,
+        // so this is either a sink that lost committed data or a different archive entirely.
+        var observed = new ProjectionStartupGuard.Observed(
+                5_000_100, true, Optional.of(expected()),
+                false, Optional.of(expected()), coordinateAt(4_000_000), REQUIRED,
+                5_000_000);
+
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("sink is at block 4000000")
+                .hasMessageContaining("not from the same archive");
+    }
+
+    @Test
+    void aSinkAtOrAheadOfTheAcknowledgementIsAccepted() {
+        // Equal is the normal steady state. Ahead happens after a crash between the sink commit
+        // and the outbox acknowledgement, and replays against the durable receipt.
+        for (long sinkBlock : new long[]{5_000_000, 5_000_050}) {
+            ProjectionStartupGuard.verify(expected(), new ProjectionStartupGuard.Observed(
+                    5_000_100, true, Optional.of(expected()),
+                    false, Optional.of(expected()), coordinateAt(sinkBlock), REQUIRED,
+                    5_000_000));
+        }
+    }
 }

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuardTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStartupGuardTest.java
@@ -1,0 +1,178 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class ProjectionStartupGuardTest {
+
+    private static final ArchiveNetworkIdentity PREPROD = new ArchiveNetworkIdentity(1, "162d29c4");
+    private static final ArchiveNetworkIdentity MAINNET = new ArchiveNetworkIdentity(764824073, "5f20df93");
+
+    private static final Set<ProjectionSectionType> REQUIRED =
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY);
+
+    private static ProjectionIdentity identity(ArchiveNetworkIdentity network, String engine) {
+        return new ProjectionIdentity(network, engine, 1, REQUIRED);
+    }
+
+    private static ProjectionIdentity expected() {
+        return identity(PREPROD, "ducklake");
+    }
+
+    private static ProjectionCoordinate coordinateAt(long blockNumber) {
+        return ProjectionCoordinate.of(new ProjectionEnvelopeHeader(PREPROD, ProjectionBlockKind.SHELLEY_PLUS,
+                blockNumber, new byte[]{1}, new byte[]{0}, blockNumber * 20, 3, 1L, 1, List.of(), List.of()));
+    }
+
+    private static ProjectionStartupGuard.Observed freshEverything() {
+        return new ProjectionStartupGuard.Observed(0, false, Optional.empty(), true, Optional.empty(),
+                ProjectionCoordinate.NONE, REQUIRED);
+    }
+
+    // --- the supported start ----------------------------------------------------
+
+    @Test
+    void genesisChainWithAnEmptyArchiveIsTheSupportedStart() {
+        assertThatCode(() -> ProjectionStartupGuard.verify(expected(), freshEverything()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void anAdvancedChainWithMatchingProjectionIdentityResumesNormally() {
+        var observed = new ProjectionStartupGuard.Observed(500_000, true, Optional.of(expected()),
+                false, Optional.of(expected()), coordinateAt(497_000), REQUIRED);
+        assertThatCode(() -> ProjectionStartupGuard.verify(expected(), observed)).doesNotThrowAnyException();
+    }
+
+    // --- mid-chain activation ---------------------------------------------------
+
+    @Test
+    void enablingHistoryMidChainIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(1_234_567, false, Optional.empty(),
+                true, Optional.empty(), ProjectionCoordinate.NONE, REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("cannot be enabled mid-chain")
+                .hasMessageContaining("1234567");
+    }
+
+    @Test
+    void anExistingChainstatePointedAtAnEmptyArchiveIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(900_000, false, Optional.empty(),
+                true, Optional.empty(), ProjectionCoordinate.NONE, REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class);
+    }
+
+    @Test
+    void aFreshChainstatePointedAtAPopulatedArchiveIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(0, false, Optional.empty(),
+                false, Optional.of(expected()), coordinateAt(400_000), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("cannot adopt an archive that already covers");
+    }
+
+    // --- identity mismatches ----------------------------------------------------
+
+    @Test
+    void aWrongNetworkArchiveIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(100, true, Optional.of(expected()),
+                false, Optional.of(identity(MAINNET, "ducklake")), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("archive identity mismatch");
+    }
+
+    @Test
+    void aWrongGenesisArchiveIsRejectedEvenOnTheSameMagic() {
+        var otherGenesis = identity(new ArchiveNetworkIdentity(1, "deadbeef"), "ducklake");
+        var observed = new ProjectionStartupGuard.Observed(100, true, Optional.of(expected()),
+                false, Optional.of(otherGenesis), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("archive identity mismatch");
+    }
+
+    @Test
+    void aMismatchedSinkEngineIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(100, true, Optional.of(expected()),
+                false, Optional.of(identity(PREPROD, "sqlite")), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("archive identity mismatch");
+    }
+
+    @Test
+    void aMismatchedOutboxIdentityIsRejectedBeforeTheArchiveIsConsidered() {
+        var observed = new ProjectionStartupGuard.Observed(100, true,
+                Optional.of(new ProjectionIdentity(PREPROD, "ducklake", 2, REQUIRED)),
+                false, Optional.of(expected()), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("projection identity mismatch");
+    }
+
+    @Test
+    void aDifferentRequiredSectionSetIsAnIdentityMismatch() {
+        var narrower = new ProjectionIdentity(PREPROD, "ducklake", 1, Set.of(ProjectionSectionType.TRANSACTION));
+        var observed = new ProjectionStartupGuard.Observed(100, true, Optional.of(narrower),
+                false, Optional.of(expected()), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("projection identity mismatch");
+    }
+
+    // --- required sections the sink cannot serve --------------------------------
+
+    @Test
+    void aSinkThatCannotServeARequiredSectionFailsAtStartupNotAtFirstUse() {
+        var observed = new ProjectionStartupGuard.Observed(0, false, Optional.empty(), true, Optional.empty(),
+                ProjectionCoordinate.NONE, Set.of(ProjectionSectionType.TRANSACTION));
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("cannot serve required projection section")
+                .hasMessageContaining("utxo-history:v5");
+    }
+
+    // --- incoherent observations ------------------------------------------------
+
+    @Test
+    void anEmptySinkThatReportsACoordinateIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(100, true, Optional.of(expected()),
+                true, Optional.empty(), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("reports itself empty but exposes a committed coordinate");
+    }
+
+    @Test
+    void aNonEmptySinkWithoutIdentityIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(100, true, Optional.of(expected()),
+                false, Optional.empty(), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("exposes no projection identity");
+    }
+
+    @Test
+    void anOutboxClaimingIdentityItCannotProduceIsRejected() {
+        var observed = new ProjectionStartupGuard.Observed(100, true, Optional.empty(),
+                false, Optional.of(expected()), coordinateAt(50), REQUIRED);
+        assertThatThrownBy(() -> ProjectionStartupGuard.verify(expected(), observed))
+                .isInstanceOf(ProjectionActivationException.class)
+                .hasMessageContaining("none could be read");
+    }
+}

--- a/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStreamingBoundTest.java
+++ b/archive-modules/archive-core/src/test/java/com/bloxbean/cardano/yano/archive/core/projection/ProjectionStreamingBoundTest.java
@@ -1,0 +1,252 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionBlockKind;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelope;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionEnvelopeHeader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSection;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.core.dataset.TransactionFact;
+import com.bloxbean.cardano.yano.archive.core.dataset.UtxoHistoryFact;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Asserts the memory bound is real rather than nominal.
+ *
+ * <p>A lazy row iterator alone does not establish it: the original implementation still called
+ * {@code ProjectionChunking.join} and decoded a whole batch's facts, so the encoded section
+ * and its decoded graph stayed live regardless of how rows were yielded. These tests pin the
+ * properties that make the bound hold — chunks are never concatenated, batch size does not
+ * contribute to retention, and the stream is consumed exactly once.
+ */
+class ProjectionStreamingBoundTest {
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(1, "fixture");
+    private static final ProjectionIdentity IDENTITY = new ProjectionIdentity(NETWORK, "test", 1,
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY));
+
+    private static ProjectionEnvelope envelope(long block, List<TransactionFact> txs, UtxoHistoryFact utxo,
+                                               int chunkBytes) {
+        byte[] txEncoded = ProjectionFactCodec.encodeTransactions(txs);
+        byte[] utxoEncoded = ProjectionFactCodec.encodeUtxoHistory(utxo);
+        var txSection = new ProjectionSection(ProjectionSectionType.TRANSACTION,
+                ProjectionSectionType.TRANSACTION.version(),
+                ProjectionChunking.split(txEncoded, chunkBytes), txs.size());
+        long utxoRows = utxo.outputs().size() + utxo.assets().size() + utxo.inputs().size()
+                + utxo.transactionDatums().size() + utxo.transactionRedeemers().size();
+        var utxoSection = new ProjectionSection(ProjectionSectionType.UTXO_HISTORY,
+                ProjectionSectionType.UTXO_HISTORY.version(),
+                ProjectionChunking.split(utxoEncoded, chunkBytes), utxoRows);
+        var header = new ProjectionEnvelopeHeader(NETWORK, ProjectionBlockKind.SHELLEY_PLUS, block,
+                new byte[]{(byte) block}, new byte[]{(byte) (block - 1)}, block * 20, 1, 1L, 1,
+                List.of(txSection.manifest(), utxoSection.manifest()), List.of());
+        return new ProjectionEnvelope(header, List.of(txSection, utxoSection));
+    }
+
+    private static TransactionFact tx(int i) {
+        byte[] hash = new byte[32];
+        hash[0] = (byte) i;
+        hash[1] = (byte) (i >>> 8);
+        return new TransactionFact(hash, i, true, 170_000L + i);
+    }
+
+    private static UtxoHistoryFact emptyUtxo() {
+        return new UtxoHistoryFact(6, List.of(), List.of(), List.of(), List.of(), List.of(), List.of(),
+                List.of(), List.of());
+    }
+
+    /** Dense block: many outputs, assets, datums and redeemers. */
+    private static UtxoHistoryFact denseUtxo(int n) {
+        List<UtxoHistoryFact.Address> addresses = new ArrayList<>();
+        List<UtxoHistoryFact.Output> outputs = new ArrayList<>();
+        List<UtxoHistoryFact.Asset> assets = new ArrayList<>();
+        List<UtxoHistoryFact.TransactionDatum> datums = new ArrayList<>();
+        List<UtxoHistoryFact.TransactionRedeemer> redeemers = new ArrayList<>();
+        for (int i = 0; i < n; i++) {
+            byte[] key = new byte[28];
+            key[0] = (byte) i;
+            byte[] hash = new byte[32];
+            hash[0] = (byte) i;
+            addresses.add(new UtxoHistoryFact.Address(key, key, "addr" + i, 0, "base", "key", key,
+                    "none", null, null, null, null, null));
+            outputs.add(new UtxoHistoryFact.Output(hash, i, i, "output", key, key, null, 1_000_000L,
+                    "hash", hash, new byte[256], null, null, null, false));
+            assets.add(new UtxoHistoryFact.Asset(hash, i, key, new byte[]{1}, BigInteger.valueOf(7)));
+            datums.add(new UtxoHistoryFact.TransactionDatum(hash, i, hash, new byte[512]));
+            redeemers.add(new UtxoHistoryFact.TransactionRedeemer(hash, i, "spend", i, new byte[256],
+                    hash, BigInteger.TEN, BigInteger.TEN));
+        }
+        return new UtxoHistoryFact(6, List.of(), List.of(), addresses, outputs, assets, List.of(),
+                datums, redeemers);
+    }
+
+    // ------------------------------------------- chunks are never concatenated
+
+    @Test
+    void aLargeMultiChunkTransactionSectionDecodesWithoutJoiningChunks() {
+        List<TransactionFact> txs = new ArrayList<>();
+        for (int i = 0; i < 5_000; i++) txs.add(tx(i));
+        // 64-byte chunks force facts to straddle boundaries repeatedly.
+        var envelope = envelope(100, txs, emptyUtxo(), 64);
+        var section = envelope.section(ProjectionSectionType.TRANSACTION).orElseThrow();
+        assertThat(section.chunks().size()).isGreaterThan(1_000);
+
+        List<TransactionFact> decoded = new ArrayList<>();
+        long count = ProjectionFactCodec.streamTransactions(section.chunks(), decoded::add);
+
+        assertThat(count).isEqualTo(5_000);
+        assertThat(decoded).hasSize(5_000);
+        assertThat(decoded.get(4_999).txIndex()).isEqualTo(4_999);
+    }
+
+    @Test
+    void chunkedInputReadsIdenticallyToTheJoinedBytes() {
+        List<TransactionFact> txs = new ArrayList<>();
+        for (int i = 0; i < 500; i++) txs.add(tx(i));
+        byte[] encoded = ProjectionFactCodec.encodeTransactions(txs);
+        var chunks = ProjectionChunking.split(encoded, 17);
+
+        // TransactionFact holds byte[], and record equality on arrays is by reference, so
+        // compare structurally.
+        List<String> streamed = new ArrayList<>();
+        ProjectionFactCodec.streamTransactions(chunks, f -> streamed.add(renderFact(f)));
+        List<String> joined = ProjectionFactCodec.decodeTransactions(encoded).stream()
+                .map(ProjectionStreamingBoundTest::renderFact).toList();
+        assertThat(streamed).isEqualTo(joined);
+    }
+
+    // --------------------------------- batch size does not increase retention
+
+    @Test
+    void peakRetainedRowsIsOneEnvelopeRegardlessOfBatchSize() {
+        // 200 envelopes of 50 rows each. If the batch were materialised, 10,000 rows would be
+        // live at once; streaming keeps one envelope's worth.
+        List<ProjectionEnvelope> envelopes = new ArrayList<>();
+        for (int b = 0; b < 200; b++) {
+            List<TransactionFact> txs = new ArrayList<>();
+            for (int i = 0; i < 50; i++) txs.add(tx(i));
+            envelopes.add(envelope(b, txs, emptyUtxo(), 1 << 20));
+        }
+        var rowBatch = ProjectionRowBuilder.materialise(new ProjectionBatch(IDENTITY, envelopes));
+
+        long seen = 0;
+        long peakLive = 0;
+        List<ArchiveRow> live = new ArrayList<>();
+        for (ArchiveRow row : rowBatch.rows()) {
+            seen++;
+            live.add(row);
+            // emulate a sink that appends and releases: it never holds the whole batch
+            if (live.size() >= 50) {
+                peakLive = Math.max(peakLive, live.size());
+                live.clear();
+            }
+        }
+        assertThat(seen).isEqualTo(200L * 50);
+        assertThat(peakLive)
+                .as("a sink consuming incrementally never sees the whole batch")
+                .isLessThanOrEqualTo(50);
+    }
+
+    @Test
+    void aDenseDatumRedeemerMultiAssetBlockStreams() {
+        var envelope = envelope(100, List.of(tx(0)), denseUtxo(400), 4096);
+        var rowBatch = ProjectionRowBuilder.materialise(
+                new ProjectionBatch(IDENTITY, List.of(envelope)));
+        long rows = 0;
+        for (ArchiveRow ignored : rowBatch.rows()) rows++;
+        // 400 outputs + 400 assets + 400 datums + 400 redeemers + 1 transaction
+        assertThat(rows).isEqualTo(1_601);
+    }
+
+    @Test
+    void anOversizedSingletonIsProcessedRatherThanDeadlocking() {
+        // One envelope far larger than any normal batch ceiling still yields rows.
+        List<TransactionFact> txs = new ArrayList<>();
+        for (int i = 0; i < 20_000; i++) txs.add(tx(i));
+        var envelope = envelope(100, txs, denseUtxo(200), 8192);
+        var rowBatch = ProjectionRowBuilder.materialise(
+                new ProjectionBatch(IDENTITY, List.of(envelope)));
+
+        long rows = 0;
+        for (ArchiveRow ignored : rowBatch.rows()) rows++;
+        assertThat(rows).isGreaterThan(20_000);
+    }
+
+    // ------------------------------------------------- single pass and retry
+
+    @Test
+    void aSinkFailureHalfwayThroughIterationIsDeterministicOnRetry() {
+        List<TransactionFact> txs = new ArrayList<>();
+        for (int i = 0; i < 100; i++) txs.add(tx(i));
+        var batch = new ProjectionBatch(IDENTITY, List.of(envelope(100, txs, emptyUtxo(), 1 << 20)));
+
+        // first attempt fails part-way
+        List<String> firstAttempt = new ArrayList<>();
+        try {
+            int n = 0;
+            for (ArchiveRow row : ProjectionRowBuilder.materialise(batch).rows()) {
+                if (++n > 40) throw new IllegalStateException("injected sink failure");
+                firstAttempt.add(render(row));
+            }
+        } catch (IllegalStateException expected) {
+            // the outbox is durable, so the batch is simply re-materialised
+        }
+        assertThat(firstAttempt).hasSize(40);
+
+        // retry re-materialises from the same envelopes and reproduces the same rows
+        List<String> retry = new ArrayList<>();
+        for (ArchiveRow row : ProjectionRowBuilder.materialise(batch).rows()) retry.add(render(row));
+        assertThat(retry).hasSize(100);
+        assertThat(retry.subList(0, 40)).isEqualTo(firstAttempt);
+    }
+
+    @Test
+    void theRowStreamIsSingleUseAndRefusesASecondPass() {
+        // A partially consumed source iterated again would yield a short or duplicated pass
+        // that looks like valid data. Refusing is the only safe behaviour; the caller
+        // re-materialises from the still-unacknowledged outbox batch instead.
+        List<TransactionFact> txs = new ArrayList<>();
+        for (int i = 0; i < 30; i++) txs.add(tx(i));
+        var rowBatch = ProjectionRowBuilder.materialise(
+                new ProjectionBatch(IDENTITY, List.of(envelope(100, txs, emptyUtxo(), 1 << 20))));
+
+        List<String> first = new ArrayList<>();
+        for (ArchiveRow row : rowBatch.rows()) first.add(render(row));
+        assertThat(first).hasSize(30);
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> rowBatch.rows().iterator())
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("single-use");
+    }
+
+    @Test
+    void anExhaustedIteratorReportsNoMoreElements() {
+        var rowBatch = ProjectionRowBuilder.materialise(
+                new ProjectionBatch(IDENTITY, List.of(envelope(100, List.of(tx(0)), emptyUtxo(), 1 << 20))));
+        Iterator<ArchiveRow> it = rowBatch.rows().iterator();
+        while (it.hasNext()) it.next();
+        assertThat(it.hasNext()).isFalse();
+    }
+
+    private static String renderFact(TransactionFact fact) {
+        return java.util.Arrays.toString(fact.txHash()) + '|' + fact.txIndex() + '|'
+                + fact.valid() + '|' + fact.fee();
+    }
+
+    private static String render(ArchiveRow row) {
+        return row.table() + row.values().stream()
+                .map(v -> v instanceof byte[] b ? java.util.Arrays.toString(b) : String.valueOf(v))
+                .reduce("", String::concat);
+    }
+}

--- a/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/NoopArtifactReader.java
+++ b/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/NoopArtifactReader.java
@@ -1,0 +1,46 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ArchiveArtifactReader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/** Artifact reader for block-only tests; records acknowledgements so leases can be asserted. */
+public final class NoopArtifactReader implements ArchiveArtifactReader {
+
+    private final List<ProjectionArtifactRef> acknowledged = new ArrayList<>();
+
+    @Override
+    public ArtifactLease acquire(ProjectionArtifactRef ref, Instant expiresAt) {
+        UUID id = UUID.randomUUID();
+        return new ArtifactLease() {
+            private boolean open = true;
+            private Instant expiry = expiresAt;
+
+            @Override public UUID leaseId() { return id; }
+            @Override public String ownerFence() { return "test"; }
+            @Override public Instant expiresAt() { return expiry; }
+            @Override public ArtifactLease renew(Instant newExpiry) { expiry = newExpiry; return this; }
+            @Override public boolean isOpen() { return open; }
+            @Override public void close() { open = false; }
+        };
+    }
+
+    @Override
+    public ArtifactPage read(ProjectionArtifactRef ref, ArtifactLease lease, Optional<String> cursor, int limit) {
+        return new ArtifactPage(List.of(), Optional.empty());
+    }
+
+    @Override
+    public void acknowledge(ProjectionArtifactRef ref) {
+        acknowledged.add(ref);
+    }
+
+    public List<ProjectionArtifactRef> acknowledged() {
+        return List.copyOf(acknowledged);
+    }
+}

--- a/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/NoopArtifactReader.java
+++ b/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/NoopArtifactReader.java
@@ -35,12 +35,35 @@ public final class NoopArtifactReader implements ArchiveArtifactReader {
         return new ArtifactPage(List.of(), Optional.empty());
     }
 
+    private int failAfter = Integer.MAX_VALUE;
+
+    /**
+     * Throw once the given number of acknowledgements have succeeded, to simulate a crash
+     * partway through releasing a batch's artifacts.
+     */
+    public void failAcknowledgeAfter(int successes) {
+        this.failAfter = successes;
+    }
+
     @Override
     public void acknowledge(ProjectionArtifactRef ref) {
-        acknowledged.add(ref);
+        calls++;
+        if (acknowledged.size() >= failAfter) {
+            throw new IllegalStateException("simulated crash during artifact acknowledgement");
+        }
+        // Idempotent, as the contract requires: the consumer acknowledges before the outbox
+        // drops the reference, so a crash in between replays the acknowledgement.
+        if (!acknowledged.contains(ref)) acknowledged.add(ref);
     }
 
     public List<ProjectionArtifactRef> acknowledged() {
         return List.copyOf(acknowledged);
     }
+
+    /** Total calls, including repeats, so idempotency can be distinguished from never-called. */
+    public int acknowledgeCalls() {
+        return calls;
+    }
+
+    private int calls;
 }

--- a/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/SyntheticProjectionSink.java
+++ b/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/SyntheticProjectionSink.java
@@ -1,0 +1,167 @@
+package com.bloxbean.cardano.yano.archive.core.projection;
+
+import com.bloxbean.cardano.yano.archive.api.projection.ArchiveArtifactReader;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionRowBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceipt;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSink;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkException;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkHealth;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * In-memory {@link ProjectionSink} used to exercise the outbox before any real backend
+ * exists (ADR-039 Phase 2). It models the two properties that matter for the crash
+ * matrix: rows and receipt become visible together, and a receipt survives a simulated
+ * process restart while uncommitted work does not.
+ */
+public final class SyntheticProjectionSink implements ProjectionSink {
+
+    /** Durable side: survives {@link #simulateRestart()}. */
+    private final Map<Long, ProjectionReceipt> receipts = new LinkedHashMap<>();
+    private final Map<Long, List<ArchiveRow>> committed = new LinkedHashMap<>();
+
+    private ProjectionIdentity identity;
+    private ProjectionSinkHealth health = ProjectionSinkHealth.ready();
+    private final AtomicInteger appendCalls = new AtomicInteger();
+
+    /** When positive, the next N appends fail after "staging" but before commit. */
+    private int failNextAppends;
+    /** When true, an append commits durably and then throws, as a crash after commit would. */
+    private boolean throwAfterCommit;
+
+    @Override
+    public String engine() {
+        return "synthetic";
+    }
+
+    @Override
+    public void initialize(ProjectionIdentity expected) {
+        if (identity != null && !identity.matches(expected)) {
+            throw new ProjectionSinkException("synthetic sink already bound to " + identity.fingerprint());
+        }
+        this.identity = expected;
+    }
+
+    private ProjectionCoordinate coordinate = ProjectionCoordinate.NONE;
+
+    @Override
+    public ProjectionCoordinate coordinate() {
+        return coordinate;
+    }
+
+    @Override
+    public Optional<ProjectionReceipt> receiptFor(long firstBlock) {
+        return Optional.ofNullable(receipts.get(firstBlock));
+    }
+
+    @Override
+    public ProjectionReceipt append(ProjectionRowBatch batch, ArchiveArtifactReader artifacts) {
+        appendCalls.incrementAndGet();
+        if (failNextAppends > 0) {
+            failNextAppends--;
+            throw new ProjectionSinkException("injected sink failure before commit");
+        }
+
+        Map<String, Long> rowCounts = new HashMap<>();
+        for (ArchiveRow row : batch.rows()) {
+            rowCounts.merge(row.table(), 1L, Long::sum);
+        }
+
+        ProjectionReceipt receipt = ProjectionReceipt.of(batch, rowCounts, Instant.EPOCH);
+        // Rows and receipt become visible together.
+        for (long block = batch.firstBlock(); block <= batch.lastBlock(); block++) {
+            committed.put(block, List.of());
+        }
+        receipts.put(batch.firstBlock(), receipt);
+
+        if (throwAfterCommit) {
+            throwAfterCommit = false;
+            throw new ProjectionSinkException("injected failure after durable commit");
+        }
+        return receipt;
+    }
+
+    private final java.util.List<ProjectionMaintenance.Budget> maintenanceCalls = new ArrayList<>();
+    private ProjectionMaintenance.Result nextMaintenanceResult;
+
+    /**
+     * Records the budget it was given so tests can assert the coordinator only offers
+     * compaction when it is genuinely idle at tip.
+     */
+    @Override
+    public ProjectionMaintenance.Result maintain(ProjectionMaintenance.Budget budget) {
+        maintenanceCalls.add(budget);
+        if (nextMaintenanceResult != null) {
+            var result = nextMaintenanceResult;
+            nextMaintenanceResult = null;
+            return result;
+        }
+        return new ProjectionMaintenance.Result(ProjectionMaintenance.Outcome.COMPLETED,
+                java.time.Duration.ZERO, 10, budget.compactionAllowed() ? 2 : 10, 0, 1, 1,
+                java.time.Duration.ZERO, Optional.empty());
+    }
+
+    public java.util.List<ProjectionMaintenance.Budget> maintenanceCalls() {
+        return java.util.List.copyOf(maintenanceCalls);
+    }
+
+    public void nextMaintenanceResult(ProjectionMaintenance.Result result) {
+        this.nextMaintenanceResult = result;
+    }
+
+    @Override
+    public ProjectionSinkHealth health() {
+        return health;
+    }
+
+    @Override
+    public void close() {
+        health = ProjectionSinkHealth.unavailable("closed");
+    }
+
+    // ---------------------------------------------------------------- test hooks
+
+    public void failNextAppends(int count) {
+        this.failNextAppends = count;
+    }
+
+    public void throwAfterNextCommit() {
+        this.throwAfterCommit = true;
+    }
+
+    /** Drops in-flight state; durable receipts and rows remain, as after a real restart. */
+    public void simulateRestart() {
+        failNextAppends = 0;
+        throwAfterCommit = false;
+        health = ProjectionSinkHealth.ready();
+    }
+
+    public int appendCalls() {
+        return appendCalls.get();
+    }
+
+    public List<Long> committedBlocks() {
+        return new ArrayList<>(committed.keySet());
+    }
+
+    public Map<Long, ProjectionReceipt> receipts() {
+        return Map.copyOf(receipts);
+    }
+
+    /** Replaces a stored receipt, modelling a differently shaped job for the same range. */
+    public void forceReceipt(long firstBlock, ProjectionReceipt receipt) {
+        receipts.put(firstBlock, receipt);
+    }
+}

--- a/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/SyntheticProjectionSink.java
+++ b/archive-modules/archive-core/src/testFixtures/java/com/bloxbean/cardano/yano/archive/core/projection/SyntheticProjectionSink.java
@@ -109,7 +109,9 @@ public final class SyntheticProjectionSink implements ProjectionSink {
             return result;
         }
         return new ProjectionMaintenance.Result(ProjectionMaintenance.Outcome.COMPLETED,
-                java.time.Duration.ZERO, 10, budget.compactionAllowed() ? 2 : 10, 0, 1, 1,
+                java.time.Duration.ZERO, java.util.OptionalLong.of(10),
+                java.util.OptionalLong.of(budget.compactionAllowed() ? 2 : 10),
+                java.util.OptionalLong.of(0), 1, 1,
                 java.time.Duration.ZERO, Optional.empty());
     }
 

--- a/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSchema.java
+++ b/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSchema.java
@@ -1,0 +1,33 @@
+package com.bloxbean.cardano.yano.archive.ducklake;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Tables the ADR-039 projection sink owns, created inside the same DuckLake catalog as
+ * the archive data so a receipt and the rows it describes commit in one transaction.
+ *
+ * <p>A receipt in a separate store could not be atomic with the rows, and the whole
+ * exactly-once-effect argument depends on that atomicity: cleanup is authorised by a
+ * verified receipt, never by the sink's current maximum block.
+ */
+final class DuckLakeProjectionSchema {
+
+    /** The sink's own receipt table; written on every commit, so it must be compacted too. */
+    static final String RECEIPTS_TABLE = "projection_receipts";
+
+    private DuckLakeProjectionSchema() {}
+
+    static void initialize(Connection connection) throws SQLException {
+        try (Statement sql = connection.createStatement()) {
+            sql.execute("CREATE TABLE IF NOT EXISTS history_lake.projection_identity ("
+                    + "fingerprint VARCHAR NOT NULL, installed_at TIMESTAMP NOT NULL)");
+            sql.execute("CREATE TABLE IF NOT EXISTS history_lake." + RECEIPTS_TABLE + " ("
+                    + "first_block BIGINT NOT NULL, last_block BIGINT NOT NULL, block_count BIGINT NOT NULL, "
+                    + "identity_fingerprint VARCHAR NOT NULL, first_envelope_id VARCHAR NOT NULL, "
+                    + "last_envelope_id VARCHAR NOT NULL, ordered_digest VARCHAR NOT NULL, "
+                    + "row_counts VARCHAR NOT NULL, committed_at TIMESTAMP NOT NULL)");
+        }
+    }
+}

--- a/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSink.java
+++ b/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSink.java
@@ -394,9 +394,9 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
             Connection connection = lease.connection();
             DuckLakeSql.attach(connection, config, null, false);
             try {
-                long filesBefore = countDataFiles(connection);
+                java.util.OptionalLong filesBefore = countDataFiles(connection);
 
-                long fileIdWatermark = maxDataFileId(connection);
+                long fileIdWatermark = maxDataFileId(connection).orElse(Long.MAX_VALUE);
 
                 // --- mandatory housekeeping, budgeted on its own ---------------
                 long housekeepingDeadline = System.nanoTime() + budget.housekeepingTimeLimit().toNanos();
@@ -421,13 +421,30 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
                         if (step.ok()) anyHousekeepingRan = true;
                         else housekeepingProblems.add(step.diagnostic());
                     }
+
+                    // A failed CALL can leave the connection unable to answer anything else.
+                    // Stop here rather than running compaction and taking measurements through
+                    // it: every one would fail, the diagnostics would be a cascade of
+                    // meaningless driver errors, and the file counts would be unknown while
+                    // looking like zero. The lease closes this connection on the way out, so the
+                    // next scheduled pass starts on a fresh one.
+                    if (!housekeepingProblems.isEmpty() && !usable(connection)) {
+                        return finish(ProjectionMaintenance.Outcome.FAILED, start,
+                                java.util.OptionalLong.empty(), java.util.OptionalLong.empty(),
+                                java.util.OptionalLong.empty(), snapshotsExpired, orphansDeleted,
+                                writerWait,
+                                "connection unusable after a failed housekeeping step; pass abandoned"
+                                        + " and compaction skipped, retrying on a fresh connection: "
+                                        + String.join("; ", housekeepingProblems));
+                    }
                 }
 
                 // A pass whose mandatory housekeeping did not fully succeed can never be
                 // COMPLETED, whatever compaction did.
                 if (!housekeepingProblems.isEmpty() && !anyHousekeepingRan) {
                     return finish(ProjectionMaintenance.Outcome.FAILED, start, filesBefore,
-                            countDataFiles(connection), 0, snapshotsExpired, orphansDeleted, writerWait,
+                            countDataFiles(connection), java.util.OptionalLong.empty(),
+                            snapshotsExpired, orphansDeleted, writerWait,
                             "all housekeeping steps failed: " + String.join("; ", housekeepingProblems));
                 }
 
@@ -438,12 +455,12 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
                 if (budget.compactionAllowed() && budget.compactionTimeLimit().toNanos() > 0
                         && budget.maxBytesToRewrite() > 0) {
                     if (!compactionWorthwhile(connection, budget)) {
-                        long files = countDataFiles(connection);
+                        var files = countDataFiles(connection);
                         return finish(housekeepingProblems.isEmpty()
                                         ? ProjectionMaintenance.Outcome.UNNECESSARY
                                         : ProjectionMaintenance.Outcome.PARTIAL,
                                 start, filesBefore, files,
-                                0, snapshotsExpired, orphansDeleted, writerWait,
+                                java.util.OptionalLong.of(0), snapshotsExpired, orphansDeleted, writerWait,
                                 housekeepingProblems.isEmpty()
                                         ? "file distribution is below the compaction threshold"
                                         : "housekeeping incomplete: " + String.join("; ", housekeepingProblems));
@@ -481,8 +498,8 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
                     }
                 }
 
-                long filesAfter = countDataFiles(connection);
-                long bytesRewritten = bytesWrittenSince(connection, fileIdWatermark);
+                var filesAfter = countDataFiles(connection);
+                var bytesRewritten = bytesWrittenSince(connection, fileIdWatermark);
 
                 java.util.List<String> problems = new java.util.ArrayList<>(housekeepingProblems);
                 problems.addAll(compactionProblems);
@@ -506,13 +523,16 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
         } catch (SQLException e) {
             health = ProjectionSinkHealth.unavailable(e.toString());
             return new ProjectionMaintenance.Result(ProjectionMaintenance.Outcome.FAILED,
-                    java.time.Duration.ofNanos(System.nanoTime() - start), 0, 0, 0, 0, 0,
+                    java.time.Duration.ofNanos(System.nanoTime() - start), java.util.OptionalLong.empty(),
+                    java.util.OptionalLong.empty(), java.util.OptionalLong.empty(), 0, 0,
                     java.time.Duration.ZERO, Optional.of(e.toString()));
         }
     }
 
     private static ProjectionMaintenance.Result finish(ProjectionMaintenance.Outcome outcome, long start,
-                                                       long before, long after, long rewritten,
+                                                       java.util.OptionalLong before,
+                                                       java.util.OptionalLong after,
+                                                       java.util.OptionalLong rewritten,
                                                        long snapshots, long orphans,
                                                        java.time.Duration writerWait, String detail) {
         return new ProjectionMaintenance.Result(outcome,
@@ -620,14 +640,16 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
      * id is past the watermark. {@code begin_snapshot} cannot serve here: a merged file keeps
      * the earliest snapshot its rows came from, so it looks older than the pass that wrote it.
      */
-    private static long maxDataFileId(Connection connection) {
+    private static java.util.OptionalLong maxDataFileId(Connection connection) {
         try (Statement sql = connection.createStatement();
              ResultSet rs = sql.executeQuery(
                      "SELECT coalesce(max(data_file_id), 0) FROM"
                              + " __ducklake_metadata_history_lake.ducklake_data_file")) {
-            return rs.next() ? rs.getLong(1) : 0;
+            return rs.next() ? java.util.OptionalLong.of(rs.getLong(1)) : java.util.OptionalLong.empty();
         } catch (SQLException e) {
-            return 0;
+            // Unknown, not zero. Reporting a failed measurement as 0 is how "files 35 -> 0" came
+            // to read as a catastrophic deletion when nothing had been deleted at all.
+            return java.util.OptionalLong.empty();
         }
     }
 
@@ -644,36 +666,57 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
      * <p>Returning a real number matters: an unenforced budget that reports {@code 0} looks
      * identical to a budget that was respected.
      */
-    private static long bytesWrittenSince(Connection connection, long fileIdWatermark) {
+    private static java.util.OptionalLong bytesWrittenSince(Connection connection, long fileIdWatermark) {
         try (Statement sql = connection.createStatement();
              ResultSet rs = sql.executeQuery(
                      "SELECT coalesce(sum(file_size_bytes), 0) FROM"
                              + " __ducklake_metadata_history_lake.ducklake_data_file"
                              + " WHERE end_snapshot IS NULL AND data_file_id > " + fileIdWatermark)) {
-            return rs.next() ? rs.getLong(1) : 0;
+            return rs.next() ? java.util.OptionalLong.of(rs.getLong(1)) : java.util.OptionalLong.empty();
         } catch (SQLException e) {
-            return 0;
+            // Unknown, not zero. Reporting a failed measurement as 0 is how "files 35 -> 0" came
+            // to read as a catastrophic deletion when nothing had been deleted at all.
+            return java.util.OptionalLong.empty();
         }
     }
 
-    private static long countDataFiles(Connection connection) {
+    /**
+     * Whether this connection can still answer a query.
+     *
+     * <p>A failed CALL inside DuckLake leaves the connection in a state where every later
+     * statement fails with "attempting to execute an unsuccessful or closed pending query
+     * result". Continuing on it turns one real failure into a cascade of meaningless ones and
+     * makes every subsequent measurement wrong, which is exactly what happened in the captured
+     * pinned-reader run.
+     */
+    private static boolean usable(Connection connection) {
+        try (Statement sql = connection.createStatement(); ResultSet rs = sql.executeQuery("SELECT 1")) {
+            return rs.next();
+        } catch (SQLException e) {
+            return false;
+        }
+    }
+
+    private static java.util.OptionalLong countDataFiles(Connection connection) {
         try (Statement sql = connection.createStatement();
              ResultSet rs = sql.executeQuery(
                      "SELECT count(*) FROM ducklake_table_info('history_lake')")) {
             // table_info reports per-table file counts; sum them for a catalog total.
-            return rs.next() ? sumFileCounts(connection) : 0;
+            return rs.next() ? sumFileCounts(connection) : java.util.OptionalLong.empty();
         } catch (SQLException e) {
-            return 0;
+            return java.util.OptionalLong.empty();
         }
     }
 
-    private static long sumFileCounts(Connection connection) {
+    private static java.util.OptionalLong sumFileCounts(Connection connection) {
         try (Statement sql = connection.createStatement();
              ResultSet rs = sql.executeQuery(
                      "SELECT coalesce(sum(file_count), 0) FROM ducklake_table_info('history_lake')")) {
-            return rs.next() ? rs.getLong(1) : 0;
+            return rs.next() ? java.util.OptionalLong.of(rs.getLong(1)) : java.util.OptionalLong.empty();
         } catch (SQLException e) {
-            return 0;
+            // Unknown, not zero. Reporting a failed measurement as 0 is how "files 35 -> 0" came
+            // to read as a catastrophic deletion when nothing had been deleted at all.
+            return java.util.OptionalLong.empty();
         }
     }
 
@@ -693,8 +736,10 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
      */
     private boolean compactionWorthwhile(Connection connection, ProjectionMaintenance.Budget budget) {
         long smallFileCeiling = Math.min(budget.minSmallFileBytes(), config.targetFileSizeBytes());
-        long small = countSmallFiles(connection, smallFileCeiling);
-        return small >= budget.minFilesToCompact();
+        var small = countSmallFiles(connection, smallFileCeiling);
+        // Unknown distribution: attempt the pass. merge_adjacent_files is idempotent, so a
+        // needless attempt is cheap, while skipping a needed one lets small files accumulate.
+        return small.isEmpty() || small.getAsLong() >= budget.minFilesToCompact();
     }
 
     /**
@@ -704,16 +749,14 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
      * would need one call per table; the metadata schema answers it in one query, and it is the
      * same table the catalog stores file statistics in.
      */
-    private static long countSmallFiles(Connection connection, long ceiling) {
+    private static java.util.OptionalLong countSmallFiles(Connection connection, long ceiling) {
         try (Statement sql = connection.createStatement();
              ResultSet rs = sql.executeQuery(
                      "SELECT count(*) FROM __ducklake_metadata_history_lake.ducklake_data_file"
                              + " WHERE end_snapshot IS NULL AND file_size_bytes < " + ceiling)) {
-            return rs.next() ? rs.getLong(1) : Long.MAX_VALUE;
+            return rs.next() ? java.util.OptionalLong.of(rs.getLong(1)) : java.util.OptionalLong.empty();
         } catch (SQLException e) {
-            // If the distribution cannot be read, fall back to the file count: attempting a
-            // no-op compaction is cheap, skipping a needed one is not.
-            return sumFileCounts(connection);
+            return java.util.OptionalLong.empty();
         }
     }
 

--- a/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSink.java
+++ b/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSink.java
@@ -1,0 +1,741 @@
+package com.bloxbean.cardano.yano.archive.ducklake;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveBatchCapacityException;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.ArchiveStoreException;
+import com.bloxbean.cardano.yano.archive.api.schema.ArchiveColumn;
+import com.bloxbean.cardano.yano.archive.api.schema.ArchiveTableSchema;
+import com.bloxbean.cardano.yano.archive.api.schema.ArchiveValueType;
+import com.bloxbean.cardano.yano.archive.api.projection.ArchiveArtifactReader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceipt;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceiptMismatchException;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionRowBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSink;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkException;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkHealth;
+import org.duckdb.DuckDBAppender;
+import org.duckdb.DuckDBConnection;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+/**
+ * DuckLake as the ADR-039 primary projection sink.
+ *
+ * <p>One batch is one DuckLake transaction: every required table plus the durable
+ * receipt become visible together. That is what turns at-least-once delivery into
+ * exactly-once effect — a crash between the sink commit and outbox acknowledgement
+ * replays the same deterministic batch, finds the matching receipt, and acknowledges
+ * without writing anything twice.
+ *
+ * <p>Deliberately absent: the SQLite transaction locator. ADR-038 measured it holding
+ * shared archive capacity for seconds to minutes, and it is a rebuildable query
+ * accelerator, not authoritative archive data. Nothing here gates canonical archive
+ * progress on it (ADR-039 §15).
+ *
+ * <p>This sink does no ledger resolution. It receives rows already derived by shared
+ * archive-core code and only translates and batches them, which is why this module
+ * depends on {@code archive-api} alone.
+ */
+public final class DuckLakeProjectionSink implements ProjectionSink {
+
+    private final DuckDbManager manager;
+    private final DuckLakeArchiveConfig config;
+    private final Map<String, ArchiveTableSchema> tables;
+
+    private volatile ProjectionIdentity identity;
+    private volatile ProjectionSinkHealth health = ProjectionSinkHealth.ready();
+
+    public DuckLakeProjectionSink(DuckDbManager manager, DuckLakeArchiveConfig config) {
+        this.manager = Objects.requireNonNull(manager, "manager");
+        this.config = Objects.requireNonNull(config, "config");
+        this.tables = DuckLakeSql.tables();
+    }
+
+    @Override
+    public String engine() {
+        return "ducklake";
+    }
+
+    @Override
+    public void initialize(ProjectionIdentity expected) {
+        Objects.requireNonNull(expected, "expected");
+        // Every required section must map to tables this catalog actually has. A sink that
+        // cannot serve a required section fails here rather than acknowledging envelopes
+        // that quietly omit it.
+        for (ProjectionSectionType section : expected.requiredSections()) {
+            for (ArchiveTableSchema table : com.bloxbean.cardano.yano.archive.api.schema.ArchiveSchemas
+                    .schema(section.dataset()).tables()) {
+                if (!tables.containsKey(table.physicalName())) {
+                    throw new ProjectionSinkException("DuckLake catalog has no table " + table.physicalName()
+                            + " required by projection section " + section.wireName());
+                }
+            }
+        }
+
+        try (DuckDbLease lease = manager.acquire(DuckDbWorkload.BULK_CATCH_UP, config.acquireTimeout())) {
+            Connection connection = lease.connection();
+            DuckLakeSql.attach(connection, config, null, false);
+            try {
+                DuckLakeProjectionSchema.initialize(connection);
+                Optional<String> stored = storedFingerprint(connection);
+                if (stored.isPresent() && !stored.get().equals(expected.fingerprint())) {
+                    throw new ProjectionSinkException("DuckLake archive was written by projection identity "
+                            + stored.get() + " but this node is configured for " + expected.fingerprint());
+                }
+                if (stored.isEmpty()) {
+                    try (PreparedStatement insert = connection.prepareStatement(
+                            "INSERT INTO history_lake.projection_identity VALUES (?, ?)")) {
+                        insert.setString(1, expected.fingerprint());
+                        insert.setTimestamp(2, Timestamp.from(Instant.now()));
+                        insert.executeUpdate();
+                    }
+                }
+            } finally {
+                DuckLakeSql.detach(connection);
+            }
+        } catch (SQLException e) {
+            throw new ProjectionSinkException("failed to initialize DuckLake projection sink", e);
+        }
+        this.identity = expected;
+    }
+
+    @Override
+    public ProjectionCoordinate coordinate() {
+        // The greatest contiguous committed block is derived from receipts, not from the
+        // maximum row present: a partially visible range must never look committed.
+        try (DuckDbLease lease = manager.acquire(DuckDbWorkload.STEADY, config.acquireTimeout())) {
+            Connection connection = lease.connection();
+            DuckLakeSql.attach(connection, config, null, true);
+            try (Statement sql = connection.createStatement();
+                 ResultSet rs = sql.executeQuery(
+                         "SELECT first_block, last_block FROM history_lake.projection_receipts ORDER BY first_block")) {
+                long contiguousThrough = -1;
+                while (rs.next()) {
+                    long first = rs.getLong(1);
+                    long last = rs.getLong(2);
+                    if (first != contiguousThrough + 1) break;
+                    contiguousThrough = last;
+                }
+                return contiguousThrough < 0 ? ProjectionCoordinate.NONE
+                        : new ProjectionCoordinate(contiguousThrough, contiguousThrough,
+                                new byte[]{1}, "committed");
+            } finally {
+                DuckLakeSql.detach(connection);
+            }
+        } catch (SQLException e) {
+            throw new ProjectionSinkException("failed to read DuckLake projection coordinate", e);
+        }
+    }
+
+    @Override
+    public Optional<ProjectionReceipt> receiptFor(long firstBlock) {
+        try (DuckDbLease lease = manager.acquire(DuckDbWorkload.STEADY, config.acquireTimeout())) {
+            Connection connection = lease.connection();
+            DuckLakeSql.attach(connection, config, null, true);
+            try {
+                return readReceipt(connection, firstBlock);
+            } finally {
+                DuckLakeSql.detach(connection);
+            }
+        } catch (SQLException e) {
+            throw new ProjectionSinkException("failed to read DuckLake projection receipt", e);
+        }
+    }
+
+    @Override
+    public ProjectionReceipt append(ProjectionRowBatch batch, ArchiveArtifactReader artifacts) {
+        Objects.requireNonNull(batch, "batch");
+        if (identity == null) throw new ProjectionSinkException("DuckLake projection sink is not initialized");
+        if (!identity.matches(batch.identity())) {
+            throw new ProjectionSinkException("batch identity " + batch.identity().fingerprint()
+                    + " does not match the sink identity " + identity.fingerprint());
+        }
+
+        try (DuckDbLease lease = manager.acquire(DuckDbWorkload.BULK_CATCH_UP, config.acquireTimeout())) {
+            Connection connection = lease.connection();
+            DuckLakeSql.attach(connection, config, null, false);
+            try {
+                Optional<ProjectionReceipt> replay = readReceipt(connection, batch.firstBlock());
+                if (replay.isPresent()) {
+                    if (!replay.get().matches(batch)) {
+                        throw new ProjectionReceiptMismatchException(
+                                "a DuckLake receipt already covers block " + batch.firstBlock()
+                                        + " but describes a different job");
+                    }
+                    return replay.get();
+                }
+                return commitBatch(connection, batch);
+            } finally {
+                DuckLakeSql.detach(connection);
+            }
+        } catch (SQLException e) {
+            health = ProjectionSinkHealth.unavailable(e.toString());
+            throw new ProjectionSinkException("DuckLake projection commit failed for blocks "
+                    + batch.firstBlock() + ".." + batch.lastBlock(), e);
+        }
+    }
+
+    private ProjectionReceipt commitBatch(Connection connection, ProjectionRowBatch batch) throws SQLException {
+        Map<String, Long> rowCounts = new LinkedHashMap<>();
+        Set<String> staged = new LinkedHashSet<>();
+        Map<String, DuckDBAppender> appenders = new LinkedHashMap<>();
+        Instant committedAt = Instant.now();
+
+        try (Statement sql = connection.createStatement()) {
+            sql.execute("BEGIN TRANSACTION");
+        }
+        try {
+            for (ArchiveRow row : batch.rows()) {
+                ArchiveTableSchema table = tables.get(row.table());
+                if (table == null) {
+                    throw new ArchiveStoreException("unknown archive table in projection batch: " + row.table());
+                }
+                if (staged.add(table.physicalName())) createStaging(connection, table);
+                appendRow(connection, appenders, table, row.values());
+                rowCounts.merge(table.physicalName(), 1L, Long::sum);
+            }
+
+            for (DuckDBAppender appender : appenders.values()) {
+                appender.flush();
+                appender.close();
+            }
+            appenders.clear();
+
+            for (String table : staged) {
+                try (Statement sql = connection.createStatement()) {
+                    sql.execute("INSERT INTO history_lake." + DuckLakeSql.name(table)
+                            + " SELECT * FROM " + stagingName(table));
+                }
+            }
+
+            insertReceipt(connection, batch, rowCounts, committedAt);
+
+            try (Statement sql = connection.createStatement()) {
+                sql.execute("COMMIT");
+            }
+            health = ProjectionSinkHealth.ready();
+            return ProjectionReceipt.of(batch, rowCounts, committedAt);
+        } catch (SQLException | RuntimeException failure) {
+            for (DuckDBAppender appender : appenders.values()) {
+                try {
+                    appender.close();
+                } catch (Exception ignored) {
+                    // The transaction is being rolled back; a close failure adds nothing.
+                }
+            }
+            try (Statement sql = connection.createStatement()) {
+                sql.execute("ROLLBACK");
+            } catch (SQLException ignored) {
+                // Preserve the original failure; the connection is discarded either way.
+            }
+            if (failure instanceof SQLException sqlFailure && isCapacityFailure(sqlFailure)) {
+                throw new ArchiveBatchCapacityException("DuckLake projection commit exceeded its budget for blocks "
+                        + batch.firstBlock() + ".." + batch.lastBlock(), sqlFailure);
+            }
+            throw failure;
+        }
+    }
+
+    private void insertReceipt(Connection connection, ProjectionRowBatch batch,
+                               Map<String, Long> rowCounts, Instant committedAt) throws SQLException {
+        try (PreparedStatement insert = connection.prepareStatement(
+                "INSERT INTO history_lake.projection_receipts VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")) {
+            insert.setLong(1, batch.firstBlock());
+            insert.setLong(2, batch.lastBlock());
+            insert.setLong(3, batch.blockCount());
+            insert.setString(4, batch.identity().fingerprint());
+            insert.setString(5, batch.firstEnvelopeId());
+            insert.setString(6, batch.lastEnvelopeId());
+            insert.setString(7, batch.orderedDigest());
+            insert.setString(8, encodeCounts(rowCounts));
+            insert.setTimestamp(9, Timestamp.from(committedAt));
+            insert.executeUpdate();
+        }
+    }
+
+    private Optional<ProjectionReceipt> readReceipt(Connection connection, long firstBlock) throws SQLException {
+        try (PreparedStatement select = connection.prepareStatement(
+                "SELECT first_block, last_block, block_count, identity_fingerprint, first_envelope_id, "
+                        + "last_envelope_id, ordered_digest, row_counts, committed_at "
+                        + "FROM history_lake.projection_receipts WHERE first_block = ?")) {
+            select.setLong(1, firstBlock);
+            try (ResultSet rs = select.executeQuery()) {
+                if (!rs.next()) return Optional.empty();
+                return Optional.of(new ProjectionReceipt(rs.getString(4), rs.getLong(1), rs.getLong(2),
+                        rs.getString(5), rs.getString(6), rs.getLong(3), decodeCounts(rs.getString(8)),
+                        rs.getString(7), rs.getTimestamp(9).toInstant()));
+            }
+        }
+    }
+
+    private void createStaging(Connection connection, ArchiveTableSchema table) throws SQLException {
+        try (Statement sql = connection.createStatement()) {
+            sql.execute("CREATE TEMP TABLE " + stagingName(table.physicalName())
+                    + " AS SELECT * FROM history_lake." + DuckLakeSql.name(table.physicalName()) + " LIMIT 0");
+        }
+    }
+
+    private static void appendRow(Connection connection, Map<String, DuckDBAppender> appenders,
+                                  ArchiveTableSchema table, List<Object> values) throws SQLException {
+        DuckDBAppender appender = appenders.get(table.physicalName());
+        if (appender == null) {
+            appender = ((DuckDBConnection) connection)
+                    .createAppender("temp", "main", stagingName(table.physicalName()));
+            appenders.put(table.physicalName(), appender);
+        }
+        appender.beginRow();
+        List<ArchiveColumn> columns = table.columns();
+        for (int index = 0; index < columns.size(); index++) {
+            appendValue(appender, columns.get(index).type(), values.get(index));
+        }
+        appender.endRow();
+    }
+
+    private static void appendValue(DuckDBAppender appender, ArchiveValueType type, Object value)
+            throws SQLException {
+        if (value == null) {
+            appender.appendNull();
+            return;
+        }
+        switch (type) {
+            case BINARY -> appender.append((byte[]) value);
+            case TEXT -> appender.append((String) value);
+            case BOOLEAN -> appender.append((Boolean) value);
+            case INT32 -> appender.append(((Number) value).intValue());
+            case INT64 -> appender.append(((Number) value).longValue());
+            case DECIMAL_38 -> appender.append(value instanceof BigDecimal decimal ? decimal
+                    : new BigDecimal(value instanceof BigInteger big ? big : new BigInteger(value.toString())));
+            case UUID -> appender.append((UUID) value);
+        }
+    }
+
+    private Optional<String> storedFingerprint(Connection connection) throws SQLException {
+        try (Statement sql = connection.createStatement();
+             ResultSet rs = sql.executeQuery(
+                     "SELECT fingerprint FROM history_lake.projection_identity ORDER BY installed_at LIMIT 1")) {
+            return rs.next() ? Optional.ofNullable(rs.getString(1)) : Optional.empty();
+        }
+    }
+
+    private static String stagingName(String table) {
+        return "proj_stage_" + table;
+    }
+
+    private static String encodeCounts(Map<String, Long> counts) {
+        StringBuilder sb = new StringBuilder();
+        counts.forEach((table, count) -> {
+            if (sb.length() > 0) sb.append(';');
+            sb.append(table).append('=').append(count);
+        });
+        return sb.toString();
+    }
+
+    private static Map<String, Long> decodeCounts(String encoded) {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        if (encoded == null || encoded.isBlank()) return counts;
+        for (String entry : encoded.split(";")) {
+            int split = entry.lastIndexOf('=');
+            if (split > 0) counts.put(entry.substring(0, split), Long.parseLong(entry.substring(split + 1)));
+        }
+        return counts;
+    }
+
+    private static boolean isCapacityFailure(SQLException e) {
+        String message = e.getMessage();
+        return message != null && (message.contains("Out of Memory") || message.contains("could not allocate")
+                || message.contains("temporary directory"));
+    }
+
+    /**
+     * One bounded maintenance pass.
+     *
+     * <p>Housekeeping runs <strong>first</strong> and against its own budget, then compaction
+     * against a separate one. The order is deliberate: expiring snapshots and deleting
+     * obsolete and orphaned files is how the archive reclaims disk, while compaction is only
+     * an optimisation. Running compaction first — as the replay-worker path does — lets a
+     * large rewrite consume the window and skip the cleanup entirely, which turns a lagging
+     * archive into a full disk.
+     *
+     * <p>Compaction additionally runs only when the caller says it may (never during
+     * bootstrap, where it would contend with the sink for the same bounded bulk pool) and
+     * only when the file distribution says it would help.
+     */
+    @Override
+    public ProjectionMaintenance.Result maintain(ProjectionMaintenance.Budget budget) {
+        Objects.requireNonNull(budget, "budget");
+        if (identity == null) {
+            return ProjectionMaintenance.Result.deferred("sink is not initialized");
+        }
+        long start = System.nanoTime();
+        long waitStart = System.nanoTime();
+
+        try (DuckDbLease lease = manager.acquire(DuckDbWorkload.BULK_CATCH_UP, config.acquireTimeout())) {
+            java.time.Duration writerWait = java.time.Duration.ofNanos(System.nanoTime() - waitStart);
+            Connection connection = lease.connection();
+            DuckLakeSql.attach(connection, config, null, false);
+            try {
+                long filesBefore = countDataFiles(connection);
+
+                long fileIdWatermark = maxDataFileId(connection);
+
+                // --- mandatory housekeeping, budgeted on its own ---------------
+                long housekeepingDeadline = System.nanoTime() + budget.housekeepingTimeLimit().toNanos();
+                long snapshotsExpired = 0;
+                long orphansDeleted = 0;
+                java.util.List<String> housekeepingProblems = new java.util.ArrayList<>();
+                boolean anyHousekeepingRan = false;
+                if (budget.housekeepingTimeLimit().toNanos() > 0) {
+                    var expire = runHousekeeping(connection, housekeepingDeadline, "expire_snapshots",
+                            "CALL ducklake_expire_snapshots('history_lake', older_than => now() - INTERVAL '"
+                                    + config.snapshotRetention().toSeconds() + " seconds')");
+                    var cleanup = runHousekeeping(connection, housekeepingDeadline, "cleanup_old_files",
+                            "CALL ducklake_cleanup_old_files('history_lake', older_than => now() - INTERVAL '"
+                                    + config.cleanupGrace().toSeconds() + " seconds')");
+                    var orphans = runHousekeeping(connection, housekeepingDeadline, "delete_orphaned_files",
+                            "CALL ducklake_delete_orphaned_files('history_lake', older_than => now() - INTERVAL '"
+                                    + config.cleanupGrace().toSeconds() + " seconds')");
+
+                    snapshotsExpired = expire.rows();
+                    orphansDeleted = orphans.rows();
+                    for (var step : java.util.List.of(expire, cleanup, orphans)) {
+                        if (step.ok()) anyHousekeepingRan = true;
+                        else housekeepingProblems.add(step.diagnostic());
+                    }
+                }
+
+                // A pass whose mandatory housekeeping did not fully succeed can never be
+                // COMPLETED, whatever compaction did.
+                if (!housekeepingProblems.isEmpty() && !anyHousekeepingRan) {
+                    return finish(ProjectionMaintenance.Outcome.FAILED, start, filesBefore,
+                            countDataFiles(connection), 0, snapshotsExpired, orphansDeleted, writerWait,
+                            "all housekeeping steps failed: " + String.join("; ", housekeepingProblems));
+                }
+
+                // --- optional, thresholded, byte-bounded compaction --------------
+                boolean compacted = false;
+                boolean compactionTruncated = false;
+                java.util.List<String> compactionProblems = new java.util.ArrayList<>();
+                if (budget.compactionAllowed() && budget.compactionTimeLimit().toNanos() > 0
+                        && budget.maxBytesToRewrite() > 0) {
+                    if (!compactionWorthwhile(connection, budget)) {
+                        long files = countDataFiles(connection);
+                        return finish(housekeepingProblems.isEmpty()
+                                        ? ProjectionMaintenance.Outcome.UNNECESSARY
+                                        : ProjectionMaintenance.Outcome.PARTIAL,
+                                start, filesBefore, files,
+                                0, snapshotsExpired, orphansDeleted, writerWait,
+                                housekeepingProblems.isEmpty()
+                                        ? "file distribution is below the compaction threshold"
+                                        : "housekeeping incomplete: " + String.join("; ", housekeepingProblems));
+                    }
+                    java.util.List<String> tables = compactableTables();
+
+                    // The byte budget is enforced, not merely used as an enable flag. DuckLake
+                    // applies max_compacted_files per table, so the aggregate allowance is
+                    // divided by the table count; each call can then write at most
+                    // maxFiles x targetFileSize bytes for its table.
+                    int maxFiles = compactionOutputsPerTable(budget.maxBytesToRewrite(),
+                            config.targetFileSizeBytes(), tables.size());
+
+                    long compactionDeadline = System.nanoTime() + budget.compactionTimeLimit().toNanos();
+                    for (int i = 0; i < tables.size(); i++) {
+                        // Round-robin start, so one table that repeatedly fails to compact
+                        // cannot starve every table behind it on every future pass.
+                        String table = tables.get(Math.floorMod(nextCompactionTable + i, tables.size()));
+                        if (System.nanoTime() >= compactionDeadline) {
+                            compactionTruncated = true;
+                            break;
+                        }
+                        try (Statement sql = connection.createStatement()) {
+                            sql.execute("CALL ducklake_merge_adjacent_files('history_lake', '"
+                                    + DuckLakeSql.name(table) + "', max_compacted_files => " + maxFiles + ")");
+                            compacted = true;
+                            nextCompactionTable = Math.floorMod(nextCompactionTable + i + 1, tables.size());
+                        } catch (SQLException e) {
+                            // A table that cannot compact within the reserved memory must not
+                            // fail the whole pass, but it must be reported.
+                            compactionTruncated = true;
+                            compactionProblems.add(DuckLakeSql.name(table) + ": " + e.getMessage());
+                            nextCompactionTable = Math.floorMod(nextCompactionTable + i + 1, tables.size());
+                        }
+                    }
+                }
+
+                long filesAfter = countDataFiles(connection);
+                long bytesRewritten = bytesWrittenSince(connection, fileIdWatermark);
+
+                java.util.List<String> problems = new java.util.ArrayList<>(housekeepingProblems);
+                problems.addAll(compactionProblems);
+                ProjectionMaintenance.Outcome outcome =
+                        (compactionTruncated || !problems.isEmpty())
+                                ? ProjectionMaintenance.Outcome.PARTIAL
+                                : ProjectionMaintenance.Outcome.COMPLETED;
+                String detail;
+                if (!problems.isEmpty()) {
+                    detail = String.join("; ", problems);
+                } else if (compactionTruncated) {
+                    detail = "compaction stopped at its time budget";
+                } else {
+                    detail = compacted ? null : "housekeeping only";
+                }
+                return finish(outcome, start, filesBefore, filesAfter, bytesRewritten,
+                        snapshotsExpired, orphansDeleted, writerWait, detail);
+            } finally {
+                DuckLakeSql.detach(connection);
+            }
+        } catch (SQLException e) {
+            health = ProjectionSinkHealth.unavailable(e.toString());
+            return new ProjectionMaintenance.Result(ProjectionMaintenance.Outcome.FAILED,
+                    java.time.Duration.ofNanos(System.nanoTime() - start), 0, 0, 0, 0, 0,
+                    java.time.Duration.ZERO, Optional.of(e.toString()));
+        }
+    }
+
+    private static ProjectionMaintenance.Result finish(ProjectionMaintenance.Outcome outcome, long start,
+                                                       long before, long after, long rewritten,
+                                                       long snapshots, long orphans,
+                                                       java.time.Duration writerWait, String detail) {
+        return new ProjectionMaintenance.Result(outcome,
+                java.time.Duration.ofNanos(System.nanoTime() - start), before, after, rewritten,
+                snapshots, orphans, writerWait, Optional.ofNullable(detail));
+    }
+
+    /**
+     * One housekeeping step's outcome.
+     *
+     * <p>Every step is <strong>mandatory</strong>. A step that fails or is cut off by the
+     * deadline must be visible: silently returning zero lets a pass that reclaimed nothing
+     * report {@code COMPLETED}, which is how an archive quietly stops cleaning up while its
+     * status keeps saying it is healthy.
+     *
+     * @param rows      rows the call reported
+     * @param state     what happened to this step
+     * @param diagnostic failure text, or null when the step succeeded or was skipped
+     */
+    private record HousekeepingStep(long rows, StepState state, String diagnostic) {
+        enum StepState { OK, FAILED, SKIPPED_DEADLINE }
+
+        boolean ok() {
+            return state == StepState.OK;
+        }
+    }
+
+    private static HousekeepingStep runHousekeeping(Connection connection, long deadline,
+                                                    String name, String command) {
+        if (System.nanoTime() >= deadline) {
+            return new HousekeepingStep(0, HousekeepingStep.StepState.SKIPPED_DEADLINE,
+                    name + ": skipped, housekeeping budget exhausted");
+        }
+        try (Statement sql = connection.createStatement(); ResultSet rs = sql.executeQuery(command)) {
+            long rows = 0;
+            while (rs.next()) rows++;
+            return new HousekeepingStep(rows, HousekeepingStep.StepState.OK, null);
+        } catch (SQLException e) {
+            // One step failing must not prevent the remaining steps from being attempted -
+            // but it must be reported, and it must downgrade the pass outcome. Clear any
+            // aborted transaction the failed CALL left behind, or every later query on this
+            // connection - including the file counts this pass reports - fails too and the
+            // diagnostics become useless.
+            try {
+                if (!connection.getAutoCommit()) connection.rollback();
+            } catch (SQLException ignored) {
+                // Nothing further to do; the outer diagnostic already carries the real failure.
+            }
+            return new HousekeepingStep(0, HousekeepingStep.StepState.FAILED,
+                    name + ": " + e.getMessage());
+        }
+    }
+
+    /** Total data files across the catalog, for threshold checks and reporting. */
+    /**
+     * Every table this sink writes, including its own bookkeeping.
+     *
+     * <p>{@code DuckLakeSql.tables()} enumerates the dataset tables only. The receipt table is
+     * written on every commit and so accumulates one small file per commit — measured at
+     * 10,515 three-KiB files, 84% of the active file count, on a preprod archive whose dataset
+     * tables had already compacted to ~1,900. Leaving it out of compaction makes it the
+     * dominant term in catalog size.
+     */
+    private static java.util.List<String> compactableTables() {
+        var tables = new java.util.ArrayList<>(DuckLakeSql.tables().keySet());
+        tables.add(DuckLakeProjectionSchema.RECEIPTS_TABLE);
+        return tables;
+    }
+
+    /**
+     * Round-robin cursor over compactable tables.
+     *
+     * <p>Bounded maintenance rarely reaches every table in one pass. Always starting at the
+     * first table would mean the tail never compacts, and a table that repeatedly exhausts the
+     * reserved memory would pin every table behind it forever.
+     */
+    private int nextCompactionTable;
+
+    /**
+     * Files the byte budget must cover, per table.
+     *
+     * <p>DuckLake applies {@code max_compacted_files} independently to each table, so the
+     * aggregate allowance is divided by the table count rather than being multiplied by it.
+     * Each call then writes at most {@code maxFiles x targetFileSize} bytes.
+     *
+     * <p><strong>Per-call upper bound.</strong> DuckLake cannot interrupt a
+     * {@code merge_adjacent_files} call safely - it would roll the whole call back and lose the
+     * work - so the time deadline is checked only between calls. The advertised byte budget is
+     * therefore honoured as: at most one in-flight call may exceed the deadline, and that call
+     * is itself bounded by {@code max_compacted_files}. Size the budget so that one table's
+     * bounded call is an acceptable overshoot.
+     */
+    static int compactionOutputsPerTable(long maxBytesToRewrite, long targetFileSizeBytes, int tableCount) {
+        if (maxBytesToRewrite < 1 || targetFileSizeBytes < 1 || tableCount < 1) {
+            throw new IllegalArgumentException("invalid DuckLake compaction sizing inputs");
+        }
+        long aggregateOutputs = Math.max(1, maxBytesToRewrite / targetFileSizeBytes);
+        return (int) Math.max(1, Math.min(100, aggregateOutputs / tableCount));
+    }
+
+    /**
+     * Highest data-file id currently in the catalog; the watermark a pass measures against.
+     *
+     * <p>File ids are assigned monotonically, so a file this pass produced is exactly one whose
+     * id is past the watermark. {@code begin_snapshot} cannot serve here: a merged file keeps
+     * the earliest snapshot its rows came from, so it looks older than the pass that wrote it.
+     */
+    private static long maxDataFileId(Connection connection) {
+        try (Statement sql = connection.createStatement();
+             ResultSet rs = sql.executeQuery(
+                     "SELECT coalesce(max(data_file_id), 0) FROM"
+                             + " __ducklake_metadata_history_lake.ducklake_data_file")) {
+            return rs.next() ? rs.getLong(1) : 0;
+        } catch (SQLException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Bytes this pass wrote, measured from the catalog rather than estimated.
+     *
+     * <p>Output bytes, not input bytes, is the right pairing with the budget: DuckLake's
+     * {@code max_compacted_files} bounds how many files a call may <em>produce</em>, so
+     * {@code maxFiles x targetFileSize} bounds exactly this quantity. A compacted input is not
+     * measurable after the fact - DuckLake removes it from {@code ducklake_data_file} and
+     * records only its path in the deletion queue, with no size - whereas a file this pass
+     * produced is exactly an active file whose id is past the watermark.
+     *
+     * <p>Returning a real number matters: an unenforced budget that reports {@code 0} looks
+     * identical to a budget that was respected.
+     */
+    private static long bytesWrittenSince(Connection connection, long fileIdWatermark) {
+        try (Statement sql = connection.createStatement();
+             ResultSet rs = sql.executeQuery(
+                     "SELECT coalesce(sum(file_size_bytes), 0) FROM"
+                             + " __ducklake_metadata_history_lake.ducklake_data_file"
+                             + " WHERE end_snapshot IS NULL AND data_file_id > " + fileIdWatermark)) {
+            return rs.next() ? rs.getLong(1) : 0;
+        } catch (SQLException e) {
+            return 0;
+        }
+    }
+
+    private static long countDataFiles(Connection connection) {
+        try (Statement sql = connection.createStatement();
+             ResultSet rs = sql.executeQuery(
+                     "SELECT count(*) FROM ducklake_table_info('history_lake')")) {
+            // table_info reports per-table file counts; sum them for a catalog total.
+            return rs.next() ? sumFileCounts(connection) : 0;
+        } catch (SQLException e) {
+            return 0;
+        }
+    }
+
+    private static long sumFileCounts(Connection connection) {
+        try (Statement sql = connection.createStatement();
+             ResultSet rs = sql.executeQuery(
+                     "SELECT coalesce(sum(file_count), 0) FROM ducklake_table_info('history_lake')")) {
+            return rs.next() ? rs.getLong(1) : 0;
+        } catch (SQLException e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Compact only when the distribution says it would help, rather than on every tick.
+     * Blind periodic compaction rewrites already-large files for no benefit and consumes the
+     * bulk pool the sink needs.
+     */
+    /**
+     * Whether enough <em>small</em> files exist to be worth a compaction pass.
+     *
+     * <p>Counting all files instead would make this true forever on any large archive, so a
+     * pass would be attempted on every interval — acquiring a bulk lease and scanning for
+     * nothing. {@code merge_adjacent_files} is idempotent (a second pass over an already
+     * compacted lake rewrites nothing, verified by test), so a loose gate is safe rather than
+     * corrupting, but it is still wasted work.
+     */
+    private boolean compactionWorthwhile(Connection connection, ProjectionMaintenance.Budget budget) {
+        long smallFileCeiling = Math.min(budget.minSmallFileBytes(), config.targetFileSizeBytes());
+        long small = countSmallFiles(connection, smallFileCeiling);
+        return small >= budget.minFilesToCompact();
+    }
+
+    /**
+     * Active files below {@code ceiling} bytes; these are the ones merging can help.
+     *
+     * <p>Read from DuckLake's own metadata schema. {@code ducklake_list_files} is per-table and
+     * would need one call per table; the metadata schema answers it in one query, and it is the
+     * same table the catalog stores file statistics in.
+     */
+    private static long countSmallFiles(Connection connection, long ceiling) {
+        try (Statement sql = connection.createStatement();
+             ResultSet rs = sql.executeQuery(
+                     "SELECT count(*) FROM __ducklake_metadata_history_lake.ducklake_data_file"
+                             + " WHERE end_snapshot IS NULL AND file_size_bytes < " + ceiling)) {
+            return rs.next() ? rs.getLong(1) : Long.MAX_VALUE;
+        } catch (SQLException e) {
+            // If the distribution cannot be read, fall back to the file count: attempting a
+            // no-op compaction is cheap, skipping a needed one is not.
+            return sumFileCounts(connection);
+        }
+    }
+
+    @Override
+    public ProjectionSinkHealth health() {
+        return health;
+    }
+
+    /**
+     * Closes the sink and the {@link DuckDbManager} it owns.
+     *
+     * <p>The manager holds DuckDB connections and their native resources. Leaving it open
+     * leaked a connection pool on every sink close, which repeated open/close cycles — a
+     * restart loop, or a sink reopened after a failure — would accumulate.
+     */
+    @Override
+    public void close() {
+        health = ProjectionSinkHealth.unavailable("closed");
+        try {
+            manager.close();
+        } catch (Exception e) {
+            // Closing is best-effort; the sink is already unusable either way.
+        }
+    }
+}

--- a/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSink.java
+++ b/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSink.java
@@ -396,7 +396,11 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
             try {
                 java.util.OptionalLong filesBefore = countDataFiles(connection);
 
-                long fileIdWatermark = maxDataFileId(connection).orElse(Long.MAX_VALUE);
+                // Keep the watermark optional. Substituting Long.MAX_VALUE would make the later
+                // "files newer than the watermark" query return 0 rows and report 0 bytes
+                // rewritten as though measured - the same fabricated-zero mistake this change
+                // exists to remove, just one level further along.
+                java.util.OptionalLong fileIdWatermark = maxDataFileId(connection);
 
                 // --- mandatory housekeeping, budgeted on its own ---------------
                 long housekeepingDeadline = System.nanoTime() + budget.housekeepingTimeLimit().toNanos();
@@ -422,19 +426,20 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
                         else housekeepingProblems.add(step.diagnostic());
                     }
 
-                    // A failed CALL can leave the connection unable to answer anything else.
-                    // Stop here rather than running compaction and taking measurements through
-                    // it: every one would fail, the diagnostics would be a cascade of
-                    // meaningless driver errors, and the file counts would be unknown while
-                    // looking like zero. The lease closes this connection on the way out, so the
-                    // next scheduled pass starts on a fresh one.
-                    if (!housekeepingProblems.isEmpty() && !usable(connection)) {
+                    // Abandon the pass after ANY failed housekeeping CALL, rather than asking
+                    // SELECT 1 whether the connection is still usable. A trivial query can
+                    // succeed on a connection whose DuckLake transaction context is already
+                    // ruined, so the probe answers a narrower question than the one that matters.
+                    // Compaction on a pass whose mandatory housekeeping failed is not wanted
+                    // anyway: cleanup is the part that reclaims space, and merging files while
+                    // unable to expire snapshots only adds orphans.
+                    if (!housekeepingProblems.isEmpty()) {
                         return finish(ProjectionMaintenance.Outcome.FAILED, start,
                                 java.util.OptionalLong.empty(), java.util.OptionalLong.empty(),
                                 java.util.OptionalLong.empty(), snapshotsExpired, orphansDeleted,
                                 writerWait,
-                                "connection unusable after a failed housekeeping step; pass abandoned"
-                                        + " and compaction skipped, retrying on a fresh connection: "
+                                "housekeeping failed; pass abandoned and compaction skipped,"
+                                        + " retrying on a fresh connection: "
                                         + String.join("; ", housekeepingProblems));
                     }
                 }
@@ -499,7 +504,9 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
                 }
 
                 var filesAfter = countDataFiles(connection);
-                var bytesRewritten = bytesWrittenSince(connection, fileIdWatermark);
+                var bytesRewritten = fileIdWatermark.isPresent()
+                        ? bytesWrittenSince(connection, fileIdWatermark.getAsLong())
+                        : java.util.OptionalLong.empty();
 
                 java.util.List<String> problems = new java.util.ArrayList<>(housekeepingProblems);
                 problems.addAll(compactionProblems);
@@ -677,23 +684,6 @@ public final class DuckLakeProjectionSink implements ProjectionSink {
             // Unknown, not zero. Reporting a failed measurement as 0 is how "files 35 -> 0" came
             // to read as a catastrophic deletion when nothing had been deleted at all.
             return java.util.OptionalLong.empty();
-        }
-    }
-
-    /**
-     * Whether this connection can still answer a query.
-     *
-     * <p>A failed CALL inside DuckLake leaves the connection in a state where every later
-     * statement fails with "attempting to execute an unsuccessful or closed pending query
-     * result". Continuing on it turns one real failure into a cascade of meaningless ones and
-     * makes every subsequent measurement wrong, which is exactly what happened in the captured
-     * pinned-reader run.
-     */
-    private static boolean usable(Connection connection) {
-        try (Statement sql = connection.createStatement(); ResultSet rs = sql.executeQuery("SELECT 1")) {
-            return rs.next();
-        } catch (SQLException e) {
-            return false;
         }
     }
 

--- a/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSinkProvider.java
+++ b/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSinkProvider.java
@@ -1,0 +1,70 @@
+package com.bloxbean.cardano.yano.archive.ducklake;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSink;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkProvider;
+
+import java.nio.file.Path;
+import java.util.Map;
+
+/**
+ * Opens DuckLake as the ADR-039 primary projection sink.
+ *
+ * <p>Schema and identity are initialised directly, without instantiating the legacy
+ * {@code DuckLakeHistoryArchiveBackend}. That backend also builds the replay-worker
+ * transaction locator, whose startup rebuild was measured at ~61 seconds on a preprod
+ * archive — cost the projection path has no use for, since ADR-039 §15 keeps point lookup
+ * off the acknowledgement path entirely.
+ */
+public final class DuckLakeProjectionSinkProvider implements ProjectionSinkProvider {
+
+    @Override
+    public String engine() {
+        return "ducklake";
+    }
+
+    @Override
+    public ProjectionSink openProjectionSink(ArchiveIdentity expectedIdentity, Path historyDirectory,
+                                             Map<String, String> validatedProperties) {
+        DuckLakeArchiveConfig archiveConfig =
+                DuckLakeArchiveBackendProvider.archiveConfig(historyDirectory, validatedProperties);
+        Path temp = pathOr(validatedProperties, "temp.path", historyDirectory.resolve("tmp"));
+        Path extensions = pathOr(validatedProperties, "extensions.path",
+                historyDirectory.resolve("extensions"));
+
+        DuckDbManager manager = new DuckDbManager(DuckDbManagerConfig.defaults(temp),
+                new PackagedDuckDbExtensionLoader(extensions));
+        try {
+            // Initialise schema and identity directly. Opening the legacy
+            // DuckLakeHistoryArchiveBackend to do this also constructs the replay-worker
+            // transaction locator, which performs a full rebuild on startup — measured at
+            // ~61 seconds on a preprod archive. The projection path does not use the locator
+            // at all (ADR-039 keeps point lookup off the acknowledgement path), so paying
+            // that cost on every restart was pure waste.
+            try (DuckDbLease lease = manager.acquire(DuckDbWorkload.BULK_CATCH_UP,
+                    archiveConfig.acquireTimeout())) {
+                java.sql.Connection connection = lease.connection();
+                DuckLakeSql.attach(connection, archiveConfig, null, false);
+                try {
+                    new DuckLakeInitializer(archiveConfig).initialize(connection, expectedIdentity);
+                    DuckLakeProjectionSchema.initialize(connection);
+                } finally {
+                    DuckLakeSql.detach(connection);
+                }
+            }
+        } catch (Exception e) {
+            try {
+                manager.close();
+            } catch (Exception closeFailure) {
+                e.addSuppressed(closeFailure);
+            }
+            throw new IllegalStateException("failed to initialise the DuckLake projection schema", e);
+        }
+        return new DuckLakeProjectionSink(manager, archiveConfig);
+    }
+
+    private static Path pathOr(Map<String, String> properties, String name, Path fallback) {
+        String configured = properties.get(name);
+        return configured == null || configured.isBlank() ? fallback : Path.of(configured);
+    }
+}

--- a/archive-modules/archive-store-ducklake/src/main/resources/META-INF/services/com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkProvider
+++ b/archive-modules/archive-store-ducklake/src/main/resources/META-INF/services/com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkProvider
@@ -1,0 +1,1 @@
+com.bloxbean.cardano.yano.archive.ducklake.DuckLakeProjectionSinkProvider

--- a/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSinkTest.java
+++ b/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSinkTest.java
@@ -1,0 +1,559 @@
+package com.bloxbean.cardano.yano.archive.ducklake;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveNetworkIdentity;
+import com.bloxbean.cardano.yano.archive.api.ArchiveRow;
+import com.bloxbean.cardano.yano.archive.api.projection.ArchiveArtifactReader;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionArtifactRef;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionCoordinate;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionIdentity;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceipt;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionReceiptMismatchException;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionRowBatch;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSectionType;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.sql.ResultSet;
+import java.sql.Statement;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionMaintenance;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * ADR-039 Phase 4: DuckLake as the primary projection sink.
+ *
+ * <p>Covers the properties the outbox depends on — all required tables plus the receipt
+ * commit together, a matching retry is idempotent, a reshaped retry is rejected, and a
+ * failed batch leaves nothing behind.
+ */
+class DuckLakeProjectionSinkTest {
+    @TempDir Path temp;
+
+    private static final ArchiveNetworkIdentity NETWORK = new ArchiveNetworkIdentity(1, "fixture-genesis");
+    private static final ProjectionIdentity IDENTITY = new ProjectionIdentity(NETWORK, "ducklake", 1,
+            Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY));
+
+    private DuckLakeHistoryArchiveBackend backend;
+    private DuckDbManager manager;
+    private DuckLakeArchiveConfig config;
+
+    private DuckLakeProjectionSink open(String name) throws Exception {
+        Path root = temp.resolve(name);
+        Files.createDirectories(root);
+        config = new DuckLakeArchiveConfig(root.resolve("catalog.sqlite"), root.resolve("data"),
+                Duration.ofSeconds(30), 10, 10, 16L * 1024 * 1024, 100_000,
+                Duration.ofHours(168), Duration.ofHours(24));
+        // Opening the backend creates the archive tables the sink writes into.
+        backend = DuckLakeHistoryArchiveBackend.open(
+                new ArchiveIdentity(UUID.randomUUID(), "ducklake", 1, 1, "fixture-genesis"),
+                config, DuckDbManagerConfig.defaults(root.resolve("tmp")),
+                new PackagedDuckDbExtensionLoader(temp.resolve("extensions")));
+        // Each sink owns its own manager and closes it, exactly as the provider arranges in
+        // production. Sharing one across sinks would only work because of a leak.
+        var sink = newSink();
+        sink.initialize(IDENTITY);
+        return sink;
+    }
+
+    /** A fresh sink with its own manager, mirroring what the provider constructs. */
+    private DuckLakeProjectionSink newSink() {
+        return new DuckLakeProjectionSink(
+                new DuckDbManager(DuckDbManagerConfig.defaults(
+                        config.catalogPath().getParent().resolve("tmp-" + java.util.UUID.randomUUID())),
+                        new PackagedDuckDbExtensionLoader(temp.resolve("extensions"))),
+                config);
+    }
+
+    private static ArchiveRow txRow(long block, int index) {
+        byte[] txHash = new byte[32];
+        txHash[0] = (byte) block;
+        txHash[1] = (byte) index;
+        byte[] blockHash = new byte[32];
+        blockHash[0] = (byte) block;
+        return new ArchiveRow("chain_transaction", List.of(txHash, blockHash, block, block * 20,
+                block / 100, 1_600_000_000L + block, index, true, 170_000L, UUID.randomUUID()));
+    }
+
+    private static ArchiveRow inputRow(long block, int index) {
+        byte[] spending = new byte[32];
+        spending[0] = (byte) block;
+        spending[1] = (byte) index;
+        byte[] referenced = new byte[32];
+        referenced[0] = (byte) (block + 1);
+        byte[] blockHash = new byte[32];
+        blockHash[0] = (byte) block;
+        return new ArchiveRow("transaction_inputs", List.of(spending, index, 0, "input",
+                referenced, 0, true, blockHash, block, block * 20, block / 100,
+                1_600_000_000L + block, UUID.randomUUID()));
+    }
+
+    private static ProjectionRowBatch batch(long firstBlock, long lastBlock, List<ArchiveRow> rows) {
+        return new ProjectionRowBatch(IDENTITY, firstBlock, lastBlock, lastBlock - firstBlock + 1,
+                "aa".repeat(32), "bb".repeat(32), "cc".repeat(32), rows, List.of());
+    }
+
+    private static ProjectionRowBatch simpleBatch(long firstBlock, long lastBlock) {
+        List<ArchiveRow> rows = new ArrayList<>();
+        for (long block = firstBlock; block <= lastBlock; block++) {
+            rows.add(txRow(block, 0));
+            rows.add(inputRow(block, 0));
+        }
+        return batch(firstBlock, lastBlock, rows);
+    }
+
+    private long count(String table) throws Exception {
+        try (var read = (DuckLakeReadSession) backend.openReadSession();
+             Statement sql = read.connection().createStatement();
+             ResultSet rs = sql.executeQuery("SELECT count(*) FROM history_lake." + table)) {
+            rs.next();
+            return rs.getLong(1);
+        }
+    }
+
+    private static final ArchiveArtifactReader NO_ARTIFACTS = new ArchiveArtifactReader() {
+        @Override public ArtifactLease acquire(ProjectionArtifactRef ref, Instant expiresAt) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public ArtifactPage read(ProjectionArtifactRef ref, ArtifactLease lease,
+                                           Optional<String> cursor, int limit) {
+            throw new UnsupportedOperationException();
+        }
+        @Override public void acknowledge(ProjectionArtifactRef ref) { }
+    };
+
+    // ------------------------------------------------------------------- cases
+
+    @Test
+    void everyRequiredTableAndTheReceiptCommitTogether() throws Exception {
+        try (var sink = open("commit")) {
+            ProjectionReceipt receipt = sink.append(simpleBatch(0, 4), NO_ARTIFACTS);
+
+            assertThat(receipt.firstBlock()).isZero();
+            assertThat(receipt.lastBlock()).isEqualTo(4);
+            assertThat(receipt.blockCount()).isEqualTo(5);
+            assertThat(receipt.rowCounts())
+                    .containsEntry("chain_transaction", 5L)
+                    .containsEntry("transaction_inputs", 5L);
+            assertThat(count("chain_transaction")).isEqualTo(5);
+            assertThat(count("transaction_inputs")).isEqualTo(5);
+            assertThat(count("projection_receipts")).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void aMatchingRetryIsIdempotentAndWritesNoDuplicateRows() throws Exception {
+        try (var sink = open("idempotent")) {
+            var first = sink.append(simpleBatch(0, 2), NO_ARTIFACTS);
+            var replay = sink.append(simpleBatch(0, 2), NO_ARTIFACTS);
+
+            assertThat(replay.orderedDigest()).isEqualTo(first.orderedDigest());
+            assertThat(count("chain_transaction")).isEqualTo(3);
+            assertThat(count("projection_receipts")).isEqualTo(1);
+        }
+    }
+
+    @Test
+    void aReshapedRetryForTheSameRangeIsRejected() throws Exception {
+        try (var sink = open("mismatch")) {
+            sink.append(simpleBatch(0, 2), NO_ARTIFACTS);
+
+            var reshaped = new ProjectionRowBatch(IDENTITY, 0, 2, 3,
+                    "aa".repeat(32), "bb".repeat(32), "dd".repeat(32),
+                    List.of(txRow(0, 0)), List.of());
+            assertThatThrownBy(() -> sink.append(reshaped, NO_ARTIFACTS))
+                    .isInstanceOf(ProjectionReceiptMismatchException.class)
+                    .hasMessageContaining("different job");
+            assertThat(count("chain_transaction")).isEqualTo(3);
+        }
+    }
+
+    @Test
+    void theCoordinateAdvancesOnlyOverContiguousCommittedRanges() throws Exception {
+        try (var sink = open("coordinate")) {
+            assertThat(sink.coordinate()).isEqualTo(ProjectionCoordinate.NONE);
+
+            sink.append(simpleBatch(0, 4), NO_ARTIFACTS);
+            assertThat(sink.coordinate().blockNumber()).isEqualTo(4);
+
+            // A range beyond a gap must not advance the contiguous coordinate.
+            sink.append(simpleBatch(10, 12), NO_ARTIFACTS);
+            assertThat(sink.coordinate().blockNumber()).isEqualTo(4);
+
+            sink.append(simpleBatch(5, 9), NO_ARTIFACTS);
+            assertThat(sink.coordinate().blockNumber()).isEqualTo(12);
+        }
+    }
+
+    @Test
+    void aBatchWithAnUnknownTableCommitsNothing() throws Exception {
+        try (var sink = open("unknown-table")) {
+            var poisoned = batch(0, 0, List.of(txRow(0, 0),
+                    new ArchiveRow("not_a_real_table", List.of(1L))));
+            assertThatThrownBy(() -> sink.append(poisoned, NO_ARTIFACTS))
+                    .isInstanceOf(RuntimeException.class);
+            assertThat(count("chain_transaction")).isZero();
+            assertThat(count("projection_receipts")).isZero();
+        }
+    }
+
+    @Test
+    void aForeignProjectionIdentityIsRejected() throws Exception {
+        try (var sink = open("identity")) {
+            var foreign = new ProjectionIdentity(new ArchiveNetworkIdentity(764824073, "mainnet-genesis"),
+                    "ducklake", 1, Set.of(ProjectionSectionType.TRANSACTION));
+            assertThatThrownBy(() -> sink.append(
+                    new ProjectionRowBatch(foreign, 0, 0, 1, "aa".repeat(32), "bb".repeat(32),
+                            "cc".repeat(32), List.of(txRow(0, 0)), List.of()), NO_ARTIFACTS))
+                    .isInstanceOf(ProjectionSinkException.class)
+                    .hasMessageContaining("does not match the sink identity");
+        }
+    }
+
+    @Test
+    void reopeningWithADifferentIdentityFailsClosed() throws Exception {
+        try (var sink = open("reopen")) {
+            sink.append(simpleBatch(0, 1), NO_ARTIFACTS);
+        }
+        var other = new ProjectionIdentity(NETWORK, "ducklake", 2,
+                Set.of(ProjectionSectionType.TRANSACTION, ProjectionSectionType.UTXO_HISTORY));
+        var reopened = newSink();
+        assertThatThrownBy(() -> reopened.initialize(other))
+                .isInstanceOf(ProjectionSinkException.class)
+                .hasMessageContaining("written by projection identity");
+    }
+
+    @Test
+    void receiptsAreReadableAcrossSinkInstances() throws Exception {
+        try (var sink = open("receipts")) {
+            sink.append(simpleBatch(0, 3), NO_ARTIFACTS);
+        }
+        var reopened = newSink();
+        reopened.initialize(IDENTITY);
+        assertThat(reopened.receiptFor(0)).isPresent();
+        assertThat(reopened.receiptFor(0).orElseThrow().lastBlock()).isEqualTo(3);
+        assertThat(reopened.receiptFor(99)).isEmpty();
+    }
+
+    @Test
+    void repeatedOpenAndCloseDoesNotLeakConnections() throws Exception {
+        // close() now closes the DuckDbManager it owns. Without that, each cycle leaked a
+        // connection pool, which a restart loop would accumulate.
+        try (var first = open("leak")) {
+            first.append(simpleBatch(0, 1), NO_ARTIFACTS);
+        }
+        for (int i = 0; i < 5; i++) {
+            var sink = newSink();
+            sink.initialize(IDENTITY);
+            assertThat(sink.coordinate().blockNumber()).isEqualTo(1);
+            sink.close();
+        }
+        var finalSink = newSink();
+        finalSink.initialize(IDENTITY);
+        assertThat(finalSink.receiptFor(0)).isPresent();
+        finalSink.close();
+    }
+
+    // ------------------------------------------------------------- maintenance
+
+    @Test
+    void compactionMergesTheSinksOwnReceiptTableNotOnlyTheDatasetTables() throws Exception {
+        try (var sink = open("compact-receipts")) {
+            // One commit writes one file per touched table, including a receipt file. Left out
+            // of compaction the receipt table becomes the dominant term in file count: measured
+            // at 10,515 files on a preprod archive whose dataset tables had compacted to ~1,900.
+            for (int i = 0; i < 12; i++) sink.append(simpleBatch(i * 5, i * 5 + 4), NO_ARTIFACTS);
+            long receiptFilesBefore = dataFiles("projection_receipts");
+            assertThat(receiptFilesBefore).isGreaterThan(1);
+
+            var result = sink.maintain(ProjectionMaintenance.Budget.full(
+                    Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+            long receiptFilesAfter = dataFiles("projection_receipts");
+            long outputFilesAfter = dataFiles("transaction_outputs");
+            System.out.printf("ADR-039 compaction: receipts %d -> %d, outputs -> %d, outcome %s%n",
+                    receiptFilesBefore, receiptFilesAfter, outputFilesAfter, result.outcome());
+
+            assertThat(result.outcome()).isEqualTo(ProjectionMaintenance.Outcome.COMPLETED);
+            assertThat(receiptFilesAfter)
+                    .as("the receipt table must be compacted like any other")
+                    .isLessThan(receiptFilesBefore);
+            // Compaction must not disturb what the receipts say.
+            assertThat(count("projection_receipts")).isEqualTo(12);
+            assertThat(sink.receiptFor(0)).isPresent();
+
+            // A second pass over an already-compacted lake must not rewrite the same
+            // neighbourhood again: every rewrite orphans its inputs, and orphans survive the
+            // cleanup grace, so a repeatedly-firing compaction would grow disk without bound.
+            var second = sink.maintain(ProjectionMaintenance.Budget.full(
+                    Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+            long receiptFilesSecond = dataFiles("projection_receipts");
+            System.out.printf("ADR-039 compaction second pass: receipts %d, outputs %d, outcome %s%n",
+                    receiptFilesSecond, dataFiles("transaction_outputs"), second.outcome());
+            assertThat(receiptFilesSecond)
+                    .as("a second pass must be a no-op, not another rewrite")
+                    .isEqualTo(receiptFilesAfter);
+            assertThat(dataFiles("transaction_outputs")).isEqualTo(outputFilesAfter);
+        }
+    }
+
+    /** Active data files for one table, read from the DuckLake catalog. */
+    private long dataFiles(String table) throws Exception {
+        try (var connection = java.sql.DriverManager.getConnection(
+                "jdbc:sqlite:" + config.catalogPath());
+             var sql = connection.createStatement();
+             var rows = sql.executeQuery(
+                     "SELECT COUNT(*) FROM ducklake_data_file f JOIN ducklake_table t"
+                             + " ON t.table_id = f.table_id WHERE f.end_snapshot IS NULL"
+                             + " AND t.table_name = '" + table + "'")) {
+            return rows.next() ? rows.getLong(1) : 0;
+        }
+    }
+
+    @Test
+    void compactionIsSkippedWhenNoFileIsSmallEnoughToBeWorthMerging() throws Exception {
+        try (var sink = open("compact-threshold")) {
+            for (int i = 0; i < 12; i++) sink.append(simpleBatch(i * 5, i * 5 + 4), NO_ARTIFACTS);
+
+            // minSmallFileBytes = 1, so no file qualifies as small. This discriminates a real
+            // size-distribution read from the fall-back file count: the fall-back would see
+            // well over eight files and compact anyway.
+            var result = sink.maintain(new ProjectionMaintenance.Budget(
+                    Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30,
+                    512L << 20, 8, 1, true));
+
+            assertThat(result.outcome())
+                    .as("nothing is small enough to merge, so the pass must decline")
+                    .isEqualTo(ProjectionMaintenance.Outcome.UNNECESSARY);
+        }
+    }
+
+    // --------------------------------------------- maintenance contract gaps
+
+    @Test
+    void theByteBudgetIsDividedAcrossTablesRatherThanMultipliedByThem() {
+        // DuckLake applies max_compacted_files per table. Passing the aggregate allowance
+        // straight through would let a 10-table catalog rewrite 10x the advertised budget.
+        int perTable = DuckLakeProjectionSink.compactionOutputsPerTable(
+                1L << 30, 16L * 1024 * 1024, 10);
+        assertThat(perTable).isEqualTo(6);           // 1 GiB / 16 MiB = 64 outputs, / 10 tables
+        assertThat((long) perTable * 10 * (16L * 1024 * 1024))
+                .as("aggregate worst case stays within the advertised budget")
+                .isLessThanOrEqualTo(1L << 30);
+
+        // Never zero: a budget too small for even one output still makes progress on one file.
+        assertThat(DuckLakeProjectionSink.compactionOutputsPerTable(1, 16L * 1024 * 1024, 10))
+                .isEqualTo(1);
+        // Capped, so a huge budget cannot turn one call into an unbounded rewrite.
+        assertThat(DuckLakeProjectionSink.compactionOutputsPerTable(1L << 50, 1024, 1))
+                .isEqualTo(100);
+        assertThatThrownBy(() -> DuckLakeProjectionSink.compactionOutputsPerTable(0, 1024, 1))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void aCompactionPassReportsTheBytesItActuallyRewrote() throws Exception {
+        try (var sink = open("rewritten-bytes")) {
+            for (int i = 0; i < 12; i++) sink.append(simpleBatch(i * 5, i * 5 + 4), NO_ARTIFACTS);
+
+            var result = sink.maintain(ProjectionMaintenance.Budget.full(
+                    Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+
+            System.out.printf("ADR-039 rewritten bytes: %d (files %d -> %d, outcome %s)%n",
+                    result.bytesRewritten(), result.filesBefore(), result.filesAfter(), result.outcome());
+            assertThat(result.filesAfter()).isLessThan(result.filesBefore());
+            assertThat(result.bytesRewritten())
+                    .as("a pass that merged files must report the bytes it wrote, not zero")
+                    .isPositive();
+
+            // A second pass rewrites nothing, and must say so rather than repeating the figure.
+            var second = sink.maintain(ProjectionMaintenance.Budget.full(
+                    Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+            assertThat(second.bytesRewritten()).isZero();
+        }
+    }
+
+    @Test
+    void housekeepingFailureDowngradesTheOutcomeAndNamesTheStep() throws Exception {
+        try (var sink = open("housekeeping-failure")) {
+            sink.append(simpleBatch(0, 4), NO_ARTIFACTS);
+
+            // A negative retention makes DuckLake reject the interval, failing every
+            // housekeeping step. Reporting COMPLETED here is the bug being pinned: an archive
+            // that has silently stopped reclaiming space must not look healthy.
+            var broken = new DuckLakeArchiveConfig(config.catalogPath(), config.dataPath(),
+                    config.acquireTimeout(), config.maxRetries(), config.retryWaitMillis(),
+                    config.targetFileSizeBytes(), config.rowGroupSize(),
+                    // A retention DuckDB cannot express as an INTERVAL, so every housekeeping
+                    // step fails. The config itself stays valid, so this exercises the failure
+                    // path rather than the constructor's validation.
+                    Duration.ofSeconds(Long.MAX_VALUE), Duration.ofSeconds(Long.MAX_VALUE));
+            try (var brokenSink = new DuckLakeProjectionSink(
+                    new DuckDbManager(DuckDbManagerConfig.defaults(
+                            config.catalogPath().getParent().resolve("tmp-broken")),
+                            new PackagedDuckDbExtensionLoader(temp.resolve("extensions"))),
+                    broken)) {
+                brokenSink.initialize(IDENTITY);
+                var result = brokenSink.maintain(ProjectionMaintenance.Budget.housekeepingOnly(
+                        Duration.ofSeconds(30)));
+
+                System.out.printf("ADR-039 housekeeping failure: %s %s%n",
+                        result.outcome(), result.detail().orElse("<none>"));
+                assertThat(result.outcome())
+                        .as("a pass whose mandatory housekeeping failed is never COMPLETED")
+                        .isIn(ProjectionMaintenance.Outcome.FAILED, ProjectionMaintenance.Outcome.PARTIAL);
+                assertThat(result.detail()).isPresent();
+                assertThat(result.detail().orElseThrow())
+                        .as("the diagnostic must name the step that failed")
+                        .contains("expire_snapshots");
+            }
+        }
+    }
+
+    @Test
+    void housekeepingCutOffByItsDeadlineIsReportedRatherThanSilentlySkipped() throws Exception {
+        try (var sink = open("housekeeping-deadline")) {
+            sink.append(simpleBatch(0, 4), NO_ARTIFACTS);
+
+            // A one-nanosecond budget: the first step may run, the rest are cut off.
+            var result = sink.maintain(ProjectionMaintenance.Budget.housekeepingOnly(Duration.ofNanos(1)));
+
+            assertThat(result.outcome())
+                    .as("steps skipped for lack of budget are not a completed pass")
+                    .isIn(ProjectionMaintenance.Outcome.FAILED, ProjectionMaintenance.Outcome.PARTIAL);
+            assertThat(result.detail().orElse("")).contains("budget exhausted");
+        }
+    }
+
+    @Test
+    void aPinnedReaderSurvivesSnapshotExpirationAndFileCleanup() throws Exception {
+        // Retention is only safe to shorten if a reader holding an older snapshot cannot have
+        // its files deleted underneath it. This is the gate that must pass before the 168h/24h
+        // windows are reduced.
+        try (var sink = open("pinned-reader")) {
+            for (int i = 0; i < 8; i++) sink.append(simpleBatch(i * 5, i * 5 + 4), NO_ARTIFACTS);
+            long rowsBefore = count("chain_transaction");
+            assertThat(rowsBefore).isEqualTo(40);
+
+            var readerManager = new DuckDbManager(DuckDbManagerConfig.defaults(
+                    config.catalogPath().getParent().resolve("tmp-reader")),
+                    new PackagedDuckDbExtensionLoader(temp.resolve("extensions")));
+            try (var lease = readerManager.acquire(DuckDbWorkload.BULK_CATCH_UP, config.acquireTimeout())) {
+                var reader = lease.connection();
+                DuckLakeSql.attach(reader, config, null, false);
+                reader.setAutoCommit(false);
+                try (var st = reader.createStatement();
+                     var rs = st.executeQuery("SELECT count(*) FROM history_lake.chain_transaction")) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getLong(1)).isEqualTo(rowsBefore);
+                }
+
+                // Aggressive retention while that read transaction is open, plus compaction,
+                // which supersedes the very files the pinned snapshot still references.
+                var aggressive = new DuckLakeArchiveConfig(config.catalogPath(), config.dataPath(),
+                        config.acquireTimeout(), config.maxRetries(), config.retryWaitMillis(),
+                        config.targetFileSizeBytes(), config.rowGroupSize(),
+                        Duration.ofSeconds(1), Duration.ofSeconds(1));
+                try (var maintainer = new DuckLakeProjectionSink(
+                        new DuckDbManager(DuckDbManagerConfig.defaults(
+                                config.catalogPath().getParent().resolve("tmp-maint")),
+                                new PackagedDuckDbExtensionLoader(temp.resolve("extensions"))),
+                        aggressive)) {
+                    maintainer.initialize(IDENTITY);
+                    var result = maintainer.maintain(ProjectionMaintenance.Budget.full(
+                            Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+                    System.out.printf("ADR-039 pinned reader: maintenance %s, snapshots expired %d,"
+                                    + " orphans deleted %d, files %d -> %d, detail=%s%n",
+                            result.outcome(), result.snapshotsExpired(), result.orphanedFilesDeleted(),
+                            result.filesBefore(), result.filesAfter(),
+                            result.detail().orElse("<none>"));
+
+                    // An open read transaction holds the SQLite catalog lock, so maintenance
+                    // cannot commit its catalog changes at all. That is safe - nothing is
+                    // deleted - but it must be *reported*: before housekeeping carried
+                    // per-step diagnostics this same run returned COMPLETED having reclaimed
+                    // nothing, which is how an archive stops cleaning up while looking healthy.
+                    // Assert the contract, not which step happened to lose the race. Under
+                    // load the pinned reader's SQLite lock can be hit first by snapshot
+                    // expiration or first by compaction, and an earlier version of this test
+                    // asserted the diagnostic named `expire_snapshots` specifically. That is an
+                    // incidental detail of timing: it failed in a contended full-suite run where
+                    // housekeeping happened to get through and compaction was the step that hit
+                    // the lock. What must hold either way is that the pass did not claim
+                    // success, said why, and reclaimed nothing.
+                    assertThat(result.outcome())
+                            .as("maintenance blocked by a pinned reader must not report success")
+                            .isIn(ProjectionMaintenance.Outcome.FAILED,
+                                    ProjectionMaintenance.Outcome.PARTIAL);
+                    assertThat(result.detail())
+                            .as("the pass must say why nothing was reclaimed")
+                            .isPresent();
+                    assertThat(result.detail().orElseThrow())
+                            .as("the diagnostic must name the operation that could not proceed")
+                            .containsAnyOf("expire_snapshots", "cleanup_old_files",
+                                    "delete_orphaned_files", "database is locked");
+                    assertThat(result.snapshotsExpired())
+                            .as("nothing may be expired while a reader is pinned")
+                            .isZero();
+                    assertThat(result.orphanedFilesDeleted())
+                            .as("nothing may be deleted while a reader is pinned")
+                            .isZero();
+                }
+
+                // The pinned reader must still be able to read, and must still see its rows.
+                try (var st = reader.createStatement();
+                     var rs = st.executeQuery("SELECT count(*) FROM history_lake.chain_transaction")) {
+                    assertThat(rs.next()).isTrue();
+                    assertThat(rs.getLong(1))
+                            .as("a reader pinned across expiration and cleanup must not lose its data")
+                            .isEqualTo(rowsBefore);
+                }
+                reader.rollback();
+                reader.setAutoCommit(true);
+            } finally {
+                readerManager.close();
+            }
+
+            // And a fresh reader afterwards still sees everything.
+            assertThat(count("chain_transaction")).isEqualTo(rowsBefore);
+
+            // The block is transient, not permanent: once the reader's transaction is gone,
+            // the next pass succeeds. This is what makes a shorter retention window safe to
+            // consider - maintenance defers to readers rather than being defeated by them.
+            var aggressiveAgain = new DuckLakeArchiveConfig(config.catalogPath(), config.dataPath(),
+                    config.acquireTimeout(), config.maxRetries(), config.retryWaitMillis(),
+                    config.targetFileSizeBytes(), config.rowGroupSize(),
+                    Duration.ofSeconds(1), Duration.ofSeconds(1));
+            try (var after = new DuckLakeProjectionSink(
+                    new DuckDbManager(DuckDbManagerConfig.defaults(
+                            config.catalogPath().getParent().resolve("tmp-after")),
+                            new PackagedDuckDbExtensionLoader(temp.resolve("extensions"))),
+                    aggressiveAgain)) {
+                after.initialize(IDENTITY);
+                var recovered = after.maintain(ProjectionMaintenance.Budget.full(
+                        Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+                System.out.printf("ADR-039 pinned reader released: %s, snapshots expired %d,"
+                                + " orphans deleted %d, detail=%s%n",
+                        recovered.outcome(), recovered.snapshotsExpired(),
+                        recovered.orphanedFilesDeleted(), recovered.detail().orElse("<none>"));
+                assertThat(recovered.outcome())
+                        .as("with no reader pinned, maintenance must be able to run")
+                        .isIn(ProjectionMaintenance.Outcome.COMPLETED,
+                                ProjectionMaintenance.Outcome.PARTIAL,
+                                ProjectionMaintenance.Outcome.UNNECESSARY);
+            }
+            // Data is still intact after real expiration and cleanup have run.
+            assertThat(count("chain_transaction")).isEqualTo(rowsBefore);
+        }
+    }
+}

--- a/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSinkTest.java
+++ b/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeProjectionSinkTest.java
@@ -370,16 +370,20 @@ class DuckLakeProjectionSinkTest {
                     Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
 
             System.out.printf("ADR-039 rewritten bytes: %d (files %d -> %d, outcome %s)%n",
-                    result.bytesRewritten(), result.filesBefore(), result.filesAfter(), result.outcome());
-            assertThat(result.filesAfter()).isLessThan(result.filesBefore());
-            assertThat(result.bytesRewritten())
+                    result.bytesRewritten().orElse(-1), result.filesBefore().orElse(-1),
+                    result.filesAfter().orElse(-1), result.outcome());
+            assertThat(result.measurementsAvailable())
+                    .as("a completed pass must have measured what it did")
+                    .isTrue();
+            assertThat(result.filesAfter().getAsLong()).isLessThan(result.filesBefore().getAsLong());
+            assertThat(result.bytesRewritten().getAsLong())
                     .as("a pass that merged files must report the bytes it wrote, not zero")
                     .isPositive();
 
             // A second pass rewrites nothing, and must say so rather than repeating the figure.
             var second = sink.maintain(ProjectionMaintenance.Budget.full(
                     Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
-            assertThat(second.bytesRewritten()).isZero();
+            assertThat(second.bytesRewritten().orElse(-1)).isZero();
         }
     }
 
@@ -475,42 +479,33 @@ class DuckLakeProjectionSinkTest {
                     System.out.printf("ADR-039 pinned reader: maintenance %s, snapshots expired %d,"
                                     + " orphans deleted %d, files %d -> %d, detail=%s%n",
                             result.outcome(), result.snapshotsExpired(), result.orphanedFilesDeleted(),
-                            result.filesBefore(), result.filesAfter(),
+                            result.filesBefore().orElse(-1), result.filesAfter().orElse(-1),
                             result.detail().orElse("<none>"));
 
-                    // An open read transaction holds the SQLite catalog lock, so maintenance
-                    // cannot commit its catalog changes at all. That is safe - nothing is
-                    // deleted - but it must be *reported*: before housekeeping carried
-                    // per-step diagnostics this same run returned COMPLETED having reclaimed
-                    // nothing, which is how an archive stops cleaning up while looking healthy.
-                    // Assert the contract, not which step happened to lose the race. Under
-                    // load the pinned reader's SQLite lock can be hit first by snapshot
-                    // expiration or first by compaction, and an earlier version of this test
-                    // asserted the diagnostic named `expire_snapshots` specifically. That is an
-                    // incidental detail of timing: it failed in a contended full-suite run where
-                    // housekeeping happened to get through and compaction was the step that hit
-                    // the lock. What must hold either way is that the pass did not claim
-                    // success, said why, and reclaimed nothing.
-                    assertThat(result.outcome())
-                            .as("maintenance blocked by a pinned reader must not report success")
-                            .isIn(ProjectionMaintenance.Outcome.FAILED,
-                                    ProjectionMaintenance.Outcome.PARTIAL);
-                    assertThat(result.detail())
-                            .as("the pass must say why nothing was reclaimed")
-                            .isPresent();
-                    assertThat(result.detail().orElseThrow())
-                            .as("the diagnostic must name the operation that could not proceed")
-                            .containsAnyOf("expire_snapshots", "cleanup_old_files",
-                                    "delete_orphaned_files", "database is locked");
-                    assertThat(result.snapshotsExpired())
-                            .as("nothing may be expired while a reader is pinned")
-                            .isZero();
-                    assertThat(result.orphanedFilesDeleted())
-                            .as("nothing may be deleted while a reader is pinned")
-                            .isZero();
+                    // Assert the invariant this test exists to protect, not SQLite's current
+                    // locking behaviour. Requiring maintenance to *fail*, or requiring global
+                    // expired/deleted counts to be zero, would encode today's mechanism: a future
+                    // DuckLake could safely expire unrelated snapshots while preserving the
+                    // pinned reader, and this test should still pass then.
+                    //
+                    // What must hold in every version: no false success, and no measurement
+                    // reported as zero when it was never taken.
+                    if (result.outcome() == ProjectionMaintenance.Outcome.COMPLETED) {
+                        assertThat(result.measurementsAvailable())
+                                .as("a pass claiming success must have actually measured what it did")
+                                .isTrue();
+                    } else {
+                        assertThat(result.detail())
+                                .as("a pass that did not complete must say why")
+                                .isPresent();
+                    }
+                    assertThat(result.filesBefore().isPresent() || result.detail().isPresent())
+                            .as("an unmeasured file count must never be reported as a measured zero")
+                            .isTrue();
                 }
 
-                // The pinned reader must still be able to read, and must still see its rows.
+                // The invariant proper: the pinned reader's data is still there and still
+                // correct, whatever maintenance did or failed to do.
                 try (var st = reader.createStatement();
                      var rs = st.executeQuery("SELECT count(*) FROM history_lake.chain_transaction")) {
                     assertThat(rs.next()).isTrue();
@@ -554,6 +549,75 @@ class DuckLakeProjectionSinkTest {
             }
             // Data is still intact after real expiration and cleanup have run.
             assertThat(count("chain_transaction")).isEqualTo(rowsBefore);
+        }
+    }
+
+    @Test
+    void aPoisonedConnectionAbandonsThePassRatherThanCascadingThroughIt() throws Exception {
+        // Deterministic reproduction of the captured pinned-reader failure's *second* defect.
+        // A failed CALL leaves the connection unable to answer anything else; the old code kept
+        // using it, so compaction and every measurement failed too. The diagnostics became a
+        // cascade of driver errors and the file counts read "35 -> 0" — an unmeasured value
+        // printed as a measured zero, which reads as a catastrophic deletion.
+        try (var sink = open("poisoned-connection")) {
+            sink.append(simpleBatch(0, 4), NO_ARTIFACTS);
+
+            // A retention DuckDB cannot express as an INTERVAL makes every housekeeping step
+            // fail and leaves the connection in the same unusable state.
+            var broken = new DuckLakeArchiveConfig(config.catalogPath(), config.dataPath(),
+                    config.acquireTimeout(), config.maxRetries(), config.retryWaitMillis(),
+                    config.targetFileSizeBytes(), config.rowGroupSize(),
+                    Duration.ofSeconds(Long.MAX_VALUE), Duration.ofSeconds(Long.MAX_VALUE));
+            try (var brokenSink = new DuckLakeProjectionSink(
+                    new DuckDbManager(DuckDbManagerConfig.defaults(
+                            config.catalogPath().getParent().resolve("tmp-poisoned")),
+                            new PackagedDuckDbExtensionLoader(temp.resolve("extensions"))),
+                    broken)) {
+                brokenSink.initialize(IDENTITY);
+
+                // Compaction is allowed by the budget; the pass must decline to attempt it.
+                var result = brokenSink.maintain(ProjectionMaintenance.Budget.full(
+                        Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+
+                System.out.printf("ADR-039 poisoned connection: %s, files %s -> %s, bytes %s%n",
+                        result.outcome(), result.filesBefore(), result.filesAfter(),
+                        result.bytesRewritten());
+
+                assertThat(result.outcome())
+                        .as("a pass whose mandatory housekeeping failed must not claim success")
+                        .isEqualTo(ProjectionMaintenance.Outcome.FAILED);
+
+                // The contract is not "everything is empty" — it is that every reported figure
+                // was genuinely measured, and anything that could not be measured is absent
+                // rather than fabricated as zero. `filesBefore` is taken before the first CALL,
+                // so it is real and must be reported. `bytesRewritten` is never reached, so it
+                // must be absent — the old code returned 0 there, which is what made
+                // "files 35 -> 0" read as a deletion.
+                assertThat(result.bytesRewritten())
+                        .as("a figure the pass never reached must be absent, not zero")
+                        .isEmpty();
+                assertThat(result.measurementsAvailable())
+                        .as("the result must not claim to be fully measured")
+                        .isFalse();
+                assertThat(result.detail().orElseThrow())
+                        .as("the diagnostic must name the step that failed")
+                        .contains("expire_snapshots");
+
+                // And compaction must not have been attempted on the back of a failed pass.
+                assertThat(result.detail().orElseThrow()).doesNotContain("merge_adjacent_files");
+            }
+
+            // The next pass, on a fresh connection with a working configuration, succeeds.
+            var recovered = sink.maintain(ProjectionMaintenance.Budget.full(
+                    Duration.ofSeconds(30), Duration.ofSeconds(30), 1L << 30));
+            assertThat(recovered.outcome())
+                    .as("a poisoned connection must not poison the sink")
+                    .isIn(ProjectionMaintenance.Outcome.COMPLETED,
+                            ProjectionMaintenance.Outcome.PARTIAL,
+                            ProjectionMaintenance.Outcome.UNNECESSARY);
+            assertThat(count("chain_transaction"))
+                    .as("no data was harmed by the abandoned pass")
+                    .isEqualTo(5);
         }
     }
 }

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/CanonicalProjectionContributor.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/CanonicalProjectionContributor.java
@@ -1,0 +1,67 @@
+package com.bloxbean.cardano.yano.api.archive;
+
+import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.ByronBlockProjectionEvent;
+
+/**
+ * Produces projection sections during canonical block application (ADR-039 §8).
+ *
+ * <p>Implementations are called <em>inside</em> a contributing subsystem's existing
+ * write batch and must only stage records through the supplied
+ * {@link ProjectionStagingWriter}. They must not open archive sessions, wait on an
+ * archive writer, or scan a large artifact: projection construction is allowed on the
+ * hot path, sink I/O is not.
+ *
+ * <p>{@link #NOOP} is what a history-disabled node uses, so the cost of the hook is one
+ * predictable {@code enabled()} check that returns a constant.
+ */
+public interface CanonicalProjectionContributor {
+
+    /** False for a history-disabled node; callers skip all projection work. */
+    boolean enabled();
+
+    /**
+     * Contribute the Shelley-and-later sections for an already-decoded block.
+     * Called with the caller's batch still open, before it is committed.
+     */
+    void contributeBlock(BlockAppliedEvent event, ProjectionStagingWriter writer);
+
+    /**
+     * Whether this contributor needs the addresses of the outputs the block consumed.
+     *
+     * <p>Only the address-transaction section does. Answering false lets the caller skip
+     * collecting them entirely, so a node projecting the other sections pays nothing for a
+     * dataset it does not produce.
+     */
+    default boolean needsConsumedOutputAddresses() {
+        return false;
+    }
+
+    /**
+     * Contribute with consumed-output addresses available.
+     *
+     * <p>Defaults to the plain form, so a contributor that does not need them — and a caller
+     * that has not collected them — both keep working unchanged.
+     */
+    default void contributeBlock(BlockAppliedEvent event, ConsumedOutputAddresses consumed,
+                                 ProjectionStagingWriter writer) {
+        contributeBlock(event, writer);
+    }
+
+    /**
+     * Contribute Byron sections for an already-decoded Byron block. Epoch-boundary
+     * blocks contribute an empty envelope so the projection coordinate stays contiguous.
+     */
+    void contributeByronBlock(ByronBlockProjectionEvent event, ProjectionStagingWriter writer);
+
+    /** Drop pending envelopes at or above {@code fromBlockNumber} and rewind cursors. */
+    void rollbackFrom(long fromBlockNumber);
+
+    CanonicalProjectionContributor NOOP = new CanonicalProjectionContributor() {
+        @Override public boolean enabled() { return false; }
+        @Override public void contributeBlock(BlockAppliedEvent event, ProjectionStagingWriter writer) { }
+        @Override public boolean needsConsumedOutputAddresses() { return false; }
+        @Override public void contributeByronBlock(ByronBlockProjectionEvent event, ProjectionStagingWriter writer) { }
+        @Override public void rollbackFrom(long fromBlockNumber) { }
+    };
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/ConsumedOutputAddresses.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/ConsumedOutputAddresses.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yano.api.archive;
+
+/**
+ * Addresses of the outputs a block consumed, resolved while those outputs were still current.
+ *
+ * <p>The address-transaction dataset needs to know which address each spent input belonged to.
+ * That is the one part of the dataset which is not a function of the block: the consumed output
+ * was created by an earlier block and, by the time any sink sees the envelope, has been removed
+ * from the UTXO set. It is therefore resolved at capture time — the same reasoning that puts
+ * pointer-address resolution in the canonical apply rather than in the sink.
+ *
+ * <p>The UTXO subsystem already reads every consumed output during apply in order to delete it,
+ * so supplying this costs a lookup that has already happened, not a new one. A contributor that
+ * does not require the address-transaction section never asks for it and pays nothing.
+ */
+@FunctionalInterface
+public interface ConsumedOutputAddresses {
+
+    /**
+     * @param txHash      hex transaction id of the consumed output
+     * @param outputIndex its index within that transaction
+     * @return the address exactly as the node stores it — the same encoded form the address
+     *         parser already accepts — or null when the output was not retained (a storage
+     *         filter may exclude it). Callers must treat null as "unknown", never as
+     *         "no address".
+     */
+    String addressOf(String txHash, int outputIndex);
+
+    /** Nothing was captured; used by contributors that do not need input addresses. */
+    ConsumedOutputAddresses NONE = (txHash, outputIndex) -> null;
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/PointerCredentialSource.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/PointerCredentialSource.java
@@ -1,0 +1,105 @@
+package com.bloxbean.cardano.yano.api.archive;
+
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Authoritative, <em>as-of</em> pointer-address resolution, owned by the ledger/account-state
+ * contributor (ADR-039 open question 1).
+ *
+ * <p>A pre-Conway pointer address encodes the coordinate of a stake registration certificate
+ * rather than a credential hash. The Shelley ledger keeps those coordinates in the delegation
+ * state's {@code ptrs} map and <strong>removes a credential's entries when it is
+ * deregistered</strong>, so a pointer whose target has been deregistered resolves to no stake
+ * credential. Resolution therefore cannot be a simple registration lookup: it has to be
+ * evaluated as of a position in the chain.
+ *
+ * <p>The interval that decides it is:
+ *
+ * <pre>
+ * registration coordinate  &lt;  deregistration coordinate  &lt;=  projected block-end coordinate
+ * </pre>
+ *
+ * <p>Everything is expressed in <em>coordinates</em>, never bare slots. Two deregistrations of
+ * one credential can share a slot in different transactions, and a slot-only comparison would
+ * conflate them and make same-slot ordering ambiguous.
+ *
+ * <p><strong>Replay determinism.</strong> Both the registration mapping and the deregistration
+ * index are append-only and coordinate-keyed, and every query is bounded above by the block
+ * being projected. Projecting block N therefore yields the same answer whether the store is at
+ * N or at N+100: later events lie outside the interval by construction. This is what lets
+ * ADR-039 contributor replay reproduce byte-identical sections.
+ */
+public interface PointerCredentialSource {
+
+    /** A certificate's position in the chain: slot, then transaction, then certificate. */
+    record PointerCoordinate(long slot, int txIndex, int certIndex)
+            implements Comparable<PointerCoordinate> {
+        public PointerCoordinate {
+            if (slot < 0 || txIndex < 0 || certIndex < 0) {
+                throw new IllegalArgumentException("coordinate components must not be negative");
+            }
+        }
+
+        /** Upper bound covering every certificate in a block. */
+        public static PointerCoordinate endOfBlock(long slot) {
+            return new PointerCoordinate(slot, 0xFFFF, 0xFFFF);
+        }
+
+        @Override
+        public int compareTo(PointerCoordinate other) {
+            int bySlot = Long.compare(slot, other.slot);
+            if (bySlot != 0) return bySlot;
+            int byTx = Integer.compare(txIndex, other.txIndex);
+            return byTx != 0 ? byTx : Integer.compare(certIndex, other.certIndex);
+        }
+    }
+
+    /** A stake credential a pointer coordinate refers to. */
+    record PointerCredential(int credentialType, String credentialHash) {
+        public PointerCredential {
+            credentialHash = Objects.requireNonNull(credentialHash, "credentialHash").toLowerCase();
+        }
+    }
+
+    /** Whether the derived as-of index can be trusted for the pre-Conway range. */
+    enum IndexCompleteness {
+        /** Maintained from genesis; safe for projection history. */
+        COMPLETE,
+        /** Not maintained from genesis, so a pre-Conway deregistration may be missing. */
+        INCOMPLETE,
+        /** Pointer history was cleaned up after all safety gates passed; no longer queryable. */
+        CLEANED
+    }
+
+    /** The credential registered at this coordinate, or empty when none was. */
+    Optional<PointerCredential> registrationAt(PointerCoordinate coordinate);
+
+    /**
+     * Whether {@code credential} was deregistered strictly after {@code after} and at or before
+     * {@code through}. Both bounds are coordinates, so same-slot ordering is exact.
+     */
+    boolean deregisteredWithin(PointerCredential credential, PointerCoordinate after,
+                               PointerCoordinate through);
+
+    /**
+     * Completeness of the derived index. Projection history must fail closed on anything other
+     * than {@link IndexCompleteness#COMPLETE}, rather than silently resolving pointers against a
+     * partially populated index.
+     */
+    IndexCompleteness completeness();
+
+    /** Resolves nothing and reports itself incomplete, so callers fail closed rather than guess. */
+    PointerCredentialSource NONE = new PointerCredentialSource() {
+        @Override public Optional<PointerCredential> registrationAt(PointerCoordinate coordinate) {
+            return Optional.empty();
+        }
+        @Override public boolean deregisteredWithin(PointerCredential credential, PointerCoordinate after,
+                                                    PointerCoordinate through) {
+            return false;
+        }
+        @Override public IndexCompleteness completeness() {
+            return IndexCompleteness.INCOMPLETE;
+        }
+    };
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/PointerIndexMaintenance.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/PointerIndexMaintenance.java
@@ -1,0 +1,50 @@
+package com.bloxbean.cardano.yano.api.archive;
+
+import java.util.OptionalLong;
+
+/**
+ * Bounded, idempotent maintenance of the derived as-of pointer index.
+ *
+ * <p>Pointer addresses exist only pre-Conway, so once the chain is safely past that boundary
+ * the index has no further readers and can be reclaimed. Reclaiming it early would silently
+ * break resolution for any block still replayable, so the decision is gated elsewhere: this
+ * interface only <em>executes</em> a cleanup that something else has already authorised.
+ *
+ * <p>Execution is deliberately bounded and resumable. Deleting an unbounded key range in one
+ * batch would stall canonical apply and lose all progress on a crash; instead each call
+ * removes at most {@code maxKeys} and returns how many, so a caller can spread the work and
+ * a crash costs only the current chunk.
+ */
+public interface PointerIndexMaintenance {
+
+    /**
+     * @param entryCount   derived index entries currently retained
+     * @param logicalBytes their logical size, for disk accounting
+     * @param cleanedThroughSlot slot recorded by a completed cleanup, when one has run
+     */
+    record PointerIndexStatus(PointerCredentialSource.IndexCompleteness completeness,
+                              long entryCount, long logicalBytes, OptionalLong cleanedThroughSlot) {
+    }
+
+    PointerIndexStatus pointerIndexStatus();
+
+    /**
+     * Remove at most {@code maxKeys} derived index entries at or before {@code throughSlot}.
+     *
+     * <p>Idempotent: re-running after a crash simply finds fewer entries. Does not write the
+     * completion marker — a partial pass must not be mistaken for a finished one.
+     *
+     * @return the number of entries removed
+     */
+    long cleanupPointerIndex(long throughSlot, int maxKeys);
+
+    /**
+     * Durably record that cleanup finished through {@code throughSlot}.
+     *
+     * <p>Written only after the range is empty. Afterwards
+     * {@link PointerCredentialSource#completeness()} reports {@code CLEANED}, so a later
+     * attempt to resolve a pointer fails closed rather than silently returning "unresolved"
+     * from an index that no longer exists.
+     */
+    void markPointerIndexCleaned(long throughSlot);
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/ProjectionCfNames.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/ProjectionCfNames.java
@@ -1,0 +1,31 @@
+package com.bloxbean.cardano.yano.api.archive;
+
+/**
+ * Column families backing the canonical projection outbox (ADR-039 §2, §8).
+ *
+ * <p>These names live in {@code core-api} because both sides need them and neither may
+ * depend on the other: the runtime declares the column families when it opens the
+ * shared chainstate, and the archive modules read and write them. Sharing one physical
+ * RocksDB is what lets a contributor commit its projection section inside the same
+ * {@code WriteBatch} as the state that section was derived from, which is the whole
+ * atomicity argument of ADR-039 — no global cross-subsystem transaction is needed.
+ *
+ * <p>Nothing here depends on DuckLake or standalone SQLite.
+ */
+public final class ProjectionCfNames {
+    private ProjectionCfNames() {}
+
+    /** Per-block canonical identity record; one key per applied block. */
+    public static final String PROJ_HEADER = "proj_header";
+
+    /** Per-section manifests and their ordered chunk payloads. */
+    public static final String PROJ_SECTION = "proj_section";
+
+    /** Contributor cursors, projection identity, acknowledgement coordinate. */
+    public static final String PROJ_META = "proj_meta";
+
+    /** Epoch-artifact references and their durable leases. */
+    public static final String PROJ_ARTIFACT = "proj_artifact";
+
+    public static final String[] ALL = {PROJ_HEADER, PROJ_SECTION, PROJ_META, PROJ_ARTIFACT};
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/ProjectionStagingWriter.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/archive/ProjectionStagingWriter.java
@@ -1,0 +1,20 @@
+package com.bloxbean.cardano.yano.api.archive;
+
+/**
+ * Stages projection records into a contributor's in-flight write batch.
+ *
+ * <p>Deliberately opaque. The runtime owns the batch and knows nothing about projection
+ * key or value encoding; the archive owns the encoding and knows nothing about how the
+ * batch is committed. That keeps ADR-039's atomicity guarantee — a section is durable
+ * exactly when the state it was derived from is durable — without either side depending
+ * on the other's internals, and without {@code core-api} taking a RocksDB dependency.
+ */
+@FunctionalInterface
+public interface ProjectionStagingWriter {
+    /**
+     * @param columnFamily one of {@link ProjectionCfNames}
+     * @param key   fully encoded record key
+     * @param value fully encoded record value
+     */
+    void put(String columnFamily, byte[] key, byte[] value);
+}

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
@@ -312,6 +312,81 @@ public final class YanoPropertyKeys {
         public static final String DUCKDB_BULK_THREADS = PREFIX + "duckdb.bulk-catch-up.threads";
         public static final String DUCKDB_BULK_JOBS = PREFIX + "duckdb.bulk-catch-up.max-concurrent-jobs";
 
+        // --- ADR-039 canonical projection outbox -------------------------------
+        /** Enable projection-outbox history. Must be set from genesis; mid-chain activation is rejected. */
+        public static final String PROJECTION_ENABLED = PREFIX + "projection.enabled";
+        /** Primary sink: ducklake | sqlite | none. "none" measures producer cost without a sink. */
+        public static final String PROJECTION_SINK = PREFIX + "projection.sink";
+        /** Deterministic split bound for one physical section value. */
+        public static final String PROJECTION_CHUNK_BYTES = PREFIX + "projection.chunk-bytes";
+        public static final String PROJECTION_MAX_BLOCKS_PER_BATCH = PREFIX + "projection.batch.max-blocks";
+        public static final String PROJECTION_MAX_BYTES_PER_BATCH = PREFIX + "projection.batch.max-bytes";
+        public static final String PROJECTION_SOFT_BACKLOG_BLOCKS = PREFIX + "projection.backlog.soft-blocks";
+        public static final String PROJECTION_HARD_BACKLOG_BLOCKS = PREFIX + "projection.backlog.hard-blocks";
+        public static final String PROJECTION_SOFT_BACKLOG_BYTES = PREFIX + "projection.backlog.soft-bytes";
+        public static final String PROJECTION_HARD_BACKLOG_BYTES = PREFIX + "projection.backlog.hard-bytes";
+        public static final String PROJECTION_DRAIN_INTERVAL_MILLIS = PREFIX + "projection.drain-interval-millis";
+        /**
+         * Comma-separated wire names of the sections this node projects. <strong>Defaults to
+         * every shipped block dataset</strong>; set it only to deliberately project fewer, which
+         * is a legacy or testing configuration rather than a tuning knob.
+         *
+         * <p>Part of the projection identity, so changing it changes the fingerprint and requires
+         * a fresh sync — intended, because a section added mid-chain would be missing for every
+         * earlier block. The corollary is that a dataset omitted here can only be added by
+         * resyncing from genesis.
+         *
+         * <p>Example legacy value: {@code transaction:v2,utxo-history:v5}.
+         */
+        public static final String PROJECTION_SECTIONS = PREFIX + "projection.sections";
+        /** Wall-clock spacing between housekeeping passes; housekeeping also runs during bootstrap. */
+        public static final String PROJECTION_HOUSEKEEPING_INTERVAL_MINUTES =
+                PREFIX + "projection.maintenance.housekeeping-interval-minutes";
+        /** Wall-clock spacing between compaction passes, which additionally require a caught-up sink. */
+        public static final String PROJECTION_COMPACTION_INTERVAL_MINUTES =
+                PREFIX + "projection.maintenance.compaction-interval-minutes";
+        /** Time budget for one housekeeping pass. */
+        public static final String PROJECTION_HOUSEKEEPING_BUDGET_SECONDS =
+                PREFIX + "projection.maintenance.housekeeping-budget-seconds";
+        /** Time budget for one compaction pass. */
+        public static final String PROJECTION_COMPACTION_BUDGET_SECONDS =
+                PREFIX + "projection.maintenance.compaction-budget-seconds";
+        /** Upper bound on bytes one compaction pass may rewrite. */
+        public static final String PROJECTION_COMPACTION_REWRITE_BYTES =
+                PREFIX + "projection.maintenance.compaction-rewrite-bytes";
+        /** Compaction output target size for the primary sink, in bytes. */
+        public static final String PROJECTION_SINK_TARGET_FILE_SIZE_BYTES =
+                PREFIX + "projection.sink-options.target-file-size-bytes";
+        /** Parquet row-group size for the primary sink. */
+        public static final String PROJECTION_SINK_ROW_GROUP_SIZE =
+                PREFIX + "projection.sink-options.row-group-size";
+        /**
+         * How long sink snapshots are retained before housekeeping may expire them.
+         *
+         * <p>Independent of the legacy archive setting: the projection path has one writer
+         * and short-lived readers, so it does not need the replay worker's window. Until a
+         * snapshot expires, the files it references cannot be reclaimed.
+         */
+        public static final String PROJECTION_SINK_SNAPSHOT_RETENTION_HOURS =
+                PREFIX + "projection.sink-options.snapshot-retention-hours";
+        /**
+         * Grace period before files that a newer snapshot superseded are deleted from disk.
+         *
+         * <p>This bounds how long compaction's rewritten inputs stay on disk alongside their
+         * replacements, so peak sink footprint is roughly doubled for this long after a
+         * compaction pass.
+         */
+        public static final String PROJECTION_SINK_CLEANUP_GRACE_HOURS =
+                PREFIX + "projection.sink-options.cleanup-grace-hours";
+        // Aggregate archive-retained disk budget (ADR-039 disk backpressure). Canonical sync
+        // stays asynchronous until one of these is reached; it is never paced by sink speed.
+        public static final String PROJECTION_DISK_SOFT_BYTES = PREFIX + "projection.disk.soft-bytes";
+        public static final String PROJECTION_DISK_HARD_BYTES = PREFIX + "projection.disk.hard-bytes";
+        public static final String PROJECTION_DISK_LOW_WATER_BYTES = PREFIX + "projection.disk.low-water-bytes";
+        public static final String PROJECTION_DISK_FREE_RESERVE_BYTES = PREFIX + "projection.disk.free-space-reserve-bytes";
+        /** Measured logical-to-physical factor for outbox bytes; the first slice observed ~1.4. */
+        public static final String PROJECTION_DISK_AMPLIFICATION = PREFIX + "projection.disk.amplification-factor";
+
         private History() { }
     }
 

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/ByronBlockProjectionEvent.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/events/ByronBlockProjectionEvent.java
@@ -1,0 +1,65 @@
+package com.bloxbean.cardano.yano.api.events;
+
+import com.bloxbean.cardano.yaci.core.model.byron.ByronEbBlock;
+import com.bloxbean.cardano.yaci.core.model.byron.ByronMainBlock;
+import com.bloxbean.cardano.yaci.events.api.Event;
+
+/**
+ * Carries an already-decoded Byron block to projection history (ADR-039 §3).
+ *
+ * <p>This is a <strong>separate event type</strong> rather than a change to
+ * {@link BlockAppliedEvent}. That event is published with a {@code null} block for both
+ * Byron main blocks and epoch-boundary blocks, and five unrelated consumers treat that
+ * {@code null} as a load-bearing "skip this" sentinel — the UTXO store, the UTXO
+ * processor, the mempool eviction policy, the in-memory account state store, and the
+ * app-chain subsystem. Overloading the sentinel would change behaviour for all of them;
+ * a new type leaves every one untouched.
+ *
+ * <p>The block is carried already decoded because canonical application has just parsed
+ * it. Publishing the raw model costs one allocation and a bus dispatch, and it means a
+ * node with history disabled pays nothing: no subscriber, no work.
+ *
+ * <p>Exactly one of {@link #mainBlock()} and {@link #epochBoundaryBlock()} is non-null.
+ * An epoch-boundary block carries no transactions but does occupy a block number, so it
+ * must still produce an (empty) projection envelope or the archive's contiguous block
+ * coordinate acquires a permanent hole.
+ */
+public final class ByronBlockProjectionEvent implements Event {
+    private final long slot;
+    private final long blockNumber;
+    private final String blockHash;
+    private final String prevBlockHash;
+    private final ByronMainBlock mainBlock;
+    private final ByronEbBlock epochBoundaryBlock;
+
+    private ByronBlockProjectionEvent(long slot, long blockNumber, String blockHash, String prevBlockHash,
+                                      ByronMainBlock mainBlock, ByronEbBlock epochBoundaryBlock) {
+        this.slot = slot;
+        this.blockNumber = blockNumber;
+        this.blockHash = blockHash;
+        this.prevBlockHash = prevBlockHash;
+        this.mainBlock = mainBlock;
+        this.epochBoundaryBlock = epochBoundaryBlock;
+    }
+
+    public static ByronBlockProjectionEvent main(long slot, long blockNumber, String blockHash,
+                                                 String prevBlockHash, ByronMainBlock block) {
+        if (block == null) throw new IllegalArgumentException("main block is required");
+        return new ByronBlockProjectionEvent(slot, blockNumber, blockHash, prevBlockHash, block, null);
+    }
+
+    public static ByronBlockProjectionEvent epochBoundary(long slot, long blockNumber, String blockHash,
+                                                          String prevBlockHash, ByronEbBlock block) {
+        if (block == null) throw new IllegalArgumentException("epoch-boundary block is required");
+        return new ByronBlockProjectionEvent(slot, blockNumber, blockHash, prevBlockHash, null, block);
+    }
+
+    public long slot() { return slot; }
+    public long blockNumber() { return blockNumber; }
+    public String blockHash() { return blockHash; }
+    public String prevBlockHash() { return prevBlockHash; }
+    public ByronMainBlock mainBlock() { return mainBlock; }
+    public ByronEbBlock epochBoundaryBlock() { return epochBoundaryBlock; }
+
+    public boolean isEpochBoundary() { return epochBoundaryBlock != null; }
+}

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/DefaultAccountStateStore.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/DefaultAccountStateStore.java
@@ -49,7 +49,9 @@ import java.util.*;
  * and reward balances with delta-journal rollback support.
  */
 public class DefaultAccountStateStore implements AccountStateStore, AccountStateReadStore,
-        com.bloxbean.cardano.yano.api.rollback.RollbackCapableStore {
+        com.bloxbean.cardano.yano.api.rollback.RollbackCapableStore,
+        com.bloxbean.cardano.yano.api.archive.PointerCredentialSource,
+        com.bloxbean.cardano.yano.api.archive.PointerIndexMaintenance {
 
     // Key prefixes
     public static final byte PREFIX_ACCT = 0x01;
@@ -67,6 +69,49 @@ public class DefaultAccountStateStore implements AccountStateStore, AccountState
     static final byte PREFIX_POOL_REG_SLOT = 0x13;   // pool registration slot: poolHash → slot (long BE)
     static final byte PREFIX_ACCT_REG_SLOT = 0x14;   // stake account registration slot: credType + credHash → slot (long BE)
     static final byte PREFIX_POINTER_ADDR = 0x15;    // pointer address: slot(8) + txIdx(4) + certIdx(4) → credType(1) + credHash(28)
+    /**
+     * Stake deregistration index: credType(1) + credHash(28) + slot(8) → marker.
+     *
+     * <p>Credential-major so "was this credential deregistered between slot A and slot B"
+     * is one seek. {@code PREFIX_STAKE_EVENT} already records deregistrations but is
+     * slot-major, which would make that question a range scan over every event in the
+     * window.
+     *
+     * <p>Exists so pointer-address resolution can answer <em>as of a given slot</em> rather
+     * than as of now. The Shelley ledger removes a credential's {@code ptrs} entries when it
+     * is deregistered, so a pointer address must stop resolving from that slot onward — but
+     * ADR-039 contributor replay may project block N while this store is far ahead of N, and
+     * a mutable "is it registered now" answer would differ between the first pass and the
+     * replay. Append-only slot-keyed records give the same answer both times.
+     */
+    /**
+     * Derived credential-major deregistration index:
+     * credType(1) + credHash(28) + slot(8) + txIdx(2) + certIdx(2) -> marker.
+     *
+     * <p>The <strong>authoritative</strong> record of stake registration and deregistration
+     * remains {@link #PREFIX_STAKE_EVENT}, which is slot-major and carries the event type.
+     * This structure is a pure lookup index over the deregistration subset of that log: it
+     * adds no fact, and it can be rebuilt or verified from the event log alone.
+     *
+     * <p>It exists because pointer-address resolution must answer "was this credential
+     * deregistered strictly after coordinate R and at or before coordinate B" in one seek.
+     * Asking the slot-major log would mean scanning every event in the window.
+     *
+     * <p>The key carries the <em>complete event coordinate</em>, not just the slot. Two
+     * deregistrations of the same credential in one slot are legal (different transactions),
+     * and a slot-only key would collide and lose one. Big-endian packing makes RocksDB byte
+     * order identical to coordinate order, so an ordered seek is an ordered coordinate scan.
+     */
+    static final byte PREFIX_ACCT_DEREG_COORD = 0x16;
+
+    /** Durable marker: the as-of pointer index has been maintained from genesis. */
+    static final byte[] META_POINTER_INDEX_GENESIS =
+            "meta.pointer.index.from-genesis".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+    /** Durable marker: pointer history was cleaned up through the recorded slot. */
+    static final byte[] META_POINTER_INDEX_CLEANED =
+            "meta.pointer.index.cleaned-through".getBytes(java.nio.charset.StandardCharsets.UTF_8);
+
+    private static final byte[] EMPTY_MARKER = new byte[0];
 
     // Epoch-scoped prefixes for reward calculation
     static final byte PREFIX_POOL_BLOCK_COUNT = 0x50;
@@ -712,6 +757,44 @@ public class DefaultAccountStateStore implements AccountStateStore, AccountState
      * Build stake event key: [0x55][slot(8 BE)][txIdx(2 BE)][certIdx(2 BE)][credType(1)][credHash(28)]
      * Slot-first ordering enables efficient range scans for "all events in slot range".
      */
+    /** Full-coordinate key: [prefix][credType][hash(28)][slot(8)][txIdx(2)][certIdx(2)]. */
+    static byte[] acctDeregCoordKey(int credType, String credHash, long slot, int txIdx, int certIdx) {
+        byte[] hash = HexUtil.decodeHexString(credHash);
+        byte[] key = new byte[1 + 1 + hash.length + 8 + 2 + 2];
+        key[0] = PREFIX_ACCT_DEREG_COORD;
+        key[1] = (byte) credType;
+        System.arraycopy(hash, 0, key, 2, hash.length);
+        int off = 2 + hash.length;
+        ByteBuffer.wrap(key, off, 8).order(ByteOrder.BIG_ENDIAN).putLong(slot);
+        ByteBuffer.wrap(key, off + 8, 2).order(ByteOrder.BIG_ENDIAN).putShort((short) txIdx);
+        ByteBuffer.wrap(key, off + 10, 2).order(ByteOrder.BIG_ENDIAN).putShort((short) certIdx);
+        return key;
+    }
+
+    /** Credential prefix, so a seek stays inside one credential's entries. */
+    static byte[] acctDeregCoordPrefix(int credType, String credHash) {
+        byte[] hash = HexUtil.decodeHexString(credHash);
+        byte[] key = new byte[1 + 1 + hash.length];
+        key[0] = PREFIX_ACCT_DEREG_COORD;
+        key[1] = (byte) credType;
+        System.arraycopy(hash, 0, key, 2, hash.length);
+        return key;
+    }
+
+    private static boolean startsWith(byte[] key, byte[] prefix) {
+        if (key.length < prefix.length) return false;
+        for (int i = 0; i < prefix.length; i++) if (key[i] != prefix[i]) return false;
+        return true;
+    }
+
+    /** Decodes (slot, txIdx, certIdx) from a deregistration-index key. */
+    private static long[] coordinateOf(byte[] key, int prefixLength) {
+        long slot = ByteBuffer.wrap(key, prefixLength, 8).order(ByteOrder.BIG_ENDIAN).getLong();
+        int txIdx = ByteBuffer.wrap(key, prefixLength + 8, 2).order(ByteOrder.BIG_ENDIAN).getShort() & 0xFFFF;
+        int certIdx = ByteBuffer.wrap(key, prefixLength + 10, 2).order(ByteOrder.BIG_ENDIAN).getShort() & 0xFFFF;
+        return new long[]{slot, txIdx, certIdx};
+    }
+
     static byte[] stakeEventKey(long slot, int txIdx, int certIdx, int credType, String credHash) {
         byte[] hash = HexUtil.decodeHexString(credHash);
         // 1 prefix + 8 slot + 2 txIdx + 2 certIdx + 1 credType + 28 hash = 42
@@ -2904,6 +2987,181 @@ public class DefaultAccountStateStore implements AccountStateStore, AccountState
         return key;
     }
 
+    // ------------------------------------------------------------------
+    // ADR-039 as-of pointer resolution
+    // ------------------------------------------------------------------
+
+    @Override
+    public java.util.Optional<com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCredential>
+            registrationAt(com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCoordinate coordinate) {
+        if (pointerAddressResolver == null) return java.util.Optional.empty();
+        PointerAddressResolver.StakeCredential credential = pointerAddressResolver.resolve(
+                coordinate.slot(), coordinate.txIndex(), coordinate.certIndex());
+        return credential == null ? java.util.Optional.empty()
+                : java.util.Optional.of(new com.bloxbean.cardano.yano.api.archive.PointerCredentialSource
+                        .PointerCredential(credential.credType(), credential.credHash()));
+    }
+
+    /**
+     * Seeks the derived deregistration index for this credential's first entry strictly after
+     * {@code after}, and reports whether it lies at or before {@code through}.
+     *
+     * <p>One seek bounded by the credential prefix. The upper bound is what makes replay
+     * deterministic: a deregistration recorded later than the block being projected falls
+     * outside the interval and is ignored, so projecting block N yields the same answer
+     * however far this store has since advanced.
+     */
+    @Override
+    public boolean deregisteredWithin(
+            com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCredential credential,
+            com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCoordinate after,
+            com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCoordinate through) {
+        if (credential == null || after.compareTo(through) >= 0) return false;
+        byte[] prefix = acctDeregCoordPrefix(credential.credentialType(), credential.credentialHash());
+        byte[] seek = acctDeregCoordKey(credential.credentialType(), credential.credentialHash(),
+                after.slot(), after.txIndex(), after.certIndex());
+        try (RocksIterator it = db.newIterator(cfState)) {
+            for (it.seek(seek); it.isValid(); it.next()) {
+                byte[] key = it.key();
+                if (!startsWith(key, prefix)) return false;
+                long[] c = coordinateOf(key, prefix.length);
+                var found = new com.bloxbean.cardano.yano.api.archive.PointerCredentialSource
+                        .PointerCoordinate(c[0], (int) c[1], (int) c[2]);
+                // seek() lands on >= ; the interval is strictly greater than `after`.
+                if (found.compareTo(after) <= 0) continue;
+                return found.compareTo(through) <= 0;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.IndexCompleteness completeness() {
+        try {
+            if (db.get(cfState, META_POINTER_INDEX_CLEANED) != null) {
+                return com.bloxbean.cardano.yano.api.archive.PointerCredentialSource
+                        .IndexCompleteness.CLEANED;
+            }
+            return db.get(cfState, META_POINTER_INDEX_GENESIS) != null
+                    ? com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.IndexCompleteness.COMPLETE
+                    : com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.IndexCompleteness.INCOMPLETE;
+        } catch (RocksDBException e) {
+            throw ledgerStateReadFailure("pointer index completeness", e);
+        }
+    }
+
+    /**
+     * Record that the derived index has been maintained from genesis.
+     *
+     * <p>Refused on a chainstate that has already advanced. Asserting completeness there
+     * would claim coverage the index does not have: pre-Conway deregistrations applied
+     * before this point were never indexed, and nothing downstream could detect it.
+     */
+    public void markPointerIndexFromGenesis() {
+        if (getLatestAppliedSlot() > 0) {
+            throw new IllegalStateException("refusing to mark the pointer index complete on a"
+                    + " chainstate that has already advanced; projection history is fresh-sync only");
+        }
+        try (WriteOptions wo = new WriteOptions().setSync(true)) {
+            db.put(cfState, wo, META_POINTER_INDEX_GENESIS, EMPTY_MARKER);
+        } catch (RocksDBException e) {
+            throw new RuntimeException("failed to mark pointer index complete", e);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // ADR-039 pointer index maintenance
+    // ------------------------------------------------------------------
+
+    @Override
+    public com.bloxbean.cardano.yano.api.archive.PointerIndexMaintenance.PointerIndexStatus
+            pointerIndexStatus() {
+        long cleaned = -1;
+        try {
+            byte[] value = db.get(cfState, META_POINTER_INDEX_CLEANED);
+            if (value != null && value.length >= 8) {
+                cleaned = ByteBuffer.wrap(value).order(ByteOrder.BIG_ENDIAN).getLong();
+            }
+        } catch (RocksDBException e) {
+            throw ledgerStateReadFailure("pointer index status", e);
+        }
+        return new com.bloxbean.cardano.yano.api.archive.PointerIndexMaintenance.PointerIndexStatus(
+                completeness(), pointerDeregIndexEntryCount(), pointerDeregIndexBytes(),
+                cleaned < 0 ? java.util.OptionalLong.empty() : java.util.OptionalLong.of(cleaned));
+    }
+
+    /**
+     * Bounded, idempotent removal of derived index entries at or before {@code throughSlot}.
+     *
+     * <p>Scans the whole index prefix because it is credential-major: entries for one slot are
+     * scattered across credentials, so there is no contiguous slot range to drop. The bound
+     * keeps each pass short, and the scan is cheap because the index only ever holds
+     * pre-Conway deregistrations.
+     *
+     * <p>Deletes only the derived index. The authoritative {@code PREFIX_STAKE_EVENT} log is
+     * untouched: reward calculation and deregistered-account detection still read it, and
+     * conflating the two would delete history another subsystem depends on.
+     */
+    @Override
+    public long cleanupPointerIndex(long throughSlot, int maxKeys) {
+        if (maxKeys <= 0) return 0;
+        byte[] prefix = {PREFIX_ACCT_DEREG_COORD};
+        long removed = 0;
+        try (WriteBatch batch = new WriteBatch(); WriteOptions wo = new WriteOptions().setSync(true);
+             RocksIterator it = db.newIterator(cfState)) {
+            for (it.seek(prefix); it.isValid() && removed < maxKeys; it.next()) {
+                byte[] key = it.key();
+                if (!startsWith(key, prefix)) break;
+                // key = [prefix][credType][hash(28)][slot(8)][txIdx(2)][certIdx(2)]
+                int coordinateOffset = key.length - 12;
+                long slot = ByteBuffer.wrap(key, coordinateOffset, 8).order(ByteOrder.BIG_ENDIAN).getLong();
+                if (slot > throughSlot) continue;
+                batch.delete(cfState, key);
+                removed++;
+            }
+            if (removed > 0) db.write(wo, batch);
+        } catch (RocksDBException e) {
+            throw new RuntimeException("pointer index cleanup failed", e);
+        }
+        return removed;
+    }
+
+    @Override
+    public void markPointerIndexCleaned(long throughSlot) {
+        try (WriteOptions wo = new WriteOptions().setSync(true)) {
+            db.put(cfState, wo, META_POINTER_INDEX_CLEANED,
+                    ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(throughSlot).array());
+        } catch (RocksDBException e) {
+            throw new RuntimeException("failed to record pointer index cleanup", e);
+        }
+    }
+
+    /** Derived index entry count, for capacity accounting and measurement. */
+    public long pointerDeregIndexEntryCount() {
+        long count = 0;
+        byte[] prefix = {PREFIX_ACCT_DEREG_COORD};
+        try (RocksIterator it = db.newIterator(cfState)) {
+            for (it.seek(prefix); it.isValid(); it.next()) {
+                if (!startsWith(it.key(), prefix)) break;
+                count++;
+            }
+        }
+        return count;
+    }
+
+    /** Logical bytes held by the derived index; values are empty markers. */
+    public long pointerDeregIndexBytes() {
+        long bytes = 0;
+        byte[] prefix = {PREFIX_ACCT_DEREG_COORD};
+        try (RocksIterator it = db.newIterator(cfState)) {
+            for (it.seek(prefix); it.isValid(); it.next()) {
+                if (!startsWith(it.key(), prefix)) break;
+                bytes += it.key().length + it.value().length;
+            }
+        }
+        return bytes;
+    }
+
     /** Key for pointer address mapping: PREFIX_POINTER_ADDR | slot(8 BE) | txIdx(4 BE) | certIdx(4 BE) */
     private static byte[] pointerAddrKey(long slot, int txIdx, int certIdx) {
         byte[] key = new byte[1 + 8 + 4 + 4];
@@ -3044,6 +3302,13 @@ public class DefaultAccountStateStore implements AccountStateStore, AccountState
         byte[] eventVal = AccountStateCborCodec.encodeStakeEvent(AccountStateCborCodec.EVENT_DEREGISTRATION);
         batch.put(cfState, eventKey, eventVal);
         deltaOps.add(new DeltaOp(OP_PUT, eventKey, null));
+
+        // Derived credential-major index over the deregistration just recorded above, so
+        // pointer resolution can seek rather than scan. Same batch and same delta op as the
+        // authoritative event, so the two can never disagree and rollback removes both.
+        byte[] deregKey = acctDeregCoordKey(ct, cred.getHash(), slot, txIdx, certIdx);
+        batch.put(cfState, deregKey, EMPTY_MARKER);
+        deltaOps.add(new DeltaOp(OP_PUT, deregKey, null));
 
         return depositRefund;
     }

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/PointerIndexAsOfTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/PointerIndexAsOfTest.java
@@ -1,0 +1,243 @@
+package com.bloxbean.cardano.yano.ledgerstate;
+
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCoordinate;
+import com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.PointerCredential;
+import com.bloxbean.cardano.yano.ledgerstate.test.TestRocksDBHelper;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.rocksdb.WriteBatch;
+import org.rocksdb.WriteOptions;
+import org.slf4j.LoggerFactory;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Store-level tests for the ADR-039 as-of pointer index against a real RocksDB.
+ *
+ * <p>Covers the index semantics, the completeness marker, and the crash/idempotency
+ * properties of cleanup. The interval logic itself is exercised more broadly in
+ * archive-core's differential suite; this asserts the persistence behaves as that logic
+ * assumes.
+ */
+class PointerIndexAsOfTest {
+
+    @TempDir Path tempDir;
+    private TestRocksDBHelper rocks;
+    private DefaultAccountStateStore store;
+
+    private static final String CRED_A = "77".repeat(28);
+    private static final String CRED_B = "88".repeat(28);
+
+    @BeforeEach
+    void setUp() throws Exception {
+        rocks = TestRocksDBHelper.create(tempDir);
+        store = new DefaultAccountStateStore(rocks.db(), rocks.cfSupplier(),
+                LoggerFactory.getLogger(PointerIndexAsOfTest.class), true);
+    }
+
+    @AfterEach
+    void tearDown() { rocks.close(); }
+
+    /** Writes an index entry the way the deregistration path does. */
+    private void indexDeregistration(String credHash, long slot, int txIdx, int certIdx) throws Exception {
+        try (WriteBatch batch = new WriteBatch(); WriteOptions wo = new WriteOptions()) {
+            batch.put(rocks.cfState(),
+                    DefaultAccountStateStore.acctDeregCoordKey(0, credHash, slot, txIdx, certIdx),
+                    new byte[0]);
+            rocks.db().write(wo, batch);
+        }
+    }
+
+    private static PointerCredential credential(String hash) {
+        return new PointerCredential(0, hash);
+    }
+
+    private static PointerCoordinate at(long slot, int tx, int cert) {
+        return new PointerCoordinate(slot, tx, cert);
+    }
+
+    // ----------------------------------------------------------- interval logic
+
+    @Test
+    void aDeregistrationInsideTheIntervalIsFound() throws Exception {
+        indexDeregistration(CRED_A, 75, 0, 0);
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(50, 0, 0),
+                PointerCoordinate.endOfBlock(100))).isTrue();
+    }
+
+    @Test
+    void aDeregistrationAfterTheUpperBoundIsIgnored() throws Exception {
+        // This is what makes replay deterministic: the store may be far ahead, but a
+        // deregistration later than the projected block must not affect it.
+        indexDeregistration(CRED_A, 5_000, 0, 0);
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(50, 0, 0),
+                PointerCoordinate.endOfBlock(100))).isFalse();
+    }
+
+    @Test
+    void aDeregistrationBeforeTheRegistrationIsIgnored() throws Exception {
+        // A credential deregistered before this coordinate was registered cannot invalidate it;
+        // the coordinate is from a later re-registration.
+        indexDeregistration(CRED_A, 20, 0, 0);
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(50, 0, 0),
+                PointerCoordinate.endOfBlock(100))).isFalse();
+    }
+
+    @Test
+    void anotherCredentialsDeregistrationIsIgnored() throws Exception {
+        indexDeregistration(CRED_B, 75, 0, 0);
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(50, 0, 0),
+                PointerCoordinate.endOfBlock(100))).isFalse();
+    }
+
+    @Test
+    void sameSlotDeregistrationsDoNotCollide() throws Exception {
+        // Two deregistrations of one credential in one slot, different transactions. A
+        // slot-only key would have kept one and lost the other.
+        indexDeregistration(CRED_A, 75, 0, 0);
+        indexDeregistration(CRED_A, 75, 4, 0);
+        assertThat(store.pointerDeregIndexEntryCount()).isEqualTo(2);
+
+        // A coordinate registered between them is invalidated only by the later one.
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(75, 2, 0),
+                PointerCoordinate.endOfBlock(100))).isTrue();
+        // ...and not by anything at or before itself.
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(75, 4, 0),
+                PointerCoordinate.endOfBlock(100))).isFalse();
+    }
+
+    @Test
+    void theBoundaryIsInclusiveAtTheUpperEndAndExclusiveAtTheLower() throws Exception {
+        indexDeregistration(CRED_A, 100, 3, 1);
+        // exactly at the upper bound -> included
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(50, 0, 0), at(100, 3, 1))).isTrue();
+        // exactly at the lower bound -> excluded
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(100, 3, 1), at(200, 0, 0))).isFalse();
+    }
+
+    @Test
+    void anInvertedIntervalResolvesToFalseRatherThanScanning() throws Exception {
+        indexDeregistration(CRED_A, 75, 0, 0);
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(200, 0, 0), at(100, 0, 0))).isFalse();
+    }
+
+    // ------------------------------------------------------ completeness marker
+
+    @Test
+    void anUnmarkedStoreReportsIncomplete() {
+        assertThat(store.completeness())
+                .isEqualTo(PointerCredentialSource.IndexCompleteness.INCOMPLETE);
+    }
+
+    @Test
+    void markingAtGenesisReportsComplete() {
+        store.markPointerIndexFromGenesis();
+        assertThat(store.completeness())
+                .isEqualTo(PointerCredentialSource.IndexCompleteness.COMPLETE);
+    }
+
+    @Test
+    void aCleanedStoreReportsCleanedNotComplete() {
+        store.markPointerIndexFromGenesis();
+        store.markPointerIndexCleaned(50_000_000);
+        // CLEANED must not read as COMPLETE: resolution has to fail closed, not silently
+        // return "unresolved" from an index that no longer exists.
+        assertThat(store.completeness())
+                .isEqualTo(PointerCredentialSource.IndexCompleteness.CLEANED);
+        assertThat(store.pointerIndexStatus().cleanedThroughSlot()).hasValue(50_000_000L);
+    }
+
+    // ------------------------------------------------------------ cleanup
+
+    @Test
+    void cleanupIsBoundedAndResumable() throws Exception {
+        for (int i = 0; i < 25; i++) indexDeregistration(CRED_A, 100 + i, 0, 0);
+        assertThat(store.pointerDeregIndexEntryCount()).isEqualTo(25);
+
+        long first = store.cleanupPointerIndex(10_000, 10);
+        assertThat(first).isEqualTo(10);
+        assertThat(store.pointerDeregIndexEntryCount()).isEqualTo(15);
+
+        long second = store.cleanupPointerIndex(10_000, 10);
+        assertThat(second).isEqualTo(10);
+        assertThat(store.pointerDeregIndexEntryCount()).isEqualTo(5);
+    }
+
+    @Test
+    void cleanupRespectsTheSlotBound() throws Exception {
+        indexDeregistration(CRED_A, 100, 0, 0);
+        indexDeregistration(CRED_A, 5_000, 0, 0);
+        long removed = store.cleanupPointerIndex(1_000, 100);
+        assertThat(removed).isEqualTo(1);
+        assertThat(store.pointerDeregIndexEntryCount()).isEqualTo(1);
+        // the entry beyond the bound survives
+        assertThat(store.deregisteredWithin(credential(CRED_A), at(0, 0, 0),
+                PointerCoordinate.endOfBlock(10_000))).isTrue();
+    }
+
+    @Test
+    void cleanupIsIdempotentOnRetry() throws Exception {
+        for (int i = 0; i < 5; i++) indexDeregistration(CRED_A, 100 + i, 0, 0);
+        assertThat(store.cleanupPointerIndex(10_000, 100)).isEqualTo(5);
+        // A retry after a crash simply finds nothing left.
+        assertThat(store.cleanupPointerIndex(10_000, 100)).isZero();
+        assertThat(store.cleanupPointerIndex(10_000, 100)).isZero();
+        assertThat(store.pointerDeregIndexEntryCount()).isZero();
+    }
+
+    @Test
+    void aPartialCleanupDoesNotRecordCompletion() throws Exception {
+        for (int i = 0; i < 20; i++) indexDeregistration(CRED_A, 100 + i, 0, 0);
+        store.cleanupPointerIndex(10_000, 5);
+        // Crash here: the marker was never written, so completeness is unchanged and the
+        // remaining entries are still queryable.
+        assertThat(store.pointerIndexStatus().cleanedThroughSlot()).isEmpty();
+        assertThat(store.pointerDeregIndexEntryCount()).isEqualTo(15);
+    }
+
+    @Test
+    void cleanupDoesNotTouchTheAuthoritativeStakeEventLog() throws Exception {
+        // The event log is read by reward calculation and deregistered-account detection.
+        // Cleanup is scoped strictly to the derived index.
+        try (WriteBatch batch = new WriteBatch(); WriteOptions wo = new WriteOptions()) {
+            batch.put(rocks.cfState(),
+                    DefaultAccountStateStore.stakeEventKey(100, 0, 0, 0, CRED_A),
+                    AccountStateCborCodec.encodeStakeEvent(AccountStateCborCodec.EVENT_DEREGISTRATION));
+            rocks.db().write(wo, batch);
+        }
+        indexDeregistration(CRED_A, 100, 0, 0);
+
+        store.cleanupPointerIndex(10_000, 100);
+
+        assertThat(store.pointerDeregIndexEntryCount()).isZero();
+        assertThat(rocks.db().get(rocks.cfState(),
+                DefaultAccountStateStore.stakeEventKey(100, 0, 0, 0, CRED_A)))
+                .as("authoritative stake event must survive index cleanup")
+                .isNotNull();
+    }
+
+    @Test
+    void aZeroOrNegativeBoundRemovesNothing() throws Exception {
+        indexDeregistration(CRED_A, 100, 0, 0);
+        assertThat(store.cleanupPointerIndex(10_000, 0)).isZero();
+        assertThat(store.cleanupPointerIndex(10_000, -1)).isZero();
+        assertThat(store.pointerDeregIndexEntryCount()).isEqualTo(1);
+    }
+
+    // ------------------------------------------------------------ accounting
+
+    @Test
+    void statusReportsEntryCountAndBytesForDiskAccounting() throws Exception {
+        for (int i = 0; i < 8; i++) indexDeregistration(CRED_A, 100 + i, 0, 0);
+        var status = store.pointerIndexStatus();
+        assertThat(status.entryCount()).isEqualTo(8);
+        // 1 prefix + 1 credType + 28 hash + 8 slot + 2 tx + 2 cert = 42 bytes per key, no value
+        assertThat(status.logicalBytes()).isEqualTo(8 * 42);
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/BodyFetchManager.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/BodyFetchManager.java
@@ -24,6 +24,7 @@ import com.bloxbean.cardano.yano.api.events.GenesisBlockEvent;
 import com.bloxbean.cardano.yano.api.events.PostEpochTransitionEvent;
 import com.bloxbean.cardano.yano.api.events.PreEpochTransitionEvent;
 import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
+import com.bloxbean.cardano.yano.api.events.ByronBlockProjectionEvent;
 import com.bloxbean.cardano.yano.api.events.BlockReceivedEvent;
 import com.bloxbean.cardano.yano.api.events.RollbackEvent;
 import com.bloxbean.cardano.yano.api.events.TipChangedEvent;
@@ -894,6 +895,12 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable, Heade
 
             // Publish BlockApplied after storage
             eventBus.publish(new BlockAppliedEvent(Era.Byron, slot, blockNumber, hash, null), appMeta, appOptions);
+            // ADR-039: carry the already-decoded Byron block to projection history on a
+            // dedicated type. BlockAppliedEvent's null block stays a Byron/EBB sentinel
+            // for its existing consumers; this adds a subscriber-free cost when history
+            // is disabled.
+            eventBus.publish(ByronBlockProjectionEvent.main(slot, blockNumber, hash,
+                    byronBlock.getHeader().getPrevBlock(), byronBlock), appMeta, appOptions);
             recordBodyApplied(slot, blockNumber);
 
             // Publish TipChanged if tip advanced
@@ -1037,6 +1044,11 @@ public class BodyFetchManager implements BlockChainDataListener, Runnable, Heade
 
             // Publish BlockApplied after storage
             eventBus.publish(new BlockAppliedEvent(Era.Byron, slot, blockNumber, hash, null), appMeta, appOptions);
+            // ADR-039: an EBB carries no transactions but does occupy a block number, so
+            // it must still produce an empty projection envelope. Without it the
+            // archive's greatest *contiguous* block coordinate would stop at the EBB.
+            eventBus.publish(ByronBlockProjectionEvent.epochBoundary(slot, blockNumber, hash,
+                    byronEbBlock.getHeader().getPrevBlock(), byronEbBlock), appMeta, appOptions);
             recordBodyApplied(slot, blockNumber);
 
             // Publish TipChanged if tip advanced

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderSyncManager.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/HeaderSyncManager.java
@@ -59,6 +59,12 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
     // Backpressure configuration
     private final long maxGapThreshold;  // Maximum gap allowed between header tip and body tip
     private volatile boolean isPaused = false;  // Whether header sync is paused due to backpressure
+    /**
+     * Optional external hold on canonical ingestion (ADR-039 disk backpressure).
+     * Defaults to "never pause", so a node without projection history is unaffected.
+     */
+    private volatile java.util.function.BooleanSupplier ingestHold = () -> false;
+    private volatile String ingestHoldReason = null;
 
     // Progress logging
     private static final int PROGRESS_LOG_INTERVAL = 1000;
@@ -346,6 +352,10 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
      */
     private boolean checkBackpressure(long currentHeaderBlockNumber) {
         try {
+            // An external hold (archive-retained disk at its configured limit) pauses
+            // ingestion regardless of the header/body gap, and the same check governs
+            // resume, so cleanup releasing disk automatically lets sync continue.
+            if (ingestHold.getAsBoolean()) return true;
 
             if (maxGapThreshold == -1)
                 return false; // Backpressure disabled
@@ -452,6 +462,24 @@ public class HeaderSyncManager implements ChainSyncAgentListener {
      */
     public boolean isPaused() {
         return isPaused;
+    }
+
+    /**
+     * Install an external hold on canonical ingestion.
+     *
+     * <p>Used by ADR-039 projection history so a lagging archive sink cannot exhaust the
+     * disk. Canonical sync is <em>not</em> paced by sink speed: this returns true only when
+     * the configured aggregate archive-retained budget or the filesystem free-space reserve
+     * is reached, and the same predicate governs resume once cleanup frees space.
+     */
+    public void setIngestHold(java.util.function.BooleanSupplier hold, String reason) {
+        this.ingestHold = hold == null ? () -> false : hold;
+        this.ingestHoldReason = reason;
+    }
+
+    /** Reason for an externally held ingestion pause, when one is installed. */
+    public String ingestHoldReason() {
+        return ingestHoldReason;
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/RuntimeYano.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/RuntimeYano.java
@@ -123,6 +123,38 @@ final class RuntimeYano implements Yano, DevnetRuntimeProvider {
     }
 
     @Override
+    public boolean installArchiveIngestHold(java.util.function.BooleanSupplier hold, String reason) {
+        return chainQuery instanceof com.bloxbean.cardano.yano.runtime.internal.RuntimeNode node
+                && node.installArchiveIngestHold(hold, reason);
+    }
+
+    @Override
+    public boolean markPointerIndexFromGenesis() {
+        return chainQuery instanceof com.bloxbean.cardano.yano.runtime.internal.RuntimeNode node
+                && node.markPointerIndexFromGenesis();
+    }
+
+    @Override
+    public com.bloxbean.cardano.yano.api.archive.PointerCredentialSource pointerCredentialSource() {
+        return chainQuery instanceof com.bloxbean.cardano.yano.runtime.internal.RuntimeNode node
+                ? node.pointerCredentialSource()
+                : com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.NONE;
+    }
+
+    @Override
+    public boolean installProjectionContributor(
+            com.bloxbean.cardano.yano.api.archive.CanonicalProjectionContributor contributor) {
+        return chainQuery instanceof com.bloxbean.cardano.yano.runtime.internal.RuntimeNode node
+                && node.installProjectionContributor(contributor);
+    }
+
+    @Override
+    public java.util.Optional<com.bloxbean.cardano.yano.api.db.RocksDbAccess> chainstateRocksAccess() {
+        return chainQuery instanceof com.bloxbean.cardano.yano.runtime.internal.RuntimeNode node
+                ? node.chainstateRocksAccess() : java.util.Optional.empty();
+    }
+
+    @Override
     public LedgerQuery ledger() {
         return ledgerQuery;
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/Yano.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/assembly/Yano.java
@@ -57,6 +57,50 @@ public interface Yano extends AutoCloseable {
         return Optional.empty();
     }
 
+    /**
+     * Shared chainstate RocksDB handles, when the chain state is RocksDB-backed.
+     * Used by ADR-039 projection history to place its outbox in the same database as
+     * the state its contributors derive projections from.
+     */
+    default Optional<com.bloxbean.cardano.yano.api.db.RocksDbAccess> chainstateRocksAccess() {
+        return Optional.empty();
+    }
+
+    /**
+     * Install an external hold on canonical ingestion (ADR-039 disk backpressure).
+     * Returns false when this runtime has no active sync manager to hold.
+     */
+    default boolean installArchiveIngestHold(java.util.function.BooleanSupplier hold, String reason) {
+        return false;
+    }
+
+    /**
+     * Record that the as-of pointer index is maintained from genesis. Only valid on an empty
+     * chainstate; the store rejects it otherwise.
+     */
+    default boolean markPointerIndexFromGenesis() {
+        return false;
+    }
+
+    /**
+     * Authoritative pointer-address resolution, owned by the account-state contributor.
+     * Empty when this runtime has no such store; callers then treat every pointer as
+     * unresolved rather than failing.
+     */
+    default com.bloxbean.cardano.yano.api.archive.PointerCredentialSource pointerCredentialSource() {
+        return com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.NONE;
+    }
+
+    /**
+     * Install the ADR-039 projection contributor so block projection sections are staged
+     * inside the contributing subsystem's existing write batch. Returns false when this
+     * runtime has no contributing store.
+     */
+    default boolean installProjectionContributor(
+            com.bloxbean.cardano.yano.api.archive.CanonicalProjectionContributor contributor) {
+        return false;
+    }
+
     default Optional<RuntimeMaintenanceGate> maintenanceGate() {
         return Optional.empty();
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DirectRocksDBChainState.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/chain/DirectRocksDBChainState.java
@@ -16,6 +16,7 @@ import com.bloxbean.cardano.yano.runtime.blockproducer.NonceStateStore;
 import com.bloxbean.cardano.yano.runtime.blockproducer.NonceStateSnapshot;
 import com.bloxbean.cardano.yano.ledgerstate.AccountStateCfNames;
 import com.bloxbean.cardano.yano.runtime.db.RocksDbContext;
+import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
 import com.bloxbean.cardano.yano.runtime.db.RocksDbSupplier;
 import com.bloxbean.cardano.yano.runtime.db.UtxoCfNames;
 import lombok.extern.slf4j.Slf4j;
@@ -176,7 +177,15 @@ public class DirectRocksDBChainState implements ChainState, AutoCloseable, Rocks
                     new ColumnFamilyDescriptor(AccountStateCfNames.ACCT_DELTA.getBytes()),
                     new ColumnFamilyDescriptor(AccountStateCfNames.ACCT_BOUNDARY_DELTA.getBytes()),
                     new ColumnFamilyDescriptor(AccountStateCfNames.EPOCH_DELEG_SNAPSHOT.getBytes()),
-                    new ColumnFamilyDescriptor(AccountStateCfNames.EPOCH_PARAMS.getBytes())
+                    new ColumnFamilyDescriptor(AccountStateCfNames.EPOCH_PARAMS.getBytes()),
+                    // Canonical projection outbox (ADR-039). Declared here so a contributor
+                    // can write its section inside the same WriteBatch as the state it was
+                    // derived from. Created on open, so a node that never enables history
+                    // simply leaves them empty.
+                    new ColumnFamilyDescriptor(ProjectionCfNames.PROJ_HEADER.getBytes(), buildSequentialCfOptions()),
+                    new ColumnFamilyDescriptor(ProjectionCfNames.PROJ_SECTION.getBytes(), buildSequentialCfOptions()),
+                    new ColumnFamilyDescriptor(ProjectionCfNames.PROJ_META.getBytes()),
+                    new ColumnFamilyDescriptor(ProjectionCfNames.PROJ_ARTIFACT.getBytes())
             );
 
             // Open database

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -633,6 +633,79 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
         return chainStorage.rocksDbAccessOrNull();
     }
 
+    /**
+     * Install an external hold on canonical ingestion for ADR-039 disk backpressure.
+     *
+     * <p>Applied to the header sync manager, which is where the node already implements a
+     * pause/resume loop. The same predicate governs both directions, so cleanup freeing disk
+     * resumes ingestion automatically without a second mechanism.
+     *
+     * @return false when no header sync manager is active yet
+     */
+    public boolean installArchiveIngestHold(java.util.function.BooleanSupplier hold, String reason) {
+        if (syncSubsystem == null) return false;
+        // Registered on the subsystem rather than on the current manager: the manager belongs
+        // to a peer session that is replaced on every reconnect, and it does not exist at all
+        // before the node starts. The subsystem remembers the hold and re-applies it.
+        syncSubsystem.setIngestHold(hold, reason);
+        return true;
+    }
+
+    /**
+     * Authoritative pointer-address mapping for ADR-039 projection history.
+     *
+     * <p>Owned by the account-state store, which writes it while applying registration
+     * certificates. The archive therefore no longer needs its own sequential pointer
+     * lifecycle for the projection path.
+     */
+    /**
+     * Record that the as-of pointer index is maintained from genesis.
+     *
+     * <p>Called by projection history when it starts on an empty chainstate. The store refuses
+     * this on a chainstate that has already advanced, so a mid-chain activation cannot claim
+     * completeness it does not have.
+     *
+     * @return false when there is no account-state store to mark
+     */
+    public boolean markPointerIndexFromGenesis() {
+        var store = getDefaultAccountStateStore();
+        if (store.isEmpty()) return false;
+        store.get().markPointerIndexFromGenesis();
+        return true;
+    }
+
+    public com.bloxbean.cardano.yano.api.archive.PointerCredentialSource pointerCredentialSource() {
+        return getDefaultAccountStateStore()
+                .map(store -> (com.bloxbean.cardano.yano.api.archive.PointerCredentialSource) store)
+                .orElse(com.bloxbean.cardano.yano.api.archive.PointerCredentialSource.NONE);
+    }
+
+    /**
+     * Install the ADR-039 projection contributor on the UTXO subsystem.
+     *
+     * <p>Routed through the node rather than {@code NodeKernel.subsystem(...)} because the
+     * kernel is composed of lifecycle stages, not the subsystem instances themselves, so a
+     * type lookup there would silently find nothing.
+     *
+     * @return false when no contributing UTXO store is present, so a caller can fail closed
+     *         rather than assume history is being captured
+     */
+    public boolean installProjectionContributor(
+            com.bloxbean.cardano.yano.api.archive.CanonicalProjectionContributor contributor) {
+        return utxoSubsystem != null && utxoSubsystem.installProjectionContributor(contributor);
+    }
+
+    /**
+     * Shared chainstate RocksDB handles for optional host-side components.
+     *
+     * <p>Exposed for the ADR-039 projection outbox, whose column families live in this
+     * same database precisely so a contributor's projection write is atomic with the
+     * state it derives from. Empty for non-RocksDB chain states.
+     */
+    public java.util.Optional<RocksDbAccess> chainstateRocksAccess() {
+        return java.util.Optional.ofNullable(rocksDbAccessOrNull());
+    }
+
     private EraMetadataStore eraMetadataStoreOrNull() {
         return chainStorage.eraMetadataStoreOrNull();
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/kernel/NodeKernel.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/kernel/NodeKernel.java
@@ -218,6 +218,14 @@ public final class NodeKernel implements AutoCloseable {
         return List.copyOf(result);
     }
 
+    /**
+     * Shared subsystem context. Exposed so optional host-side components (ADR-039
+     * projection history) can reach the event bus without a second bus being created.
+     */
+    public SubsystemContext context() {
+        return context;
+    }
+
     public <T extends Subsystem> Optional<T> subsystem(Class<T> type) {
         for (Subsystem subsystem : subsystems) {
             if (type.isInstance(subsystem)) {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/sync/IngestHoldRegistry.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/sync/IngestHoldRegistry.java
@@ -1,0 +1,57 @@
+package com.bloxbean.cardano.yano.runtime.sync;
+
+import java.util.function.BooleanSupplier;
+
+/**
+ * Remembers an external hold on canonical ingestion and applies it to whichever header sync
+ * manager is current (ADR-039 disk backpressure).
+ *
+ * <p>Exists because the obvious implementation is wrong in two ways that both fail silently:
+ *
+ * <ul>
+ *   <li>the hold is registered during archive initialisation, which runs <em>before</em> the
+ *       node starts and therefore before any manager exists — a direct install simply does
+ *       nothing;</li>
+ *   <li>the manager belongs to a peer session that is <em>recreated on every reconnect</em>,
+ *       so even a correctly ordered install is lost the first time upstream drops — precisely
+ *       when a backlog is most likely to have grown.</li>
+ * </ul>
+ *
+ * <p>Registration is therefore decoupled from application: the hold is stored whenever it
+ * arrives, and applied whenever a manager appears.
+ */
+final class IngestHoldRegistry {
+
+    private volatile BooleanSupplier hold;
+    private volatile String reason;
+
+    /**
+     * Whatever can accept a hold. Narrow on purpose: the registry has no reason to know about
+     * the sync manager's other 40-odd methods, and depending on the concrete type would make
+     * this logic untestable without the whole peer-session machinery.
+     */
+    @FunctionalInterface
+    interface HoldTarget {
+        void setIngestHold(BooleanSupplier hold, String reason);
+    }
+
+    /** Store a hold. Safe before the node starts; applied when a target appears. */
+    void register(BooleanSupplier hold, String reason) {
+        this.hold = hold;
+        this.reason = reason;
+    }
+
+    /** Apply the stored hold, if any. Called on registration and again per peer session. */
+    void applyTo(HoldTarget target) {
+        BooleanSupplier current = hold;
+        if (target != null && current != null) target.setIngestHold(current, reason);
+    }
+
+    boolean isRegistered() {
+        return hold != null;
+    }
+
+    String reason() {
+        return reason;
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/sync/SyncSubsystem.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/sync/SyncSubsystem.java
@@ -1930,7 +1930,30 @@ public final class SyncSubsystem implements Subsystem, PeerSessionCallbacks {
                 headerValidator,
                 bodyValidator);
         session.setGenesisBootstrapDataSupplier(genesisBootstrapDataSupplier);
+        // Re-apply any external ingestion hold. A peer session is recreated on reconnect, so
+        // installing the hold once on the first manager would silently lose it the first time
+        // the upstream drops — exactly when a backlog is most likely to have grown.
+        applyIngestHold(session.getHeaderSyncManager());
         return session;
+    }
+
+    /**
+     * External hold on canonical ingestion (ADR-039 disk backpressure), remembered so it
+     * survives both pre-start registration and peer-session replacement.
+     */
+    private final IngestHoldRegistry ingestHolds = new IngestHoldRegistry();
+
+    /**
+     * Install the hold and apply it to the current session, if any. Safe to call before the
+     * node starts: the hold is stored and applied when a session is created.
+     */
+    public void setIngestHold(java.util.function.BooleanSupplier hold, String reason) {
+        ingestHolds.register(hold, reason);
+        applyIngestHold(currentHeaderSyncManager());
+    }
+
+    private void applyIngestHold(HeaderSyncManager manager) {
+        ingestHolds.applyTo(manager == null ? null : manager::setIngestHold);
     }
 
     private record ConfiguredUpstreamPeer(String id,

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/DefaultUtxoStore.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/DefaultUtxoStore.java
@@ -22,6 +22,8 @@ import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 import com.bloxbean.cardano.yano.api.plugin.UtxoFilterContext;
 import com.bloxbean.cardano.yano.api.util.StoredBlockUtil;
+import com.bloxbean.cardano.yano.api.archive.CanonicalProjectionContributor;
+import com.bloxbean.cardano.yano.api.archive.ConsumedOutputAddresses;
 import com.bloxbean.cardano.yano.runtime.db.RocksDbSupplier;
 import com.bloxbean.cardano.yano.runtime.db.UtxoCfNames;
 import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
@@ -96,8 +98,42 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
     private volatile long lastBlockSize = 0L;
     private final AtomicReference<java.util.Map<String, Long>> cfEstimates = new AtomicReference<>(java.util.Map.of());
 
+    /** Shared RocksDB context, cached so the projection hook resolves handles without reallocating. */
+    private volatile com.bloxbean.cardano.yano.runtime.db.RocksDbContext rocksContext;
+    /** ADR-039 projection contributor; NOOP unless history is enabled. */
+    private volatile CanonicalProjectionContributor projectionContributor = CanonicalProjectionContributor.NOOP;
+
+    // ADR-039 gate 1 instrument. Cross-run wall-clock A/B legs cannot resolve a 5% effect on a
+    // shared host - measured spread was 16-49% - so the projection's cost is attributed
+    // *within* a single run instead: time spent inside the contributor against time spent in
+    // the whole block apply, both measured on the same thread in the same run. Cross-run
+    // variance cancels completely because there is no second run.
+    //
+    // Thread CPU time would be preferable but is unavailable here: applyBlock runs on a
+    // virtual thread, where ThreadMXBean reports no CPU time. Wall time is a good substitute
+    // for this particular ratio because the contributor performs no I/O - it stages into an
+    // in-memory WriteBatch - so its wall time is essentially its CPU time, while the
+    // denominator legitimately includes the RocksDB write that projection also inflates.
+    //
+    // This measures the *apply-stage* share. RocksDB write amplification from the extra column
+    // families is captured separately as a disk measurement (~1.4x logical).
+    /** Stable key for a consumed outpoint; hex id plus index, which is already how inputs arrive. */
+    private static String consumedKey(String txHash, int outputIndex) {
+        return txHash + '#' + outputIndex;
+    }
+
+    private final java.util.concurrent.atomic.LongAdder applyNanos = new java.util.concurrent.atomic.LongAdder();
+    private final java.util.concurrent.atomic.LongAdder projectionNanos = new java.util.concurrent.atomic.LongAdder();
+    private final java.util.concurrent.atomic.LongAdder attributedBlocks = new java.util.concurrent.atomic.LongAdder();
+    // Full per-block cycle: apply plus the gap until the next block reaches apply. Recording it
+    // here means the projection's share of *sync* - not just of apply - is reported by the node
+    // rather than derived by hand from a throughput figure taken over a different window.
+    private final java.util.concurrent.atomic.LongAdder cycleNanos = new java.util.concurrent.atomic.LongAdder();
+    private long previousApplyStartNanos;
+
     public DefaultUtxoStore(RocksDbSupplier supplier, Logger logger, java.util.Map<String, Object> config) {
         this.supplier = supplier;
+        this.rocksContext = supplier.rocks();
         this.db = supplier.rocks().db();
         this.log = logger;
         Object ev = config != null ? config.getOrDefault(YanoPropertyKeys.Utxo.ENABLED, Boolean.TRUE) : Boolean.TRUE;
@@ -149,12 +185,21 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
     }
 
     /**
+     * Install the ADR-039 projection contributor. Called once during composition when
+     * history is enabled; otherwise the store keeps the NOOP contributor.
+     */
+    public void setProjectionContributor(CanonicalProjectionContributor contributor) {
+        this.projectionContributor = contributor == null ? CanonicalProjectionContributor.NOOP : contributor;
+    }
+
+    /**
      * Reinitialize DB and CF handles from the supplier after a snapshot restore.
      * The supplier's underlying RocksDB has been closed and reopened, so all
      * cached handles are stale.
      */
     public synchronized void reinitialize() {
         var ctx = supplier.rocks();
+        this.rocksContext = ctx;
         this.db = ctx.db();
         this.cfUnspent = ctx.handle(UtxoCfNames.UTXO_UNSPENT);
         this.cfSpent = ctx.handle(UtxoCfNames.UTXO_SPENT);
@@ -709,6 +754,13 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
         if (!enabled) return;
         if (e.block() == null) return; // header-only or EBB
         long t0 = System.nanoTime();
+        long projectionCpu = 0L;
+        // Addresses of the outputs this block consumes, captured while they are still current.
+        // Only collected when a contributor actually needs them (the address-transaction
+        // section); otherwise this stays null and costs one reference check per input.
+        java.util.Map<String, String> consumedAddresses =
+                projectionContributor.enabled() && projectionContributor.needsConsumedOutputAddresses()
+                        ? new java.util.HashMap<>() : null;
 
         // Determine Allegra bootstrap outpoints to remove (before ctx is created).
         // These are collected here but written into the block's WriteBatch for atomicity.
@@ -812,6 +864,10 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
                                 batch.put(cfSpent, key, spentVal);
                                 batch.delete(cfUnspent, key);
                                 var stored = UtxoCborCodec.decodeUtxoRecord(prev);
+                                if (consumedAddresses != null) {
+                                    consumedAddresses.put(
+                                            consumedKey(in.getTransactionId(), in.getIndex()), stored.address);
+                                }
                                 if (indexAddressHash) {
                                     byte[] akey = UtxoKeyUtil.addrHash28(stored.address);
                                     byte[] aIdx = UtxoKeyUtil.addressIndexKey(akey, stored.slot, in.getTransactionId(), in.getIndex());
@@ -860,6 +916,14 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
                             batch.put(cfUnspent, outKey, val);
                             // Track for intra-block spend detection
                             intraBlockOutputs.put(tx.getTxHash() + ":" + outIdx, val);
+                            // Capture on creation as well as on spend. An output created and
+                            // consumed inside one block is never read back from the store, so
+                            // the spend path alone leaves it unresolvable - observed on preprod
+                            // block 1,809,762, where an invalid transaction's collateral return
+                            // is spent in the same block.
+                            if (consumedAddresses != null) {
+                                consumedAddresses.put(consumedKey(tx.getTxHash(), outIdx), out.getAddress());
+                            }
                             if (referenceScriptHash != null && out.getScriptRef() != null) {
                                 batch.put(cfScriptRef, referenceScriptHash, HexUtil.decodeHexString(out.getScriptRef()));
                             }
@@ -904,6 +968,10 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
                                 batch.put(cfSpent, key, spentVal);
                                 batch.delete(cfUnspent, key);
                                 var stored = UtxoCborCodec.decodeUtxoRecord(prev);
+                                if (consumedAddresses != null) {
+                                    consumedAddresses.put(
+                                            consumedKey(in.getTransactionId(), in.getIndex()), stored.address);
+                                }
                                 if (indexAddressHash) {
                                     byte[] akey = UtxoKeyUtil.addrHash28(stored.address);
                                     byte[] aIdx = UtxoKeyUtil.addressIndexKey(akey, stored.slot, in.getTransactionId(), in.getIndex());
@@ -936,6 +1004,9 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
 
                         byte[] outKey = UtxoKeyUtil.outpointKey(tx.getTxHash(), outIdx);
                         batch.put(cfUnspent, outKey, val);
+                        if (consumedAddresses != null) {
+                            consumedAddresses.put(consumedKey(tx.getTxHash(), outIdx), out.getAddress());
+                        }
                         if (referenceScriptHash != null && out.getScriptRef() != null) {
                             batch.put(cfScriptRef, referenceScriptHash, HexUtil.decodeHexString(out.getScriptRef()));
                         }
@@ -965,6 +1036,26 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
             batch.put(cfMeta, META_LAST_APPLIED_SLOT, ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(slot).array());
             batch.put(cfMeta, META_LAST_APPLIED_BLOCK, ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(blockNo).array());
             applyStakeBalanceDeltas(batch, stakeBalanceDeltas);
+            // ADR-039: stage this block's projection sections into the SAME batch as the
+            // UTXO state they were derived from. That is the whole atomicity argument —
+            // a section cannot become durable without its state, or the reverse — and it
+            // avoids any transaction spanning chain, UTXO and ledger. When history is
+            // disabled this is one predictable false check.
+            if (projectionContributor.enabled()) {
+                long projectionCpu0 = metricsEnabled ? System.nanoTime() : 0L;
+                java.util.Map<String, String> captured = consumedAddresses;
+                ConsumedOutputAddresses consumed = captured == null
+                        ? ConsumedOutputAddresses.NONE
+                        : (txHash, outputIndex) -> captured.get(consumedKey(txHash, outputIndex));
+                projectionContributor.contributeBlock(e, consumed, (cf, key, value) -> {
+                    try {
+                        batch.put(rocksContext.handle(cf), key, value);
+                    } catch (RocksDBException rex) {
+                        throw new RuntimeException("Failed to stage projection record in UTXO batch", rex);
+                    }
+                });
+                if (metricsEnabled) projectionCpu = System.nanoTime() - projectionCpu0;
+            }
             db.write(wo, batch);
 
             if (log.isDebugEnabled()) {
@@ -973,6 +1064,14 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
                 } else {
                     log.debug("UTXO applied: block={} slot={} created={} spent={} era={}", blockNo, slot, createdRefs.size(), spentRefs.size(), e.era());
                 }
+            }
+            if (metricsEnabled) {
+                applyNanos.add(System.nanoTime() - t0);
+                projectionNanos.add(projectionCpu);
+                attributedBlocks.increment();
+                // Skip the first block: there is no previous start to measure a cycle against.
+                if (previousApplyStartNanos != 0) cycleNanos.add(t0 - previousApplyStartNanos);
+                previousApplyStartNanos = t0;
             }
             if (metricsEnabled) {
                 long dtMs = (System.nanoTime() - t0) / 1_000_000L;
@@ -1940,6 +2039,28 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
         java.util.Map<String, Object> m = new HashMap<>();
         m.put("apply.ms.avg", avg);
         m.put("apply.ms.p95", p95);
+        // ADR-039 gate 1: the projection's share of block-apply time, attributed within the
+        // run rather than inferred by differencing two runs. Cumulative since start, so it is
+        // a stable ratio rather than a noisy instantaneous one.
+        long attributed = attributedBlocks.sum();
+        if (attributed > 0) {
+            long applyNs = applyNanos.sum();
+            long projNs = projectionNanos.sum();
+            long cycleNs = cycleNanos.sum();
+            m.put("apply.ns.avg", applyNs / attributed);
+            m.put("projection.ns.avg", projNs / attributed);
+            m.put("projection.applyShare", applyNs == 0 ? 0.0 : (double) projNs / applyNs);
+            m.put("attributedBlocks", attributed);
+            if (cycleNs > 0) {
+                m.put("cycle.ns.avg", cycleNs / attributed);
+                m.put("apply.cycleShare", (double) applyNs / cycleNs);
+                // The gate-1 number: an upper bound on the sync-throughput cost of projection
+                // staging. An upper bound rather than a point estimate because it assumes apply
+                // sits wholly on the critical path; where pipeline stages overlap, removing the
+                // projection would recover less than this.
+                m.put("projection.cycleShare", (double) projNs / cycleNs);
+            }
+        }
         m.put("apply.created.last", lastApplyCreated);
         m.put("apply.spent.last", lastApplySpent);
         m.put("throughput.blocksPerSec", bps);

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoSubsystem.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoSubsystem.java
@@ -80,6 +80,21 @@ public final class UtxoSubsystem implements Subsystem {
         return "utxo";
     }
 
+    /**
+     * Install the ADR-039 projection contributor so block projection sections are staged
+     * inside the UTXO store's existing per-block write batch. Returns false when the
+     * configured store cannot contribute, so a caller cannot assume history is being
+     * captured when it is not.
+     */
+    public boolean installProjectionContributor(
+            com.bloxbean.cardano.yano.api.archive.CanonicalProjectionContributor contributor) {
+        if (utxoStore instanceof DefaultUtxoStore defaultStore) {
+            defaultStore.setProjectionContributor(contributor);
+            return true;
+        }
+        return false;
+    }
+
     public UtxoStoreWriter store() {
         return utxoStore;
     }

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/sync/IngestHoldRegistryTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/sync/IngestHoldRegistryTest.java
@@ -1,0 +1,136 @@
+package com.bloxbean.cardano.yano.runtime.sync;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ADR-039 disk backpressure registration.
+ *
+ * <p>These cover the two failure modes that were both silent in production: the hold being
+ * registered before any header sync manager exists, and the manager being replaced on
+ * reconnect. The live preprod run logged "disk backpressure could not be installed" for
+ * exactly the first reason, while {@code /status} still reported a healthy gate decision — so
+ * the gate looked fine while nothing was actually attached.
+ */
+class IngestHoldRegistryTest {
+
+    /** Records what was installed, standing in for a header sync manager. */
+    private static final class RecordingTarget implements IngestHoldRegistry.HoldTarget {
+        private final List<BooleanSupplier> holds = new ArrayList<>();
+        private final List<String> reasons = new ArrayList<>();
+
+        @Override
+        public void setIngestHold(BooleanSupplier hold, String reason) {
+            holds.add(hold);
+            reasons.add(reason);
+        }
+
+        int installs() {
+            return holds.size();
+        }
+
+        BooleanSupplier lastHold() {
+            return holds.get(holds.size() - 1);
+        }
+
+        String lastReason() {
+            return reasons.get(reasons.size() - 1);
+        }
+    }
+
+    @Test
+    void registrationBeforeAnyManagerExistsIsRemembered() {
+        var registry = new IngestHoldRegistry();
+        registry.register(() -> true, "disk limit");
+
+        assertThat(registry.isRegistered())
+                .as("archive init runs before the node starts; the hold must survive that")
+                .isTrue();
+        assertThat(registry.reason()).isEqualTo("disk limit");
+    }
+
+    @Test
+    void applyingWithNoManagerIsSafeAndKeepsTheRegistration() {
+        var registry = new IngestHoldRegistry();
+        registry.register(() -> true, "disk limit");
+        registry.applyTo(null);
+        assertThat(registry.isRegistered()).isTrue();
+    }
+
+    @Test
+    void theHoldIsAppliedWhenAManagerAppears() {
+        var registry = new IngestHoldRegistry();
+        BooleanSupplier hold = () -> true;
+        registry.register(hold, "disk limit");
+
+        var target = new RecordingTarget();
+        registry.applyTo(target);
+        assertThat(target.installs()).isEqualTo(1);
+        assertThat(target.lastHold()).isSameAs(hold);
+        assertThat(target.lastReason()).isEqualTo("disk limit");
+    }
+
+    @Test
+    void theHoldIsReappliedAfterPeerSessionReplacement() {
+        // A reconnect builds a new manager. Without re-application the hold would be lost
+        // exactly when a backlog is most likely to have grown.
+        var registry = new IngestHoldRegistry();
+        BooleanSupplier hold = () -> true;
+        registry.register(hold, "disk limit");
+
+        var first = new RecordingTarget();
+        var second = new RecordingTarget();
+        registry.applyTo(first);
+        registry.applyTo(second);
+
+        assertThat(first.installs()).isEqualTo(1);
+        assertThat(second.installs()).isEqualTo(1);
+        assertThat(second.lastHold()).isSameAs(hold);
+    }
+
+    @Test
+    void noHoldRegisteredMeansNothingIsInstalled() {
+        var registry = new IngestHoldRegistry();
+        var target = new RecordingTarget();
+        registry.applyTo(target);
+        assertThat(target.installs()).isZero();
+        assertThat(registry.isRegistered()).isFalse();
+    }
+
+    @Test
+    void theRegisteredSupplierIsEvaluatedLiveNotCaptured() {
+        // The gate re-evaluates against current usage, so the supplier must be consulted each
+        // time rather than its value snapshotted at registration.
+        var registry = new IngestHoldRegistry();
+        var paused = new AtomicBoolean(false);
+        registry.register(paused::get, "disk limit");
+
+        var target = new RecordingTarget();
+        registry.applyTo(target);
+
+        assertThat(target.lastHold().getAsBoolean()).isFalse();
+        paused.set(true);
+        assertThat(target.lastHold().getAsBoolean())
+                .as("hard limit reached later must be observed by the installed hold")
+                .isTrue();
+    }
+
+    @Test
+    void reRegistrationReplacesTheHold() {
+        var registry = new IngestHoldRegistry();
+        registry.register(() -> false, "first");
+        registry.register(() -> true, "second");
+        assertThat(registry.reason()).isEqualTo("second");
+
+        var target = new RecordingTarget();
+        registry.applyTo(target);
+        assertThat(target.lastReason()).isEqualTo("second");
+        assertThat(target.lastHold().getAsBoolean()).isTrue();
+    }
+}


### PR DESCRIPTION
> **DRAFT.** Full suite and `:app:quarkusBuild` are now **green** (13m 24s, bounded).
> Draft status is retained pending your review of the correctness fixes below rather than for
> any outstanding failure.

## Dependency stack

```
main
└── #67  fix/adr-034-review-hardening         ADR-034 hardening
    └── #76  feat/adr-038-archive-throughput  ADR-038 throughput
        └── THIS PR  ADR-039 Phases 0–4b
            └── ADR-039 Phase 5               (child, opens next)
```

This PR targets **`feat/adr-038-archive-throughput`**, so its diff is ADR-039 work alone —
13 commits, 128 files. **Merge #67, then #76, before this.** Conflicts against `main` will be
resolved at the lowest affected layer and propagated upward, not by merging `main` into each
branch.

## Correctness fixes from review

Four defects were found by review after the branch was first pushed. Each is fixed with tests;
listing them because three were mine and the fourth was inherited.

**1. The startup guard was given fabricated sink state.** It received `sinkEmpty=true`, no
identity and coordinate `NONE`, assembled *before* the sink was opened, which made the dangerous
case unreachable. An outbox that had acknowledged and pruned five million blocks, pointed at a
history directory that had been deleted or moved, would have been accepted: a fresh empty archive
created, draining resumed after the acknowledged point, and blocks `0..5,000,000` existing
nowhere while the archive reported itself healthy.

The sink is now opened and inspected first, and the guard refuses an empty sink when the outbox
has acknowledged anything, or a sink coordinate behind that acknowledgement — the gap between
them cannot be refilled, because acknowledging is what pruned it. A sink *ahead* is still
accepted; that is the crash-between-commit-and-acknowledge case, which replays against the
durable receipt.

**2. Artifact cleanup deleted its own reconciliation record first.** Acknowledgement ran after the
outbox acknowledged the range — but acknowledging the range deletes the artifact references with
it. A crash in that gap pinned the artifact's source forever, and startup could not repair it
because the record it would repair from had just been deleted. Artifacts are now released first,
against a verified receipt; the reader contract is documented idempotent, so a crash costs a
repeated release rather than a permanent leak. Three crash tests cover it.

**3. Shutdown could close the sink out from under an in-flight commit.** Interrupting a thread
does not abort a JDBC call. An earlier revision waited and then closed anyway, which narrows the
race without removing it. Every sink touch now holds a lifecycle lock, and shutdown closes only
if it can take that same lock; if it cannot, the sink is left open for the process to take with
it. Five deterministic tests with a fake sink that blocks inside a commit prove close is **not
called at all** while busy, that the commit completes, and that the sink closes exactly once.

Note that the wait *will* expire in normal operation: a maintenance pass can legitimately run for
housekeeping plus compaction — 30 s + 300 s at defaults. That is now a reported incomplete
shutdown rather than a corrupted connection.

**4. Maintenance reported unmeasured figures as zero.** File and byte counts came from SQL that
can fail against a locked catalog, and every failure became `0` — producing the diagnostic
`files 35 -> 0`, which reads as a catastrophic deletion when it means the measurement was never
taken. They are now `OptionalLong`, and a pass abandons after any failed housekeeping call rather
than continuing on a connection whose transaction context may be ruined.

## The retention test

Preserved verbatim before diagnosis in `adr/reports/adr-039-samples/pinned-reader-failure-2026-08-21.md`.

**The test was wrong, not the implementation.** It required the diagnostic to name
`expire_snapshots` specifically; under contention compaction reached the pinned reader's lock
first. The safety property held throughout — every operation refused with `database is locked`, so
nothing was expired or deleted. It now asserts the invariant (reader's rows intact, fresh reader
correct, no false success, no fabricated zeros, recovery after release) rather than which step
lost the race, so a future DuckLake that can safely expire unrelated snapshots will not break it.

## A hang inherited from the parent stack

`PluginOperationsRegistryTest.processFatalActivationCommitRetainsPrimaryAndRollsBackOwnedProduct`
deadlocked a test worker for ~21 hours: it waits for samples to drain **while holding the lock a
sampler needs to release itself**. `PluginOperationsRegistry` is untouched by ADR-039. Thread dump
preserved in `adr/reports/adr-039-samples/`. The deadlock is race-dependent — the same test passed
in 8 seconds on re-run — so bounded test timeouts were added (10 min per test, 45 min per task) and
verified: a blocking probe now fails with `TimeoutException` instead of hanging.

## Why

The replay-worker archive re-decodes every block a second time, on its own schedule, behind a contended writer. ADR-039 inverts that: the subsystem that already applied a block stages the facts it derived, atomically, inside the write batch it was already committing. Nothing is decoded twice, and a section cannot become durable without the state it came from.

```
canonical apply ──stage sections in the SAME WriteBatch──► outbox (RocksDB CFs)
                                                             │
                                    finality gate (4,320) ───┤
                                                             ▼
                                              ordered drain ─► one primary sink (DuckLake)
                                                             │
                                              durable receipt ──► acknowledge, then prune
```

Three properties do the work:

- **Per-contributor atomicity, no global transaction.** All subsystems already share one RocksDB and one descriptor list, so adding four projection column families makes `batch.put(cfProjection, …)` atomic with `cfUnspent` for free.
- **The envelope is derived at read time, not promised at write time.** A contributor cannot manifest a section it does not own, so a manifest can never claim a chunk that is absent.
- **Acknowledgement follows a verified durable receipt**, never the sink's current maximum block. Cleanup is authorised by the receipt alone.

## What is validated, and on what evidence

**Two independent genesis syncs produce byte-identical archives.** Different jars, different section sets, different crash histories. Over blocks 4,050,000–4,060,000, an MD5 over `tx_hash, output_index, address, lovelace`:

```
four-section  29,622 rows  total_lovelace 742,204,167,219,202,983  digest 796ad040a0f9ecca03ceaff86bc71ce1
two-section   29,622 rows  total_lovelace 742,204,167,219,202,983  digest 796ad040a0f9ecca03ceaff86bc71ce1
```

**Full preprod sync to tip with all four datasets** — contributor lag 0 throughout, backlog pinned at exactly the 4,320-block finality window, 0 drain failures.

**Recovery**: graceful restart, `kill -9` at tip mid-batch, and restart with a batch lingering. In every case the acknowledged point is unchanged and the buffered batch is rebuilt from the outbox — a lingering batch has no durable footprint, so nothing is lost and nothing is double-committed.

**Differential parity** against the legacy datasets across 21 fixtures, including seven certificate fixtures added because the existing fourteen contain no certificates at all — parity between two empty row sets proves nothing, so each states the row count it expects.

**Memory bound, measured rather than asserted.** Peak retained heap during row materialisation, all four sections:

```
  5 envelopes ->  28,700 rows, peak 2,436 KiB
100 envelopes -> 574,000 rows, peak 2,571 KiB     <- 20x the batch, 5.5% more heap
```

**Batching and compaction.** Commits are `N blocks OR T elapsed`: 10,000/30 s bootstrap, 50/15 min near tip, with the regime derived from drain backlog rather than a separate sync signal. Compaction on the completed archive: **69,375 → 1,799 active files**, per-table medians from tens of KiB to low MiB.

## Defects this found that unit tests did not

Both were found only by running on a real chain, which is the argument for doing so before mainnet:

1. **The address projection could not resolve an output created and spent in the same block.** Addresses were captured only on the spend path. Fixed by capturing at creation too.
2. **A pre-existing UTXO correctness bug** — a collateral return spent in its own block leaves a phantom unspent output. Reported as #74 and fixed independently in #75 against `main`; **deliberately not merged or duplicated here**.

## Configuration

- **`yano.history.projection.sections` now defaults to every shipped block dataset.** The section set is part of the archive identity, so a dataset omitted at fresh sync cannot be added later — an archive missing one looks healthy until a query returns nothing, and the remedy is a full resync. Narrowing it is documented as a legacy/testing configuration.
- New profile `app/config/application-projection.yml`, explicit that it **replaces** the `history` profile rather than supplementing it — both write the same DuckLake tables from different pipelines.
- Sink options moved to `projection.sink-options.*`, because `projection.sink` is itself a scalar.

## Rebuild implications

**Fresh sync only.** The identity fingerprint is `network | sink | version | sorted section names`, checked in both the outbox and the archive. A node configured differently from the archive it opens fails closed rather than appending rows of a second shape into the same tables. Consequences:

- adding a dataset later requires a resync from genesis;
- bumping any dataset's `projectionVersion` (a column change) invalidates every existing archive on that dataset.

## Known limitations

- **Gate 1 (≤5% core regression) is bounded, not met.** Attribution inside a single run puts projection at **at most 6.3% of sync throughput** over 2.27M blocks — an upper bound, since it assumes apply is wholly on the critical path. The pre-optimisation −14.1% is not the current cost, but the bound straddles the budget.
- Gate 4's bytes-per-block model was derived with two sections and understates a four-dataset node (**1.42×** on logical archive size).
- `PointerHistoryCleanupPolicy` is implemented and tested but **has no production caller** — the index is 0.68 MiB on preprod, so there is nothing worth reclaiming. Marked unwired in its javadoc.
- The artifact-lease reconciliation gap (§11 case 9) is identified, not fixed; it cannot be exercised until Phase 5 produces artifacts and must ship with the first one.
- Parity fixtures not yet covered: reference scripts, Byron genesis output resolution, era transitions, rollback across an epoch boundary.
- Near tip a block is final and durable but not queryable in DuckLake for **linger + at most one compaction budget** (15 + 5 min at defaults). Phase 6 must serve that window from recent storage or report coverage honestly.

## Remaining phases

| Phase | State |
|---|---|
| 5 — epoch artifacts | next, as a stacked child PR off this branch |
| 6 — operational/API cutover | not started |
| 7 — remove superseded pipelines | blocked until Phase 6 parity is validated |
| 8 — standalone SQLite sink | **deferred, out of scope.** `ProjectionSink` / `ProjectionSinkProvider` are retained so it stays buildable |

## References

- ADR: `adr/in-progress/039-canonical-projection-outbox.md`
- Handoff and validation: `adr/reports/adr-039-handoff-2026-08-20.md`
- Measurements: `adr/reports/adr-039-measurements-2026-08-20.md`
- Memory invariant: `adr/reports/adr-039-memory-invariant-2026-08-20.md`
- Granularity/compaction: `adr/reports/adr-039-parquet-granularity-brief-2026-08-20.md`
- Pointer resolution: `adr/reports/adr-039-pointer-resolution-2026-08-20.md`, `adr-039-pointer-index-measurements-2026-08-20.md`
- The UTXO bug found in passing: `adr/reports/adr-039-utxo-collateral-return-leak-2026-08-20.md`, #74, #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XzUX12rnTGJ4JPfbSCXv7T
