### PR TITLE
Post-validation cleanup for ADR-048

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Yano's initial goal is to fill three roles:
 
 ### Requirements
 
-- **JDK 25** (Temurin or Oracle GraalVM 25; GraalVM is required only for native image builds)
+- **JDK 25** (Temurin or Oracle GraalVM); native image builds require **Oracle GraalVM 25.3**
 - Gradle 9.4.1 (use the bundled `./gradlew`)
 
 ### Build
@@ -160,7 +160,7 @@ binary (`app/build/yano`).
 ## Native image (GraalVM)
 
 ```bash
-# JAVA_HOME must point at GraalVM Java 25
+# JAVA_HOME must point at Oracle GraalVM 25.3
 ./gradlew :app:build -Dquarkus.profile=native
 ./app/build/yano -Dquarkus.profile=devnet -Dquarkus.http.port=7070
 ```

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
@@ -25,6 +25,7 @@ import com.bloxbean.cardano.yano.api.config.UpstreamValidationConfig;
 import com.bloxbean.cardano.yano.api.config.UpstreamValidationStartConfig;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.api.config.YanoPropertyKeys;
+import com.bloxbean.cardano.yano.api.db.IncompatibleChainStateException;
 import com.bloxbean.cardano.yano.api.plugin.PluginCatalogView;
 import com.bloxbean.cardano.yano.api.plugin.operations.PluginOperationsView;
 import com.bloxbean.cardano.yano.app.bootstrap.BootstrapConfigParser;
@@ -1048,6 +1049,13 @@ public class YanoProducer {
                 log.error(sanitized.getMessage());
                 throw sanitized;
             }
+            IncompatibleChainStateException incompatibleChainState =
+                    incompatibleChainStateFailure(e);
+            if (incompatibleChainState != null) {
+                log.error("YANO_STARTUP_FAILURE code=INCOMPATIBLE_CHAINSTATE");
+                log.error(incompatibleChainState.getMessage());
+                throw incompatibleChainState;
+            }
             if (e instanceof Error error) {
                 throw error;
             }
@@ -1064,6 +1072,18 @@ public class YanoProducer {
 
     static boolean isPluginStartupFailure(Throwable failure) {
         return pluginStartupFailure(failure) != null;
+    }
+
+    private static IncompatibleChainStateException incompatibleChainStateFailure(
+            Throwable failure) {
+        Throwable current = failure;
+        while (current != null) {
+            if (current instanceof IncompatibleChainStateException incompatible) {
+                return incompatible;
+            }
+            current = current.getCause();
+        }
+        return null;
     }
 
     private static Throwable pluginStartupFailure(Throwable failure) {

--- a/app/src/test/java/com/bloxbean/cardano/yano/app/YanoProducerTest.java
+++ b/app/src/test/java/com/bloxbean/cardano/yano/app/YanoProducerTest.java
@@ -3,6 +3,7 @@ package com.bloxbean.cardano.yano.app;
 import com.bloxbean.cardano.yano.api.config.UpstreamPreset;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.api.config.YanoPropertyKeys;
+import com.bloxbean.cardano.yano.api.db.IncompatibleChainStateException;
 import com.bloxbean.cardano.yano.api.plugin.PluginActivationException;
 import com.bloxbean.cardano.yano.app.archive.HistoryArchiveService;
 import com.bloxbean.cardano.yano.app.archive.ProjectionHistoryService;
@@ -128,6 +129,34 @@ class YanoProducerTest {
     void startupBuildsPluginRuntimeEvenWhenAutoSyncIsDisabled() {
         var producer = new StartupProbeProducer(null);
         producer.autoSyncStart = false;
+
+        producer.onStart(null);
+
+        assertEquals(1, producer.ensureCalls);
+    }
+
+    @Test
+    void startupRejectsWrappedIncompatibleChainStateWhenBootstrapIsDisabled() {
+        var incompatible = new IncompatibleChainStateException(
+                "Existing chainstate is not compatible; resync is required.");
+        var producer = new StartupProbeProducer(
+                new IllegalStateException("Failed to initialize ledger-state subsystem", incompatible));
+        producer.autoSyncStart = false;
+        producer.bootstrapEnabled = false;
+
+        IncompatibleChainStateException thrown = assertThrows(
+                IncompatibleChainStateException.class, () -> producer.onStart(null));
+
+        assertSame(incompatible, thrown);
+        assertEquals(1, producer.ensureCalls);
+    }
+
+    @Test
+    void startupKeepsOrdinaryRuntimeFailureRecoverableWhenBootstrapIsDisabled() {
+        var producer = new StartupProbeProducer(
+                new IllegalStateException("Temporary runtime initialization failure"));
+        producer.autoSyncStart = false;
+        producer.bootstrapEnabled = false;
 
         producer.onStart(null);
 

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/db/IncompatibleChainStateException.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/db/IncompatibleChainStateException.java
@@ -1,0 +1,8 @@
+package com.bloxbean.cardano.yano.api.db;
+
+/** Raised when persisted chainstate cannot be opened safely by the running build. */
+public final class IncompatibleChainStateException extends IllegalStateException {
+    public IncompatibleChainStateException(String message) {
+        super(message);
+    }
+}

--- a/ledger-state/docs/design.md
+++ b/ledger-state/docs/design.md
@@ -411,23 +411,68 @@ Phase 2: RATIFY + REST (processRatificationPhase)
 
 ## Delta Journal & Rollback
 
-Every `applyBlock()` records a delta journal for rollback support:
+Account state uses rollback format v1. There is no second on-disk journal version
+or automatic format migration.
 
-```
+Every `applyBlock()` records the previous value of each changed account-state key
+in `acct_delta`. Epoch-boundary phases record the same `DeltaOp` representation in
+`acct_boundary_delta`, keyed by boundary slot, explicit phase and bounded chunk.
+Governance enactment and ratification, rewards, MIR credits, pool reaping and their
+derived indexes therefore participate in the same reverse-chronological rollback.
+
+```text
 DeltaOp = (opType, key, previousValue)
     opType: OP_PUT (0x01) or OP_DELETE (0x02)
     key: full byte key including prefix
-    previousValue: value before this block's mutation (null if new)
+    previousValue: value before this mutation (null if new)
 
-Storage: cfDelta[blockNumber] = CBOR-encoded list of DeltaOps
+acct_delta[blockNumber] = CBOR list of DeltaOps plus its slot
+acct_boundary_delta[slot(8) | phase(1) | chunk(4)] = CBOR list of DeltaOps
 ```
 
-On `rollbackTo(blockNumber)`:
-1. Read all `cfDelta` entries with blockNumber >= target
-2. Apply in reverse order (newest first)
-3. For `OP_PUT`: restore `previousValue` (or delete if was new)
-4. For `OP_DELETE`: restore `previousValue`
-5. Update `META_LAST_APPLIED_BLOCK`
+Rollback merges block and boundary entries into one newest-first timeline. At an
+equal slot, the block is undone before the boundary because block application
+followed the boundary transition. Boundary chunks and ordinary block entries are
+committed in bounded batches.
+
+Before the first mutation, rollback writes a durable `rollback-v1` target marker.
+The marker is cleared only with the final metadata commit; startup resumes the
+same target if the process stops between chunks. Forward boundary recovery remains
+separate: boundary step markers skip completed phases, while snapshot generations
+remain `BUILDING` until all rows and completion metadata are durable.
+
+Epoch snapshots are restored by generation rather than by row-level delta. A
+rollback deletes every credential-major, pool-major and reward-flag row for stale
+or incomplete generations, fixes `META_LAST_SNAPSHOT_EPOCH`, removes stale AdaPot
+and boundary-progress metadata, and then permits replay to rebuild them. Account
+derived indexes (stake events, deregistration coordinates, reward events and DRep
+reverse delegations) are journaled with their owning mutations. UTXO rollback
+independently restores its stake-balance and pointer indexes in the same UTXO
+journal operations as their UTXOs.
+
+The manual `rollback-to-slot` and `rollback-to-epoch` startup options use this same
+path. The runtime first resolves a canonical retained block point and validates the
+common rollback floor, then rolls back account state, UTXO state and chain state in
+dependency order. A target below the floor is rejected: pruned reward inputs or
+epoch snapshots cannot be reconstructed safely. Snapshot retention and
+`epoch-block-data-retention-lag` therefore define how far manual rollback can go;
+use a checkpoint or resync for older targets.
+
+### Required fallbacks versus removed trial oracles
+
+- Epoch snapshot `balance-mode=auto` prefers the coordinate-bound
+  `utxo_stake_balance` index and falls back to the historical UTXO scan only when
+  the index view is unavailable before boundary mutation. `index` is fail-closed;
+  `scan` (and the `full-scan` alias) forces the historical path.
+- Before Conway, pointer-address stake is still required. The pointer index is the
+  normal path; a coordinate for which it cannot be prepared uses the
+  pointer-only UTXO scan. Conway and later exclude pointer stake.
+- Streaming reward calculation is the default when a complete pool-major snapshot
+  exists. The legacy whole-snapshot calculation remains the bootstrap/emergency
+  fallback. An interrupted streaming calculation must resume in streaming mode;
+  it cannot switch algorithms mid-boundary.
+- The removed DRep point-lookup and pointer shadow paths were validation oracles,
+  not recovery fallbacks. Production keeps one DRep ordered-merge implementation.
 
 ---
 
@@ -466,18 +511,6 @@ Dependents:
 
 ## TODO / Known Issues
 
-### Epoch boundary rollback handling
-
-The delta journal handles block-level rollback (via `DeltaOp` entries per block in `cfDelta`). However, epoch boundary processing (rewards, snapshots, governance) uses separate `WriteBatch` commits that are NOT part of the block-level delta system.
-
-**Restart recovery via STEP markers:** Each step in `EpochBoundaryProcessor.processEpochBoundary()` writes a `META_BOUNDARY_STEP` marker on completion. On restart, `recoverInterruptedBoundary()` reads the marker to determine which step to resume from, skipping already-committed steps. Steps with markers: STEP_STARTED (0), STEP_REWARDS (1), STEP_SNAPSHOT (2), STEP_POOLREAP (3), STEP_GOVERNANCE (4), STEP_COMPLETE (5).
-
-**What is NOT rollback-safe:**
-- Governance two-phase commit: Phase 1 and Phase 2 are separate `WriteBatch` writes with no delta tracking. If the process crashes between Phase 1 commit and Phase 2 commit, Phase 1 enactments are applied but Phase 2 ratification/DRep updates are not. The STEP_GOVERNANCE marker is only written after both phases complete, so a restart would re-run the entire governance step, which could double-enact proposals if Phase 1 already committed.
-- Delegation snapshot writes to `cfEpochSnapshot` are not delta-tracked.
-- AdaPot updates are not delta-tracked.
-- PV10 reverse-index rebuild is restart-safe via `MARKER_PV10_REVERSE_REBUILD` (idempotent).
-
 ### Earlier reward calculation start
 
 Currently reward calculation starts at the epoch boundary (first block of new epoch). The Cardano spec allows starting reward calculation after the stability window of the previous epoch (2k/f slots before the epoch boundary) since the snapshot is frozen at that point. Starting earlier would reduce epoch boundary processing time and the stall visible to downstream consumers.
@@ -489,11 +522,3 @@ At epoch 526 (mainnet), 53 DReps show a mismatch: Yano computes expiryEpoch=528 
 ### Defensive timing guard in `resolveDRepKey`
 
 The `DRepDistributionCalculator.resolveDRepKey()` method includes a defensive check `delegSlot <= prevDeregSlot` that skips delegations made before the DRep's previous deregistration. This guard does not exist in the Haskell implementation, which instead relies on the UMap structure automatically cleaning delegations on DRep deregistration. After the PV10 reverse-index rebuild and the unconditional `clearDRepDelegationsForDeregisteredDRep` cleanup on deregistration, this check is less critical -- stale delegations should already be removed. The guard remains as a safety net for Yano's tombstone-based DRep state model where deregistered DReps are not fully deleted but marked with `prevDeregSlot`.
-
-### Governance exception silently swallowed in `EpochBoundaryProcessor`
-
-`EpochBoundaryProcessor` catches exceptions thrown during governance processing (Step 5), logs them, and continues to mark `STEP_GOVERNANCE` complete. This means a governance failure (e.g., a bug in ratification, DRep distribution, or enactment) can be silently skipped for an entire epoch. The step marker prevents it from being retried on restart. This should either re-throw the exception (failing the epoch boundary and halting sync) or not mark the step complete so that a restart retries governance processing.
-
-### `buildActiveDRepKeys` exception swallowing
-
-`GovernanceEpochProcessor.buildActiveDRepKeys()` catches any exception and returns a partial or empty active DRep set instead of propagating the error. If the active set is wrong (missing DReps or including expired ones), ratification vote tallies will use incorrect weights, potentially causing proposals to be ratified or rejected incorrectly. This catch-all should be removed or narrowed so that a failure in building the active set halts governance processing rather than producing a silently wrong result.

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/DefaultAccountStateStore.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/DefaultAccountStateStore.java
@@ -25,6 +25,7 @@ import com.bloxbean.cardano.yano.api.account.LedgerStateProvider;
 import com.bloxbean.cardano.yano.api.account.OpCertCounterState;
 import com.bloxbean.cardano.yano.api.archive.EpochArchiveStagingSink;
 import com.bloxbean.cardano.yano.api.config.YanoPropertyKeys;
+import com.bloxbean.cardano.yano.api.db.IncompatibleChainStateException;
 import com.bloxbean.cardano.yano.api.model.ProtocolParamsSnapshot;
 import com.bloxbean.cardano.yano.api.util.CostModelUtil;
 import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
@@ -420,7 +421,7 @@ public class DefaultAccountStateStore implements AccountStateStore, AccountState
                 return;
             }
             if (version != null || !isAccountStateEmpty()) {
-                throw new IllegalStateException(
+                throw new IncompatibleChainStateException(
                         "This preview build requires epoch-boundary state v1. The existing non-empty "
                                 + "account chainstate is not compatible; retain a backup and resync into "
                                 + "a new chainstate directory.");
@@ -442,13 +443,14 @@ public class DefaultAccountStateStore implements AccountStateStore, AccountState
     private void requireEpochBoundaryIndexes() throws RocksDBException {
         if (!Arrays.equals(db.get(cfState, META_SNAPSHOT_DEREG_INDEX_VERSION),
                 SNAPSHOT_DEREG_INDEX_VERSION)) {
-            throw new IllegalStateException(
-                    "epoch-boundary state is missing its snapshot deregistration index marker");
+            throw new IncompatibleChainStateException(
+                    "Epoch-boundary state is missing its snapshot deregistration index marker; "
+                            + "resync is required.");
         }
         if (!Arrays.equals(db.get(cfState, META_REWARD_EVENT_INDEX_VERSION),
                 REWARD_EVENT_INDEX_VERSION)) {
-            throw new IllegalStateException(
-                    "epoch-boundary state is missing its reward event index marker; resync is required");
+            throw new IncompatibleChainStateException(
+                    "Epoch-boundary state is missing its reward event index marker; resync is required.");
         }
     }
 
@@ -460,7 +462,7 @@ public class DefaultAccountStateStore implements AccountStateStore, AccountState
     public void requirePointerIndexReady(boolean pointerIndexReady) {
         if (!enabled || db == null || cfState == null) return;
         if (!pointerIndexReady) {
-            throw new IllegalStateException(
+            throw new IncompatibleChainStateException(
                     "This preview build requires a complete pointer UTXO index. "
                             + "The existing chainstate is not compatible; retain a backup and resync into "
                             + "a new chainstate directory.");

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/DRepDistributionCalculator.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/DRepDistributionCalculator.java
@@ -108,24 +108,13 @@ public class DRepDistributionCalculator {
                                                    Map<com.bloxbean.cardano.yano.ledgerstate.UtxoBalanceAggregator.CredentialKey,
                                                            BigInteger> utxoBalances,
                                                    Map<String, BigInteger> spendableRewardRest) throws RocksDBException {
-        return calculateInternal(snapshotEpoch, utxoBalances, spendableRewardRest, true);
-    }
-
-    /**
-     * Point-lookup implementation retained as a test oracle for the ordered merge.
-     */
-    Map<DRepDistKey, BigInteger> calculateWithPointLookupsForParity(int snapshotEpoch,
-            Map<com.bloxbean.cardano.yano.ledgerstate.UtxoBalanceAggregator.CredentialKey,
-                    BigInteger> utxoBalances,
-            Map<String, BigInteger> spendableRewardRest) throws RocksDBException {
-        return calculateInternal(snapshotEpoch, utxoBalances, spendableRewardRest, false);
+        return calculateInternal(snapshotEpoch, utxoBalances, spendableRewardRest);
     }
 
     private Map<DRepDistKey, BigInteger> calculateInternal(int snapshotEpoch,
             Map<com.bloxbean.cardano.yano.ledgerstate.UtxoBalanceAggregator.CredentialKey,
                     BigInteger> utxoBalances,
-            Map<String, BigInteger> spendableRewardRest,
-            boolean useOrderedAccountMerge) throws RocksDBException {
+            Map<String, BigInteger> spendableRewardRest) throws RocksDBException {
         Map<DRepDistKey, BigInteger> distribution = new HashMap<>();
         StakeBalanceView stakeBalanceView = null;
         if (utxoBalances == null && stakeBalanceViewSupplier != null) {
@@ -170,8 +159,7 @@ public class DRepDistributionCalculator {
 
         // Iterate all DRep delegations
         try (StakeBalanceView closeableView = stakeBalanceView;
-             AccountLookup accountLookup = useOrderedAccountMerge
-                     ? new OrderedAccountLookup() : new PointAccountLookup()) {
+             OrderedAccountLookup accountLookup = new OrderedAccountLookup()) {
             RocksIterator it = accountLookup.delegations();
             while (it.isValid()) {
                 byte[] key = it.key();
@@ -194,7 +182,7 @@ public class DRepDistributionCalculator {
                 }
 
                 // Check if the stake credential is registered
-                byte[] acctVal = accountLookup.accountValue(key, credType, credHash);
+                byte[] acctVal = accountLookup.accountValue(key);
                 if (acctVal == null) {
                     skippedAcct++;
                     it.next();
@@ -260,19 +248,7 @@ public class DRepDistributionCalculator {
         return distribution;
     }
 
-    private interface AccountLookup extends AutoCloseable {
-        RocksIterator delegations();
-
-        byte[] accountValue(byte[] delegationKey, int credentialType,
-                            String credentialHash) throws RocksDBException;
-
-        void verifyHealthy() throws RocksDBException;
-
-        @Override
-        void close();
-    }
-
-    private final class OrderedAccountLookup implements AccountLookup {
+    private final class OrderedAccountLookup implements AutoCloseable {
         private final Snapshot snapshot = db.getSnapshot();
         private final ReadOptions options = new ReadOptions()
                 .setFillCache(false)
@@ -285,14 +261,11 @@ public class DRepDistributionCalculator {
             accounts.seek(new byte[]{DefaultAccountStateStore.PREFIX_ACCT});
         }
 
-        @Override
-        public RocksIterator delegations() {
+        private RocksIterator delegations() {
             return delegations;
         }
 
-        @Override
-        public byte[] accountValue(byte[] delegationKey, int credentialType,
-                                   String credentialHash) {
+        private byte[] accountValue(byte[] delegationKey) {
             while (accounts.isValid()) {
                 byte[] accountKey = accounts.key();
                 if (accountKey.length < 2
@@ -310,8 +283,7 @@ public class DRepDistributionCalculator {
             return null;
         }
 
-        @Override
-        public void verifyHealthy() throws RocksDBException {
+        private void verifyHealthy() throws RocksDBException {
             delegations.status();
             accounts.status();
         }
@@ -322,35 +294,6 @@ public class DRepDistributionCalculator {
             delegations.close();
             options.close();
             db.releaseSnapshot(snapshot);
-        }
-    }
-
-    private final class PointAccountLookup implements AccountLookup {
-        private final RocksIterator delegations = db.newIterator(cfState);
-
-        private PointAccountLookup() {
-            delegations.seek(new byte[]{DefaultAccountStateStore.PREFIX_DREP_DELEG});
-        }
-
-        @Override
-        public RocksIterator delegations() {
-            return delegations;
-        }
-
-        @Override
-        public byte[] accountValue(byte[] delegationKey, int credentialType,
-                                   String credentialHash) throws RocksDBException {
-            return db.get(cfState, accountKey(credentialType, credentialHash));
-        }
-
-        @Override
-        public void verifyHealthy() throws RocksDBException {
-            delegations.status();
-        }
-
-        @Override
-        public void close() {
-            delegations.close();
         }
     }
 
@@ -510,16 +453,6 @@ public class DRepDistributionCalculator {
             throw new RuntimeException("Failed to read DRep snapshot stake for epoch "
                     + epoch + ", credType=" + credType + ", credHash=" + credHash, e);
         }
-    }
-
-    /** Build account key matching PREFIX_ACCT pattern in DefaultAccountStateStore */
-    private static byte[] accountKey(int credType, String credHash) {
-        byte[] hash = HexUtil.decodeHexString(credHash);
-        byte[] key = new byte[1 + 1 + hash.length];
-        key[0] = DefaultAccountStateStore.PREFIX_ACCT;
-        key[1] = (byte) credType;
-        System.arraycopy(hash, 0, key, 2, hash.length);
-        return key;
     }
 
     /**

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/DRepDistributionCalculator.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/DRepDistributionCalculator.java
@@ -238,7 +238,7 @@ public class DRepDistributionCalculator {
                 new DRepDistKey(DREP_NO_CONF, NO_CONFIDENCE_HASH), BigInteger.ZERO);
         log.info("Computed DRep distribution for snapshot epoch {}: {} DReps, {} total delegations",
                 snapshotEpoch, distribution.size(), totalDist);
-        log.info("  DRep virtual distribution for epoch {}: abstain={}, noConfidence={}",
+        log.debug("  DRep virtual distribution for epoch {}: abstain={}, noConfidence={}",
                 snapshotEpoch + 1, abstain, noConfidence);
         log.info("  DRep dist breakdown: utxo={}, rewards={}, rewardRest={}, proposalDeposits={}",
                 totalUtxo, totalRewards, totalRewardRest, totalPropDeposits);

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/EpochBoundaryStateVersionTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/EpochBoundaryStateVersionTest.java
@@ -1,5 +1,6 @@
 package com.bloxbean.cardano.yano.ledgerstate;
 
+import com.bloxbean.cardano.yano.api.db.IncompatibleChainStateException;
 import com.bloxbean.cardano.yano.ledgerstate.test.TestRocksDBHelper;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -27,7 +28,7 @@ class EpochBoundaryStateVersionTest {
 
             assertThat(rocks.db().get(rocks.cfState(), VERSION_KEY)).containsExactly(1);
             assertThatThrownBy(() -> store.requirePointerIndexReady(false))
-                    .isInstanceOf(IllegalStateException.class)
+                    .isInstanceOf(IncompatibleChainStateException.class)
                     .hasMessageContaining("complete pointer UTXO index")
                     .hasMessageContaining("resync");
             assertThatCode(() -> store.requirePointerIndexReady(true))
@@ -45,7 +46,7 @@ class EpochBoundaryStateVersionTest {
             var restarted = new DefaultAccountStateStore(
                     rocks.db(), rocks.cfSupplier(), LoggerFactory.getLogger(getClass()), true);
             assertThatThrownBy(() -> restarted.requirePointerIndexReady(false))
-                    .isInstanceOf(IllegalStateException.class)
+                    .isInstanceOf(IncompatibleChainStateException.class)
                     .hasMessageContaining("resync");
             assertThat(rocks.db().get(rocks.cfState(), VERSION_KEY)).containsExactly(1);
 
@@ -67,7 +68,7 @@ class EpochBoundaryStateVersionTest {
 
             assertThatThrownBy(() -> new DefaultAccountStateStore(
                     rocks.db(), rocks.cfSupplier(), LoggerFactory.getLogger(getClass()), true))
-                    .isInstanceOf(IllegalStateException.class)
+                    .isInstanceOf(IncompatibleChainStateException.class)
                     .hasMessageContaining("requires epoch-boundary state v1")
                     .hasMessageContaining("resync");
             assertThat(rocks.db().get(rocks.cfState(), VERSION_KEY)).containsExactly(2);
@@ -83,7 +84,7 @@ class EpochBoundaryStateVersionTest {
 
             assertThatThrownBy(() -> new DefaultAccountStateStore(
                     rocks.db(), rocks.cfSupplier(), LoggerFactory.getLogger(getClass()), true))
-                    .isInstanceOf(IllegalStateException.class)
+                    .isInstanceOf(IncompatibleChainStateException.class)
                     .hasMessageContaining("existing non-empty account chainstate is not compatible")
                     .hasMessageContaining("resync");
             assertThat(rocks.db().get(rocks.cfState(), VERSION_KEY)).isNull();

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/DRepDistributionCalculatorTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/governance/epoch/DRepDistributionCalculatorTest.java
@@ -270,7 +270,7 @@ class DRepDistributionCalculatorTest {
     }
 
     @Test
-    void orderedAccountMergeMatchesPointLookupOracleForRegisteredAndSkippedCredentials()
+    void orderedAccountMergeHandlesRegisteredAndSkippedCredentials()
             throws Exception {
         registerDRep(0, DREP_A, 200, 84974395L);
         var deregisteredDRep = new DRepStateRecord(
@@ -296,19 +296,15 @@ class DRepDistributionCalculatorTest {
                 BigInteger.valueOf(300));
         var rewardRest = Map.of("0:" + CRED1, BigInteger.valueOf(5));
 
-        var pointLookup = calculator.calculateWithPointLookupsForParity(
-                230, balances, rewardRest);
         var orderedMerge = calculator.calculate(230, balances, rewardRest);
 
-        assertThat(orderedMerge).isEqualTo(pointLookup);
-        assertThat(orderedMerge.get(new DRepDistributionCalculator.DRepDistKey(0, DREP_A)))
-                .isEqualTo(BigInteger.valueOf(112));
-        assertThat(orderedMerge).doesNotContainKey(
-                new DRepDistributionCalculator.DRepDistKey(0, DREP_B));
+        assertThat(orderedMerge).containsExactly(
+                Map.entry(new DRepDistributionCalculator.DRepDistKey(0, DREP_A),
+                        BigInteger.valueOf(112)));
     }
 
     @Test
-    void orderedAccountMergeMatchesPointLookupAcrossCredentialTypesAndVirtualDReps()
+    void orderedAccountMergeHandlesCredentialTypesAndVirtualDReps()
             throws Exception {
         registerDRep(0, DREP_A, 200, 84974395L);
         registerDRep(1, DREP_B, 200, 84974396L);
@@ -332,23 +328,19 @@ class DRepDistributionCalculatorTest {
                 BigInteger.valueOf(40));
         var rewardRest = Map.of("1:" + CRED1, BigInteger.ONE);
 
-        var pointLookup = calculator.calculateWithPointLookupsForParity(
-                230, balances, rewardRest);
         var orderedMerge = calculator.calculate(230, balances, rewardRest);
 
-        assertThat(orderedMerge).isEqualTo(pointLookup);
-        assertThat(orderedMerge)
-                .containsEntry(new DRepDistributionCalculator.DRepDistKey(2, "abstain"),
-                        BigInteger.valueOf(11))
-                .containsEntry(new DRepDistributionCalculator.DRepDistKey(3, "no_confidence"),
-                        BigInteger.valueOf(33))
-                .containsEntry(new DRepDistributionCalculator.DRepDistKey(1, DREP_B),
-                        BigInteger.valueOf(44))
-                .doesNotContainKey(new DRepDistributionCalculator.DRepDistKey(0, DREP_A));
+        assertThat(orderedMerge).containsExactlyInAnyOrderEntriesOf(Map.of(
+                new DRepDistributionCalculator.DRepDistKey(2, "abstain"),
+                BigInteger.valueOf(11),
+                new DRepDistributionCalculator.DRepDistKey(3, "no_confidence"),
+                BigInteger.valueOf(33),
+                new DRepDistributionCalculator.DRepDistKey(1, DREP_B),
+                BigInteger.valueOf(44)));
     }
 
     @Test
-    void orderedAccountMergeSkipsAccountsWithoutDRepDelegations() throws Exception {
+    void orderedAccountMergeSkipsAccountsWithoutDelegationsAndHandlesKeyGaps() throws Exception {
         String delegationBeforeFirstAccount = "00".repeat(27) + "01";
         String accountBeforeRegisteredDelegation = "00".repeat(27) + "02";
         String accountBetweenDelegations = "80".repeat(28);
@@ -375,15 +367,11 @@ class DRepDistributionCalculatorTest {
                 new com.bloxbean.cardano.yano.ledgerstate.UtxoBalanceAggregator.CredentialKey(
                         0, CRED1), BigInteger.valueOf(100));
 
-        var pointLookup = calculator.calculateWithPointLookupsForParity(
-                230, balances, Map.of());
         var orderedMerge = calculator.calculate(230, balances, Map.of());
 
-        assertThat(orderedMerge).isEqualTo(pointLookup);
-        assertThat(orderedMerge)
-                .containsOnlyKeys(new DRepDistributionCalculator.DRepDistKey(0, DREP_A))
-                .containsEntry(new DRepDistributionCalculator.DRepDistKey(0, DREP_A),
-                        BigInteger.valueOf(129));
+        assertThat(orderedMerge).containsExactly(
+                Map.entry(new DRepDistributionCalculator.DRepDistKey(0, DREP_A),
+                        BigInteger.valueOf(129)));
     }
 
     @Test


### PR DESCRIPTION
## Summary

- remove the accepted DRep point-lookup oracle and replace implementation-parity assertions with fixed golden distributions
- demote the post-#99 virtual-DRep diagnostic from INFO to DEBUG
- terminate Quarkus cleanly when persisted chainstate fails a required format/index gate, while preserving ordinary recoverable startup handling
- correct the ledger design documentation for bounded resumable rollback-v1, manual rollback/index compatibility, rollback floors, and retained fallbacks

## Acceptance gates

The DRep ordered merge was accepted after exact mainnet validation across 116 Conway epochs and 87,599 distribution rows. Issue #99 is closed. The mainnet node reached tip on the final #101/#102 lineage before this cleanup.

The following are deliberately retained:

- `balance-mode=auto` historical UTXO-scan fallback, plus strict `index` and forced `scan` modes
- pre-Conway pointer-only UTXO scan when the coordinate-bound pointer index cannot be prepared
- legacy whole-snapshot reward calculation as a bootstrap/emergency fallback; streaming remains the default and cannot switch mid-resume
- chainstate format v1 with fail-closed gates; no migration or v2 path is introduced

The parked fast-CBOR experiment never merged and requires no main-branch removal.

## Startup lifecycle

`IncompatibleChainStateException` is emitted only by the epoch-boundary format marker, the two required derived-index markers, and required pointer-index readiness. Runtime construction cleanup preserves that typed cause. `YanoProducer` now rethrows it with `YANO_STARTUP_FAILURE code=INCOMPATIBLE_CHAINSTATE`, so Quarkus exits with the existing resync guidance rather than serving a half-started application. Plugin sanitization, bootstrap failure behavior, and ordinary recoverable initialization failures are unchanged.

## Validation

- core-api: 276 tests, 0 failures
- ledger-state: 329 tests, 0 failures
- runtime: 1,444 tests, 0 failures, 3 existing skips
- app: 319 tests, 0 failures
- focused rollback-v1 chunk/crash recovery, snapshot generation, AdaPot/governance reversal, and UTXO stake-index/manual rollback coverage: green

Five saved rehearsal/mainnet start-command text files were also cleaned of the already-removed pointer backfill/shadow properties. They are deployment evidence outside Git and do not affect this diff. The healthy mainnet process was not restarted.

Closes #100
