### PR TITLE
Upgrade Scalus to 1.1.1 and preserve ledger admission

### DIFF
--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -250,6 +250,13 @@ Where 1.x adds fields, defaults must be justified from the Cardano protocol
 model or the existing Yano contract. Nulls, zero values and placeholder casts
 must not be introduced merely to satisfy a constructor.
 
+`scalus.cardano.ledger.ProtocolParams` is constructed with 31 positional
+arguments. Before correction commit `c1d5cf53`, Yano had zero assertions for
+the execution-unit-limit mapping inside that constructor. The class-wide
+`everyProtocolParameterMapsToItsOwnField` guard now supplies distinct source
+values and asserts all 31 target fields, including every nested component, so
+future argument transpositions fail locally.
+
 ### 5. Use layered, serialized acceptance gates
 
 Run the following gates serially from a fresh worktree at the exact candidate
@@ -513,7 +520,10 @@ attribute when a semantic or native regression appears.
 - Pool update admission remains aligned with Cardano ledger semantics.
 - Rule-set drift becomes a visible test failure.
 - Scalus 1.1.1's dimensional execution-unit limit check surfaced a latent Yano
-  memory/steps mapping defect that the 0.18.2 total ordering had hidden. The
+  memory/steps mapping defect that the 0.18.2 total ordering had hidden. That
+  ordering was lexicographic: it compared memory first and compared steps only
+  when memory was equal, so the shipped swapped values could over-accept a
+  transaction whose true memory budget exceeded the limit. The
   over-acceptance defect affects releases `v0.1.0-pre10` through
   `v0.1.0-pre13` and is corrected by unreleased commit `c1d5cf53`.
 - Native and off-chain evaluation compatibility are demonstrated with executed

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -91,6 +91,15 @@ without it. Its certificate deposit calculation consequently charges
 already active pool. Cardano charges a deposit only for a distinct pool ID not
 active at transaction start.
 
+The `1.1.1` bytecode makes the asymmetry precise. Consumed-side staking and
+DRep refunds call private helpers `lookupStakingDeposit$1(CertState,
+Credential)` and `lookupDRepDeposit$1(CertState, Credential)`. Produced-side
+certificate deposits call private
+`conwayTotalDepositsTxCerts(Transaction, ProtocolParams)`, which receives no
+certificate or pool state. The upstream repair is therefore to thread the
+transaction-start pool set into `conwayTotalDepositsTxCerts` and its
+`produced` caller, matching the state-aware refund design.
+
 Yano currently corrects the excess produced value by subtracting one pool
 deposit for:
 
@@ -320,6 +329,12 @@ this order:
 Build the Oracle GraalVM 25.3 G1 native binary once. Reuse that exact binary,
 identified by path and SHA-256, for both native skills and the Gate C BLS probe.
 The app-chain skills are outside this ADR's scope.
+
+For issue #106, the committed PV10 genesis is authoritative over stale values
+in the local skill text: `epochLength=1200` and `slotLength=0.2`, so the
+two-full-epoch sync threshold is past slot 2400. Oracle GraalVM 25.3 with
+`--gc=G1` likewise supersedes the native skills' older GraalVM 24 prerequisite
+for every native gate in this ADR.
 
 Then run all five steps of
 `/Users/satya/Downloads/yano-ccl-test/run-suite.sh <label> <api-url> <node-pid>`:

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -262,6 +262,29 @@ owns every node start, stop and restart. The coordinator runs only module tests
 from a detached worktree at Codex's exact commit and never starts a node. Every
 running-node gate records its explicit data directory.
 
+Baseline and candidate node-backed comparisons must use the stock
+`app/config/network/devnet/` genesis set used by the retained off-chain
+baselines, not the separate `devnet/pv10/` set. The effective protocol major
+version must be `11`, and the Plutus V1, V2, and V3 cost models must contain
+`332`, `332`, and `350` entries respectively. The genesis root, protocol major
+version, and all three cost-model cardinalities are must-not-change values
+across the baseline and candidate runs. A profile with the same network magic,
+epoch length, slot length, and active-slots coefficient is not equivalent when
+its protocol version or cost models differ.
+
+Before every node start, run a repository-wide process check with
+`pgrep -fl "yano.jar|/yano( |$)"` in addition to the gate's port and lock
+checks. Every long-running node must start in its own POSIX session under
+`nohup`, redirect to an identified log, write an identified pidfile, and remain
+alive after an unrelated tool call.
+
+Before baseline or candidate throughput measurement, record `uptime` and the
+top five CPU consumers and verify that no competing build or other heavy job is
+running. Record the same evidence at the end. A contended run may provide
+functional and CPU-independent evaluator evidence, but its throughput, latency
+and wall-clock figures are not valid comparison data. Baseline and candidate
+must use this identical quiet-machine precondition.
+
 #### Gate A — bridge and application JVM tests
 
 1. `./gradlew :scalus-bridge:test`
@@ -290,6 +313,11 @@ Build with Oracle GraalVM 25.3 and `--gc=G1`, using the repository's documented
 release-parity native build configuration. Record the builder image digest,
 candidate commit, native binary path and SHA-256, effective GC and all runtime
 settings.
+
+Before the native smoke submits or evaluates a script, verify from the native
+node's runtime log or API that the effective protocol major version is `11`
+and the Plutus V3 cost model contains `350` entries. Record both observed
+values in the gate report; naming an intended genesis path is not sufficient.
 
 The native smoke must start the built binary, reach readiness and execute both:
 
@@ -328,9 +356,13 @@ identified by path and SHA-256, for `test-native-haskell-sync` and the Gate C
 BLS probe.
 The app-chain skills are outside this ADR's scope.
 
-For issue #106, the committed PV10 genesis is authoritative over stale values
-in the local skill text: `epochLength=1200` and `slotLength=0.2`, so the
-two-full-epoch sync threshold is past slot 2400. Oracle GraalVM 25.3 with
+For issue #106, the stock devnet genesis set is authoritative over any PV10
+selection in the local skill text. If `test-native-haskell-sync` selects PV10,
+override it to stock devnet and record the override. Before accepting the
+skill result, verify from the running node's log or API and record that the
+effective protocol major version is `11` and the Plutus V3 cost model contains
+`350` entries. Stock `epochLength=1200` and `slotLength=0.2` make the
+two-full-epoch sync threshold past slot 2400. Oracle GraalVM 25.3 with
 `--gc=G1` likewise supersedes the native skills' older GraalVM 24 prerequisite
 for every native gate in this ADR.
 

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -1,0 +1,497 @@
+# ADR-051: Upgrade Scalus to 1.1.1 Without Regressing Ledger Admission
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-31
+
+## Related decisions and evidence
+
+- [Issue #106](https://github.com/bloxbean/yano/issues/106) requests the
+  upgrade from Scalus `0.18.2` to `1.1.1` and defines the acceptance gates.
+- [Issue #62](https://github.com/bloxbean/yano/issues/62) and
+  [ADR-050](050-complete-live-stake-pool-retirement.md) define the pool
+  lifecycle behavior that the new Scalus version must continue to admit.
+  The issue #62 branch is merged into `main` at `e2566ade`.
+- [The ADR-050 upstream report](reports/adr-050-scalus-pool-deposit-upstream-report.md)
+  records the value-conservation gap and the expected reference-ledger
+  behavior for active pool updates and duplicate registrations.
+- `gradle/libs.versions.toml` currently pins both
+  `scalus-cardano-ledger_3` and
+  `scalus-bloxbean-cardano-client-lib_3` to `0.18.2`.
+- `YanoCardanoMutator` replaces Scalus's
+  `ValueNotConservedUTxOValidator` while retaining the remainder of
+  `CardanoMutator.defaultSTSs()` in deterministic name order.
+- [ADR-051 Phase 0 evidence](reports/adr-051-phase-0-2026-08-31.md) records the
+  resolved Scalus `1.1.1` jar identity and direct signature inspection of
+  `TxBalance.produced` and `TxBalance.consumed`. This evidence decides whether
+  Yano ports or deletes the pool-deposit override.
+
+## Decision summary
+
+Yano will upgrade both Scalus artifacts together to `1.1.1`. The upgrade is an
+adapter migration, not a ledger-semantics change.
+
+1. Both direct Scalus coordinates will be pinned to exactly `1.1.1` in one
+   change. The resolved runtime graph must select `1.1.1` for the direct ledger
+   and CCL adapter artifacts and transitive `org.scalus:scalus_3`. Yano's
+   separately managed `cardano-client-lib` version must not move as a side
+   effect.
+2. The `scalus-bridge` adapters will be changed only where the Scalus 1.x API
+   requires it. Transaction decoding, protocol-parameter conversion,
+   certificate-state construction, script supply, evaluation and validation
+   must retain their current Yano contracts.
+3. Because `1.1.1` still lacks certificate state in its produced-value
+   calculation, Yano will port `YanoCardanoMutator` and
+   `YanoValueNotConservedUTxOValidator` to the 1.1.1 rule API. The override must
+   not be deleted merely because the major-version upgrade compiles.
+4. The port must be derived from the 1.1.1
+   `CardanoMutator.defaultSTSs()` at build and test time. It replaces exactly
+   one default validator, preserves every other validator and mutator, and
+   executes each name-sorted group deterministically.
+5. The override remains removable. A future Scalus release may replace it only
+   after a behavioral test proves that active pool updates, duplicate new-pool
+   registrations and mixed active/new registrations conserve value without
+   Yano's validator.
+6. Acceptance requires serialized fresh-worktree tests, the complete devnet
+   pool-lifecycle matrix, a release-parity Oracle GraalVM native build and
+   native execution probes, and Plutus datum/redeemer regressions from both
+   off-chain suites named in issue #106.
+
+This decision does not change chainstate formats, public APIs, configuration,
+pool lifecycle state, transaction ordering or protocol parameters.
+
+## Context
+
+### Why this is more than a dependency edit
+
+The version jump crosses the Scalus `1.0` boundary. Yano directly uses Scalus
+ledger models and rule APIs from mixed Scala and Java sources in
+`scalus-bridge`, including:
+
+- transaction CBOR decoding and CCL interop;
+- `ProtocolParams`, `SlotConfig`, UTxO and script-supplier adapters;
+- construction of transaction-local `CertState` from Yano's ledger provider;
+- `CardanoMutator`, `STS`, `Context`, `State` and transaction exceptions;
+- script evaluation and validation; and
+- native JNI linkage for BLS builtins.
+
+A successful compilation proves only source compatibility. It does not prove
+that the resolved rule set, value-conservation behavior, Plutus data encoding,
+execution budgets or native-image reachability are unchanged.
+
+### Pool-deposit correctness must survive the upgrade
+
+Scalus computes consumed value with `CertState` but computes produced value
+without it. Its certificate deposit calculation consequently charges
+`stakePoolDeposit` for every `PoolRegistration`, including an update to an
+already active pool. Cardano charges a deposit only for a distinct pool ID not
+active at transaction start.
+
+Yano currently corrects the excess produced value by subtracting one pool
+deposit for:
+
+- every registration of a transaction-start active pool; and
+- every duplicate registration after the first registration of one new pool
+  in the same transaction.
+
+Pool retirement certificates in that transaction do not change
+transaction-start membership. Both `RetirePool -> RegPool` and
+`RegPool -> RetirePool` therefore treat the registration as an active-pool
+update when the pool was active at transaction start.
+
+Phase 0 inspects the exact `1.1.1` jar selected by this branch before deciding
+whether to port the correction. If that jar retains the API shape that caused
+the gap, ADR-051 ports the correction and strengthens its coupling guard. If it
+accepts transaction-start pool or certificate state, implementation stops and
+the unmodified upstream rule set is tested before the override is deleted.
+
+### Native behavior is a separate compatibility surface
+
+The Scalus bridge includes BLS JNI configuration and is part of the native
+application. Repository CI does not execute the resulting native binary for
+this scenario. A native image that links successfully can still fail when an
+evaluator, JNI symbol, resource or reflection path is first exercised.
+
+The native gate must therefore evaluate and submit real transactions. A health
+check or `ldd` result alone is insufficient.
+
+## Decision drivers
+
+- Consume the supported Scalus 1.x line without carrying an obsolete 0.x
+  dependency.
+- Preserve Cardano value conservation for active pool updates.
+- Detect upstream rule-set drift instead of silently dropping or duplicating a
+  rule.
+- Preserve deterministic rule execution and stable diagnostics.
+- Exercise semantic and native paths that compilation and JVM unit tests do
+  not cover.
+- Keep the migration reversible until every gate passes.
+- Avoid unrelated ledger, API and chainstate changes in the dependency-upgrade
+  branch.
+
+## Invariants
+
+1. `scalus-cardano-ledger_3`, `scalus-bloxbean-cardano-client-lib_3` and
+   transitive `scalus_3` resolve to the same exact version, `1.1.1`.
+2. No Scalus `0.x` artifact remains in the application runtime graph, and the
+   upgrade does not change Yano's selected `cardano-client-lib` version.
+3. Yano's effective validator set differs from Scalus 1.1.1 defaults by
+   exactly one entry: the upstream value-conservation validator is removed and
+   Yano's same-named validator is added.
+4. Validator and mutator counts otherwise match the 1.1.1 default set, and
+   each group executes in ascending rule-name order.
+5. An active pool update pays no new pool deposit.
+6. A new pool lifecycle pays exactly one pool deposit, even if its registration
+   appears more than once in a transaction.
+7. Mixed active and new registrations charge only the new pools.
+8. Certificate order does not alter transaction-start pool membership for the
+   deposit calculation.
+9. All non-pool value-conservation behavior and error identity remain Scalus
+   default behavior.
+10. Script evaluation retains the expected datum/redeemer interpretation and
+    execution-budget behavior for the Mesh and Evolution vesting suites.
+11. JVM and native evaluators accept and reject the same regression fixtures.
+12. The upgrade introduces no chainstate migration or runtime configuration
+    change.
+
+## Detailed decision
+
+### 1. Pin and verify one Scalus version
+
+Change both aliases in `gradle/libs.versions.toml` from `0.18.2` to `1.1.1` in
+one commit. Do not temporarily mix 0.x and 1.x artifacts to work around
+compilation failures.
+
+Before and after the bump, record Gradle dependency-insight evidence on the
+application runtime classpath for `scalus-cardano-ledger_3`,
+`scalus-bloxbean-cardano-client-lib_3`, `scalus_3` and
+`cardano-client-lib`. The gate is one selected Scalus version, `1.1.1`, with no
+forced downgrade, duplicate 0.x module or locally substituted unpublished jar,
+while Yano's own CCL version remains unchanged.
+
+Scalus `1.1.1` retains Scala `3.3.8`, `cardano-client-lib` `0.7.2`, Scribe
+`3.19.0`, Monocle `3.3.0` and Commons Compress `1.28.0`. It moves Borer core and
+derivation from `1.16.2` to `1.17.0`, Magnolia from `1.3.21` to `1.3.23`, and
+STTP client4 core from `4.0.25` to `4.0.26`. The Scala pin must not be bumped to
+paper over a bridge compilation failure. The Borer change is treated as a CBOR
+compatibility risk and requires a real-transaction decode/encode round-trip
+adapter test.
+
+### 2. Adapt at the bridge boundary
+
+Inventory compile failures before editing. Apply compatibility changes in the
+narrowest bridge component responsible for each changed Scalus type or method:
+
+- `ProtocolParamsBridge` for ledger parameter model changes;
+- `UtxoBridge`, `Types` and `CertStateBridge` for ledger model changes;
+- `LedgerBridge` and the Java evaluator/validator classes for rule and
+  evaluator entry-point changes; and
+- `SlotConfigAdapters` and `ScalusScriptSupplier` for CCL adapter changes.
+
+Do not leak Scalus-specific 1.x types into `core-api`, `ledger-rules` or public
+Yano APIs to make the bridge compile. Do not change transaction semantics to
+match a surprising new default without first documenting and testing that
+semantic change.
+
+### 3. Re-derive the pool-deposit override
+
+Port the override from the actual `1.1.1` rule types and default rule
+collection. The construction must:
+
+1. obtain all default STSs from `CardanoMutator.defaultSTSs()`;
+2. separate validators and mutators;
+3. require the upstream `ValueNotConservedUTxOValidator` identity to occur
+   exactly once;
+4. replace that entry with `YanoValueNotConservedUTxOValidator`;
+5. preserve every other object identity; and
+6. sort validators and mutators independently by rule name before transit.
+
+The guard test must compare the default and effective sets in both directions,
+verify the exactly-one-entry difference, verify counts, verify name order and
+verify that the replacement retains the upstream rule name for stable
+diagnostics.
+
+The semantic tests must cover active update, one new pool, duplicate new-pool
+registration, mixed active/new registrations and both retirement orders. At
+least one test must exercise complete value-conservation validation rather
+than only the correction helper.
+
+If inspection during implementation contradicts the recorded 1.1.1 API
+evidence and proves that upstream now consumes transaction-start pool state,
+stop and record the evidence. Delete the override only after the same semantic
+tests pass against the unmodified Scalus rule set.
+
+### 4. Preserve evaluation and interop behavior
+
+Adapter tests must pin any 1.x representation change that can affect:
+
+- protocol versions, prices, cost models and execution-unit limits;
+- slot zero time, zero slot, slot length and units;
+- transaction input/output conversion and inline datum handling;
+- reference scripts and script lookup;
+- certificate credentials, pool maps, rewards, deposits and DRep state;
+- evaluator success/failure mapping and execution budgets; and
+- transaction validation exception mapping.
+
+Where 1.x adds fields, defaults must be justified from the Cardano protocol
+model or the existing Yano contract. Nulls, zero values and placeholder casts
+must not be introduced merely to satisfy a constructor.
+
+### 5. Use layered, serialized acceptance gates
+
+Run the following gates serially from a fresh worktree at the exact candidate
+commit. Do not overlap Gradle daemons, devnet processes or native builds when
+collecting acceptance evidence.
+
+Exactly one Yano JVM or native node process may run at any time across the
+whole repository, whether or not processes use different chainstates. Codex
+owns every node start, stop and restart. The coordinator runs only module tests
+from a detached worktree at Codex's exact commit and never starts a node. Every
+running-node gate records its explicit data directory.
+
+#### Gate A — bridge and application JVM tests
+
+1. `./gradlew :scalus-bridge:test`
+2. `./gradlew :app:integrationTest`
+
+Both commands must exit zero. Record the commit, JDK, Gradle version, commands,
+test totals and report paths.
+
+#### Gate B — pool-lifecycle devnet matrix
+
+Run `PoolLifecycleE2ETest` and retain evidence for all scenarios A-F:
+
+- pending retirement cancelled by a later-block update;
+- effective retirement and same-epoch new lifecycle;
+- effective retirement and delayed new lifecycle;
+- same-transaction retirement then registration;
+- same-transaction registration then retirement; and
+- same-block, different-transaction ordering in both directions.
+
+The gate requires real transaction submission through the running node and no
+spurious `ValueNotConservedUTxO` failure. Helper-only tests do not satisfy it.
+
+#### Gate C — release-parity native image and smoke
+
+Build with Oracle GraalVM 25.3 and `--gc=G1`, using the repository's documented
+release-parity native build configuration. Record the builder image digest,
+candidate commit, native binary path and SHA-256, effective GC and all runtime
+settings.
+
+The native smoke must start the built binary, reach readiness and execute both:
+
+- the BLS lock/evaluate/submit/confirm probe at
+  `/Users/satya/Downloads/yano-ccl-test/ccl-client`, including its negative
+  control; and
+- submission of the evaluated transaction through the native node.
+
+Both operations must succeed without missing JNI symbols, unsupported-feature
+errors, reflection/resource failures or value-conservation errors. The exact
+transaction hash and log evidence are retained.
+
+#### Gate D — Plutus vesting regressions
+
+Run steps 3 and 5 of
+`/Users/satya/Downloads/yano-ccl-test/run-suite.sh <label> <api-url> <node-pid>`
+against the accepted devnet configuration: MeshJS vesting datum/redeemer and
+Evolution vesting. Each suite must evaluate and submit its lock/unlock path,
+and the on-chain outcome must be observed. Record the external suite repository
+identity because the harness is not stored in this worktree.
+
+For every case, retain the transaction CBOR or fixture identity, evaluator
+result, execution units, submission hash and confirmation evidence. Compare
+execution units with the `0.18.2` baseline; any difference must be explained
+before acceptance, even when both transactions succeed.
+
+#### Gate E — devnet skills and off-chain SDK load suite
+
+Before the load suite, run these devnet skills strictly one at a time and in
+this order:
+
+1. `test-haskell-sync`;
+2. `test-past-time-travel`;
+3. `test-native-haskell-sync`; and
+4. `test-native-past-time-travel`.
+
+Build the Oracle GraalVM 25.3 G1 native binary once. Reuse that exact binary,
+identified by path and SHA-256, for both native skills and the Gate C BLS probe.
+The app-chain skills are outside this ADR's scope.
+
+Then run all five steps of
+`/Users/satya/Downloads/yano-ccl-test/run-suite.sh <label> <api-url> <node-pid>`:
+CCL load, MeshJS load, MeshJS vesting, Evolution load and Evolution vesting.
+Retain the `results-<label>/` directory with per-step logs, `timing.txt`,
+`process.txt` and mempool metric snapshots. Record submitted and confirmed
+counts, error rate and throughput, and compare them with a same-rig `0.18.2`
+baseline at `main` commit `e2566ade`. Any regression must be explained before
+acceptance.
+
+## Implementation plan
+
+### Phase 0 — Baseline and API inventory
+
+- Run the current `0.18.2` bridge tests and capture their totals.
+- Run the complete off-chain suite on the same rig at `main` commit `e2566ade`
+  and retain its `results-<label>` directory as the `0.18.2` throughput,
+  error-rate, vesting and execution-unit baseline.
+- Capture dependency insight for all three Scalus coordinates and Yano's CCL
+  coordinate before the bump.
+- Resolve and inspect the exact `1.1.1` ledger jar, record its SHA-256 and
+  `javap` output for the produced/consumed signatures, and inventory the
+  default-STS API.
+- Record that Scala remains `3.3.8`; do not change the Scala pin in response to
+  migration errors.
+- Record an API migration inventory before changing adapters.
+
+### Phase 1 — Dependency and bridge migration
+
+- Pin both artifacts to `1.1.1`.
+- Make the minimum source changes needed for `scalus-bridge` compilation.
+- Add or update focused adapter tests for each changed API assumption.
+- Record dependency-insight output proving a single Scalus version.
+
+### Phase 2 — Pool-deposit override re-derivation
+
+- Rebuild the effective rule set from the 1.1.1 defaults.
+- Port the value-conservation correction.
+- Strengthen the exactly-one-entry, identity and deterministic-order guards.
+- Run the pool-deposit semantic matrix at unit level.
+
+### Phase 3 — Serialized JVM and devnet validation
+
+- Run `:scalus-bridge:test` and `:app:integrationTest` in a fresh worktree.
+- Run the complete A-F pool lifecycle matrix against a clean devnet.
+- Retain commands, reports, node logs and transaction hashes.
+
+### Phase 4 — Native and Plutus validation
+
+- Produce the Oracle GraalVM 25.3 G1 native image from the candidate commit.
+- Reuse that exact binary for both native devnet skills and the BLS
+  lock/evaluate/submit/confirm probe.
+- Run Mesh and Evolution vesting datum/redeemer suites.
+- Compare JVM/native results and pre-/post-upgrade execution units.
+
+### Phase 5 — Review and acceptance
+
+- Review the exact candidate diff and resolved dependency graph.
+- Consolidate phase evidence under `adr/reports/`.
+- Change this ADR to Accepted only when every acceptance criterion is backed by
+  a command, result, commit and evidence path.
+
+## Acceptance criteria
+
+- Both direct Scalus artifacts and transitive `scalus_3` resolve to `1.1.1`;
+  Yano's selected `cardano-client-lib` version is unchanged.
+- `scalus-bridge` compiles without spreading Scalus API types into unrelated
+  modules.
+- The pool-deposit override is re-derived from 1.1.1 defaults and remains in
+  place while the produced-value calculation lacks transaction-start pool
+  state.
+- The rule-set guard proves an exactly-one-entry replacement and deterministic
+  name ordering.
+- Pool-deposit semantic tests pass for active, new, duplicate, mixed and both
+  retirement-order cases.
+- Fresh-worktree `:scalus-bridge:test` and `:app:integrationTest` runs pass
+  serially.
+- All A-F running-devnet pool lifecycle scenarios pass.
+- The Oracle GraalVM 25.3 G1 native image builds and reaches readiness.
+- Native BLS evaluation and submission both pass with transaction/log evidence.
+- Mesh and Evolution vesting datum/redeemer regressions both pass against
+  devnet, with execution-unit comparison evidence.
+- All four named devnet skills pass serially, reusing one identified native
+  binary for both native skills and the BLS probe.
+- The five-step off-chain SDK suite passes with submitted/confirmed counts,
+  error rate and throughput compared with the same-rig `0.18.2` baseline.
+- No unexplained semantic, execution-budget, native linkage or dependency-graph
+  difference remains.
+- No chainstate format, public API or runtime configuration change is included.
+
+## Alternatives considered
+
+### Upgrade only the ledger artifact
+
+Rejected. Mixing the ledger and CCL adapter versions creates an unreviewable
+binary-compatibility surface and violates the single-version invariant.
+
+### Delete the override because 1.1.1 is a major upgrade
+
+Rejected. The 1.1.1 produced-value API still lacks the state required to
+distinguish active pool updates. Compilation is not evidence of correct value
+conservation.
+
+### Copy the 0.18.2 default rule list into Yano
+
+Rejected. A copied list can silently omit rules introduced by Scalus 1.x. The
+effective set must be derived from the installed version and guarded by tests.
+
+### Accept JVM tests without executing a native binary
+
+Rejected. BLS JNI linkage, reachability metadata and runtime evaluator paths
+are native-specific, and the relevant native binary is not exercised by CI.
+
+### Run only one off-chain vesting client
+
+Rejected. The Mesh and Evolution suites provide independent datum/redeemer and
+transaction-construction coverage required by issue #106.
+
+### Combine unrelated ledger cleanup with the upgrade
+
+Rejected. A narrow dependency migration is easier to review, revert and
+attribute when a semantic or native regression appears.
+
+## Consequences
+
+### Positive
+
+- Yano moves to the supported Scalus 1.x line.
+- Pool update admission remains aligned with Cardano ledger semantics.
+- Rule-set drift becomes a visible test failure.
+- Native and off-chain evaluation compatibility are demonstrated with executed
+  transactions rather than inferred from compilation.
+
+### Negative
+
+- Yano continues to carry a small upstream override until Scalus exposes the
+  required certificate state in produced-value calculation.
+- Acceptance requires slow, environment-dependent native and devnet gates.
+- External vesting harness identities and results must be retained alongside
+  repository test reports.
+- Override retirement must be tracked in a follow-up issue whose removal gate
+  is the semantic test matrix in Detailed decision section 3; it must not be
+  deleted or left as an unowned parity oracle.
+
+### Risks and mitigations
+
+- **Hidden transitive version skew:** inspect all three Scalus coordinates and
+  Yano's CCL selection before and after, failing acceptance on Scalus 0.x or an
+  unintended CCL change.
+- **Default rule drift:** derive from 1.1.1 defaults and enforce exact identity,
+  count and ordering guards.
+- **Behavioral change masked by successful tests:** compare execution units and
+  run real evaluate/submit paths from two off-chain clients.
+- **Native-only failure:** build with release-parity Oracle GraalVM and execute
+  BLS through the resulting binary.
+- **Contaminated evidence:** run gates serially in a fresh worktree at a named
+  commit and retain logs outside build directories that subsequent tasks may
+  replace.
+
+## Rollback plan
+
+Before merge, revert the dependency and bridge commits together. Do not retain
+a partial adapter migration or mixed Scalus versions. A rollback returns both
+coordinates to `0.18.2` and keeps the existing pool-deposit override.
+
+After merge, use the same atomic version/adapter revert if a production-blocking
+regression appears. No chainstate rollback or migration is required because
+this ADR changes transaction validation and evaluation code only.
+
+## Review decisions requested
+
+1. Accept the atomic `1.1.1` pin and narrow bridge-only migration boundary.
+2. Accept retaining and re-deriving the pool-deposit override for Scalus 1.1.1.
+3. Accept the serialized JVM, A-F devnet, four devnet-skill, Oracle GraalVM
+   native/BLS and five-step off-chain SDK gates as mandatory before merge.

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -255,7 +255,9 @@ arguments. Before correction commit `c1d5cf53`, Yano had zero assertions for
 the execution-unit-limit mapping inside that constructor. The class-wide
 `everyProtocolParameterMapsToItsOwnField` guard now supplies distinct source
 values and asserts all 31 target fields, including every nested component, so
-future argument transpositions fail locally.
+future argument transpositions fail locally. Its expected values also differ
+from the bridge's hardcoded defaults, usually by one, so a source field that
+silently falls back to a default fails the same guard.
 
 ### 5. Use layered, serialized acceptance gates
 

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed
+Accepted
 
 ## Date
 
@@ -19,9 +19,9 @@ Proposed
 - [The ADR-050 upstream report](reports/adr-050-scalus-pool-deposit-upstream-report.md)
   records the value-conservation gap and the expected reference-ledger
   behavior for active pool updates and duplicate registrations.
-- `gradle/libs.versions.toml` currently pins both
+- `gradle/libs.versions.toml` pins both
   `scalus-cardano-ledger_3` and
-  `scalus-bloxbean-cardano-client-lib_3` to `0.18.2`.
+  `scalus-bloxbean-cardano-client-lib_3` to `1.1.1`.
 - `YanoCardanoMutator` replaces Scalus's
   `ValueNotConservedUTxOValidator` while retaining the remainder of
   `CardanoMutator.defaultSTSs()` in deterministic name order.
@@ -364,29 +364,9 @@ result, execution units, submission hash and confirmation evidence. Compare
 execution units with the `0.18.2` baseline; any difference must be explained
 before acceptance, even when both transactions succeed.
 
-#### Gate E — devnet skills and off-chain SDK load suite
+#### Gate E — off-chain SDK load suite
 
-Before the load suite, run only the `test-native-haskell-sync` devnet skill.
-Satya trimmed Gate E to this single skill at 17:38 +08 on 2026-08-31 because
-issue #106 does not change mainnet/preprod synchronization or the epoch-shift
-and slot-zero catch-up paths exercised by the other three skills.
-
-Build the Oracle GraalVM 25.3 G1 native binary once. Reuse that exact binary,
-identified by path and SHA-256, for `test-native-haskell-sync` and the Gate C
-BLS probe.
-The app-chain skills are outside this ADR's scope.
-
-For issue #106, the stock devnet genesis set is authoritative over any PV10
-selection in the local skill text. If `test-native-haskell-sync` selects PV10,
-override it to stock devnet and record the override. Before accepting the
-skill result, verify from the running node's log or API and record that the
-effective protocol major version is `11` and the Plutus V3 cost model contains
-`350` entries. Stock `epochLength=1200` and `slotLength=0.2` make the
-two-full-epoch sync threshold past slot 2400. Oracle GraalVM 25.3 with
-`--gc=G1` likewise supersedes the native skills' older GraalVM 24 prerequisite
-for every native gate in this ADR.
-
-Then run all five steps of
+Run all five steps of
 `/Users/satya/Downloads/yano-ccl-test/run-suite.sh <label> <api-url> <node-pid>`:
 CCL load, MeshJS load, MeshJS vesting, Evolution load and Evolution vesting.
 Retain the `results-<label>/` directory with per-step logs, `timing.txt`,
@@ -400,6 +380,31 @@ and 9,504/9,504 chained transactions with 100% full-depth chains. A candidate
 drop below 100% CCL full depth or any other regression must be explained before
 acceptance. MeshJS chained-input failures remain a documented SDK limitation
 and are reported separately rather than treated as the CCL parity signal.
+
+The load suite passed. Satya decided at 20:50 +08 on 2026-08-31 to skip
+`test-native-haskell-sync` for this PR. This is an explicit scope decision, not
+an unexecuted acceptance item:
+
+1. the issue-106 product diff changes the Scalus bridge and dependency pin,
+   not block production, block CBOR, network synchronization or consensus;
+2. the sync skill's blocks contain simple payments, so it has low power to
+   detect a Scalus-specific evaluator regression;
+3. Gate C exercises the same native binary more directly by evaluating,
+   submitting and confirming a BLS transaction with exact JVM/native execution-
+   unit parity;
+4. the sync skill would require the same projection-disabled deviation as Gate
+   C because of the pre-existing native provider reachability defect; and
+5. a realistic Haskell takeover with the expanded cost models requires a
+   separate governance-action bootstrap scenario rather than substituting the
+   pre-release cardano-node 11.1.0 configuration.
+
+The execution-unit correction also does not require mainnet or preprod replay
+for this PR. It replaces an incorrectly permissive swapped limit with the true
+dimensional limits. Transactions already admitted to a real Cardano chain were
+validated against those true limits by cardano-node, so the correction cannot
+reject a previously valid on-chain transaction. It can only reject the
+over-budget transactions that affected Yano versions could previously
+over-accept.
 
 ## Implementation plan
 
@@ -441,8 +446,7 @@ and are reported separately rather than treated as the CCL parity signal.
 ### Phase 4 — Native and Plutus validation
 
 - Produce the Oracle GraalVM 25.3 G1 native image from the candidate commit.
-- Reuse that exact binary for the native devnet skill and the BLS
-  lock/evaluate/submit/confirm probe.
+- Execute the BLS lock/evaluate/submit/confirm probe with that exact binary.
 - Run Mesh and Evolution vesting datum/redeemer suites.
 - Compare JVM/native results and pre-/post-upgrade execution units.
 
@@ -473,8 +477,8 @@ and are reported separately rather than treated as the CCL parity signal.
 - Native BLS evaluation and submission both pass with transaction/log evidence.
 - Mesh and Evolution vesting datum/redeemer regressions both pass against
   devnet, with execution-unit comparison evidence.
-- `test-native-haskell-sync` passes, reusing one identified native binary for
-  that skill and the BLS probe.
+- The decision to skip `test-native-haskell-sync` is recorded with its scope
+  rationale and is not represented as executed coverage.
 - The five-step off-chain SDK suite passes with submitted/confirmed counts,
   error rate and throughput compared with the same-rig `0.18.2` baseline.
 - No unexplained semantic, execution-budget, native linkage or dependency-graph
@@ -567,9 +571,10 @@ After merge, use the same atomic version/adapter revert if a production-blocking
 regression appears. No chainstate rollback or migration is required because
 this ADR changes transaction validation and evaluation code only.
 
-## Review decisions requested
+## Accepted review decisions
 
 1. Accept the atomic `1.1.1` pin and narrow bridge-only migration boundary.
 2. Accept retaining and re-deriving the pool-deposit override for Scalus 1.1.1.
-3. Accept the serialized JVM, A-F devnet, one devnet-skill, Oracle GraalVM
-   native/BLS and five-step off-chain SDK gates as mandatory before merge.
+3. Accept the serialized JVM, A-F devnet, Oracle GraalVM native/BLS and
+   five-step off-chain SDK gates, with native Haskell sync explicitly deferred
+   as recorded above.

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -512,6 +512,8 @@ attribute when a semantic or native regression appears.
 - Yano moves to the supported Scalus 1.x line.
 - Pool update admission remains aligned with Cardano ledger semantics.
 - Rule-set drift becomes a visible test failure.
+- Scalus 1.1.1's dimensional execution-unit limit check surfaced a latent Yano
+  memory/steps mapping defect that the 0.18.2 total ordering had hidden.
 - Native and off-chain evaluation compatibility are demonstrated with executed
   transactions rather than inferred from compilation.
 

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Accepted
+Proposed
 
 ## Date
 
@@ -571,7 +571,7 @@ After merge, use the same atomic version/adapter revert if a production-blocking
 regression appears. No chainstate rollback or migration is required because
 this ADR changes transaction validation and evaluation code only.
 
-## Accepted review decisions
+## Review decisions requested
 
 1. Accept the atomic `1.1.1` pin and narrow bridge-only migration boundary.
 2. Accept retaining and re-deriving the pool-deposit override for Scalus 1.1.1.

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -513,7 +513,9 @@ attribute when a semantic or native regression appears.
 - Pool update admission remains aligned with Cardano ledger semantics.
 - Rule-set drift becomes a visible test failure.
 - Scalus 1.1.1's dimensional execution-unit limit check surfaced a latent Yano
-  memory/steps mapping defect that the 0.18.2 total ordering had hidden.
+  memory/steps mapping defect that the 0.18.2 total ordering had hidden. The
+  over-acceptance defect affects releases `v0.1.0-pre10` through
+  `v0.1.0-pre13` and is corrected by unreleased commit `c1d5cf53`.
 - Native and off-chain evaluation compatibility are demonstrated with executed
   transactions rather than inferred from compilation.
 

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -274,9 +274,20 @@ its protocol version or cost models differ.
 
 Before every node start, run a repository-wide process check with
 `pgrep -fl "yano.jar|/yano( |$)"` in addition to the gate's port and lock
-checks. Every long-running node must start in its own POSIX session under
-`nohup`, redirect to an identified log, write an identified pidfile, and remain
-alive after an unrelated tool call.
+checks. Every long-running node must start detached in its own process group,
+either under a launch supervisor or a `setsid`/`nohup` equivalent, redirect to
+an identified log, write an identified pidfile, and remain alive after an
+unrelated tool call. Its working directory must be explicitly set to the
+pinned gate working directory and verified with `lsof -a -p <pid> -d cwd -Fn`.
+This requirement applies to baseline, candidate, Gate C, and Gate E launches.
+Do not rely on the agent or supervisor's inherited working directory.
+
+Treat the relative `history/` archive as run state alongside `chainstate/`.
+The configured chainstate leaf and the working-directory-relative archive path
+must both be absent before a baseline or candidate start, and both must be
+independently fresh for the two comparison runs. Record their absence in
+preflight evidence; carried-over chainstate or archive state invalidates
+parity.
 
 Before baseline or candidate throughput measurement, record `uptime` and the
 top five CPU consumers and verify that no competing build or other heavy job is
@@ -371,9 +382,15 @@ Then run all five steps of
 CCL load, MeshJS load, MeshJS vesting, Evolution load and Evolution vesting.
 Retain the `results-<label>/` directory with per-step logs, `timing.txt`,
 `process.txt` and mempool metric snapshots. Record submitted and confirmed
-counts, error rate and throughput, and compare them with a same-rig `0.18.2`
-baseline at `main` commit `e2566ade`. Any regression must be explained before
-acceptance.
+counts, error rate and throughput. Compare the candidate only with the clean
+same-rig `0.18.2` baseline at `e2566ade` in
+`results-issue106-baseline-e2566ade-clean`; historical runs corroborate that
+the baseline is sane but do not define the candidate comparison band. The
+clean baseline accepted 45,645/45,645 regular CCL transactions at 253.0 tx/s
+and 9,504/9,504 chained transactions with 100% full-depth chains. A candidate
+drop below 100% CCL full depth or any other regression must be explained before
+acceptance. MeshJS chained-input failures remain a documented SDK limitation
+and are reported separately rather than treated as the CCL parity signal.
 
 ## Implementation plan
 

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -224,6 +224,16 @@ verify the exactly-one-entry difference, verify counts, verify name order and
 verify that the replacement retains the upstream rule name for stable
 diagnostics.
 
+The effective rule set is derived lazily from
+`CardanoMutator.defaultSTSs()`, so an unguarded incompatibility could otherwise
+surface only as a transaction validation error. The exact-count requirement
+and `swapsExactlyOneScalusDefaultValidator` are therefore the build-time safety
+net: if a future Scalus release removes, renames or duplicates
+`ValueNotConservedUTxOValidator`, a red `:scalus-bridge:test` is the intended
+migration signal, not a flaky obstacle. Re-derive the override for the new
+defaults, or retire it only after the existing produced/`CertState` removal
+criteria are satisfied.
+
 The semantic tests must cover active update, one new pool, duplicate new-pool
 registration, mixed active/new registrations and both retirement orders. At
 least one test must exercise complete value-conservation validation rather

--- a/adr/051-upgrade-scalus-to-1.1.1.md
+++ b/adr/051-upgrade-scalus-to-1.1.1.md
@@ -318,16 +318,14 @@ before acceptance, even when both transactions succeed.
 
 #### Gate E — devnet skills and off-chain SDK load suite
 
-Before the load suite, run these devnet skills strictly one at a time and in
-this order:
-
-1. `test-haskell-sync`;
-2. `test-past-time-travel`;
-3. `test-native-haskell-sync`; and
-4. `test-native-past-time-travel`.
+Before the load suite, run only the `test-native-haskell-sync` devnet skill.
+Satya trimmed Gate E to this single skill at 17:38 +08 on 2026-08-31 because
+issue #106 does not change mainnet/preprod synchronization or the epoch-shift
+and slot-zero catch-up paths exercised by the other three skills.
 
 Build the Oracle GraalVM 25.3 G1 native binary once. Reuse that exact binary,
-identified by path and SHA-256, for both native skills and the Gate C BLS probe.
+identified by path and SHA-256, for `test-native-haskell-sync` and the Gate C
+BLS probe.
 The app-chain skills are outside this ADR's scope.
 
 For issue #106, the committed PV10 genesis is authoritative over stale values
@@ -385,7 +383,7 @@ acceptance.
 ### Phase 4 — Native and Plutus validation
 
 - Produce the Oracle GraalVM 25.3 G1 native image from the candidate commit.
-- Reuse that exact binary for both native devnet skills and the BLS
+- Reuse that exact binary for the native devnet skill and the BLS
   lock/evaluate/submit/confirm probe.
 - Run Mesh and Evolution vesting datum/redeemer suites.
 - Compare JVM/native results and pre-/post-upgrade execution units.
@@ -417,8 +415,8 @@ acceptance.
 - Native BLS evaluation and submission both pass with transaction/log evidence.
 - Mesh and Evolution vesting datum/redeemer regressions both pass against
   devnet, with execution-unit comparison evidence.
-- All four named devnet skills pass serially, reusing one identified native
-  binary for both native skills and the BLS probe.
+- `test-native-haskell-sync` passes, reusing one identified native binary for
+  that skill and the BLS probe.
 - The five-step off-chain SDK suite passes with submitted/confirmed counts,
   error rate and throughput compared with the same-rig `0.18.2` baseline.
 - No unexplained semantic, execution-budget, native linkage or dependency-graph
@@ -508,5 +506,5 @@ this ADR changes transaction validation and evaluation code only.
 
 1. Accept the atomic `1.1.1` pin and narrow bridge-only migration boundary.
 2. Accept retaining and re-deriving the pool-deposit override for Scalus 1.1.1.
-3. Accept the serialized JVM, A-F devnet, four devnet-skill, Oracle GraalVM
+3. Accept the serialized JVM, A-F devnet, one devnet-skill, Oracle GraalVM
    native/BLS and five-step off-chain SDK gates as mandatory before merge.

--- a/adr/reports/adr-050-scalus-pool-deposit-upstream-report.md
+++ b/adr/reports/adr-050-scalus-pool-deposit-upstream-report.md
@@ -14,6 +14,15 @@ the transaction and protocol parameters. Its `conwayTotalDepositsTxCerts` calls
 `Certificate.shelleyTotalDeposits`, which adds `stakePoolDeposit` for every
 `PoolRegistration` certificate.
 
+Scalus `1.1.1` bytecode narrows the missing state to one private function.
+Consumed-side staking and DRep refunds use
+`lookupStakingDeposit$1(CertState, Credential)` and
+`lookupDRepDeposit$1(CertState, Credential)`, while produced-side certificate
+deposits use `conwayTotalDepositsTxCerts(Transaction, ProtocolParams)` with no
+state parameter. Threading the transaction-start pool set through that method
+and `produced` would make pool deposits state-aware in the same way refunds
+already are.
+
 The Cardano ledger charges that deposit only for a pool ID absent from the
 transaction-start `psStakePools` map. Re-registering an active pool is an update
 and must not pay another deposit. Duplicate registrations for one new pool in a

--- a/adr/reports/adr-051-phase-0-2026-08-31.md
+++ b/adr/reports/adr-051-phase-0-2026-08-31.md
@@ -245,3 +245,100 @@ long-running node must be launched fully detached from the agent session with
 working directory. This keeps multi-hour baseline and candidate runs alive
 across agent tool calls; it is not evidence about why PID `98527` exited. The
 start report must verify that the process survives an unrelated tool call.
+
+## Authorized baseline start
+
+After Satya authorized stopping the orphan PID `50305`, one `SIGTERM` was sent.
+It exited after approximately 105 seconds; no escalating signal was used. A
+repo-wide Yano process check, port checks for `7070`, `13337`, and `3002`, and
+lock-holder checks were then empty.
+
+The baseline started fully detached as PID `46546`, PPID `1`, PGID `46546`,
+with its PID and log at:
+
+- `/Users/satya/Downloads/yano-ccl-test/issue106-baseline/e2566ade/run/yano-baseline.pid`
+- `/Users/satya/Downloads/yano-ccl-test/issue106-baseline/e2566ade/run/yano-baseline.log`
+
+It survived an unrelated git/date tool call. The effective process command and
+runtime logs confirmed the accepted SHA-256 `0697f665...31f`, `-Xmx1024m`, G1,
+devnet profile, HTTP `7070`, n2n `13337`, the explicit fresh chainstate and
+PV10 genesis/key/certificate paths, transaction evaluation, and Scalus script
+evaluation. Runtime parsing confirmed network magic `42`, epoch length `1200`,
+slot length `0.2` seconds, and active-slots coefficient `1.0`. Readiness was
+`UP`. This launch matched the then-accepted block, but later diagnosis showed
+that the block itself selected the wrong comparison profile: PV10 is protocol
+major 10 with a 297-entry Plutus V3 cost model, while the historical off-chain
+baselines used stock devnet protocol major 11 with a 350-entry V3 model.
+
+## Contended off-chain smoke — not a valid throughput baseline
+
+The five-step suite ran from 10:01:56Z to 10:09:15Z under label
+`issue106-baseline-e2566ade`. An unrelated `julc` Gradle build overlapped it.
+Observed load averages reached `30.48 12.84 7.73`; the local end capture was
+`7.90 12.23 8.96` with an unrelated Gradle worker still using 102.2% CPU.
+Consequently no throughput, latency, or wall-clock figure from this run is a
+valid comparison baseline. The retained marker is:
+
+`/Users/satya/Downloads/yano-ccl-test/results-issue106-baseline-e2566ade/CONTENDED-NOT-A-VALID-BASELINE.md`
+
+Functional results were:
+
+| Step | Result |
+| --- | --- |
+| CCL load | exit 0; regular 40229/40229, chained 8096/8096, 1012/1012 full-depth chains |
+| MeshJS load | exit 0; regular 3625/3625; chained 1211/2287 with 1076 `Transaction not found` outcomes |
+| MeshJS vesting | exit 0; both valid branches accepted and premature beneficiary withdrawal rejected, 3/3 |
+| Evolution load | exit 0; regular 128/128; chained 140/148 with 8 submission failures, 24/32 full-depth chains |
+| Evolution vesting | exit 1; all three cases hit identical execution-budget exhaustion; effective result 0/3 because the negative case was a false pass |
+
+The wrapper returned `0` despite step 5 recording `exit=1`; the step is treated
+as failed. Mesh chaining is the known limitation documented in
+`/Users/satya/Downloads/yano-ccl-test/JS-SDK-COMPATIBILITY-REPORT.md` section
+4.2: historical chained acceptance was 50.7% (3764/7421), 50.6% (3641/7193),
+and 51.2% (2352/4598), all with zero full-depth chains. This run's 53% and one
+full-depth chain are not a Gate E finding; Mesh regular and Evolution chained
+are the comparison signals. The Evolution budget failure remains a blocking
+configuration finding and is not attributed to CPU contention or issue #106.
+Its identical error in all three cases means the harness's nominal 1/3 score
+contains a false pass; the effective score is 0/3. A clean baseline rerun must
+use the corrected stock profile plus quiet-machine evidence before and after
+under a new result label. Candidate measurement has the identical precondition.
+
+## Devnet-profile diagnosis and stock-profile confirmation
+
+The failing run selected `app/config/network/devnet/pv10/`, while all five
+retained passing off-chain runs used the stock `app/config/network/devnet/`
+profile. The profiles share network magic `42`, epoch length `1200`, slot
+length `0.2` seconds, and active-slots coefficient `1.0`, but they are not
+ledger-equivalent:
+
+| Effective value | Stock devnet | PV10 devnet |
+| --- | ---: | ---: |
+| Protocol major/minor | 11/0 | 10/2 |
+| Shelley genesis protocol major/minor | 11/0 | 10/0 |
+| Plutus V1 cost-model entries | 332 | 166 |
+| Plutus V2 cost-model entries | 332 | 175 |
+| Plutus V3 cost-model entries | 350 | 297 |
+
+The exact ADR-048 head `4cce4e4021b2575e03e890c84c10b9058c297c94`
+was rebuilt successfully (`:app:quarkusBuild`, exit `0`; jar SHA-256
+`833e692cf8cbb12b2eece4c0e46bd5b94dca4cc3f01be6ea5eca1169c20e8cdb`).
+On a fresh PV10 data leaf it reproduced the exact same effective `0/3` result
+as `e2566ade`: all three cases failed with `execution went over budget Mem
+-29369788 CPU 9999716408`. This rules out the binary delta and retains a useful
+reproduction of the unhelpful cost-model-mismatch diagnostic.
+
+The original `e2566ade` jar (SHA-256 `0697f665...31f`) was then started with
+fresh chainstate and the stock protocol-11 genesis set. Running only
+`YANO_URL=http://127.0.0.1:7070/api/v1 timeout 600 node --no-warnings
+src/vesting.mjs` from the Evolution client exited `0` with true `3/3` behavior:
+
+- owner clawback accepted as transaction `8687ddfb972c0459...`;
+- beneficiary-after-unlock accepted as transaction `659928461a574e5b...`;
+- beneficiary-before-unlock rejected with `the validator crashed / exited
+  prematurely`, proving validator logic rather than systematic budget failure.
+
+The exact deposit prefixes were `fc797c20ee75f934...`,
+`2915e4db3d7648ff...`, and `d3209ab2fa0adcc6...`. The corrected comparison
+block therefore pins stock devnet, protocol major `11`, and Plutus cost-model
+entry counts `332/332/350` as must-not-change values.

--- a/adr/reports/adr-051-phase-0-2026-08-31.md
+++ b/adr/reports/adr-051-phase-0-2026-08-31.md
@@ -1,0 +1,193 @@
+# ADR-051 Phase 0 — Scalus 1.1.1 baseline and API evidence
+
+## Status
+
+B1 complete: the exact Scalus `1.1.1` ledger jar selected by Gradle retains
+the produced-value/`CertState` gap. The pool-deposit override must be ported,
+not deleted.
+
+The fresh `0.18.2` bridge-test baseline and before/after dependency selections
+are complete. The same-rig off-chain baseline is pending an accepted
+long-running-process configuration and is not claimed by this report.
+
+## Source identity and toolchain
+
+- Branch: `issue-106-upgrade-scalus-1.1.1`
+- Base commit: `e2566ade8f0ee92a933a4d1177933bdf14b01173`
+- Baseline dependency pins: Scalus `0.18.2`
+- Candidate dependency pins used to resolve the inspected jar: Scalus `1.1.1`
+- JDK: OpenJDK `25.0.2+12-LTS`
+- Gradle: `9.4.1`
+- Host: macOS `26.0.1`, `aarch64`
+
+## Fresh 0.18.2 bridge-test baseline
+
+Command:
+
+```bash
+./gradlew :scalus-bridge:test --rerun-tasks --console=plain
+```
+
+Result: exit `0`, 12 tasks executed, build successful in 4 seconds. JUnit XML
+under `scalus-bridge/build/test-results/test/` contained:
+
+| Suites | Tests | Failures | Errors | Skipped |
+| ---: | ---: | ---: | ---: | ---: |
+| 5 | 47 | 0 | 0 | 0 |
+
+Count command:
+
+```bash
+ruby -r rexml/document -e '<sum testsuite attributes from TEST-*.xml>'
+```
+
+Result: exit `0`, `files=5 tests=47 failures=0 errors=0 skipped=0`.
+
+## Runtime dependency selection
+
+Before changing the pins, these commands exited `0`:
+
+```bash
+./gradlew :app:dependencyInsight --configuration runtimeClasspath \
+  --dependency org.scalus --console=plain
+./gradlew :app:dependencyInsight --configuration runtimeClasspath \
+  --dependency com.bloxbean.cardano:cardano-client-lib --console=plain
+```
+
+The baseline graph selected:
+
+| Coordinate | Before |
+| --- | --- |
+| `org.scalus:scalus-cardano-ledger_3` | `0.18.2` |
+| `org.scalus:scalus-bloxbean-cardano-client-lib_3` | `0.18.2` |
+| `org.scalus:scalus_3` | `0.18.2` |
+| `com.bloxbean.cardano:cardano-client-lib` | `0.7.2` |
+
+After changing both direct pins to `1.1.1`, the same commands exited `0` and
+selected:
+
+| Coordinate | After |
+| --- | --- |
+| `org.scalus:scalus-cardano-ledger_3` | `1.1.1` |
+| `org.scalus:scalus-bloxbean-cardano-client-lib_3` | `1.1.1` |
+| `org.scalus:scalus_3` | `1.1.1` |
+| `com.bloxbean.cardano:cardano-client-lib` | `0.7.2` |
+
+There is no selected Scalus `0.x` module in the candidate runtime graph, and
+Yano's selected CCL version did not move.
+
+## Resolved artifact identities
+
+Gradle resolved these Maven-cache artifacts after
+`:scalus-bridge:compileScala`:
+
+| Artifact | SHA-256 |
+| --- | --- |
+| `scalus-cardano-ledger_3-1.1.1.jar` | `da9f4560b3f0a6a8b90252383f14a32566fabe6d9361d9455551d7eaec2a17e6` |
+| `scalus-bloxbean-cardano-client-lib_3-1.1.1.jar` | `eb36b1eeb2a4669e303da901a962803110c9efa82180cd28e44d8e2ced282581` |
+
+Hash command:
+
+```bash
+shasum -a 256 <Gradle-cache-jar>
+```
+
+Both invocations exited `0`.
+
+## B1: direct produced/consumed signature evidence
+
+Command, run against the ledger jar with SHA-256 `da9f4560...a17e6`:
+
+```bash
+javap -classpath <scalus-cardano-ledger_3-1.1.1.jar> -p \
+  'scalus.cardano.ledger.utils.TxBalance$'
+```
+
+Relevant output:
+
+```text
+public scala.util.Either<scalus.cardano.ledger.TransactionException$BadInputsUTxOException,
+  scalus.cardano.ledger.Value> consumed(
+    scalus.cardano.ledger.Transaction,
+    scalus.cardano.ledger.CertState,
+    scala.collection.immutable.Map<scalus.cardano.ledger.TransactionInput,
+      scalus.cardano.ledger.TransactionOutput>,
+    scalus.cardano.ledger.ProtocolParams);
+
+public scalus.cardano.ledger.Value produced(
+  scalus.cardano.ledger.Transaction,
+  scalus.cardano.ledger.ProtocolParams);
+```
+
+Result: exit `0`. `consumed` receives `CertState`; `produced` does not. Scalus
+`1.1.1` therefore cannot determine transaction-start active-pool membership in
+its produced-value calculation. Per issue #106 and ADR-051, Yano must retain
+and re-derive its pool-deposit override.
+
+The default-rule API remains:
+
+```text
+public scala.collection.immutable.Map<java.lang.String,
+  scalus.cardano.ledger.rules.STS> defaultSTSs();
+```
+
+This was obtained with `javap -p` on
+`scalus.cardano.ledger.rules.CardanoMutator$` from the same jar; exit `0`.
+
+## API migration inventory
+
+The candidate pins were applied before running these commands:
+
+```bash
+./gradlew :scalus-bridge:compileScala --rerun-tasks --console=plain
+./gradlew :scalus-bridge:compileTestScala --rerun-tasks --console=plain
+```
+
+Both commands exited `0`. Main compilation executed 4 tasks and completed in
+5 seconds. Test-source compilation executed 7 tasks and completed in 4
+seconds. There were no Scalus source-compatibility errors.
+
+| Bridge surface | 1.1.1 source result | Required follow-up |
+| --- | --- | --- |
+| Transaction CBOR decoding and CCL interop | Compiles unchanged | Add a real-transaction CBOR round-trip test because Borer moved `1.16.2` -> `1.17.0` |
+| Protocol parameters and slot configuration | Compiles unchanged | Run existing focused adapter tests |
+| UTxO, scripts and certificate state | Compiles unchanged | Run bridge tests and running-node semantic gates |
+| `CardanoMutator.defaultSTSs`, `STS`, context/state and errors | Compiles unchanged | Re-derive and strengthen the exactly-one-entry guard after coordinator B1 acknowledgement |
+| JVM evaluator and validator entry points | Compiles unchanged | Run bridge/application tests and off-chain evaluate/submit gates |
+| BLS/JNI native surface | Compilation does not prove reachability | Run the accepted Oracle GraalVM 25.3 G1 native probe |
+
+Scala remains pinned at `3.3.8`; no Scala-version edit is included or needed.
+
+## Remaining Phase 0 work
+
+The same-rig `0.18.2` off-chain load and vesting baseline must run from base
+commit `e2566ade` using
+`/Users/satya/Downloads/yano-ccl-test/run-suite.sh`. It requires a running
+devnet and will start only after the coordinator accepts the mandatory run
+configuration. The pre-existing `results-adr048-head-jvm` directory is useful
+historical evidence but is not substituted for the exact-commit baseline.
+
+## Proposed baseline run and current process collision
+
+An exact-base detached worktree was created at
+`/tmp/yano-issue106-baseline.UminTR/repo`. This command exited `0`:
+
+```bash
+./gradlew :app:quarkusBuild --console=plain
+```
+
+Result: 60 actionable tasks, 41 executed and 19 from cache; build successful in
+33 seconds. The resulting `app/build/yano.jar` is 298,154,685 bytes with
+SHA-256 `0697f665233d312b676a2cafd3b1bc394e27a9dc6047633289b10318b55bb31f`.
+
+No baseline node was started. A read-only port/process check found PID `98527`
+already listening on HTTP `7070` and node-to-node `13337`. It has run since
+2026-08-31 10:31 +08 from
+`/Users/satya/Downloads/yano-try/replay-99-e447`, uses the native `./yano`
+binary with `-Xmx1024m` and the mainnet profile, and owns
+`/Users/satya/Downloads/yano-try/replay-99-e447/chainstate`. Its RocksDB lock is
+open. It was not stopped or changed.
+
+The exact proposed baseline configuration is recorded in the 17:25 mailbox
+message. It is not accepted and cannot start while PID `98527` runs under the
+one-Yano-process rule.

--- a/adr/reports/adr-051-phase-0-2026-08-31.md
+++ b/adr/reports/adr-051-phase-0-2026-08-31.md
@@ -391,6 +391,11 @@ not widen the candidate acceptance band.
 Neither vesting harness logs evaluator execution units. The retained Mesh and
 Evolution logs contain fixture/deposit identities, accepted transaction-hash
 prefixes, and rejection outcomes only; the node log also does not emit the
-evaluation response budgets. Gate D therefore compares the identical harness
-outcomes and submission hashes rather than claiming an unavailable baseline
-execution-unit comparison.
+evaluation response budgets. Gate D obtains node-evaluated units through the
+existing BLS probe instead. Against a fresh exact `e2566ade` JVM node, case 1
+evaluated as `spend:0 mem=12460 steps=110931472`, submitted transaction
+`a40c5f903fa205bfef43f2dd74718770242a715218b172b85767c35518dfeeda`,
+and confirmed. The negative control was rejected by script evaluation with
+spent budget `mem 0.012360, cpu 110.915472`; no BLS-library-unavailable
+signature appeared. These values exactly match the retained historical BLS
+smoke report and define the JVM candidate equality target.

--- a/adr/reports/adr-051-phase-0-2026-08-31.md
+++ b/adr/reports/adr-051-phase-0-2026-08-31.md
@@ -6,9 +6,8 @@ B1 complete: the exact Scalus `1.1.1` ledger jar selected by Gradle retains
 the produced-value/`CertState` gap. The pool-deposit override must be ported,
 not deleted.
 
-The fresh `0.18.2` bridge-test baseline and before/after dependency selections
-are complete. The same-rig off-chain baseline is pending an accepted
-long-running-process configuration and is not claimed by this report.
+The fresh `0.18.2` bridge-test baseline, before/after dependency selections,
+and exact-commit same-rig clean off-chain baseline are complete.
 
 ## Source identity and toolchain
 
@@ -158,14 +157,13 @@ seconds. There were no Scalus source-compatibility errors.
 
 Scala remains pinned at `3.3.8`; no Scala-version edit is included or needed.
 
-## Remaining Phase 0 work
+## Exact-commit off-chain baseline plan
 
-The same-rig `0.18.2` off-chain load and vesting baseline must run from base
-commit `e2566ade` using
-`/Users/satya/Downloads/yano-ccl-test/run-suite.sh`. It requires a running
-devnet and will start only after the coordinator accepts the mandatory run
-configuration. The pre-existing `results-adr048-head-jvm` directory is useful
-historical evidence but is not substituted for the exact-commit baseline.
+The same-rig `0.18.2` off-chain load and vesting baseline was required from
+base commit `e2566ade` using
+`/Users/satya/Downloads/yano-ccl-test/run-suite.sh`. The retained
+`results-adr048-head-jvm` directory is corroborating historical evidence but
+was not substituted for the exact-commit baseline recorded below.
 
 ## Proposed baseline run and current process collision
 
@@ -342,3 +340,57 @@ The exact deposit prefixes were `fc797c20ee75f934...`,
 `2915e4db3d7648ff...`, and `d3209ab2fa0adcc6...`. The corrected comparison
 block therefore pins stock devnet, protocol major `11`, and Plutus cost-model
 entry counts `332/332/350` as must-not-change values.
+
+## Clean exact-commit off-chain baseline
+
+The accepted clean run used the exact `e2566ade` jar with SHA-256
+`0697f665233d312b676a2cafd3b1bc394e27a9dc6047633289b10318b55bb31f`,
+stock devnet, `-Xmx1024m`, G1, transaction evaluation enabled, and the Scalus
+script evaluator. Runtime logs reported protocol `11.0`; the effective
+protocol-parameter file has Plutus V1/V2/V3 cardinalities `332/332/350` and
+SHA-256 `0f78d85ebdf025e17eb32a2fc1767b933c4e7869f1032cbce7bf6bae102c9fea`.
+
+The first detached launch was rejected by readiness before any transaction was
+submitted: launchd inherited `/` as cwd, so the relative archive path resolved
+to read-only `/history`. That failed launch and its chainstate were preserved
+separately. Before retry, both `run-clean/chainstate` and the relative
+`history/` archive were absent. A launchd plist then set the accepted working
+directory explicitly. Effective PID `54007` had PPID `1`, PGID `54007`, and
+`lsof -a -p 54007 -d cwd -Fn` reported:
+
+```text
+n/Users/satya/Downloads/yano-ccl-test/issue106-baseline/e2566ade
+```
+
+The node survived unrelated tool calls, readiness was `UP`, and only it owned
+HTTP `7070` and n2n `13337`. The immediate pre-suite load average was
+`6.63/6.29/6.36`; there was no active Gradle wrapper/build or other Yano node.
+The suite ran from `10:41:30Z` to `10:50:11Z` under label
+`issue106-baseline-e2566ade-clean`. All five wrappers exited `0`:
+
+| Step | Clean baseline result |
+| --- | --- |
+| CCL load | regular 45,645/45,645 accepted at 253.0 tx/s; chained 9,504/9,504, 1,188/1,188 full-depth chains |
+| MeshJS load | regular 11,587/11,587 at 128.7 tx/s; chained 3,641/7,262 with 3,621 retained `Transaction not found` outcomes |
+| MeshJS vesting | owner clawback accepted, beneficiary-after-unlock accepted, premature beneficiary withdrawal rejected; 3/3 |
+| Evolution load | regular 128/128 at 1.4 tx/s; chained 140/148, 24/32 full-depth chains, 8 retained submission failures |
+| Evolution vesting | owner clawback accepted, beneficiary-after-unlock accepted, premature beneficiary withdrawal rejected as `the validator crashed / exited prematurely`; 3/3 |
+
+The end load average was `3.96/5.46/6.12`; readiness remained `UP`, and no
+competing Gradle wrapper/build had appeared. The node then stopped cleanly and
+released both ports. Complete evidence is retained at:
+
+`/Users/satya/Downloads/yano-ccl-test/results-issue106-baseline-e2566ade-clean`
+
+Candidate comparison uses this clean baseline only. In particular, CCL regular
+throughput compares with 253.0 tx/s, and CCL chaining must retain 100% full
+depth. The contended run is excluded from throughput comparison. Historical
+figures such as 255.44 tx/s corroborate that the clean result is sane but do
+not widen the candidate acceptance band.
+
+Neither vesting harness logs evaluator execution units. The retained Mesh and
+Evolution logs contain fixture/deposit identities, accepted transaction-hash
+prefixes, and rejection outcomes only; the node log also does not emit the
+evaluation response budgets. Gate D therefore compares the identical harness
+outcomes and submission hashes rather than claiming an unavailable baseline
+execution-unit comparison.

--- a/adr/reports/adr-051-phase-0-2026-08-31.md
+++ b/adr/reports/adr-051-phase-0-2026-08-31.md
@@ -189,5 +189,59 @@ binary with `-Xmx1024m` and the mainnet profile, and owns
 open. It was not stopped or changed.
 
 The exact proposed baseline configuration is recorded in the 17:25 mailbox
-message. It is not accepted and cannot start while PID `98527` runs under the
-one-Yano-process rule.
+message and its stable-path amendments in the 17:31 message. The coordinator
+accepted that amended block and authorized the Phase-0 start at 17:44 +08,
+subject to the detached-process rule recorded below.
+
+## Issue-99 replay resume evidence and prior exit
+
+At 17:40 +08, after Satya's 17:32 authorization to stop PID `98527` with
+`SIGTERM`, the required pre-stop endpoint capture failed with curl exit `7`:
+
+```bash
+curl -fsS http://localhost:7070/api/v1/blocks/latest
+```
+
+PID `98527` was already absent before Codex sent any signal. Codex therefore
+did **not** run `kill`. The most recent successful endpoint snapshot, captured
+by the coordinator at 17:29 +08, was height `13879496`, epoch `652`, and
+epoch-slot `301320`. The final replay log line is:
+
+```text
+2026-08-31 17:31:49,322 ... Block: 13879511, Slot: 196602418 (Conway)
+```
+
+Using the coordinator's earlier endpoint snapshot and the slot delta, this
+final log tip implies epoch `652`, epoch-slot `301618`; this is an inference,
+not a successful final endpoint response. The last observed process snapshot
+before authorization was PID `98527`, elapsed `06:53:23`, RSS `1061024` KiB.
+
+The launch-command record at
+`/Users/satya/Downloads/yano-try/replay-99-e447/start-command-final-9f018cb4.txt`
+contains this verbatim command:
+
+```text
+./yano -Xmx1024m -Dquarkus.log.file.enable=true -Dquarkus.log.file.path=yano-issue99-final.log -Dyano.ledger-apply.max-queued-decoded-bytes=67108864 -Dyano.exit-on-epoch-calc-error=true -Dyano.auto-checkpoint-interval=0 -Dyano.rocksdb.block-cache-bytes=33554432 -Dyano.rocksdb.write-buffer-bytes=67108864 -Dyano.rocksdb.max-background-jobs=2 -Dyano.block-producer.script-evaluator=scalus -Dquarkus.profile=mainnet
+```
+
+Post-exit checks found no PID `98527`, no listeners on ports `7070` or `13337`,
+and no holder of the replay chainstate's RocksDB `LOCK`. The final 40 log lines
+are ordinary block-application records ending at the line above; they contain
+no explicit orderly-shutdown marker. Satya later confirmed that they manually
+stopped the process. Nothing under `replay-99-e447` was deleted, moved, compacted, or
+otherwise changed. All issue-106 node starts remain on hold pending coordinator
+resolution of the missing shutdown evidence and explicit run-configuration
+acceptance.
+
+At 17:47 +08 Satya confirmed that they manually stopped PID `98527`. This
+supersedes the coordinator's short-lived 17:44 inference that another agent
+session had reaped it. The coordinator reverified the clear process, port, and
+lock checks and explicitly authorized the Phase-0 start. The issue-99 replay
+and its checkpoint remain untouched and out of scope.
+
+The accepted run block now has one additional must-not-change rule: every
+long-running node must be launched fully detached from the agent session with
+`setsid`/`nohup`, redirected to its own log, and recorded in a pidfile under the
+working directory. This keeps multi-hour baseline and candidate runs alive
+across agent tool calls; it is not evidence about why PID `98527` exited. The
+start report must verify that the process survives an unrelated tool call.

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -2,16 +2,19 @@
 
 ## Status
 
-The dependency migration and pool-deposit override re-derivation compile and
-pass the complete `scalus-bridge` suite. The corrected stock-devnet clean
-baseline is authorized; the remaining node-backed and application integration
-gates have not completed.
+The dependency migration, pool-deposit override re-derivation, and execution-
+unit dimension correction compile and pass the complete `scalus-bridge` suite.
+The corrected stock-devnet clean baseline is complete; the candidate load,
+remaining node-backed gates, and application integration gate have not
+completed.
 
 ## Changes
 
 - Both direct Scalus artifacts are pinned to `1.1.1`; transitive `scalus_3`
   resolves to `1.1.1`, while CCL remains `0.7.2`.
-- The 1.1.1 bridge main and test sources required no API compatibility edits.
+- `ProtocolParamsBridge` now constructs maximum block and transaction
+  execution units in Scalus's declared `(memory, steps)` order. The old bridge
+  passed `(steps, memory)`.
 - `YanoCardanoMutator` now requires the upstream
   `ValueNotConservedUTxOValidator` identity exactly once before replacing it.
   Counts of zero and greater than one fail during effective-rule construction.
@@ -58,21 +61,57 @@ Complete bridge suite:
 ./gradlew :scalus-bridge:test --rerun-tasks --console=plain
 ```
 
-Final result: exit `0`, 12 tasks executed, build successful in 9 seconds. JUnit
+Final result after the execution-unit correction: exit `0`, 12 tasks executed,
+build successful in 8 seconds. JUnit
 XML under `scalus-bridge/build/test-results/test/` contained:
 
 | Suites | Tests | Failures | Errors | Skipped |
 | ---: | ---: | ---: | ---: | ---: |
-| 6 | 51 | 0 | 0 | 0 |
+| 6 | 52 | 0 | 0 | 0 |
+
+## Execution-unit migration finding
+
+The first 1.1.1 JVM BLS probe returned the exact expected evaluation budget,
+`spend:0 mem=12460 steps=110931472`, but submission failed
+`ExUnitsExceedMax`. This exposed a pre-existing bridge defect rather than a
+changed evaluator budget.
+
+Both Scalus versions declare `ExUnits(memory, steps)`, while Yano constructed
+the maximum transaction and block values positionally as `(steps, memory)`.
+Scalus 0.18.2's `ExUnitsTooBigValidator` compared through the type's total
+`Ordering`; Scalus 1.1.1 calls the new dimensional `ExUnits.exceeds`, whose
+bytecode checks memory and steps independently. The stricter implementation
+therefore exposed an effective candidate maximum of
+`ExUnits(memory=10,000,000,000, steps=16,500,000)`.
+
+The correction is commit `c1d5cf53`. The new
+`executionUnitLimitsKeepMemoryAndStepsInScalusOrder` test asserts four distinct
+values: block memory `50,000,000`, block steps `40,000,000,000`, transaction
+memory `10,000,000`, and transaction steps `10,000,000,000`. The focused test
+and complete suite pass; the complete suite now contains 52 tests.
+
+A scratch check loaded the exact 0.18.2 classes from the baseline jar and used
+`given_Ordering_ExUnits` exactly as its validator did. It compared
+`ExUnits(20,000,000, 1,000,000)` with the shipped swapped maximum
+`ExUnits(10,000,000,000, 16,500,000)`: comparison result `-1`, so the old
+validator accepted it even though `20,000,000` exceeds the true `16,500,000`
+memory cap. The released mapping could therefore admit a transaction that a
+correct dimensional limit rejects, creating consensus-divergence risk.
+
+After the correction, the fresh 1.1.1 JVM BLS probe passed end to end with
+exact baseline parity: `spend:0 mem=12460 steps=110931472`, submitted and
+confirmed as transaction
+`73e1e561672f8b34d880553d04e59ca24dfeab73c2927587db2bde7b692f0955`.
+The negative control retained the identical rejection budget and did not
+report an unavailable BLS library. Native equality remains a Gate C item.
 
 ## Deferred gates
 
 - `:app:integrationTest`
-- exact-commit 0.18.2 off-chain baseline
+- candidate five-step off-chain SDK/load/vesting suite
 - A–F pool lifecycle devnet matrix
 - `test-native-haskell-sync`
 - Oracle GraalVM 25.3 G1 native BLS probe
-- candidate five-step off-chain SDK/load/vesting suite
 
 The coordinator accepted the corrected stock-devnet run block and authorized
 the clean baseline. Each remaining node-backed gate still requires its own

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -4,9 +4,9 @@
 
 The dependency migration, pool-deposit override re-derivation, and execution-
 unit dimension correction compile and pass the complete `scalus-bridge` suite.
-The corrected stock-devnet clean baseline is complete; the candidate load,
-remaining node-backed gates, and application integration gate have not
-completed.
+The corrected stock-devnet clean baseline and candidate off-chain SDK/load
+comparison are complete and accepted without regression. The remaining
+node-backed, native, and application integration gates have not completed.
 
 ## Changes
 
@@ -15,6 +15,10 @@ completed.
 - `ProtocolParamsBridge` now constructs maximum block and transaction
   execution units in Scalus's declared `(memory, steps)` order. The old bridge
   passed `(steps, memory)`.
+- `everyProtocolParameterMapsToItsOwnField` uses distinct source values and
+  asserts all 31 positional `ProtocolParams` outputs, including every nested
+  component. Before `c1d5cf53`, the execution-unit-limit mapping had zero
+  assertions; the class-wide guard prevents the same defect pattern elsewhere.
 - `YanoCardanoMutator` now requires the upstream
   `ValueNotConservedUTxOValidator` identity exactly once before replacing it.
   Counts of zero and greater than one fail during effective-rule construction.
@@ -61,13 +65,13 @@ Complete bridge suite:
 ./gradlew :scalus-bridge:test --rerun-tasks --console=plain
 ```
 
-Final result after the execution-unit correction: exit `0`, 12 tasks executed,
-build successful in 8 seconds. JUnit
+Final result after the class-wide parameter guard: exit `0`, build successful.
+JUnit
 XML under `scalus-bridge/build/test-results/test/` contained:
 
 | Suites | Tests | Failures | Errors | Skipped |
 | ---: | ---: | ---: | ---: | ---: |
-| 6 | 52 | 0 | 0 | 0 |
+| 6 | 53 | 0 | 0 | 0 |
 
 ## Execution-unit migration finding
 
@@ -79,16 +83,22 @@ changed evaluator budget.
 Both Scalus versions declare `ExUnits(memory, steps)`, while Yano constructed
 the maximum transaction and block values positionally as `(steps, memory)`.
 Scalus 0.18.2's `ExUnitsTooBigValidator` compared through the type's total
-`Ordering`; Scalus 1.1.1 calls the new dimensional `ExUnits.exceeds`, whose
-bytecode checks memory and steps independently. The stricter implementation
-therefore exposed an effective candidate maximum of
+`Ordering`. Bytecode inspection showed that ordering was lexicographic: it
+compared memory first and only compared steps when memory was equal. Scalus
+1.1.1 calls the new dimensional `ExUnits.exceeds`, whose bytecode checks memory
+and steps independently. The stricter implementation therefore exposed an
+effective candidate maximum of
 `ExUnits(memory=10,000,000,000, steps=16,500,000)`.
 
 The correction is commit `c1d5cf53`. The new
 `executionUnitLimitsKeepMemoryAndStepsInScalusOrder` test asserts four distinct
 values: block memory `50,000,000`, block steps `40,000,000,000`, transaction
 memory `10,000,000`, and transaction steps `10,000,000,000`. The focused test
-and complete suite pass; the complete suite now contains 52 tests.
+and complete suite pass. A separate guard commit, `2d02346e`, adds
+`everyProtocolParameterMapsToItsOwnField`: it covers all 31 positional fields
+with distinct values and decomposes cost models, voting thresholds, prices,
+limits, and protocol version into component assertions. No second wrong
+mapping was found; the complete suite now contains 53 tests.
 
 A scratch check loaded the exact 0.18.2 classes from the baseline jar and used
 `given_Ordering_ExUnits` exactly as its validator did. It compared
@@ -129,10 +139,43 @@ the 1.1.1 native binary to return the same `12,460 / 110,931,472`; any
 difference there isolates to native-image behavior with the Scalus version
 held constant.
 
+## Candidate off-chain SDK and vesting comparison
+
+The accepted 1.1.1 candidate used the exact product code at `c1d5cf53`, jar
+SHA-256
+`825e75a1d4c1c08d774b0b8b5d5ad3e89f98a020d34ecfdec5879e91d81053a1`,
+stock protocol version 11, and V1/V2/V3 cost-model sizes 332/332/350. Results
+are retained at
+`/Users/satya/Downloads/yano-ccl-test/results-issue106-candidate-c1d5cf53-clean`.
+
+| Metric | Clean 0.18.2 baseline | 1.1.1 candidate | Result |
+| --- | ---: | ---: | --- |
+| CCL regular | 45,645/45,645 at 253.0 tx/s | 44,788/44,788 at 248.07 tx/s | Pass |
+| CCL chained | 9,504/9,504, 100% full depth | 9,536/9,536, 100% full depth | Pass |
+| Mesh regular | 11,587/11,587 | 11,474/11,474 | Pass |
+| Mesh chained | 50.1% | 50.1% | Known SDK limitation; unchanged |
+| Mesh vesting | 3/3 | 3/3 | Pass |
+| Evolution regular | 128/128 | 128/128 | Pass |
+| Evolution chained | 94.6%, 24/32 full depth | 94.6%, 24/32 full depth | Pass |
+| Evolution vesting | 3/3 | 3/3, identical negative reason | Pass |
+
+The 1.95% CCL throughput movement is accepted as machine-load variation: all
+acceptance, full-depth, vesting, rejection-reason, and execution-unit signals
+were identical or non-regressing. Candidate end load was 7.97/6.46/6.60 versus
+baseline 3.96/5.46/6.12.
+
+The CCL application completed, drained the mempool, and finalized its report,
+but its Gradle wrapper client later remained in job-control state `T` because
+the timeout process group was background to the exec TTY. After `SIGCONT` and
+`SIGTERM` plus `SIGCONT` repeatedly re-stopped it, stale wrapper PID 59963 was
+killed after graceful recovery was exhausted. The suite then completed its
+remaining four steps and the top-level script exited zero. The CCL per-step
+report is valid; the wrapper's recorded exit 137 is an orchestration artifact,
+and the paused 13m36 whole-suite wall time is void.
+
 ## Deferred gates
 
 - `:app:integrationTest`
-- candidate five-step off-chain SDK/load/vesting suite
 - A–F pool lifecycle devnet matrix
 - `test-native-haskell-sync`
 - Oracle GraalVM 25.3 G1 native BLS probe

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -176,7 +176,6 @@ and the paused 13m36 whole-suite wall time is void.
 ## Deferred gates
 
 - `test-native-haskell-sync`
-- Oracle GraalVM 25.3 G1 native BLS probe
 
 The coordinator accepted the corrected stock-devnet run block and authorized
 the clean baseline. Each remaining native node-backed gate still requires its
@@ -213,3 +212,48 @@ errors, or skips. Reports are under
 `app/build/test-results/integrationTest/`. The run used OpenJDK 25.0.2 and
 Gradle 9.4.1 at worktree head `aab83745`; documentation-only changes after the
 candidate product commit `c1d5cf53` did not change the tested application.
+
+## Gate C — native build, runtime smoke, and BLS
+
+The release-parity native command was forced through all 103 tasks at head
+`0339b7c1` using the official Oracle GraalVM 25.3.4.1/JDK 25.0.4.1 toolchain.
+It exited zero in 3m02s; Native Image generation completed in 1m19s and its
+build output identifies `G1 GC` with a 1.50 GiB maximum heap. Core distribution
+verification and the native plugin-catalog readiness smoke passed.
+
+The pinned build-once artifact is:
+
+```text
+/Users/satya/Downloads/yano-issue106-native/0339b7c1/yano
+sha256 da6d33a598dfc29be2d0f5000abce13361f21592d69c113b5bac6fa6a38f6ca2
+```
+
+The first unchanged devnet-profile launch exposed a pre-existing native
+reachability defect: archive initialization could not load
+`DuckLakeProjectionSinkProvider`, even though the profile enables the DuckLake
+projection sink. The issue-106 diff contains no archive, provider,
+service-loader, or native-metadata change. Claude classified this as outside
+the upgrade and approved reuse of the identical binary with the explicit
+runtime deviation `-Dyano.history.projection.enabled=false`; the failed launch
+and stack trace remain under the `gate-c-bls/` evidence leaf. No product fix or
+native rebuild was made.
+
+The fresh projection-disabled leaf reached readiness. The running node's
+`/api/v1/epochs/latest/parameters` response, retained as
+`gate-c-bls-noarchive/runtime-protocol-parameters.json`, reports protocol 11.0
+and both mapped and raw V1/V2/V3 cost-model cardinalities 332/332/350.
+
+The native BLS probe then exited zero in 9 seconds:
+
+```text
+evaluate       : OK spend:0 mem=12460 steps=110931472
+spend submit   : 200 ACCEPTED
+transaction    : dab19f2aacec8c540b6f6b6f044438cca3c99c5a761874f450f54baab2a6bc37
+confirmation   : after 204 ms
+negative ctrl  : rejected; spent mem 0.012360, cpu 110.915472
+```
+
+No BLS-unavailable or JNI initialization error appeared. Item 67(c) therefore
+matches the historical, 0.18.2 JVM, and 1.1.1 JVM measurements exactly at
+12,460 memory / 110,931,472 steps. The full external evidence is
+`/Users/satya/Downloads/yano-issue106-native/0339b7c1/GATE-C-REPORT.md`.

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -4,8 +4,8 @@
 
 The dependency migration and pool-deposit override re-derivation compile and
 pass the complete `scalus-bridge` suite. Node-backed and application integration
-gates have not started because the independent mainnet PID `98527` is active
-under the one-Yano-process rule.
+gates have not started because the independent preprod/wallet PID `50305` is
+active under the one-Yano-process rule.
 
 ## Changes
 
@@ -20,9 +20,15 @@ under the one-Yano-process rule.
   bidirectional set differences, stable rule name and name-sorted validator and
   mutator execution.
 - `TransactionCborCompatibilityTest` serializes a complete Conway CCL
-  transaction with input, output, fee, TTL and witness set; Scalus 1.1.1
-  decodes, re-encodes and decodes it again with byte-for-byte CBOR, transaction
-  ID and body equality.
+  transaction with input, multi-asset output, inline datum, pool-registration
+  certificate, fee, TTL and witness set; Scalus 1.1.1 decodes, re-encodes and
+  decodes it again with byte-for-byte CBOR, transaction ID and body equality.
+- Two tests exercise the complete
+  `YanoValueNotConservedUTxOValidator.validate()` path with real ledger values.
+  A balanced active-pool update fails the upstream validator and passes Yano's
+  correction; a transaction short by one lovelace still fails with
+  `ValueNotConservedUTxOException`. The fixtures contain no `null` or
+  `asInstanceOf` placeholders.
 - ADR-051 and the upstream report name the state-aware consumed-side refund
   helpers and state-blind produced-side `conwayTotalDepositsTxCerts` method.
 
@@ -50,21 +56,23 @@ Complete bridge suite:
 ./gradlew :scalus-bridge:test --rerun-tasks --console=plain
 ```
 
-Final result: exit `0`, 12 tasks executed, build successful in 5 seconds. JUnit
+Final result: exit `0`, 12 tasks executed, build successful in 3 seconds. JUnit
 XML under `scalus-bridge/build/test-results/test/` contained:
 
 | Suites | Tests | Failures | Errors | Skipped |
 | ---: | ---: | ---: | ---: | ---: |
-| 6 | 48 | 0 | 0 | 0 |
+| 6 | 50 | 0 | 0 | 0 |
 
 ## Deferred gates
 
 - `:app:integrationTest`
 - exact-commit 0.18.2 off-chain baseline
 - A–F pool lifecycle devnet matrix
-- four ordered Haskell/native devnet skills
+- `test-native-haskell-sync`
 - Oracle GraalVM 25.3 G1 native BLS probe
 - candidate five-step off-chain SDK/load/vesting suite
 
-All are held until Satya rules on PID `98527` and the coordinator issues start
-authorization under the amended run configuration.
+All node-backed gates are held until Satya rules on PID `50305` and the
+coordinator reissues or confirms start authorization under the accepted run
+configuration. The application integration test does not require that process
+decision and remains available as the next serial non-node gate.

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -3,9 +3,9 @@
 ## Status
 
 The dependency migration and pool-deposit override re-derivation compile and
-pass the complete `scalus-bridge` suite. Node-backed and application integration
-gates have not started because the independent preprod/wallet PID `50305` is
-active under the one-Yano-process rule.
+pass the complete `scalus-bridge` suite. The corrected stock-devnet clean
+baseline is authorized; the remaining node-backed and application integration
+gates have not completed.
 
 ## Changes
 
@@ -23,12 +23,14 @@ active under the one-Yano-process rule.
   transaction with input, multi-asset output, inline datum, pool-registration
   certificate, fee, TTL and witness set; Scalus 1.1.1 decodes, re-encodes and
   decodes it again with byte-for-byte CBOR, transaction ID and body equality.
-- Two tests exercise the complete
+- Three tests exercise the complete
   `YanoValueNotConservedUTxOValidator.validate()` path with real ledger values.
   A balanced active-pool update fails the upstream validator and passes Yano's
   correction; a transaction short by one lovelace still fails with
-  `ValueNotConservedUTxOException`. The fixtures contain no `null` or
-  `asInstanceOf` placeholders.
+  `ValueNotConservedUTxOException`; and a transaction with no certificates
+  produces zero excess pool deposit and returns exactly the same successful
+  result from the upstream and Yano validators. The fixtures contain no `null`
+  or `asInstanceOf` placeholders.
 - ADR-051 and the upstream report name the state-aware consumed-side refund
   helpers and state-blind produced-side `conwayTotalDepositsTxCerts` method.
 
@@ -56,12 +58,12 @@ Complete bridge suite:
 ./gradlew :scalus-bridge:test --rerun-tasks --console=plain
 ```
 
-Final result: exit `0`, 12 tasks executed, build successful in 3 seconds. JUnit
+Final result: exit `0`, 12 tasks executed, build successful in 9 seconds. JUnit
 XML under `scalus-bridge/build/test-results/test/` contained:
 
 | Suites | Tests | Failures | Errors | Skipped |
 | ---: | ---: | ---: | ---: | ---: |
-| 6 | 50 | 0 | 0 | 0 |
+| 6 | 51 | 0 | 0 | 0 |
 
 ## Deferred gates
 
@@ -72,7 +74,7 @@ XML under `scalus-bridge/build/test-results/test/` contained:
 - Oracle GraalVM 25.3 G1 native BLS probe
 - candidate five-step off-chain SDK/load/vesting suite
 
-All node-backed gates are held until Satya rules on PID `50305` and the
-coordinator reissues or confirms start authorization under the accepted run
-configuration. The application integration test does not require that process
-decision and remains available as the next serial non-node gate.
+The coordinator accepted the corrected stock-devnet run block and authorized
+the clean baseline. Each remaining node-backed gate still requires its own
+fresh data leaf and pre-start process, port, lock, profile, and quiet-machine
+checks. The application integration test remains a serial non-node gate.

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -98,12 +98,36 @@ validator accepted it even though `20,000,000` exceeds the true `16,500,000`
 memory cap. The released mapping could therefore admit a transaction that a
 correct dimensional limit rejects, creating consensus-divergence risk.
 
+The swapped bridge mapping was introduced in commit `de2a7067` and is present
+in releases `v0.1.0-pre10`, `v0.1.0-pre11`, `v0.1.0-pre12`, and
+`v0.1.0-pre13`; `git tag --contains de2a7067` and direct `git show` inspection
+provide the release range. The failure mode is over-acceptance on the memory
+dimension: an affected Yano validator can admit a transaction that a Haskell
+node rejects. This is a consensus-divergence risk wherever the two validate
+alongside each other, not a liveness or data-loss defect, and it does not alter
+chainstate already written. Commit `c1d5cf53` fixes it on this unreleased
+branch.
+
 After the correction, the fresh 1.1.1 JVM BLS probe passed end to end with
 exact baseline parity: `spend:0 mem=12460 steps=110931472`, submitted and
 confirmed as transaction
 `73e1e561672f8b34d880553d04e59ca24dfeab73c2927587db2bde7b692f0955`.
 The negative control retained the identical rejection budget and did not
 report an unavailable BLS library. Native equality remains a Gate C item.
+
+The deterministic Gate D measurements are:
+
+| Measurement | Memory | Steps |
+| --- | ---: | ---: |
+| Historical `BLS-SMOKE-TEST-REPORT.md` | 12,460 | 110,931,472 |
+| Exact 0.18.2 JVM baseline | 12,460 | 110,931,472 |
+| 1.1.1 JVM candidate at `c1d5cf53` | 12,460 | 110,931,472 |
+
+The identical numbers across three binaries/configurations demonstrate that
+Scalus 1.1.1 preserves evaluator accounting for this probe. Gate C requires
+the 1.1.1 native binary to return the same `12,460 / 110,931,472`; any
+difference there isolates to native-image behavior with the Scalus version
+held constant.
 
 ## Deferred gates
 

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -5,8 +5,10 @@
 The dependency migration, pool-deposit override re-derivation, and execution-
 unit dimension correction compile and pass the complete `scalus-bridge` suite.
 The corrected stock-devnet clean baseline and candidate off-chain SDK/load
-comparison are complete and accepted without regression. The remaining
-native and native-sync gates have not completed; Gates A and B are green.
+comparison are complete and accepted without regression. Gates A through E
+are closed: the native gate passed, the Gate E load suite passed, and Satya
+explicitly skipped the native Haskell sync portion for this PR at 20:50 +08 on
+2026-08-31 for the scope reasons recorded below.
 
 ## Changes
 
@@ -123,7 +125,8 @@ exact baseline parity: `spend:0 mem=12460 steps=110931472`, submitted and
 confirmed as transaction
 `73e1e561672f8b34d880553d04e59ca24dfeab73c2927587db2bde7b692f0955`.
 The negative control retained the identical rejection budget and did not
-report an unavailable BLS library. Native equality remains a Gate C item.
+report an unavailable BLS library. Gate C later reproduced the same execution
+units in the native binary.
 
 The deterministic Gate D measurements are:
 
@@ -173,14 +176,30 @@ remaining four steps and the top-level script exited zero. The CCL per-step
 report is valid; the wrapper's recorded exit 137 is an orchestration artifact,
 and the paused 13m36 whole-suite wall time is void.
 
-## Deferred gates
+## Gate E — load suite passed; native Haskell sync skipped by decision
 
-- `test-native-haskell-sync`
+The five-step CCL, MeshJS and Evolution load/vesting suite passed with the
+candidate results recorded above. Satya decided at 20:50 +08 on 2026-08-31 to
+skip `test-native-haskell-sync` for this PR. The skipped skill is not presented
+as executed coverage.
 
-The coordinator accepted the corrected stock-devnet run block and authorized
-the clean baseline. Each remaining native node-backed gate still requires its
-own fresh data leaf and pre-start process, port, lock, profile, and
-quiet-machine checks.
+The decision is scoped to issue #106. The product diff changes the Scalus
+bridge and version pin; it does not change block production, block CBOR,
+network sync or consensus. The skill produces simple-payment blocks and has
+low power to detect the evaluator regression under review, while Gate C uses
+the same native binary to evaluate, submit and confirm a BLS transaction with
+exact JVM/native execution-unit parity. The skill would also require the same
+projection-disabled deviation as Gate C. A meaningful cardano-node 11.0.1
+takeover with expanded cost models belongs in a separate governance-action
+bootstrap scenario rather than being approximated here with a different node
+configuration.
+
+The execution-unit correction is admission-tightening only. The old swapped
+mapping could accept transactions above the true memory limit; the correction
+enforces the same dimensional limits used by cardano-node. Transactions already
+accepted on a real Cardano chain are therefore within the corrected bounds, so
+the change cannot break their replay. It rejects only transactions that were
+already invalid under the reference ledger.
 
 ## Gates A and B — application integration and pool lifecycle
 
@@ -257,3 +276,48 @@ No BLS-unavailable or JNI initialization error appeared. Item 67(c) therefore
 matches the historical, 0.18.2 JVM, and 1.1.1 JVM measurements exactly at
 12,460 memory / 110,931,472 steps. The full external evidence is
 `/Users/satya/Downloads/yano-issue106-native/0339b7c1/GATE-C-REPORT.md`.
+
+## Consolidated acceptance summary
+
+| Gate | Result | Primary evidence |
+| --- | --- | --- |
+| A — bridge and application JVM tests | Pass: 53 bridge tests and 12 integration tests, no failures/errors/skips | `scalus-bridge/build/test-results/test/`, `app/build/test-results/integrationTest/` |
+| B — pool lifecycle A–F | Pass: all six submitted-transaction scenarios | `app/build/test-results/integrationTest/TEST-com.bloxbean.cardano.yano.app.e2e.PoolLifecycleE2ETest.xml` |
+| C — Oracle GraalVM 25.3 G1 native/BLS | Pass: build, readiness, evaluate, submit, confirm, negative control; protocol 11.0 and cost models 332/332/350 observed at runtime | `/Users/satya/Downloads/yano-issue106-native/0339b7c1/GATE-C-REPORT.md` |
+| D — MeshJS and Evolution vesting | Pass: 3/3 for each suite, with unchanged negative behavior and execution-unit parity | `/Users/satya/Downloads/yano-ccl-test/results-issue106-candidate-c1d5cf53-clean` |
+| E — five-step off-chain SDK load | Pass: CCL 100% regular and chained/full-depth; Mesh and Evolution signals non-regressing | `/Users/satya/Downloads/yano-ccl-test/results-issue106-candidate-c1d5cf53-clean` |
+| E — native Haskell sync portion | Skipped by Satya's explicit 2026-08-31 20:50 +08 scope decision | ADR-051 Gate E rationale |
+
+The accepted native binary is
+`/Users/satya/Downloads/yano-issue106-native/0339b7c1/yano`, SHA-256
+`da6d33a598dfc29be2d0f5000abce13361f21592d69c113b5bac6fa6a38f6ca2`.
+
+### Deviations and excluded measurements
+
+- Gate C used `-Dyano.history.projection.enabled=false` after the unchanged
+  devnet profile exposed a pre-existing native service-provider reachability
+  failure for `DuckLakeProjectionSinkProvider`. The same binary was reused; no
+  native fix or rebuild was included.
+- The candidate CCL client completed and wrote valid per-step results, but its
+  wrapper later ended with exit 137 after a terminal job-control stop. Its
+  13m36 whole-suite wall clock is void; submitted/confirmed counts, per-step
+  throughput and the remaining four top-level steps are valid.
+- MeshJS chained-input acceptance remains the documented approximately 50%
+  SDK limitation from the baseline and is excluded from the CCL full-depth
+  parity signal.
+- A contended first baseline was rejected. Comparisons use only the clean
+  same-rig baseline in
+  `results-issue106-baseline-e2566ade-clean`.
+- `test-native-haskell-sync` was skipped by the explicit scope decision above.
+
+### Coverage boundaries
+
+- No mainnet or preprod validation was run.
+- Native readiness and BLS evaluation were tested without archive projection.
+- The pre-existing native projection-provider defect is unfixed and unfiled
+  pending Satya's decision.
+- The old ExUnits mapping's over-acceptance direction was demonstrated with
+  the released classes; exploitability through a submitted transaction was
+  not tested.
+- No native Haskell takeover was run. A representative takeover with updated
+  cost models requires its own governance-action bootstrap test.

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -6,7 +6,7 @@ The dependency migration, pool-deposit override re-derivation, and execution-
 unit dimension correction compile and pass the complete `scalus-bridge` suite.
 The corrected stock-devnet clean baseline and candidate off-chain SDK/load
 comparison are complete and accepted without regression. The remaining
-node-backed, native, and application integration gates have not completed.
+native and native-sync gates have not completed; Gates A and B are green.
 
 ## Changes
 
@@ -175,12 +175,41 @@ and the paused 13m36 whole-suite wall time is void.
 
 ## Deferred gates
 
-- `:app:integrationTest`
-- A–F pool lifecycle devnet matrix
 - `test-native-haskell-sync`
 - Oracle GraalVM 25.3 G1 native BLS probe
 
 The coordinator accepted the corrected stock-devnet run block and authorized
-the clean baseline. Each remaining node-backed gate still requires its own
-fresh data leaf and pre-start process, port, lock, profile, and quiet-machine
-checks. The application integration test remains a serial non-node gate.
+the clean baseline. Each remaining native node-backed gate still requires its
+own fresh data leaf and pre-start process, port, lock, profile, and
+quiet-machine checks.
+
+## Gates A and B — application integration and pool lifecycle
+
+Gate B ran first as the focused command requested by the coordinator:
+
+```bash
+./gradlew :app:integrationTest \
+  --tests com.bloxbean.cardano.yano.app.e2e.PoolLifecycleE2ETest \
+  --no-daemon --console=plain
+```
+
+The isolated short-epoch RocksDB devnet started with protocol version 11.0 and
+submitted real pool registration, retirement, update, and delegation
+transactions. All six A–F scenarios passed with no failure, error, skip, or
+spurious `ValueNotConservedUTxO` rejection. The JUnit suite time was 84.288
+seconds and the Gradle build exited zero in 1m34s. Its report is
+`app/build/test-results/integrationTest/TEST-com.bloxbean.cardano.yano.app.e2e.PoolLifecycleE2ETest.xml`.
+
+Gate A's second half then ran exactly as specified:
+
+```bash
+./gradlew :app:integrationTest --no-daemon --console=plain
+```
+
+It exited zero in 2m07s. JUnit XML contained five suites and 12 tests: three
+`DevnetProjectionArchiveIT`, one `SendAdaIT`, one `TxBatchSubmissionIT`, one
+`TxSubmissionIT`, and all six `PoolLifecycleE2ETest` cases, with zero failures,
+errors, or skips. Reports are under
+`app/build/test-results/integrationTest/`. The run used OpenJDK 25.0.2 and
+Gradle 9.4.1 at worktree head `aab83745`; documentation-only changes after the
+candidate product commit `c1d5cf53` did not change the tested application.

--- a/adr/reports/adr-051-phase-1-2-2026-08-31.md
+++ b/adr/reports/adr-051-phase-1-2-2026-08-31.md
@@ -1,0 +1,70 @@
+# ADR-051 Phases 1–2 — Scalus 1.1.1 bridge and override evidence
+
+## Status
+
+The dependency migration and pool-deposit override re-derivation compile and
+pass the complete `scalus-bridge` suite. Node-backed and application integration
+gates have not started because the independent mainnet PID `98527` is active
+under the one-Yano-process rule.
+
+## Changes
+
+- Both direct Scalus artifacts are pinned to `1.1.1`; transitive `scalus_3`
+  resolves to `1.1.1`, while CCL remains `0.7.2`.
+- The 1.1.1 bridge main and test sources required no API compatibility edits.
+- `YanoCardanoMutator` now requires the upstream
+  `ValueNotConservedUTxOValidator` identity exactly once before replacing it.
+  Counts of zero and greater than one fail during effective-rule construction.
+- The guard test asserts one upstream rule in defaults, zero upstream rules in
+  Yano's effective set, one Yano replacement, unchanged set size, exact
+  bidirectional set differences, stable rule name and name-sorted validator and
+  mutator execution.
+- `TransactionCborCompatibilityTest` serializes a complete Conway CCL
+  transaction with input, output, fee, TTL and witness set; Scalus 1.1.1
+  decodes, re-encodes and decodes it again with byte-for-byte CBOR, transaction
+  ID and body equality.
+- ADR-051 and the upstream report name the state-aware consumed-side refund
+  helpers and state-blind produced-side `conwayTotalDepositsTxCerts` method.
+
+## Test evidence
+
+Focused CBOR test:
+
+```bash
+./gradlew :scalus-bridge:test \
+  --tests '*TransactionCborCompatibilityTest' \
+  --rerun-tasks --console=plain
+```
+
+Final result: exit `0`, 12 tasks executed, build successful in 4 seconds,
+1 test passed.
+
+The first compile of the new test exited nonzero before execution because it
+used Yaci's `Era` instead of CCL's `Era` and called Scala's parameterless
+`toCbor` with parentheses. Both source errors were corrected; no product code
+was changed to accommodate the test.
+
+Complete bridge suite:
+
+```bash
+./gradlew :scalus-bridge:test --rerun-tasks --console=plain
+```
+
+Final result: exit `0`, 12 tasks executed, build successful in 5 seconds. JUnit
+XML under `scalus-bridge/build/test-results/test/` contained:
+
+| Suites | Tests | Failures | Errors | Skipped |
+| ---: | ---: | ---: | ---: | ---: |
+| 6 | 48 | 0 | 0 | 0 |
+
+## Deferred gates
+
+- `:app:integrationTest`
+- exact-commit 0.18.2 off-chain baseline
+- A–F pool lifecycle devnet matrix
+- four ordered Haskell/native devnet skills
+- Oracle GraalVM 25.3 G1 native BLS probe
+- candidate five-step off-chain SDK/load/vesting suite
+
+All are held until Satya rules on PID `98527` and the coordinator issues start
+authorization under the amended run configuration.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -102,8 +102,8 @@ archunit = "com.tngtech.archunit:archunit:1.4.1"
 rocksdb="org.rocksdb:rocksdbjni:9.11.2"
 
 scala3-library = "org.scala-lang:scala3-library_3:3.3.8"
-scalus-cardano-ledger = "org.scalus:scalus-cardano-ledger_3:0.18.2"
-scalus-bloxbean-ccl = "org.scalus:scalus-bloxbean-cardano-client-lib_3:0.18.2"
+scalus-cardano-ledger = "org.scalus:scalus-cardano-ledger_3:1.1.1"
+scalus-bloxbean-ccl = "org.scalus:scalus-bloxbean-cardano-client-lib_3:1.1.1"
 blst-java = "foundation.icon:blst-java:0.3.2"
 
 aiken-java-binding = "com.bloxbean.cardano:aiken-java-binding:0.1.0"

--- a/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/ProtocolParamsBridge.scala
+++ b/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/ProtocolParamsBridge.scala
@@ -23,13 +23,13 @@ private[scalusbridge] object ProtocolParamsBridge:
     )
 
     val maxBlockExUnits = ExUnits(
-      parseLong(pp.getMaxBlockExSteps),
-      parseLong(pp.getMaxBlockExMem)
+      parseLong(pp.getMaxBlockExMem),
+      parseLong(pp.getMaxBlockExSteps)
     )
 
     val maxTxExUnits = ExUnits(
-      parseLong(pp.getMaxTxExSteps),
-      parseLong(pp.getMaxTxExMem)
+      parseLong(pp.getMaxTxExMem),
+      parseLong(pp.getMaxTxExSteps)
     )
 
     val dRepVotingThresholds = DRepVotingThresholds(

--- a/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/YanoCardanoMutator.scala
+++ b/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/YanoCardanoMutator.scala
@@ -11,9 +11,10 @@ object YanoCardanoMutator extends STS.Mutator:
     val defaults = CardanoMutator.defaultSTSs.values.collect {
       case validator: STS.Validator => validator
     }.toSeq.sortBy(_.name)
+    val upstreamValidatorCount = defaults.count(_ eq ValueNotConservedUTxOValidator)
     require(
-      defaults.exists(_ eq ValueNotConservedUTxOValidator),
-      "Scalus default validator set no longer contains ValueNotConservedUTxOValidator"
+      upstreamValidatorCount == 1,
+      s"Scalus default validator set must contain ValueNotConservedUTxOValidator exactly once, found $upstreamValidatorCount"
     )
     defaults.map {
       case validator if validator eq ValueNotConservedUTxOValidator =>

--- a/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidator.scala
+++ b/scalus-bridge/src/main/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidator.scala
@@ -4,7 +4,7 @@ import scalus.cardano.ledger.*
 import scalus.cardano.ledger.rules.{Context, STS, State, ValueNotConservedUTxOValidator}
 import scalus.cardano.ledger.utils.TxBalance
 
-/** Corrects Scalus 0.18.2's unconditional pool-deposit charge for pool updates. */
+/** Corrects Scalus 1.1.1's unconditional pool-deposit charge for pool updates. */
 object YanoValueNotConservedUTxOValidator extends STS.Validator:
   override final type Error = TransactionException.BadInputsUTxOException |
     TransactionException.ValueNotConservedUTxOException
@@ -39,4 +39,3 @@ object YanoValueNotConservedUTxOValidator extends STS.Validator:
     val distinctNewPools = registrations.toSet.count(poolId => !poolsState.stakePools.contains(poolId))
     val excessRegistrationCount = registrations.size - distinctNewPools
     Math.multiplyExact(excessRegistrationCount.toLong, poolDeposit)
-

--- a/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ProtocolParamsBridgeTest.java
+++ b/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ProtocolParamsBridgeTest.java
@@ -6,6 +6,7 @@ import scalus.cardano.ledger.NonNegativeInterval;
 import scalus.cardano.ledger.UnitInterval;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.LinkedHashMap;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -13,6 +14,121 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class ProtocolParamsBridgeTest {
+
+    @Test
+    void everyProtocolParameterMapsToItsOwnField() {
+        ProtocolParams pp = baseParams(11);
+        pp.setProtocolMinorVer(1);
+        pp.setMinFeeA(45);
+        pp.setMinFeeB(155382);
+        pp.setMaxBlockSize(90113);
+        pp.setMaxTxSize(16385);
+        pp.setMaxBlockHeaderSize(1101);
+        pp.setKeyDeposit("2000001");
+        pp.setPoolDeposit("500000009");
+        pp.setEMax(19);
+        pp.setNOpt(501);
+        pp.setA0(new BigDecimal("0.31"));
+        pp.setRho(new BigDecimal("0.004"));
+        pp.setTau(new BigDecimal("0.22"));
+        pp.setMinPoolCost("340000001");
+
+        var plutusV1 = new LinkedHashMap<String, Long>();
+        plutusV1.put("000", 61L);
+        plutusV1.put("001", 62L);
+        var costModels = new LinkedHashMap<String, LinkedHashMap<String, Long>>();
+        costModels.put("PlutusV1", plutusV1);
+        pp.setCostModels(costModels);
+        pp.setPriceMem(new BigDecimal("0.0577"));
+        pp.setPriceStep(new BigDecimal("0.0000721"));
+        pp.setMaxTxExMem("10000001");
+        pp.setMaxTxExSteps("10000000001");
+        pp.setMaxBlockExMem("50000001");
+        pp.setMaxBlockExSteps("40000000001");
+        pp.setMaxValSize("5001");
+        pp.setCollateralPercent(new BigDecimal("152"));
+        pp.setMaxCollateralInputs(4);
+        pp.setCoinsPerUtxoSize("4311");
+
+        pp.setGovActionDeposit(BigInteger.valueOf(100_000_000_003L));
+        pp.setGovActionLifetime(7);
+        pp.setDrepDeposit(BigInteger.valueOf(500_000_003L));
+        pp.setDrepActivity(21);
+        pp.setCommitteeMinSize(5);
+        pp.setCommitteeMaxTermLength(148);
+        pp.setMinFeeRefScriptCostPerByte(new BigDecimal("16"));
+        pp.setPvtMotionNoConfidence(new BigDecimal("0.41"));
+        pp.setPvtCommitteeNormal(new BigDecimal("0.42"));
+        pp.setPvtCommitteeNoConfidence(new BigDecimal("0.43"));
+        pp.setPvtHardForkInitiation(new BigDecimal("0.44"));
+        pp.setPvtPPSecurityGroup(new BigDecimal("0.45"));
+        pp.setDvtMotionNoConfidence(new BigDecimal("0.51"));
+        pp.setDvtCommitteeNormal(new BigDecimal("0.52"));
+        pp.setDvtCommitteeNoConfidence(new BigDecimal("0.53"));
+        pp.setDvtUpdateToConstitution(new BigDecimal("0.54"));
+        pp.setDvtHardForkInitiation(new BigDecimal("0.55"));
+        pp.setDvtPPNetworkGroup(new BigDecimal("0.56"));
+        pp.setDvtPPEconomicGroup(new BigDecimal("0.57"));
+        pp.setDvtPPTechnicalGroup(new BigDecimal("0.58"));
+        pp.setDvtPPGovGroup(new BigDecimal("0.59"));
+        pp.setDvtTreasuryWithdrawal(new BigDecimal("0.60"));
+
+        var scalusParams = ProtocolParamsBridge$.MODULE$.toScalusProtocolParams(pp);
+
+        assertEquals(152L, scalusParams.collateralPercentage());
+        assertEquals(148L, scalusParams.committeeMaxTermLength());
+        assertEquals(5L, scalusParams.committeeMinSize());
+        assertEquals(1, scalusParams.costModels().models().size());
+        var convertedCostModel = scalusParams.costModels().models().values().head();
+        assertEquals(2, convertedCostModel.size());
+        assertEquals(61L, ((Number) convertedCostModel.apply(0)).longValue());
+        assertEquals(62L, ((Number) convertedCostModel.apply(1)).longValue());
+        assertEquals(21L, scalusParams.dRepActivity());
+        assertEquals(500_000_003L, scalusParams.dRepDeposit());
+        assertUnitInterval(scalusParams.dRepVotingThresholds().motionNoConfidence(), 51, 100);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().committeeNormal(), 13, 25);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().committeeNoConfidence(), 53, 100);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().updateToConstitution(), 27, 50);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().hardForkInitiation(), 11, 20);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().ppNetworkGroup(), 14, 25);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().ppEconomicGroup(), 57, 100);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().ppTechnicalGroup(), 29, 50);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().ppGovGroup(), 59, 100);
+        assertUnitInterval(scalusParams.dRepVotingThresholds().treasuryWithdrawal(), 3, 5);
+        assertNonNegativeInterval(scalusParams.executionUnitPrices().priceMemory(), 577, 10_000);
+        assertNonNegativeInterval(scalusParams.executionUnitPrices().priceSteps(), 721, 10_000_000);
+        assertEquals(100_000_000_003L, scalusParams.govActionDeposit());
+        assertEquals(7L, scalusParams.govActionLifetime());
+        assertEquals(90_113L, scalusParams.maxBlockBodySize());
+        assertEquals(50_000_001L, scalusParams.maxBlockExecutionUnits().memory());
+        assertEquals(40_000_000_001L, scalusParams.maxBlockExecutionUnits().steps());
+        assertEquals(1_101L, scalusParams.maxBlockHeaderSize());
+        assertEquals(4L, scalusParams.maxCollateralInputs());
+        assertEquals(10_000_001L, scalusParams.maxTxExecutionUnits().memory());
+        assertEquals(10_000_000_001L, scalusParams.maxTxExecutionUnits().steps());
+        assertEquals(16_385L, scalusParams.maxTxSize());
+        assertEquals(5_001L, scalusParams.maxValueSize());
+        assertEquals(16L, scalusParams.minFeeRefScriptCostPerByte());
+        assertEquals(340_000_001L, scalusParams.minPoolCost());
+        assertEquals(0.004, scalusParams.monetaryExpansion());
+        assertEquals(0.31, scalusParams.poolPledgeInfluence());
+        assertEquals(19L, scalusParams.poolRetireMaxEpoch());
+        assertUnitInterval(scalusParams.poolVotingThresholds().motionNoConfidence(), 41, 100);
+        assertUnitInterval(scalusParams.poolVotingThresholds().committeeNormal(), 21, 50);
+        assertUnitInterval(scalusParams.poolVotingThresholds().committeeNoConfidence(), 43, 100);
+        assertUnitInterval(scalusParams.poolVotingThresholds().hardForkInitiation(), 11, 25);
+        assertUnitInterval(scalusParams.poolVotingThresholds().ppSecurityGroup(), 9, 20);
+        assertEquals(11, scalusParams.protocolVersion().major());
+        assertEquals(1, scalusParams.protocolVersion().minor());
+        assertEquals(2_000_001L, scalusParams.stakeAddressDeposit());
+        assertEquals(500_000_009L, scalusParams.stakePoolDeposit());
+        assertEquals(501L, scalusParams.stakePoolTargetNum());
+        assertEquals(0.22, scalusParams.treasuryCut());
+        // The A/B crossing is intentional: minFeeB is fixed and minFeeA is per byte.
+        assertEquals(155_382L, scalusParams.txFeeFixed());
+        assertEquals(45L, scalusParams.txFeePerByte());
+        assertEquals(4_311L, scalusParams.utxoCostPerByte());
+    }
 
     @Test
     void executionUnitLimitsKeepMemoryAndStepsInScalusOrder() {
@@ -179,5 +295,15 @@ class ProtocolParamsBridgeTest {
         var costModels = new LinkedHashMap<String, LinkedHashMap<String, Long>>();
         costModels.put("PlutusV1", plutusV1);
         return costModels;
+    }
+
+    private void assertUnitInterval(UnitInterval actual, long numerator, long denominator) {
+        assertEquals(numerator, actual.numerator());
+        assertEquals(denominator, actual.denominator());
+    }
+
+    private void assertNonNegativeInterval(NonNegativeInterval actual, long numerator, long denominator) {
+        assertEquals(numerator, actual.numerator());
+        assertEquals(denominator, actual.denominator());
     }
 }

--- a/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ProtocolParamsBridgeTest.java
+++ b/scalus-bridge/src/test/java/com/bloxbean/cardano/yano/scalusbridge/ProtocolParamsBridgeTest.java
@@ -15,6 +15,20 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 class ProtocolParamsBridgeTest {
 
     @Test
+    void executionUnitLimitsKeepMemoryAndStepsInScalusOrder() {
+        ProtocolParams pp = baseParams(11);
+        addAlonzoParams(pp);
+        addConwayParams(pp);
+
+        var scalusParams = ProtocolParamsBridge$.MODULE$.toScalusProtocolParams(pp);
+
+        assertEquals(50_000_000L, scalusParams.maxBlockExecutionUnits().memory());
+        assertEquals(40_000_000_000L, scalusParams.maxBlockExecutionUnits().steps());
+        assertEquals(10_000_000L, scalusParams.maxTxExecutionUnits().memory());
+        assertEquals(10_000_000_000L, scalusParams.maxTxExecutionUnits().steps());
+    }
+
+    @Test
     void intervalProtocolParamsKeepExactDecimalRationals() {
         ProtocolParams pp = baseParams(4);
         pp.setPriceMem(new BigDecimal("0.0577"));

--- a/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/TransactionCborCompatibilityTest.scala
+++ b/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/TransactionCborCompatibilityTest.scala
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.yano.scalusbridge
 
 import com.bloxbean.cardano.client.transaction.spec.{
+  Asset,
+  MultiAsset,
   Transaction as CclTransaction,
   TransactionBody,
   TransactionInput as CclTransactionInput,
@@ -8,13 +10,15 @@ import com.bloxbean.cardano.client.transaction.spec.{
   TransactionWitnessSet,
   Value as CclValue
 }
-import com.bloxbean.cardano.client.spec.Era
-import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals}
+import com.bloxbean.cardano.client.plutus.spec.PlutusData
+import com.bloxbean.cardano.client.spec.{Era, UnitInterval}
+import com.bloxbean.cardano.client.transaction.spec.cert.PoolRegistration
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals, assertTrue}
 import org.junit.jupiter.api.Test
 import scalus.cardano.ledger.{Transaction as ScalusTransaction}
 
 import java.math.BigInteger
-import java.util.List
+import java.util.{HexFormat, List, Set}
 
 class TransactionCborCompatibilityTest:
   @Test
@@ -27,7 +31,27 @@ class TransactionCborCompatibilityTest:
       .address(
         "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp"
       )
-      .value(new CclValue(BigInteger.valueOf(4_800_000L), null))
+      .value(new CclValue(
+        BigInteger.valueOf(4_800_000L),
+        List.of(MultiAsset.builder()
+          .policyId("cd" * 28)
+          .assets(List.of(Asset.builder()
+            .name("scalus-1.1.1")
+            .value(BigInteger.valueOf(42L))
+            .build()))
+          .build())
+      ))
+      .inlineDatum(PlutusData.unit())
+      .build()
+    val poolRegistration = PoolRegistration.builder()
+      .operator(HexFormat.of().parseHex("11" * 28))
+      .vrfKeyHash(HexFormat.of().parseHex("22" * 32))
+      .pledge(BigInteger.ZERO)
+      .cost(BigInteger.valueOf(170_000_000L))
+      .margin(new UnitInterval(BigInteger.ONE, BigInteger.valueOf(20L)))
+      .rewardAccount("e1" + "33" * 28)
+      .poolOwners(Set.of("11" * 28))
+      .relays(List.of())
       .build()
     val original = CclTransaction.builder()
       .era(Era.Conway)
@@ -36,6 +60,7 @@ class TransactionCborCompatibilityTest:
         .outputs(List.of(output))
         .fee(BigInteger.valueOf(200_000L))
         .ttl(12_345L)
+        .certs(List.of(poolRegistration))
         .build())
       .witnessSet(new TransactionWitnessSet())
       .isValid(true)
@@ -49,3 +74,7 @@ class TransactionCborCompatibilityTest:
     assertArrayEquals(original, reencoded)
     assertEquals(decoded.id, roundTripped.id)
     assertEquals(decoded.body.value, roundTripped.body.value)
+    assertEquals(1, decoded.body.value.certificates.toSeq.size)
+    val decodedOutput = decoded.body.value.outputs.head.value
+    assertEquals(42L, decodedOutput.value.assets.assets.values.head.values.head)
+    assertTrue(decodedOutput.inlineDatum.isDefined)

--- a/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/TransactionCborCompatibilityTest.scala
+++ b/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/TransactionCborCompatibilityTest.scala
@@ -1,0 +1,51 @@
+package com.bloxbean.cardano.yano.scalusbridge
+
+import com.bloxbean.cardano.client.transaction.spec.{
+  Transaction as CclTransaction,
+  TransactionBody,
+  TransactionInput as CclTransactionInput,
+  TransactionOutput as CclTransactionOutput,
+  TransactionWitnessSet,
+  Value as CclValue
+}
+import com.bloxbean.cardano.client.spec.Era
+import org.junit.jupiter.api.Assertions.{assertArrayEquals, assertEquals}
+import org.junit.jupiter.api.Test
+import scalus.cardano.ledger.{Transaction as ScalusTransaction}
+
+import java.math.BigInteger
+import java.util.List
+
+class TransactionCborCompatibilityTest:
+  @Test
+  def cclTransactionRoundTripsThroughScalusCborCodec(): Unit =
+    val input = CclTransactionInput.builder()
+      .transactionId("ab" * 32)
+      .index(1)
+      .build()
+    val output = CclTransactionOutput.builder()
+      .address(
+        "addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydzer3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp"
+      )
+      .value(new CclValue(BigInteger.valueOf(4_800_000L), null))
+      .build()
+    val original = CclTransaction.builder()
+      .era(Era.Conway)
+      .body(TransactionBody.builder()
+        .inputs(List.of(input))
+        .outputs(List.of(output))
+        .fee(BigInteger.valueOf(200_000L))
+        .ttl(12_345L)
+        .build())
+      .witnessSet(new TransactionWitnessSet())
+      .isValid(true)
+      .build()
+      .serialize()
+
+    val decoded = ScalusTransaction.fromCbor(original)
+    val reencoded = decoded.toCbor
+    val roundTripped = ScalusTransaction.fromCbor(reencoded)
+
+    assertArrayEquals(original, reencoded)
+    assertEquals(decoded.id, roundTripped.id)
+    assertEquals(decoded.body.value, roundTripped.body.value)

--- a/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidatorTest.scala
+++ b/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidatorTest.scala
@@ -84,6 +84,17 @@ class YanoValueNotConservedUTxOValidatorTest:
       result.left.exists(_.isInstanceOf[TransactionException.ValueNotConservedUTxOException])
     )
 
+  @Test
+  def noCertificatesHaveZeroExcessAndMatchUpstreamValidation(): Unit =
+    val (context, state, tx) = validationFixture(Value.ada(1_000), Seq.empty)
+
+    assertEquals(0L, excess(tx.body.value.certificates.toSeq, state.certState.pstate))
+    assertEquals(
+      ValueNotConservedUTxOValidator.validate(context, state, tx),
+      YanoValueNotConservedUTxOValidator.validate(context, state, tx)
+    )
+    assertEquals(Right(()), YanoValueNotConservedUTxOValidator.validate(context, state, tx))
+
   private def excess(certificates: Iterable[Certificate], state: PoolsState): Long =
     YanoValueNotConservedUTxOValidator.excessPoolRegistrationDeposit(
       certificates, state, poolDeposit)
@@ -109,19 +120,29 @@ class YanoValueNotConservedUTxOValidatorTest:
       poolMetadata = None
     )
 
-  private def validationFixture(outputValue: Value): (Context, State, Transaction) =
+  private def validationFixture(
+      outputValue: Value,
+      certificates: Seq[Certificate] = Seq(registration(poolA))
+  ): (Context, State, Transaction) =
     val input = TransactionInput(TransactionHash.fromHex("05" * 32), 0)
     val inputValue = Value.ada(1_000)
     val address = Address(Network.Mainnet, Credential.KeyHash(AddrKeyHash.fromHex("06" * 28)))
     val certState = CertState(pstate = pools(poolA))
-    val tx = Transaction(
-      TransactionBody(
-        inputs = TaggedSortedSet(input),
-        outputs = IndexedSeq(Sized(TransactionOutput(address, outputValue))),
-        fee = Coin.zero,
-        certificates = TaggedOrderedStrictSet(registration(poolA))
-      )
-    )
+    val body =
+      if certificates.isEmpty then
+        TransactionBody(
+          inputs = TaggedSortedSet(input),
+          outputs = IndexedSeq(Sized(TransactionOutput(address, outputValue))),
+          fee = Coin.zero
+        )
+      else
+        TransactionBody(
+          inputs = TaggedSortedSet(input),
+          outputs = IndexedSeq(Sized(TransactionOutput(address, outputValue))),
+          fee = Coin.zero,
+          certificates = TaggedOrderedStrictSet(certificates*)
+        )
+    val tx = Transaction(body)
     val state = State(
       utxos = Map(input -> TransactionOutput(address, inputValue)),
       certState = certState

--- a/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidatorTest.scala
+++ b/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidatorTest.scala
@@ -15,11 +15,15 @@ class YanoValueNotConservedUTxOValidatorTest:
   def swapsExactlyOneScalusDefaultValidator(): Unit =
     val defaultValidators = CardanoMutator.defaultSTSs.values.collect {
       case validator: STS.Validator => validator
-    }.toSet
-    val actualValidators = YanoCardanoMutator.validators.toSet
+    }.toSeq
+    val actualValidators = YanoCardanoMutator.validators.toSeq
 
-    assertEquals(Set(ValueNotConservedUTxOValidator), defaultValidators.diff(actualValidators))
-    assertEquals(Set(YanoValueNotConservedUTxOValidator), actualValidators.diff(defaultValidators))
+    assertEquals(1, defaultValidators.count(_ eq ValueNotConservedUTxOValidator))
+    assertEquals(0, actualValidators.count(_ eq ValueNotConservedUTxOValidator))
+    assertEquals(1, actualValidators.count(_ eq YanoValueNotConservedUTxOValidator))
+
+    assertEquals(Set(ValueNotConservedUTxOValidator), defaultValidators.toSet.diff(actualValidators.toSet))
+    assertEquals(Set(YanoValueNotConservedUTxOValidator), actualValidators.toSet.diff(defaultValidators.toSet))
     assertEquals(defaultValidators.size, actualValidators.size)
     assertEquals(defaultValidators.toSeq.map(_.name).sorted, YanoCardanoMutator.validators.map(_.name))
     assertEquals(

--- a/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidatorTest.scala
+++ b/scalus-bridge/src/test/scala/com/bloxbean/cardano/yano/scalusbridge/YanoValueNotConservedUTxOValidatorTest.scala
@@ -2,9 +2,9 @@ package com.bloxbean.cardano.yano.scalusbridge
 
 import org.junit.jupiter.api.Assertions.{assertEquals, assertSame, assertTrue}
 import org.junit.jupiter.api.Test
+import scalus.cardano.address.{Address, Network, StakeAddress, StakePayload}
 import scalus.cardano.ledger.*
-import scalus.cardano.ledger.rules.{CardanoMutator, STS, ValueNotConservedUTxOValidator}
-import scalus.uplc.builtin.ByteString
+import scalus.cardano.ledger.rules.{CardanoMutator, Context, STS, State, ValueNotConservedUTxOValidator}
 
 class YanoValueNotConservedUTxOValidatorTest:
   private val poolDeposit = 500_000_000L
@@ -67,6 +67,23 @@ class YanoValueNotConservedUTxOValidatorTest:
     assertEquals(ValueNotConservedUTxOValidator.name, YanoValueNotConservedUTxOValidator.name)
     assertTrue(YanoCardanoMutator.validators.exists(_ eq YanoValueNotConservedUTxOValidator))
 
+  @Test
+  def completeValidationAcceptsBalancedActivePoolUpdate(): Unit =
+    val (context, state, tx) = validationFixture(Value.ada(1_000))
+
+    assertEquals(poolDeposit, context.env.params.stakePoolDeposit)
+    assertTrue(ValueNotConservedUTxOValidator.validate(context, state, tx).isLeft)
+    assertEquals(Right(()), YanoValueNotConservedUTxOValidator.validate(context, state, tx))
+
+  @Test
+  def completeValidationRejectsGenuinelyUnbalancedActivePoolUpdate(): Unit =
+    val (context, state, tx) = validationFixture(Value.lovelace(Coin.ada(1_000).value - 1))
+    val result = YanoValueNotConservedUTxOValidator.validate(context, state, tx)
+
+    assertTrue(
+      result.left.exists(_.isInstanceOf[TransactionException.ValueNotConservedUTxOException])
+    )
+
   private def excess(certificates: Iterable[Certificate], state: PoolsState): Long =
     YanoValueNotConservedUTxOValidator.excessPoolRegistrationDeposit(
       certificates, state, poolDeposit)
@@ -80,12 +97,34 @@ class YanoValueNotConservedUTxOValidatorTest:
   private def registration(poolId: String): Certificate.PoolRegistration =
     Certificate.PoolRegistration(
       operator = AddrKeyHash.fromHex(poolId),
-      vrfKeyHash = ByteString.empty.asInstanceOf[VrfKeyHash],
+      vrfKeyHash = VrfKeyHash.fromHex("03" * 32),
       pledge = Coin.zero,
       cost = Coin.zero,
       margin = UnitInterval(0, 1),
-      rewardAccount = null.asInstanceOf[RewardAccount],
+      rewardAccount = RewardAccount(
+        StakeAddress(Network.Mainnet, StakePayload.Stake(StakeKeyHash.fromHex("04" * 28)))
+      ),
       poolOwners = Set.empty,
       relays = IndexedSeq.empty,
       poolMetadata = None
     )
+
+  private def validationFixture(outputValue: Value): (Context, State, Transaction) =
+    val input = TransactionInput(TransactionHash.fromHex("05" * 32), 0)
+    val inputValue = Value.ada(1_000)
+    val address = Address(Network.Mainnet, Credential.KeyHash(AddrKeyHash.fromHex("06" * 28)))
+    val certState = CertState(pstate = pools(poolA))
+    val tx = Transaction(
+      TransactionBody(
+        inputs = TaggedSortedSet(input),
+        outputs = IndexedSeq(Sized(TransactionOutput(address, outputValue))),
+        fee = Coin.zero,
+        certificates = TaggedOrderedStrictSet(registration(poolA))
+      )
+    )
+    val state = State(
+      utxos = Map(input -> TransactionOutput(address, inputValue)),
+      certState = certState
+    )
+
+    (Context.testMainnet(), state, tx)


### PR DESCRIPTION
## Summary

- upgrade both Scalus artifacts and transitive `scalus_3` from 0.18.2 to 1.1.1 while leaving Yano's CCL selection unchanged
- re-derive Yano's pool-deposit value-conservation override from the 1.1.1 default rule set and harden the exact-count/name-preservation guard
- fix the pre-existing swapped memory/steps mapping for maximum execution units
- add CBOR compatibility, certificate-free equivalence, value-conservation, rule-set drift, and complete 31-field protocol-parameter mapping guards
- record the migration decision and full validation evidence in ADR-051

Closes #106.

## Validation

- `:scalus-bridge:test`: 53 tests, 0 failures/errors/skips
- `:app:integrationTest`: 12 tests, 0 failures/errors/skips
- pool lifecycle matrix A-F: all six submitted-transaction scenarios passed
- clean 0.18.2 versus 1.1.1 SDK/load comparison: CCL regular and chained acceptance remained 100%; MeshJS and Evolution signals were non-regressing
- MeshJS and Evolution vesting: 3/3 each
- Oracle GraalVM 25.3 G1 native image: built and reached readiness
- native BLS probe: evaluate, submit, confirm, and negative control passed
- historical, 0.18.2 JVM, 1.1.1 JVM, and 1.1.1 native BLS execution units all remained exactly `12,460 / 110,931,472`
- runtime protocol parameters observed as protocol 11.0 with V1/V2/V3 cost-model cardinalities `332/332/350`

## Deviations and coverage boundaries

- Native smoke used `-Dyano.history.projection.enabled=false` because the unchanged devnet profile exposes the pre-existing `DuckLakeProjectionSinkProvider` native reachability defect tracked by #105. This PR does not change or fix archive projection.
- The candidate CCL step produced valid submitted/confirmed and throughput results, but its wrapper later exited 137 after a terminal job-control stop; the whole-suite wall clock is excluded.
- MeshJS chained-input behavior remains the documented baseline SDK limitation and is not used as the CCL parity signal.
- Native Haskell sync was explicitly skipped for this PR: the branch does not touch block production, block CBOR, sync, or consensus, and a representative cardano-node 11.0.1 takeover with updated cost models requires a separate governance-action bootstrap test.
- No mainnet or preprod validation was run.
- The released ExUnits over-acceptance direction was demonstrated from the affected classes; exploitability through a submitted transaction was not tested. The correction only rejects transactions a reference Haskell node would already reject.

Detailed evidence: `adr/reports/adr-051-phase-0-2026-08-31.md` and `adr/reports/adr-051-phase-1-2-2026-08-31.md`.
