### PR TITLE
fix(native): enable projection history providers

### DIFF
--- a/adr/052-native-projection-history-service-providers.md
+++ b/adr/052-native-projection-history-service-providers.md
@@ -1,0 +1,832 @@
+# ADR-052: Retain Projection History Providers in Native Images
+
+## Status
+
+Proposed
+
+## Date
+
+2026-08-31
+
+## Related decisions and evidence
+
+- [Issue #105](https://github.com/bloxbean/yano/issues/105) records the native
+  startup failure when DuckLake projection history is enabled.
+- [PR #108](https://github.com/bloxbean/yano/pull/108) supplies the Scalus
+  `1.1.1` base on which this change is stacked. Its native acceptance run
+  reproduced issue #105 and proceeded only by explicitly disabling projection.
+- [ADR-039](in-progress/039-canonical-projection-outbox.md) makes the canonical
+  projection outbox and `ProjectionSink` the sole archive write path.
+- [ADR-046](046-archive-aware-epoch-artifact-apis.md) defines the history reads
+  backed by the completed projection archive.
+- [ADR-047](047-remove-residual-legacy-history-machinery.md) removes the old
+  replay-worker archive and leaves projection as the only history writer.
+- [ADR-051 Phase 1/2 evidence](reports/adr-051-phase-1-2-2026-08-31.md)
+  records the failed native devnet launch and the projection-disabled deviation.
+- [`application-projection.yml`](../app/config/application-projection.yml)
+  selects all four block projections and all five epoch-level projections when
+  the `projection` profile is composed after a network profile.
+- The embedded [preprod AdaPot oracle](../ledger-state/src/main/resources/expected_ada_pots_preprod.json)
+  covers epochs 5 through 280, including the fixed 186 through 188 comparison
+  range selected by this ADR.
+
+## Decision summary
+
+Yano will make the DuckLake archive module own native-image reachability for
+both of its ServiceLoader providers and will execute the projection path in the
+native CI gate.
+
+1. `archive-store-ducklake` will retain the no-argument constructors of
+   `DuckLakeProjectionSinkProvider` and `DuckLakeArchiveBackendProvider` in
+   module-owned native-image metadata. The module will also own precise resource
+   metadata for its two ServiceLoader descriptors. Additional resource, JNI or
+   class-initialization metadata discovered by the executed native gates is in
+   scope, but every addition must be justified by a reproduced failure.
+2. Tests in the DuckLake module will require the provider classes, descriptors,
+   and native metadata to agree exactly. Adding, removing, or renaming a provider
+   without updating native reachability must fail a normal JVM build.
+3. A dedicated native projection-history smoke will start the already-built
+   Yano distribution with the `devnet,projection` profiles. It must cross epoch
+   boundaries 0→1→2, prove all four selected block sections plus `epoch_stake`
+   and `ada_pot`, and exercise projection-backed reads. The smoke names and
+   excludes `reward`, `drep_distribution`, and
+   `governance_proposal_status` because a pre-existing block-producing-mode
+   ordering defect prevents their staged writers from resolving the boundary
+   block on both JVM and native. Gate D proves those three through the
+   unaffected fetched-block path.
+4. The `native-core` CI job will run that smoke against the same binary already
+   used for distribution and plugin-catalog verification. A native build that
+   starts only after projection is disabled is a failure.
+5. Native and JVM binaries will project the same fixed preprod range, epochs 186
+   through 188, from equivalent starting state. Their block-section rows,
+   epoch-artifact rows, coverage and coordinates must match; AdaPot values must
+   additionally match the embedded preprod oracle.
+6. Only after the preprod differential passes, JVM and native binaries will run
+   mainnet epochs 0 through 100 as an explicitly bounded Byron-genesis parity
+   check. This final gate proves JVM/native equivalence only; it is not an
+   absolute Byron-correctness or performance validation.
+
+This decision does not replace ServiceLoader, make the archive module an
+application compile-time dependency, alter projection schemas, change history
+configuration defaults, or change chainstate formats.
+
+## Context
+
+The application depends on `archive-api` and `archive-core` at implementation
+time and includes `archive-store-ducklake` at runtime. The DuckLake module
+publishes two service descriptors:
+
+```text
+ProjectionSinkProvider -> DuckLakeProjectionSinkProvider
+ArchiveBackendProvider -> DuckLakeArchiveBackendProvider
+```
+
+The JVM distribution discovers both providers. The native image includes the
+service descriptor resource pattern, but the closed-world analysis does not
+retain the provider implementation required by the descriptor. With the
+`devnet` profile, where projection is enabled by default, startup fails before
+history can open:
+
+```text
+ServiceConfigurationError: ProjectionSinkProvider:
+Provider DuckLakeProjectionSinkProvider not found
+```
+
+The projection writer is the first failing lookup. Registering only that class
+would leave the read-side `ArchiveBackendProvider` exposed to the same defect
+when history endpoints open the archive, so both implementations are one
+correctness unit.
+
+The existing native checks do not cover this path. Distribution verification
+inspects the ZIP. `nativePluginCatalogSmoke` starts the binary with automatic
+sync disabled and does not enable projection. A binary can therefore pass both
+checks while the default native devnet profile is unusable and projection-backed
+history cannot be served on any network.
+
+The full `projection` profile is broader than the ServiceLoader lookup that
+fails first. Its block sections are:
+
+- `transaction:v1`;
+- `utxo-history:v1`;
+- `account-events:v1`; and
+- `address-transaction:v1`.
+
+Its epoch artifacts are:
+
+- `reward:v1`;
+- `epoch-stake:v1`;
+- `ada-pot:v1`;
+- `drep-distribution:v1`; and
+- `governance-proposal-status:v1`.
+
+Epoch artifacts execute at epoch boundaries through a different collector and
+coverage path from ordinary block sections. A one-block startup smoke cannot
+prove their native reachability or correctness. The DuckLake implementation
+also carries DuckDB JDBC, SQLite JDBC and generated `ducklake` and
+`sqlite_scanner` extension resources. Fixing the first missing provider may
+therefore expose further closed-world resource, JNI or initialization failures.
+Those failures are part of issue #105 when they prevent the configured
+projection profile from working in native mode.
+
+## Decision drivers
+
+- The native and JVM distributions must support the same built-in DuckLake
+  projection and history features.
+- Provider reachability must be owned next to the provider rather than by an
+  unrelated application-wide list that can drift.
+- Both the write-side and read-side ServiceLoader contracts must remain valid.
+- All block and epoch projections selected by `application-projection.yml` must
+  work in native mode, not only the provider lookup and first block write.
+- The regression gate must execute the native binary and prove persisted
+  projection progress, not infer correctness from packaging or liveness.
+- Native output must be checked against a JVM same-range oracle so empty or
+  incorrect rows cannot pass as mere progress.
+- Native CI should build the expensive image once and reuse that exact artifact
+  for all runtime smokes.
+- The change must remain narrowly stacked on PR #108 and avoid unrelated archive
+  semantics or configuration changes.
+
+## Invariants
+
+1. The DuckLake JAR contains exactly one provider for
+   `ProjectionSinkProvider` and exactly one provider for
+   `ArchiveBackendProvider`.
+2. The two descriptor entries resolve to concrete, public provider classes with
+   usable no-argument constructors.
+3. The provider portion of native-image metadata retains exactly those two
+   provider constructors and exactly those two service descriptors. Additional
+   driver, JNI and extension entries are allowed only in separately tested,
+   evidence-named sets.
+4. JVM ServiceLoader discovery continues to return both DuckLake providers.
+5. A native launch reaches liveness without a `ServiceConfigurationError` or
+   projection initialization error while preserving the devnet profile's
+   projection selection, sink and enabled settings. Isolated ports and absolute
+   chainstate, history and temporary paths are allowed test overrides.
+6. Native projection coverage reports `enabled=true`, carries a bound identity,
+   reports no error, and eventually reports `genesisCaptured=true`.
+7. At least one canonical block is produced and the projection watermark or
+   coordinate advances through a real block. Startup alone is not acceptance.
+8. The history read facade opens the same DuckLake archive in native mode, so
+   the read-side provider is exercised rather than only inspected.
+9. The smoke uses an isolated temporary chainstate and history directory and
+   leaves no retained process.
+10. Projection is never disabled or changed to sink `none` in the acceptance
+    path.
+11. Native devnet crosses boundaries 0→1→2 and records complete `epoch_stake`
+    generations for epochs 0 and 1 and a complete `ada_pot` generation for
+    epoch 2 without gaps. It continues to select all five configured epoch
+    artifacts, but explicitly excludes `reward`, `drep_distribution`, and
+    `governance_proposal_status` from producer-mode completion until their
+    pre-existing boundary-ordering defect is fixed. Gate D must execute and
+    compare those three on the fetched-block path; a valid zero-row generation
+    there is accepted only when its receipt proves the writer ran and the
+    equivalent JVM fixture has the same row count.
+12. `transaction`, `utxo_history`, `account_event`, and
+    `address_transaction` block sections are populated and queryable in native
+    mode.
+13. For fixed preprod epochs 186 through 188, native and JVM projection rows,
+    coverage intervals and committed coordinates are identical after
+    normalization of explicitly non-semantic values such as run-local paths.
+14. Native preprod AdaPot rows for epochs 186 through 188 equal the embedded
+    treasury, reserves, fees, deposits and UTXO values exactly.
+15. Mainnet is not started before the preprod differential passes and is never
+    run beyond epoch 100 for this issue. The bounded mainnet run is the final
+    gate and exists only to exercise Byron genesis with JVM/native parity.
+
+## Detailed decision
+
+### 1. Put native reachability in the provider module
+
+Add module-owned Native Image metadata under a non-colliding path such as:
+
+```text
+archive-store-ducklake/src/main/resources/META-INF/native-image/
+  com.bloxbean.cardano/yano-archive-store-ducklake/
+    reflect-config.json
+    resource-config.json
+```
+
+The reflection configuration retains, at minimum, the declared constructors of:
+
+- `com.bloxbean.cardano.yano.archive.ducklake.DuckLakeProjectionSinkProvider`;
+- `com.bloxbean.cardano.yano.archive.ducklake.DuckLakeArchiveBackendProvider`.
+
+The resource configuration names, at minimum, the corresponding
+`META-INF/services/...ProjectionSinkProvider` and
+`META-INF/services/...ArchiveBackendProvider` descriptors. It does not use a
+broad `META-INF/services/.*` pattern.
+
+Provider-owned metadata is preferred to an app-level list because the provider
+module is independently publishable and runtime-only. Its JAR must carry the
+metadata needed by every native consumer. It is also preferred to introducing a
+Quarkus deployment module solely to emit two `ServiceProviderBuildItem`s; that
+would add an extension lifecycle and build-time dependency direction without a
+runtime behavior that requires one.
+
+If Gate A's build-input probe proves that Oracle GraalVM 25.3 ignores
+dependency-owned metadata in the Quarkus build, stop and record the generated
+native-image inputs before changing direction. The allowed fallback is
+application-generated constructor metadata derived from the two service
+descriptors, not a second handwritten provider list. That fallback must preserve
+the exact-set drift test below.
+
+The two provider entries are the first slice, not an assumption that all native
+work is known in advance. After each slice, rerun the native path and capture the
+next concrete failure. Resource entries for bundled DuckDB/SQLite native
+libraries or DuckDB extensions, JNI entries, or `--initialize-at-run-time`
+settings are added only when that evidence requires them. Each addition must be
+owned by the narrowest module that can carry it and must gain an exact metadata
+contract test. Speculative catch-all reflection, JNI or resource patterns are
+not permitted.
+
+The metadata contract intentionally compares exact entry sets. When a later
+evidence-led slice adds DuckDB or SQLite metadata, that test must first turn red
+and its expected set must be updated deliberately in the same change. It must
+not be weakened to a subset or `contains` assertion merely to accept new
+entries; the failure is the drift signal, following ADR-051's
+`swapsExactlyOneScalusDefaultValidator` precedent.
+
+#### DuckDB and SQLite native enablement
+
+The providers are only the first reachable objects. Opening them reaches three
+additional closed-world surfaces in the same runtime-only module:
+
+- `PackagedDuckDbExtensionLoader.extract(...)` reads versioned
+  `duckdb-extensions/<version>/<platform>/ducklake.sha256`,
+  `sqlite_scanner.sha256`, and their `.duckdb_extension` payloads through
+  `getResourceAsStream`;
+- `DuckDbManager` loads `org.duckdb.DuckDBDriver` with `Class.forName`; and
+- `DuckLakeTransactionLocator` loads `org.sqlite.JDBC` with `Class.forName`.
+
+The drivers also carry platform JNI libraries and classes that own native
+handles. ADR-052 therefore includes the narrow resource, reflection, JNI and
+runtime-initialization metadata needed to open both drivers and load both
+packaged DuckDB extensions. Prefer metadata already published by the JDBC JARs;
+do not duplicate it when the exact Oracle GraalVM build inputs prove it is
+present and effective.
+
+DuckDB connection acquisition is a separate boundary from archive-provider
+discovery. `DuckDbManager` owns an explicit `DuckDBDriver` instance and calls
+that driver's `connect` method because Quarkus initializes `DriverManager` at
+image build time; it does not replace or bypass the `ProjectionSinkProvider`
+and `ArchiveBackendProvider` ServiceLoader contracts. Those provider contracts
+remain descriptor-driven and are still guarded by the exact-set metadata test.
+
+The driver runtime-initialization entry is retained for the direct mechanism,
+not to restore `DriverManager` registration. It ensures explicit construction
+executes `DuckDBDriver.<clinit>` in the runtime process and establishes its
+mutable scheduler, locks and registries there instead of inheriting their
+build-time state. The later JNI load remains owned by `DuckDBNative` and must be
+classified independently if it fails.
+
+The SQLite transaction-locator connection follows the same explicit-driver
+boundary: `DuckLakeTransactionLocator` owns an `org.sqlite.JDBC` instance and
+calls `connect` directly because Quarkus' build-time `DriverManager` state is
+not a runtime registry. Unlike DuckDB, sqlite-jdbc already ships and activates
+`org.sqlite.nativeimage.SqliteJdbcFeature`; the Oracle native build lists that
+feature and it owns SQLite's platform libraries, resources and JNI metadata.
+The SQLite path therefore adds no handwritten reachability metadata or
+distribution sidecar. Any later SQLite native failure must first be reported
+against that upstream feature rather than duplicating its registrations.
+
+Native history remains a supported distribution capability because Yano also
+targets wallet use cases, where projection-history parity between JVM and native
+packaging is product behavior rather than an optional server-only extra. The
+DuckDB JNI library is therefore a native-distribution sidecar, not an embedded
+image resource: each platform ZIP carries exactly its matching
+`libduckdb_java.so_<platform>` file and SHA-256 record beside `yano`. This keeps
+the executable size flat and lets DuckDB's existing current-executable-directory
+fallback load the library without downloading or extracting it on every
+restart. All native projection and restart gates run from that staged
+distribution, never from a bare `app/build/yano` binary.
+
+This layout depends specifically on DuckDB's third native-library fallback:
+after the classpath lookup is empty and `System.loadLibrary("duckdb_java")`
+fails, `loadFromCurrentJarDir` resolves the jar-style filename beside the
+current executable. The staged native log proves that sequence. A future
+DuckDB change to its current-jar-directory behavior can therefore surface as a
+missing-sidecar packaging failure and must be checked when upgrading the JDBC
+driver.
+
+Sidecar selection follows the built native executable, not the Gradle host.
+The distribution task runs after `quarkusBuild`, identifies the target from the
+ELF, Mach-O or PE header and extracts only that target's entry from the pinned
+DuckDB JDBC JAR. Packaging and verification both fail closed for an unsupported
+format, architecture or mismatched sidecar. This preserves the documented
+macOS-hosted Linux container build instead of pairing its ELF binary with the
+host's macOS library. `prepareYanoDockerNativeContext` strips only the ZIP's top
+directory, leaving the sidecar beside `yano` under `yano/`; the native
+Dockerfile's `COPY yano/ /app/` consequently installs both at `/app` without a
+second packaging path.
+
+Extension selection is target-aware independently of JNI sidecar naming. The
+generated resource tree contains exactly `ducklake.duckdb_extension`,
+`ducklake.sha256`, `sqlite_scanner.duckdb_extension`, and
+`sqlite_scanner.sha256` under one
+`duckdb-extensions/<duckdb-version>/<target-platform>/` directory, plus native
+resource metadata naming exactly those four paths. A native container build
+selects Linux extensions even on a macOS host and honors an explicit Docker
+`--platform=linux/amd64` or `--platform=linux/arm64`. The post-build verifier
+derives the extension target and JNI sidecar separately from the same native
+binary header and rejects a module JAR containing another or additional
+platform. This distinction is required on macOS: DuckDB's JNI JAR uses
+`osx_universal`, while the extension repository uses `osx_arm64` or
+`osx_amd64`. No `duckdb-extensions/**` catch-all is retained in the image.
+
+The first native measurement embeds these four extension resources so the
+executed projection gate can proceed. Because the two raw extension payloads
+are approximately 52 MB together, the resulting executable and ZIP deltas are
+reported to the maintainer before this packaging choice is ratified. Moving
+the checksum-verified extensions beside the executable remains an open
+packaging decision; it must not be inferred from the sidecar decision.
+
+The DuckDB JNI access list is evidence-derived, not a blanket registration. A
+pinned Oracle GraalVM tracing-agent run opened projection and crossed the
+devnet 0-to-1 epoch boundary, exercising reward, ada-pot, stake snapshot,
+governance/DRep and artifact-finalization paths. Its hard-interrupt shutdown did
+not flush metadata, so a second run used periodic writes and captured the same
+eager JNI-on-load lookups before a retained-history identity mismatch stopped
+projection initialization. The unified metadata contained 42 JNI-accessible
+classes; curation removed the unrelated
+`sun.management.VMManagementImpl` entry and the unrelated
+`Boolean.getBoolean(String)` lookup, leaving 41 classes, 49 methods and 11
+fields. That set is cross-checked against DuckDB Java 1.5.5.0's eager
+`create_refs` table. A clean projection open proves the eager JNI-on-load
+handles; later lazy lookup remains covered by the epoch-boundary and preprod
+parity gates rather than claimed closed from startup alone.
+
+If the sidecar is absent, the archive layer reports an actionable startup error
+that names the expected path and tells the operator to use the complete native
+distribution. `verifyCoreNativeDistribution` independently checks the exact
+platform-derived filename, size, digest and checksum record, and rejects extra
+DuckDB sidecars.
+
+The current repository has no macOS/Windows platform code-signing or
+notarization path for native-distribution payloads; `-PskipSigning` controls
+publication signing, not executable/library signing. A future signed native
+release pipeline must sign and verify the JNI sidecar under the target
+platform's policy together with the executable.
+
+Add these entries in evidence-led slices. Gate A first preserves the provider
+failure. After the minimum provider metadata lands, each subsequent native run
+must preserve the exact missing-resource, checksum, class-loading, JNI or
+initialization failure before adding the corresponding narrow entry. Generated
+extension paths must be derived from the build's DuckDB version and platform,
+and their contract test must cover both extension payloads and checksums. Broad
+classpath or native-library wildcards remain prohibited unless the owning
+third-party artifact itself publishes and requires that pattern.
+
+### 2. Make descriptor and metadata drift fail on the JVM
+
+Add a focused metadata contract test to `archive-store-ducklake`. It will parse
+the two service files and the two native configuration files and assert:
+
+- one unique implementation name per service interface;
+- the implementation names are exactly the two shipped provider classes;
+- each class is assignable to its declared service interface;
+- each class exposes the constructor required by ServiceLoader;
+- the provider reflection entries contain exactly those implementation names
+  and only constructor retention; any additional driver entries form a separate,
+  evidence-named expected set;
+- the ServiceLoader resource entries contain exactly the two escaped descriptor
+  paths; generated DuckDB-extension and JNI resources form separate,
+  evidence-named expected sets;
+- there are no duplicate native metadata entries.
+
+The test verifies source metadata, not native behavior. It provides a fast red
+signal when providers change, while the executed native smoke remains the
+closed-world acceptance gate.
+
+### 3. Execute native projection history in the producer-mode devnet binary
+
+Add a separate Gradle task, `nativeProjectionHistorySmoke`, that accepts the
+same `-PyanoNativeBinary` / `YANO_NATIVE_BINARY` override convention as the
+existing native plugin-catalog smoke. It stages the already-built native ZIP so
+the executable, DuckDB sidecar, config and extension resources are tested in
+their release layout. It must not invoke another native build.
+
+The task will:
+
+1. allocate isolated loopback ports and a temporary root;
+2. start the binary with `devnet,projection`, automatic sync and lazy block
+   production enabled so the control API, rather than wall-clock scheduling,
+   owns every produced block;
+3. point chainstate, history, DuckDB temporary files, and extension extraction
+   at the temporary root;
+4. leave `yano.history.projection.enabled=true` and sink `ducklake` effective;
+5. await liveness, then use the devnet control API to cross epoch boundaries
+   0→1→2 while producing canonical blocks;
+6. derive finality from the staged devnet genesis as `2 * securityParam`, then
+   poll `/history/coverage` until the committed coordinate converges exactly to
+   `tip - finalityBlocks`. If a valid near-tip batch remains below its normal
+   minimum, add deterministic single-slot advances until it reaches a real
+   commit boundary rather than changing production batch policy or encoding an
+   observed lag as a constant;
+7. stop block production and require the same finalized-frontier convergence,
+   captured genesis row-count/digest evidence, and independently queryable
+   watermarks for all four block sections;
+8. require complete `epoch_stake` coverage for epochs 0 and 1 and complete
+   `ada_pot` coverage for epoch 2. Keep all five artifacts selected, but print
+   the producer-mode exclusions `reward`, `drep_distribution`, and
+   `governance_proposal_status` with the pre-existing-defect reason. Their
+   executed row-count and zero-row parity moves to Gate D's fetched-block run;
+9. call projection-backed history reads and the watermark endpoint to exercise
+   `DuckLakeArchiveBackendProvider` as well as the projection sink provider;
+10. fail on early process exit, timeout, provider error, unexpected projection
+    error, missing progress, or non-successful history response; and
+11. terminate the process gracefully, escalating to forced termination only as
+   a reported test failure.
+
+On failure, the task preserves its temporary root and prints the log tail,
+effective paths, ports, binary path, and SHA-256. On success, it removes the
+temporary root and reports the observed block and projection coordinate.
+
+The exact block number is intentionally not fixed. The gate derives its
+finalized target from the observed tip and staged genesis, and proves that real
+blocks and two epoch boundaries crossed the canonical apply, projection outbox,
+block and supported producer-mode epoch collectors, DuckLake sink, coverage
+store, and history read path within the bounded timeout.
+
+The producer-mode exclusion is an independently reproduced product defect, not
+a native exception. At the unmodified PR #108 head
+`de4bbdfd5dc0523682a0cd56a1de526d29beeaaf`, the packaged JVM fixture fails
+while opening the epoch-1 reward writer with
+`ArchiveStoreException: canonical epoch boundary is unavailable`. All three
+block-producing call sites publish `prepareEpochTransitionBeforeBlock` before
+the boundary block is built and stored; the staged writer synchronously asks
+`ChainQuery` for that not-yet-existent block. The fetched-block path stores the
+block before publishing the transition events and is unaffected. The separate
+issue remains subject to maintainer approval and is not fixed in issue #105.
+
+### 4. Compare native and JVM projection output on preprod
+
+The fixed preprod acceptance window is epochs 186, 187 and 188
+because it crosses two boundaries, has previously exercised Conway epoch
+processing in this repository, and is fully covered by the embedded AdaPot
+oracle.
+
+Create the comparison input once; do not perform two independent genesis syncs:
+
+1. Before starting, estimate history growth from preprod genesis through epoch
+   188 with all projections enabled. Record the source measurements and margin
+   to the shipped 8 GiB soft budget. If the estimate reaches or exceeds the soft
+   budget, obtain a maintainer decision before launch; do not change the budget
+   during a run.
+2. Start one JVM process from empty state with `preprod,projection` and the
+   complete default selection from `application-projection.yml`. Use explicit
+   absolute chainstate and history paths under the evidence root.
+3. Stop gracefully at the start of epoch 186 only after the projection outbox is
+   drained to its expected finality window, the archive is healthy, and its
+   committed coordinate is recorded. This genesis sync establishes
+   `genesisCaptured=true` for both later legs.
+4. With no Yano process running, snapshot chainstate and history together as one
+   seed and record their manifests/digests. Make two byte-identical copies named
+   `jvm` and `native`; verify the copied manifests before either is opened.
+5. Run the JVM copy forward through the end of epoch 188, then stop it
+   gracefully. Only after it exits, run the Oracle GraalVM 25.3 native copy over
+   the same window. Never open either copy concurrently or reuse one leg's
+   mutated state for the other.
+
+Run only one Yano process at a time and record the effective profile, projection
+selection, sink, paths, disk budgets, binary/JAR identity and toolchain before
+accepting a measurement. Because both legs inherit the same genesis-built
+archive and rollback history, exact row parity is meaningful and
+`genesisCaptured=true` remains reachable without a second long sync.
+
+Hold housekeeping and compaction configuration identical across both legs and
+record whether either task fired, including its start/end coordinate and
+result. Maintenance scheduling is wall-clock and disk-triggered, so physical
+file layout, snapshot history and expired-file state are not parity fields.
+Logical rows remain the hard gate. Coverage intervals, receipts and identities
+are compared semantically; normalize a maintenance-only difference only when
+the evidence names the task that caused it and proves no logical row, gap,
+identity or coordinate changed.
+
+Export deterministic evidence for each run:
+
+- all rows in `transaction`, `utxo_history`, `account_event`, and
+  `address_transaction` whose canonical coordinates fall within the fixed
+  comparison window;
+- every complete `reward`, `epoch_stake`, `ada_pot`, `drep_distribution`, and
+  `governance_proposal_status` generation for epochs 186 through 188;
+- coverage intervals, gaps, projection identities, receipts and committed
+  coordinates; and
+- history-directory size at each boundary and at the end of the window; and
+- housekeeping and compaction events, including whether either ran in only one
+  leg.
+
+Sort by each dataset's canonical key, normalize only documented run-local
+fields, and compare row counts, canonical keys and serialized semantic values.
+Every dataset must be populated and native must match JVM exactly. For AdaPot,
+also compare treasury, reserves, fees, deposits and UTXO to
+`expected_ada_pots_preprod.json`; the oracle contains all three selected epochs.
+Evidence is retained below an issue-specific path such as
+`/Users/satya/Downloads/yano-issue105-native-projection/preprod-186-188/`, with
+separate `jvm/`, `native/`, and `comparison/` leaves.
+
+The shipped projection disk budgets remain unchanged: soft 8 GiB, hard 32 GiB,
+low-water 4 GiB. Record history size at every boundary. If actual growth departs
+materially from the approved estimate or approaches a threshold, stop and
+report rather than silently raising a budget.
+
+The pre-sync estimate recorded on 2026-08-31 is below, but close enough to the
+soft limit to require monitoring. ADR-039 measured a four-block-section fresh
+preprod sync to tip at 4.50 GB logical size. Its later projection-only validation
+with all four block sections and all five epoch artifacts reached block
+5,087,259 with 7.3 GB on disk. Epoch 188 is earlier than that retained full-tip
+measurement, so 7.3 GB decimal (6.80 GiB) is the conservative genesis-to-188
+estimate. It consumes 85.0% of the 8 GiB soft budget and leaves 1.29 GB decimal
+of margin. The two offline comparison copies multiply host storage, but do not
+change the per-history-directory budget. Treat 7.5 GB observed usage as an early
+warning and obtain a maintainer decision before the soft threshold is reached.
+
+### 5. Exercise mainnet Byron genesis last, with known limitations
+
+Only after the preprod Gate D differential has completed successfully, run one
+additional JVM/native parity test from mainnet genesis through the end of epoch
+100. Do not start this run earlier, do not sync beyond epoch 100, and do not
+extend it into a full mainnet validation. Its evidence root sits beside the
+preprod evidence, for example
+`/Users/satya/Downloads/yano-issue105-native-projection/mainnet-0-100/`, with
+separate seed, JVM, native, and comparison leaves.
+
+Epochs 0 through 100 exercise Byron genesis bootstrap and the mainnet Byron
+genesis UTXO/AVVM distributions, which the Shelley-era preprod window does not.
+The acceptance criterion is exact JVM/native semantic equivalence for the
+bounded window, including genesis capture, projected rows, coverage, receipts,
+identities and coordinates. It deliberately does not claim that those balances
+or rows are correct in absolute terms.
+
+Two existing open issues are pre-declared limitations, not failures introduced
+by native-image support:
+
+- Issue #87 records that Byron transactions are not applied to the UTXO set,
+  producing wrong balances and phantom genesis UTXOs. A green Gate F proves
+  only that native matches JVM behavior; it must never be cited as Byron
+  correctness validation.
+- Issue #88 records the per-block durable-write bottleneck of approximately 121
+  blocks per second. Epochs 0 through 100 may therefore take roughly five
+  hours. Do not tune, bypass, or fix that performance path in issue #105, and do
+  not classify its known cost as a native-image regression.
+
+### 6. Run the devnet smoke in native CI and release workflows
+
+Add `:app:nativeProjectionHistorySmoke` to the `native-core` invocation after
+the one native build and distribution verification. Keep
+`nativePluginCatalogSmoke`; the tasks cover independent native reachability
+surfaces.
+
+Any workflow that advertises a native release artifact must run the same
+projection smoke or invoke a shared aggregate verification task that includes
+it on the platforms ratified for this ADR. Linux `native-core` coverage is
+required. Windows is an explicit open decision because `dist-dev.yml` already
+builds a Windows native binary and executes `nativePluginCatalogSmoke`; adding
+projection coverage there also commits this PR to Windows DuckDB-extension
+packaging and Windows process-start/termination behavior. The workflow must not
+silently include or exempt Windows before that choice is made.
+
+The executed native devnet smoke requested by issue #105 item 2 is proposed as
+in scope for this PR, not deferred. Ratifying this ADR accepts that scope;
+before ratification it remains an explicit maintainer decision. The longer
+preprod JVM/native differential is an acceptance gate and retained evidence,
+but need not run on every pull request.
+
+### 7. Preserve the stacked-PR boundary
+
+The implementation branch starts at PR #108 head and its pull request targets
+`issue-106-upgrade-scalus-1.1.1`, not `main`. Its diff must contain only ADR-052,
+DuckLake native-enablement metadata and tests, the native projection smoke, and
+the workflow wiring required for issue #105. After PR #108 merges, the stacked
+PR may be retargeted to `main` without rebasing away its review history.
+
+## Acceptance gates
+
+### Gate A — baseline reproduction and metadata inspection
+
+- Preserve the issue #105 failure log from the PR #108 native binary.
+- Record the binary SHA-256 and Oracle GraalVM/JDK versions.
+- Inspect the native build inputs to show the service descriptor is retained
+  while the provider constructor is absent before the fix.
+- After each native metadata slice, retain the next failure before adding more
+  GraalVM configuration; no entry is justified only by expectation.
+
+### Gate B — module and JVM regression tests
+
+- `:archive-modules:archive-store-ducklake:test` passes, including the exact-set
+  metadata contract.
+- Application unit and integration tests pass.
+- A packaged JVM devnet still opens projection and passes the existing
+  `DevnetProjectionArchiveIT` behavior.
+
+Executed JVM oracle evidence is retained at
+`/Users/satya/Downloads/yano-issue105-native-projection/slice5-sidecar-distribution-de4bbdfd/jni-agent-runtime/jvm-devnet-agent.log`.
+The staged JVM ZIP opened the DuckLake sink and all nine datasets
+(`account_event`, `ada_pot`, `address_transaction`, `drep_distribution`,
+`epoch_stake`, `governance_proposal_status`, `reward`, `transaction`, and
+`utxo_history`), produced through slot 1,315, and completed the devnet epoch
+0-to-1 boundary at slot 1,200 with every boundary phase successful.
+
+The run also proves that a devnet execution can mutate its extracted
+distribution. Against a fresh extraction, the exact differences were a new
+2.0 MiB `chainstate/` tree (29 files), new `yano.log`/`yano.log.1` files, and a
+single content change in `config/network/devnet/shelley-genesis.json`:
+`systemStart` was updated from `2026-06-03T11:05:36Z` to the producer start time
+`2026-08-31T14:34:28Z`. Therefore JVM/native parity legs never share an
+extracted distribution. Each leg receives a fresh extraction plus its own copy
+of the common seed snapshot, and the post-run comparison includes both the
+explicit data directories and any files created below that leg's distribution
+root. This prevents launcher fallback paths or devnet genesis updates from
+contaminating the other leg.
+
+The preprod parity legs do not rewrite `shelley-genesis.json`. Source inspection
+shows `resolveAndPersistGenesisTimestamp(...)` is called only by devnet producer
+startup, or by slot-leader startup while `devMode=true`; non-dev slot-leader
+startup reads `systemStart`, and the preprod sync-only gate does not start a
+producer. Fresh extraction is still required independently for both parity
+legs so the test does not rely on that implementation detail and captures any
+unexpected distribution-root mutation.
+
+### Gate C — release-parity native devnet projection smoke
+
+- Build once with the CI Oracle GraalVM 25.3 toolchain and G1 configuration.
+- `verifyCoreNativeDistribution`, `nativePluginCatalogSmoke`, and
+  `nativeProjectionHistorySmoke` all run against that exact binary.
+- The projection smoke crosses devnet 0→1→2 and proves captured genesis,
+  finalized-frontier convergence, populated/queryable coverage for all four
+  block sections, and complete producer-mode generations for `epoch_stake`
+  epochs 0..1 and `ada_pot` epoch 2, with projection enabled throughout. It
+  names the three producer-blocked staged artifacts as exclusions rather than
+  silently accepting their absence.
+- The log contains no ServiceLoader provider failure, projection initialization
+  failure, packaged-extension missing-resource error, extension checksum
+  mismatch, or archive degradation other than the explicitly scoped
+  producer-mode staged-artifact exclusion. Both DuckDB extensions must load
+  from packaged resources; runtime download is not a supported fallback.
+
+The first executed Gate C smoke passed on 2026-09-01 against native binary
+SHA-256
+`09cc2786f73acee2008b0e10eafb917ca3ab78d84a9c73cc211395c23616192d`.
+The lazy devnet stopped at tip 2,600; staged genesis supplied `k=100`, so the
+derived finality window was 200 and the exact queryable frontier was block
+2,400. Projection reached 2,400 with zero single-slot convergence nudges and
+retained that coordinate after production stopped. `epoch_stake` completed
+epochs 0..1, `ada_pot` completed epoch 2, all four individual block-dataset
+watermarks reported range 0..2,400, and a projection-backed
+address-transaction lookup returned HTTP 200. The task printed the three
+producer-mode exclusions by name. It ran the existing native distribution and
+did not invoke another native build or add workflow wiring.
+
+### Gate D — preprod JVM/native differential
+
+- Use preprod only and the fixed epoch 186-through-188 window.
+- Perform one projection-enabled genesis sync to the start of epoch 186,
+  snapshot chainstate and history together, verify byte-identical copies, then
+  run JVM and native serially through epoch 188 with the full `projection`
+  profile and unchanged disk budgets.
+- Require exact semantic equality for every row of all four block sections and
+  all five epoch artifacts, plus coverage and coordinate equality.
+- Require native AdaPot fields to match the embedded oracle for epochs 186,
+  187 and 188.
+- Retain exports, comparison reports, logs, identities and per-boundary disk
+  usage under the named issue evidence root.
+
+### Gate E — restart durability
+
+- Use a dedicated isolated root, separate from the CI smoke's disposable root.
+- Start the same native binary, cross one boundary with all projections enabled,
+  record the archive identity and coordinate, and stop gracefully without
+  deleting the root.
+- Restart against that retained chainstate and history directory, then cross the
+  next boundary.
+- Require clean provider discovery, archive identity reuse, no destructive
+  reinitialization, and projection progress beyond the pre-restart coordinate.
+- Remove the dedicated root only after both legs pass; preserve it with both log
+  tails and effective configuration on any failure.
+
+Gate E may run in a dedicated acceptance task if keeping the per-PR CI smoke
+short is necessary, but it must complete before ADR-052 is accepted.
+
+### Gate F — bounded mainnet Byron-genesis parity, last
+
+- Start only after Gate D has passed; preserve the one-process-at-a-time rule.
+- Run mainnet from genesis through epoch 100 and stop there. A full mainnet sync
+  or any epoch beyond 100 is outside this authorization.
+- Use equivalent isolated JVM/native inputs and require exact semantic parity
+  for genesis capture, projected rows, coverage, receipts, identities and
+  coordinates within the bounded window.
+- Treat balance or phantom-genesis-UTXO errors covered by issue #87 as known JVM
+  behavior, not proof of native correctness or a new native defect. This gate
+  must not be cited as Byron correctness validation.
+- Pre-declare issue #88's approximately 121-block/second throughput and roughly
+  five-hour expectation. Do not tune or work around it in this issue and do not
+  report the known cost as a native regression.
+- Retain manifests, logs, exports and comparison output under the dedicated
+  `mainnet-0-100` evidence root.
+
+## Alternatives considered
+
+### Disable projection in native profiles
+
+Rejected. It makes the native product feature-incomplete, hides the default
+devnet failure, and contradicts the projection-only history architecture.
+
+### Register only `DuckLakeProjectionSinkProvider`
+
+Rejected. The writer would start, but the read facade would retain the same
+uncovered ServiceLoader risk for `DuckLakeArchiveBackendProvider`.
+
+### Move providers into the application module
+
+Rejected. It reverses the archive API dependency boundary and couples the app
+at compile time to DuckLake implementation types.
+
+### Replace ServiceLoader with direct construction or CDI injection
+
+Rejected for this issue. Either choice changes the pluggable archive boundary
+defined by the existing ADRs. Narrow native reachability metadata for the two
+built-in providers, their drivers and packaged extensions preserves that
+boundary.
+
+### Use only application-wide reflection configuration
+
+Rejected as the primary design. It can make the current binary pass while
+leaving the independently published provider module incomplete and prone to
+drift. It remains a constrained fallback only if build-input evidence proves
+dependency-owned metadata is not consumed.
+
+### Treat a successful native build or liveness check as acceptance
+
+Rejected. Issue #105 already passes both kinds of indirect signal. Only a real
+projection write and history read prove the closed-world runtime surface.
+
+### Validate only devnet
+
+Rejected. Devnet is the fast closed-world path and can exercise epoch writers,
+but its tiny synthetic data is not a correctness oracle. The fixed preprod
+JVM/native differential is required. A bounded mainnet 0-through-100 parity
+gate then runs last solely to exercise Byron genesis under the known issue #87
+correctness limitation and issue #88 performance cost.
+
+## Consequences
+
+### Positive
+
+- Native devnet works with its shipped projection defaults.
+- Native users can serve DuckLake-backed history rather than running a
+  projection-disabled binary.
+- Every block and epoch projection in the shipped `projection` profile gains a
+  native execution and correctness gate across the devnet smoke and the
+  fetched-block preprod differential; the producer-mode exclusion remains
+  explicit until its separate defect is resolved.
+- Write-side and read-side provider reachability have one owner and one drift
+  test.
+- CI catches both missing native metadata and a provider that is retained but
+  fails while opening DuckLake.
+- The expensive native image is reused across independent smokes.
+
+### Costs and risks
+
+- Native CI runs a second process-level smoke and waits for real block and
+  projection progress across two epoch boundaries.
+- The preprod JVM/native differential consumes time and disk and must be run
+  serially with explicit paths and retained evidence.
+- The smoke exercises DuckDB native code and bundled extensions, so failures may
+  expose platform packaging defects beyond ServiceLoader reachability. Those
+  are product failures, but their evidence must be classified precisely.
+- Reflection metadata must be updated when provider implementations change.
+  The exact-set test intentionally turns that maintenance obligation into a
+  build failure.
+
+## Rollback
+
+Revert the provider metadata, metadata test, smoke task and workflow wiring as
+one change. No chainstate or archive migration is required. Disabling projection
+is permitted only as an explicitly documented diagnostic workaround; it is not
+an accepted release state for this ADR.
+
+## Open maintainer decisions
+
+1. After reviewing the measured executable and ZIP deltas, choose whether the
+   two checksum-verified DuckDB extension payloads remain embedded native-image
+   resources or move beside the executable as distribution files.
+2. Ratify that `nativeProjectionHistorySmoke` and Linux `native-core` workflow
+   wiring ship in this PR rather than being deferred.
+3. Choose whether Windows `dist-dev` also runs the projection smoke in this PR.
+   Including it adds Windows DuckDB extension packaging and Windows process
+   lifecycle to the acceptance surface. Exempting it must be explicit and leaves
+   Windows native projection as a recorded coverage gap; the existing Windows
+   plugin-catalog smoke alone is not projection evidence.
+4. If the preprod genesis-to-188 history estimate reaches the 8 GiB soft budget,
+   decide whether the test budget may be raised before launch or whether the
+   fixed comparison range must change. No agent may alter the shipped budget
+   silently or during the run.
+5. Ratify ADR-052, then separately authorize commit, push and creation of the
+   stacked PR. ADR ratification does not authorize merge.
+
+## Acceptance
+
+ADR-052 remains `Proposed` until the metadata contract, JVM projection behavior,
+release-parity native devnet projection smoke, preprod JVM/native differential,
+and restart-durability gate pass and the maintainer ratifies the decision. The
+ratification must also decide that the executed CI smoke ships in this PR.
+Creating the branch or opening a stacked PR does not change this status.

--- a/adr/052-native-projection-history-service-providers.md
+++ b/adr/052-native-projection-history-service-providers.md
@@ -21,14 +21,18 @@ Proposed
   backed by the completed projection archive.
 - [ADR-047](047-remove-residual-legacy-history-machinery.md) removes the old
   replay-worker archive and leaves projection as the only history writer.
+- ADR-053 is the proposed stacked follow-up that binds staged facts after the
+  boundary block becomes canonical. It removes this ADR's three producer-mode
+  exclusions without changing native provider reachability; its document ships
+  on that separate lifecycle branch.
 - [ADR-051 Phase 1/2 evidence](reports/adr-051-phase-1-2-2026-08-31.md)
   records the failed native devnet launch and the projection-disabled deviation.
 - [`application-projection.yml`](../app/config/application-projection.yml)
   selects all four block projections and all five epoch-level projections when
   the `projection` profile is composed after a network profile.
 - The embedded [preprod AdaPot oracle](../ledger-state/src/main/resources/expected_ada_pots_preprod.json)
-  covers epochs 5 through 280, including the fixed 186 through 188 comparison
-  range selected by this ADR.
+  covers epochs 5 through 280, including the epoch-192 baseline and the epoch
+  193/194 boundaries selected for the executed comparison.
 
 ## Decision summary
 
@@ -57,14 +61,17 @@ native CI gate.
 4. The `native-core` CI job will run that smoke against the same binary already
    used for distribution and plugin-catalog verification. A native build that
    starts only after projection is disabled is a failure.
-5. Native and JVM binaries will project the same fixed preprod range, epochs 186
-   through 188, from equivalent starting state. Their block-section rows,
-   epoch-artifact rows, coverage and coordinates must match; AdaPot values must
-   additionally match the embedded preprod oracle.
+5. Native and JVM binaries will project the same preprod range from a
+   byte-identical stopped epoch-192 baseline, crossing epoch 193 and optionally
+   epoch 194. Their block-section rows, epoch-artifact rows, coverage and
+   coordinates must match; AdaPot values must additionally match the embedded
+   preprod oracle. Per-dataset row counts prove generation independently of
+   cross-leg equality.
 6. Only after the preprod differential passes, JVM and native binaries will run
    mainnet epochs 0 through 100 as an explicitly bounded Byron-genesis parity
-   check. This final gate proves JVM/native equivalence only; it is not an
-   absolute Byron-correctness or performance validation.
+   check. This final gate asserts genesis capture against the configured genesis
+   file and requires JVM/native equivalence for the remaining bounded rows. It
+   is not a broader Byron-correctness or performance validation.
 
 This decision does not replace ServiceLoader, make the archive module an
 application compile-time dependency, alter projection schemas, change history
@@ -184,11 +191,17 @@ projection profile from working in native mode.
 12. `transaction`, `utxo_history`, `account_event`, and
     `address_transaction` block sections are populated and queryable in native
     mode.
-13. For fixed preprod epochs 186 through 188, native and JVM projection rows,
-    coverage intervals and committed coordinates are identical after
-    normalization of explicitly non-semantic values such as run-local paths.
-14. Native preprod AdaPot rows for epochs 186 through 188 equal the embedded
-    treasury, reserves, fees, deposits and UTXO values exactly.
+13. For the recorded preprod epoch-192 baseline window, native and JVM
+    projection rows, coverage intervals and committed coordinates are identical
+    after normalization of explicitly non-semantic values such as run-local
+    paths. Each of the nine datasets also reports a per-epoch row count. Every
+    count expected to be non-zero must be non-zero; a zero is accepted only when
+    predicted before comparison, justified from chain activity and matched by
+    the JVM leg.
+14. Native preprod AdaPot rows for every selected boundary equal the embedded
+    treasury, reserves, fees, deposits and UTXO values exactly. This is an
+    absolute oracle for one dataset; the other eight rely on generation checks
+    plus exact JVM/native semantic equality.
 15. Mainnet is not started before the preprod differential passes and is never
     run beyond epoch 100 for this issue. The bounded mainnet run is the final
     gate and exists only to exercise Byron genesis with JVM/native parity.
@@ -460,32 +473,34 @@ issue remains subject to maintainer approval and is not fixed in issue #105.
 
 ### 4. Compare native and JVM projection output on preprod
 
-The fixed preprod acceptance window is epochs 186, 187 and 188
-because it crosses two boundaries, has previously exercised Conway epoch
-processing in this repository, and is fully covered by the embedded AdaPot
-oracle.
+The executed preprod acceptance window starts from a stopped common baseline in
+epoch 192 and crosses the boundary into epoch 193. It may continue through the
+boundary into epoch 194 when the second boundary is inexpensive. The evidence
+root retains `preprod-186-188` in its name because that was the originally
+planned window; renaming a retained multi-gigabyte tree would add risk without
+changing the recorded coordinates. Satya explicitly accepted one or two epochs
+on 2026-09-01. The selected window remains Conway, exercises real governance
+content and is fully covered by the embedded AdaPot oracle.
 
 Create the comparison input once; do not perform two independent genesis syncs:
 
-1. Before starting, estimate history growth from preprod genesis through epoch
-   188 with all projections enabled. Record the source measurements and margin
-   to the shipped 8 GiB soft budget. If the estimate reaches or exceeds the soft
-   budget, obtain a maintainer decision before launch; do not change the budget
-   during a run.
-2. Start one JVM process from empty state with `preprod,projection` and the
-   complete default selection from `application-projection.yml`. Use explicit
-   absolute chainstate and history paths under the evidence root.
-3. Stop gracefully at the start of epoch 186 only after the projection outbox is
-   drained to its expected finality window, the archive is healthy, and its
-   committed coordinate is recorded. This genesis sync establishes
-   `genesisCaptured=true` for both later legs.
-4. With no Yano process running, snapshot chainstate and history together as one
+1. Record the stopped seed's chain tip, projection coordinate, history size and
+   margin to the shipped 8 GiB soft budget. If projection has not converged to
+   the exact `tip - 2 * securityParam` frontier, resume only under a guarded
+   stop condition that cannot overshoot the required coordinate unnoticed.
+2. Before copying, require one stable projection identity, all nine configured
+   datasets reachable, zero gaps, a healthy archive and an exact committed
+   frontier. This genesis-built seed establishes `genesisCaptured=true` for
+   both later legs.
+3. With no Yano process running, snapshot chainstate and history together as one
    seed and record their manifests/digests. Make two byte-identical copies named
-   `jvm` and `native`; verify the copied manifests before either is opened.
-5. Run the JVM copy forward through the end of epoch 188, then stop it
-   gracefully. Only after it exits, run the Oracle GraalVM 25.3 native copy over
-   the same window. Never open either copy concurrently or reuse one leg's
-   mutated state for the other.
+   `jvm` and `native`; verify the copied manifests before either is opened. Each
+   leg receives a freshly extracted matching distribution.
+4. Run the JVM copy across the epoch-193 boundary and to an exact finalized
+   projection frontier; continue through epoch 194 only when the first boundary
+   is cheap. Stop it gracefully. Only after it exits, run the Oracle GraalVM
+   25.3 native copy across the identical coordinate range. Never open either
+   copy concurrently or reuse one leg's mutated state for the other.
 
 Run only one Yano process at a time and record the effective profile, projection
 selection, sink, paths, disk budgets, binary/JAR identity and toolchain before
@@ -505,10 +520,11 @@ identity or coordinate changed.
 Export deterministic evidence for each run:
 
 - all rows in `transaction`, `utxo_history`, `account_event`, and
-  `address_transaction` whose canonical coordinates fall within the fixed
-  comparison window;
-- every complete `reward`, `epoch_stake`, `ada_pot`, `drep_distribution`, and
-  `governance_proposal_status` generation for epochs 186 through 188;
+  `address_transaction` whose canonical coordinates fall within the recorded
+  baseline-to-final comparison window;
+- every newly complete `reward`, `epoch_stake`, `ada_pot`,
+  `drep_distribution`, and `governance_proposal_status` generation produced by
+  the selected epoch-193 and optional epoch-194 boundaries;
 - coverage intervals, gaps, projection identities, receipts and committed
   coordinates; and
 - history-directory size at each boundary and at the end of the window; and
@@ -517,10 +533,15 @@ Export deterministic evidence for each run:
 
 Sort by each dataset's canonical key, normalize only documented run-local
 fields, and compare row counts, canonical keys and serialized semantic values.
-Every dataset must be populated and native must match JVM exactly. For AdaPot,
-also compare treasury, reserves, fees, deposits and UTXO to
-`expected_ada_pots_preprod.json`; the oracle contains all three selected epochs.
-Evidence is retained below an issue-specific path such as
+For each of the nine datasets, the comparison report records the actual row
+count per semantic epoch. Every count expected to be non-zero must be non-zero.
+A legitimate zero is accepted only when its expected epoch and chain-derived
+reason were written down before the comparison and the JVM leg has the same
+zero-row complete generation; an unpredicted zero fails the gate. Native must
+match JVM exactly. For AdaPot, also compare treasury, reserves, fees, deposits
+and UTXO to `expected_ada_pots_preprod.json` for every selected epoch. AdaPot is
+the one absolute dataset oracle; the other eight are protected by explicit
+generation assertions plus cross-leg equality. Evidence is retained below
 `/Users/satya/Downloads/yano-issue105-native-projection/preprod-186-188/`, with
 separate `jvm/`, `native/`, and `comparison/` leaves.
 
@@ -529,16 +550,14 @@ low-water 4 GiB. Record history size at every boundary. If actual growth departs
 materially from the approved estimate or approaches a threshold, stop and
 report rather than silently raising a budget.
 
-The pre-sync estimate recorded on 2026-08-31 is below, but close enough to the
-soft limit to require monitoring. ADR-039 measured a four-block-section fresh
-preprod sync to tip at 4.50 GB logical size. Its later projection-only validation
-with all four block sections and all five epoch artifacts reached block
-5,087,259 with 7.3 GB on disk. Epoch 188 is earlier than that retained full-tip
-measurement, so 7.3 GB decimal (6.80 GiB) is the conservative genesis-to-188
-estimate. It consumes 85.0% of the 8 GiB soft budget and leaves 1.29 GB decimal
-of margin. The two offline comparison copies multiply host storage, but do not
-change the per-history-directory budget. Treat 7.5 GB observed usage as an early
-warning and obtain a maintainer decision before the soft threshold is reached.
+The stopped epoch-192 seed measured 5,984,876 KiB (5.71 GiB) in its history
+directory, 71.4% of the 8 GiB soft budget and below the 7.5 GB decimal early
+warning. Its 11,751,496 KiB chainstate is host-capacity information, not part of
+the archive ingest-gate budget. The two offline comparison copies multiply host
+storage, but do not change the per-history-directory budget. Record actual free
+space and per-leg usage before launch. Treat 7.5 GB observed history usage as
+an early warning and obtain a maintainer decision before the soft threshold is
+reached.
 
 ### 5. Exercise mainnet Byron genesis last, with known limitations
 
@@ -552,22 +571,21 @@ separate seed, JVM, native, and comparison leaves.
 
 Epochs 0 through 100 exercise Byron genesis bootstrap and the mainnet Byron
 genesis UTXO/AVVM distributions, which the Shelley-era preprod window does not.
-The acceptance criterion is exact JVM/native semantic equivalence for the
-bounded window, including genesis capture, projected rows, coverage, receipts,
-identities and coordinates. It deliberately does not claim that those balances
-or rows are correct in absolute terms.
+This is also the only gate whose genesis input exercises the full mainnet AVVM
+distribution rather than preprod's single genesis row. As soon as genesis
+capture completes, before waiting for epoch 100, the gate independently parses
+`app/config/network/mainnet/byron-genesis.json`, derives the expected AVVM row
+count and lovelace total, and compares both with the projection. For the current
+file those derived values are 14,505 rows and 31,112,484,745,000,000 lovelace.
+The assertion must not hardcode them. It records the genesis digest and later
+requires the JVM and native legs to produce that same digest.
 
-Two existing open issues are pre-declared limitations, not failures introduced
-by native-image support:
-
-- Issue #87 records that Byron transactions are not applied to the UTXO set,
-  producing wrong balances and phantom genesis UTXOs. A green Gate F proves
-  only that native matches JVM behavior; it must never be cited as Byron
-  correctness validation.
-- Issue #88 records the per-block durable-write bottleneck of approximately 121
-  blocks per second. Epochs 0 through 100 may therefore take roughly five
-  hours. Do not tune, bypass, or fix that performance path in issue #105, and do
-  not classify its known cost as a native-image regression.
+The remainder of the bounded run requires exact JVM/native semantic
+equivalence for projected rows, coverage, receipts, identities and coordinates.
+Report the observed blocks per second, including any material change by era.
+Issue #88 may help interpret a measured slow rate, but the gate does not
+pre-declare a bottleneck or a completion time and does not tune production code
+as part of issue #105.
 
 ### 6. Run the devnet smoke in native CI and release workflows
 
@@ -678,15 +696,23 @@ did not invoke another native build or add workflow wiring.
 
 ### Gate D — preprod JVM/native differential
 
-- Use preprod only and the fixed epoch 186-through-188 window.
-- Perform one projection-enabled genesis sync to the start of epoch 186,
-  snapshot chainstate and history together, verify byte-identical copies, then
-  run JVM and native serially through epoch 188 with the full `projection`
-  profile and unchanged disk budgets.
+- Use preprod only and the recorded epoch-192 common baseline. Cross the
+  epoch-193 boundary and optionally epoch 194 when the second boundary is
+  inexpensive.
+- Require the stopped seed to be healthy and exactly converged to its derived
+  finalized frontier. Snapshot chainstate and history together, verify
+  byte-identical `jvm` and `native` copies, then run the two legs serially over
+  the same coordinate window with the full `projection` profile and unchanged
+  disk budgets.
 - Require exact semantic equality for every row of all four block sections and
   all five epoch artifacts, plus coverage and coordinate equality.
-- Require native AdaPot fields to match the embedded oracle for epochs 186,
-  187 and 188.
+- Record the actual row count per semantic epoch for each of the nine datasets.
+  Require non-zero counts wherever content is expected. Accept zero only when
+  the epoch and chain-derived reason were predicted before comparison and the
+  JVM leg has the same complete zero-row generation; any unpredicted zero fails.
+- Require native AdaPot fields to match the embedded oracle for every selected
+  epoch. This is an absolute check for one dataset; the other eight rely on
+  explicit generation assertions plus exact cross-leg equality.
 - Retain exports, comparison reports, logs, identities and per-boundary disk
   usage under the named issue evidence root.
 
@@ -711,15 +737,18 @@ short is necessary, but it must complete before ADR-052 is accepted.
 - Start only after Gate D has passed; preserve the one-process-at-a-time rule.
 - Run mainnet from genesis through epoch 100 and stop there. A full mainnet sync
   or any epoch beyond 100 is outside this authorization.
+- Fail fast after genesis capture: derive the expected row count and lovelace
+  total from `app/config/network/mainnet/byron-genesis.json`, then require the
+  projection to contain exactly that set. With the current file the derived
+  values are 14,505 rows and 31,112,484,745,000,000 lovelace; neither value is
+  hardcoded in the assertion. Record the digest and require it to match between
+  the JVM and native legs.
 - Use equivalent isolated JVM/native inputs and require exact semantic parity
-  for genesis capture, projected rows, coverage, receipts, identities and
+  for the remaining projected rows, coverage, receipts, identities and
   coordinates within the bounded window.
-- Treat balance or phantom-genesis-UTXO errors covered by issue #87 as known JVM
-  behavior, not proof of native correctness or a new native defect. This gate
-  must not be cited as Byron correctness validation.
-- Pre-declare issue #88's approximately 121-block/second throughput and roughly
-  five-hour expectation. Do not tune or work around it in this issue and do not
-  report the known cost as a native regression.
+- Report measured blocks per second rather than assuming issue #88's historical
+  rate. Record any material rate change by era; do not tune or work around it in
+  this issue.
 - Retain manifests, logs, exports and comparison output under the dedicated
   `mainnet-0-100` evidence root.
 
@@ -762,10 +791,11 @@ projection write and history read prove the closed-world runtime surface.
 ### Validate only devnet
 
 Rejected. Devnet is the fast closed-world path and can exercise epoch writers,
-but its tiny synthetic data is not a correctness oracle. The fixed preprod
+but its tiny synthetic data is not a correctness oracle. The recorded preprod
 JVM/native differential is required. A bounded mainnet 0-through-100 parity
-gate then runs last solely to exercise Byron genesis under the known issue #87
-correctness limitation and issue #88 performance cost.
+gate then runs last to exercise the much larger Byron genesis distribution,
+assert that initial capture against the genesis file, and measure the bounded
+JVM/native path including its observed throughput.
 
 ## Consequences
 
@@ -816,12 +846,11 @@ an accepted release state for this ADR.
    lifecycle to the acceptance surface. Exempting it must be explicit and leaves
    Windows native projection as a recorded coverage gap; the existing Windows
    plugin-catalog smoke alone is not projection evidence.
-4. If the preprod genesis-to-188 history estimate reaches the 8 GiB soft budget,
-   decide whether the test budget may be raised before launch or whether the
-   fixed comparison range must change. No agent may alter the shipped budget
-   silently or during the run.
-5. Ratify ADR-052, then separately authorize commit, push and creation of the
-   stacked PR. ADR ratification does not authorize merge.
+4. Review the measured preprod history usage and decide whether the shipped
+   8 GiB soft budget remains appropriate. No agent may alter it silently or
+   during a run.
+5. Ratify ADR-052. Commit, push and creation of the reviewed, tested stacked PR
+   are already authorized; ADR ratification does not authorize merge.
 
 ## Acceptance
 

--- a/adr/052-native-projection-history-service-providers.md
+++ b/adr/052-native-projection-history-service-providers.md
@@ -321,14 +321,14 @@ DuckDB change to its current-jar-directory behavior can therefore surface as a
 missing-sidecar packaging failure and must be checked when upgrading the JDBC
 driver.
 
-Sidecar selection follows the built native executable, not the Gradle host.
-The distribution task runs after `quarkusBuild`, identifies the target from the
-ELF, Mach-O or PE header and extracts only that target's entry from the pinned
-DuckDB JDBC JAR. Packaging and verification both fail closed for an unsupported
-format, architecture or mismatched sidecar. This preserves the documented
-macOS-hosted Linux container build instead of pairing its ELF binary with the
-host's macOS library. `prepareYanoDockerNativeContext` strips only the ZIP's top
-directory, leaving the sidecar beside `yano` under `yano/`; the native
+Sidecar selection follows the supported native-build contract. A local build
+targets the Gradle host operating system and CPU; a Quarkus container build
+targets Linux on the host CPU. Unknown operating systems and CPUs fail closed,
+as does an explicit Docker `--platform` whose CPU differs from the host. The
+distribution task extracts only that target's entry from the pinned DuckDB JDBC
+JAR. This preserves the normal macOS-hosted Linux container build without a
+low-level executable parser. `prepareYanoDockerNativeContext` strips only the
+ZIP's top directory, leaving the sidecar beside `yano` under `yano/`; the native
 Dockerfile's `COPY yano/ /app/` consequently installs both at `/app` without a
 second packaging path.
 
@@ -338,11 +338,10 @@ generated resource tree contains exactly `ducklake.duckdb_extension`,
 `sqlite_scanner.sha256` under one
 `duckdb-extensions/<duckdb-version>/<target-platform>/` directory, plus native
 resource metadata naming exactly those four paths. A native container build
-selects Linux extensions even on a macOS host and honors an explicit Docker
-`--platform=linux/amd64` or `--platform=linux/arm64`. The post-build verifier
-derives the extension target and JNI sidecar separately from the same native
-binary header and rejects a module JAR containing another or additional
-platform. This distinction is required on macOS: DuckDB's JNI JAR uses
+selects Linux extensions even on a macOS host. The packaging verifier derives
+the extension target and JNI sidecar from the same build-target helper and
+rejects a module JAR containing another or additional platform. This
+distinction is required on macOS: DuckDB's JNI JAR uses
 `osx_universal`, while the extension repository uses `osx_arm64` or
 `osx_amd64`. No `duckdb-extensions/**` catch-all is retained in the image.
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,10 +3,16 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
+import java.io.RandomAccessFile
+import java.security.MessageDigest
+
 plugins {
     id 'application'
     id 'io.quarkus' version "${quarkusPluginVersion}"
 }
+
+def duckDbJdbcVersion = libs.duckdb.jdbc.get().version.toString()
+def duckDbNativeSidecarDir = layout.buildDirectory.dir('generated/duckdb-native-sidecar')
 
 def jacksonPatchVersion = libs.versions.jackson.get()
 def jacksonAnnotationsVersion = jacksonPatchVersion.replaceFirst(/\.\d+$/, '')
@@ -711,6 +717,231 @@ def isWindowsHost = {
 
 def nativeBinaryFileName = {
     isWindowsHost() ? 'yano.exe' : 'yano'
+}
+
+def readNativeUnsignedShort = { RandomAccessFile binary, boolean littleEndian ->
+    int first = binary.readUnsignedByte()
+    int second = binary.readUnsignedByte()
+    littleEndian ? first | (second << 8) : (first << 8) | second
+}
+
+def readNativeUnsignedInt = { RandomAccessFile binary, boolean littleEndian ->
+    long first = binary.readUnsignedByte()
+    long second = binary.readUnsignedByte()
+    long third = binary.readUnsignedByte()
+    long fourth = binary.readUnsignedByte()
+    littleEndian
+            ? first | (second << 8) | (third << 16) | (fourth << 24)
+            : (first << 24) | (second << 16) | (third << 8) | fourth
+}
+
+def duckDbTargetForNativeBinary = { File executable ->
+    new RandomAccessFile(executable, 'r').withCloseable { binary ->
+        if (binary.length() < 20) {
+            throw new GradleException(
+                    "Native binary at ${executable.path} is too small to identify its target")
+        }
+
+        byte[] magic = new byte[4]
+        binary.readFully(magic)
+        int first = magic[0] & 0xff
+        int second = magic[1] & 0xff
+        int third = magic[2] & 0xff
+        int fourth = magic[3] & 0xff
+
+        if (first == 0x7f && second == 0x45 && third == 0x4c && fourth == 0x46) {
+            binary.seek(5)
+            int encoding = binary.readUnsignedByte()
+            if (encoding != 1 && encoding != 2) {
+                throw new GradleException(
+                        "Unsupported ELF byte order ${encoding} in ${executable.path}")
+            }
+            binary.seek(18)
+            int machine = readNativeUnsignedShort(binary, encoding == 1)
+            if (machine == 0x3e) {
+                return [sidecarName: 'libduckdb_java.so_linux_amd64',
+                        extensionPlatform: 'linux_amd64']
+            }
+            if (machine == 0xb7) {
+                return [sidecarName: 'libduckdb_java.so_linux_arm64',
+                        extensionPlatform: 'linux_arm64']
+            }
+            throw new GradleException(
+                    "Unsupported ELF machine 0x${Integer.toHexString(machine)} in ${executable.path}")
+        }
+
+        boolean littleEndianMachO = first == 0xcf && second == 0xfa &&
+                third == 0xed && fourth == 0xfe
+        boolean bigEndianMachO = first == 0xfe && second == 0xed &&
+                third == 0xfa && fourth == 0xcf
+        if (littleEndianMachO || bigEndianMachO) {
+            binary.seek(4)
+            long cpuType = readNativeUnsignedInt(binary, littleEndianMachO)
+            if (cpuType == 0x01000007L) {
+                return [sidecarName: 'libduckdb_java.so_osx_universal',
+                        extensionPlatform: 'osx_amd64']
+            }
+            if (cpuType == 0x0100000cL) {
+                return [sidecarName: 'libduckdb_java.so_osx_universal',
+                        extensionPlatform: 'osx_arm64']
+            }
+            throw new GradleException(
+                    "Unsupported Mach-O CPU type 0x${Long.toHexString(cpuType)} " +
+                            "in ${executable.path}")
+        }
+
+        if (first == 0x4d && second == 0x5a) {
+            if (binary.length() < 64) {
+                throw new GradleException(
+                        "PE binary at ${executable.path} is too small to identify its target")
+            }
+            binary.seek(0x3c)
+            long peOffset = readNativeUnsignedInt(binary, true)
+            if (peOffset < 0 || peOffset + 6 > binary.length()) {
+                throw new GradleException(
+                        "Invalid PE header offset ${peOffset} in ${executable.path}")
+            }
+            binary.seek(peOffset)
+            if (binary.readUnsignedByte() != 0x50 || binary.readUnsignedByte() != 0x45 ||
+                    binary.readUnsignedByte() != 0 || binary.readUnsignedByte() != 0) {
+                throw new GradleException("Invalid PE signature in ${executable.path}")
+            }
+            int machine = readNativeUnsignedShort(binary, true)
+            if (machine == 0x8664) {
+                return [sidecarName: 'libduckdb_java.so_windows_amd64',
+                        extensionPlatform: 'windows_amd64']
+            }
+            if (machine == 0xaa64) {
+                return [sidecarName: 'libduckdb_java.so_windows_arm64',
+                        extensionPlatform: 'windows_arm64']
+            }
+            throw new GradleException(
+                    "Unsupported PE machine 0x${Integer.toHexString(machine)} in ${executable.path}")
+        }
+
+        throw new GradleException(
+                "Unsupported native binary format at ${executable.path}; " +
+                        'cannot select a safe DuckDB JNI sidecar')
+    }
+}
+
+def duckDbSidecarNameForNativeBinary = { File executable ->
+    duckDbTargetForNativeBinary(executable).sidecarName
+}
+
+def duckDbExtensionArchive = {
+    def artifact = configurations.runtimeClasspath.incoming.artifactView { }
+            .artifacts.artifacts.find { candidate ->
+        candidate.id.componentIdentifier instanceof ProjectComponentIdentifier &&
+                candidate.id.componentIdentifier.projectPath ==
+                ':archive-modules:archive-store-ducklake'
+    }
+    if (artifact == null || !artifact.file.isFile()) {
+        throw new GradleException(
+                'DuckLake archive-store artifact is absent from app runtimeClasspath')
+    }
+    artifact.file
+}
+
+def verifyDuckDbExtensionsMatchNativeBinary = { File executable ->
+    def expectedPlatform = duckDbTargetForNativeBinary(executable).extensionPlatform
+    def extensionVersion = duckDbJdbcVersion.endsWith('.0')
+            ? duckDbJdbcVersion.substring(0, duckDbJdbcVersion.length() - 2)
+            : duckDbJdbcVersion
+    def extensionRoot = "duckdb-extensions/${extensionVersion}/${expectedPlatform}/"
+    def expectedEntries = ['ducklake.duckdb_extension', 'ducklake.sha256',
+                           'sqlite_scanner.duckdb_extension', 'sqlite_scanner.sha256']
+            .collect { extensionRoot + it }
+            .toSet()
+    def metadataPath = 'META-INF/native-image/com.bloxbean.cardano/' +
+            'yano-archive-store-ducklake-extensions/resource-config.json'
+
+    new java.util.zip.ZipFile(duckDbExtensionArchive()).withCloseable { archive ->
+        def packagedEntries = archive.entries().findAll { entry ->
+            !entry.isDirectory() && entry.name.startsWith('duckdb-extensions/')
+        }.collect { it.name }.toSet()
+        if (packagedEntries != expectedEntries) {
+            throw new GradleException(
+                    "DuckDB extension resources do not match native image target " +
+                            "${expectedPlatform}: expected ${expectedEntries.sort()}, " +
+                            "found ${packagedEntries.sort()}")
+        }
+        def metadataEntry = archive.getEntry(metadataPath)
+        if (metadataEntry == null) {
+            throw new GradleException(
+                    "DuckDB extension native resource metadata is missing: ${metadataPath}")
+        }
+        def metadata = archive.getInputStream(metadataEntry).withCloseable { input ->
+            new groovy.json.JsonSlurper().parse(input)
+        }
+        def actualPatterns = metadata.resources?.includes?.collect { it.pattern }?.toSet()
+        def expectedPatterns = expectedEntries.collect { "\\Q${it}\\E" }.toSet()
+        if (actualPatterns != expectedPatterns) {
+            throw new GradleException(
+                    "DuckDB extension resource metadata does not match native image target " +
+                            "${expectedPlatform}: expected ${expectedPatterns.sort()}, " +
+                            "found ${actualPatterns?.sort()}")
+        }
+    }
+    expectedPlatform
+}
+
+def verifyDuckDbSidecarMatchesNativeBinary = { File executable ->
+    def expectedName = duckDbSidecarNameForNativeBinary(executable)
+    def packagedNames = duckDbNativeSidecarDir.get().asFile.listFiles()
+            .findAll { it.isFile() && !it.name.endsWith('.sha256') }
+            *.name
+    if (packagedNames != [expectedName]) {
+        throw new GradleException(
+                "DuckDB JNI sidecar does not match native image target: " +
+                        "${executable.name} requires ${expectedName}, found ${packagedNames}. " +
+                        'Cross-target native distributions must derive the sidecar from the ' +
+                        'built image target, not the Gradle host.')
+    }
+    expectedName
+}
+
+def duckDbNativeSidecarTask = tasks.register('bundleDuckDbNativeSidecar', Sync) {
+    dependsOn tasks.named('quarkusBuild')
+    description = 'Extracts the native-image-target DuckDB JNI library for distribution packaging.'
+    def executable = layout.buildDirectory.file(nativeBinaryFileName())
+    inputs.file(executable)
+    inputs.files(configurations.runtimeClasspath)
+    outputs.dir(duckDbNativeSidecarDir)
+
+    from({
+        def jdbcJar = configurations.runtimeClasspath.files.find {
+            it.name == "duckdb_jdbc-${duckDbJdbcVersion}.jar"
+        }
+        if (jdbcJar == null) {
+            throw new GradleException("DuckDB JDBC ${duckDbJdbcVersion} jar not found")
+        }
+        zipTree(jdbcJar)
+    }) {
+        include { details ->
+            details.path == duckDbSidecarNameForNativeBinary(executable.get().asFile)
+        }
+    }
+    into(duckDbNativeSidecarDir)
+
+    doLast {
+        def libraryName = duckDbSidecarNameForNativeBinary(executable.get().asFile)
+        def library = duckDbNativeSidecarDir.get().file(libraryName).asFile
+        if (!library.isFile()) {
+            throw new GradleException(
+                    "DuckDB JDBC ${duckDbJdbcVersion} does not contain ${libraryName}")
+        }
+        def digest = MessageDigest.getInstance('SHA-256')
+        library.withInputStream { input ->
+            byte[] buffer = new byte[64 * 1024]
+            for (int read = input.read(buffer); read >= 0; read = input.read(buffer)) {
+                if (read > 0) digest.update(buffer, 0, read)
+            }
+        }
+        duckDbNativeSidecarDir.get().file("${libraryName}.sha256").asFile
+                .setText(digest.digest().encodeHex().toString() + System.lineSeparator(), 'UTF-8')
+        verifyDuckDbExtensionsMatchNativeBinary(executable.get().asFile)
+    }
 }
 
 // ADR-011.2 packaged/native conformance: activate every typed fixture through
@@ -1459,6 +1690,478 @@ tasks.register('nativePluginCatalogSmoke') {
     }
 }
 
+tasks.register('nativeProjectionHistorySmoke') {
+    group = 'verification'
+    description = 'Runs projection history through the staged native distribution on devnet'
+    mustRunAfter tasks.named('yanoNativeDistZip')
+    outputs.upToDateWhen { false }
+
+    doLast {
+        def distributionOverride = providers.gradleProperty('yanoNativeDistribution')
+                .orElse(providers.environmentVariable('YANO_NATIVE_DISTRIBUTION'))
+                .orNull
+        def distribution = distributionOverride == null || distributionOverride.isBlank()
+                ? tasks.named('yanoNativeDistZip', Zip).get().archiveFile.get().asFile
+                : rootProject.file(distributionOverride)
+        if (!distribution.isFile()) {
+            throw new GradleException(
+                    "Native distribution not found at ${distribution.absolutePath}. Build "
+                            + ':app:yanoNativeDistZip first or set '
+                            + '-PyanoNativeDistribution=/absolute/or/root-relative/path.')
+        }
+
+        def timeoutText = providers.gradleProperty('yanoNativeProjectionSmokeTimeoutSeconds')
+                .getOrElse('240')
+        int timeoutSeconds
+        try {
+            timeoutSeconds = Integer.parseInt(timeoutText)
+        } catch (NumberFormatException e) {
+            throw new GradleException(
+                    "yanoNativeProjectionSmokeTimeoutSeconds must be a positive integer: "
+                            + timeoutText, e)
+        }
+        if (timeoutSeconds <= 0) {
+            throw new GradleException(
+                    'yanoNativeProjectionSmokeTimeoutSeconds must be positive: '
+                            + timeoutSeconds)
+        }
+
+        def tempParent = layout.buildDirectory.dir('tmp').get().asFile
+        tempParent.mkdirs()
+        def smokeRoot = java.nio.file.Files.createTempDirectory(
+                tempParent.toPath(), 'native-projection-history-smoke-')
+        def stageParent = java.nio.file.Files.createDirectory(smokeRoot.resolve('distribution'))
+        def chainState = smokeRoot.resolve('chainstate')
+        def history = smokeRoot.resolve('history')
+        def logFile = smokeRoot.resolve('native.log')
+        Process process = null
+        Throwable primaryFailure = null
+
+        def logTail = {
+            if (!java.nio.file.Files.isRegularFile(logFile)) {
+                return '<native process produced no log>'
+            }
+            def lines = java.nio.file.Files.readAllLines(
+                    logFile, java.nio.charset.StandardCharsets.UTF_8)
+            return lines.takeRight(240).join(System.lineSeparator())
+        }
+
+        try {
+            project.copy {
+                from zipTree(distribution)
+                into stageParent.toFile()
+            }
+            def stagedRoots = stageParent.toFile().listFiles()?.findAll { it.isDirectory() } ?: []
+            if (stagedRoots.size() != 1) {
+                throw new GradleException(
+                        "Native distribution must contain one top-level directory; found "
+                                + stagedRoots*.name)
+            }
+            def stagedRoot = stagedRoots.first().toPath()
+            def binary = stagedRoot.resolve(nativeBinaryFileName())
+            def binaryOverride = providers.gradleProperty('yanoNativeBinary')
+                    .orElse(providers.environmentVariable('YANO_NATIVE_BINARY'))
+                    .orNull
+            if (binaryOverride != null && !binaryOverride.isBlank()) {
+                def overrideFile = rootProject.file(binaryOverride)
+                if (!overrideFile.isFile()) {
+                    throw new GradleException(
+                            "Native binary override not found at ${overrideFile.absolutePath}")
+                }
+                java.nio.file.Files.copy(overrideFile.toPath(), binary,
+                        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+                        java.nio.file.StandardCopyOption.COPY_ATTRIBUTES)
+            }
+            if (!java.nio.file.Files.isRegularFile(binary)) {
+                throw new GradleException(
+                        "Native distribution is missing ${nativeBinaryFileName()}")
+            }
+            if (!isWindowsHost() && !binary.toFile().canExecute()
+                    && !binary.toFile().setExecutable(true, true)) {
+                throw new GradleException("Native binary is not executable: ${binary}")
+            }
+
+            def genesisFile = stagedRoot.resolve('config/network/devnet/shelley-genesis.json')
+            if (!java.nio.file.Files.isRegularFile(genesisFile)) {
+                throw new GradleException(
+                        "Native distribution is missing devnet Shelley genesis: ${genesisFile}")
+            }
+            def genesis = new groovy.json.JsonSlurper().parse(genesisFile.toFile())
+            long securityParam = (genesis.securityParam as Number).longValue()
+            long epochLength = (genesis.epochLength as Number).longValue()
+            long finalityBlocks = Math.multiplyExact(securityParam, 2L)
+            int genesisRows = (genesis.initialFunds as Map).size()
+            if (securityParam <= 0 || epochLength <= 0 || genesisRows <= 0) {
+                throw new GradleException(
+                        "Invalid devnet genesis smoke inputs: k=${securityParam}, "
+                                + "epochLength=${epochLength}, initialFunds=${genesisRows}")
+            }
+
+            def ports = allocateLoopbackPorts.call(2)
+            int httpPort = ports[0]
+            int nodePort = ports[1]
+            String apiPrefix = bakedApiPathPrefix()
+            def command = [
+                    binary.toAbsolutePath().toString(),
+                    '-Xmx1536m',
+                    '-Dquarkus.profile=devnet,projection',
+                    '-Dquarkus.http.host=127.0.0.1',
+                    "-Dquarkus.http.port=${httpPort}",
+                    '-Dquarkus.console.color=false',
+                    "-Dyano.server.port=${nodePort}",
+                    "-Dyano.storage.path=${chainState.toAbsolutePath()}",
+                    "-Dyano.history.dir=${history.toAbsolutePath()}",
+                    '-Dyano.block-producer.lazy=true',
+                    '-Dyano.block-producer.script-evaluator=scalus'
+            ].collect { it.toString() }
+            def processBuilder = new ProcessBuilder(command)
+                    .directory(stagedRoot.toFile())
+                    .redirectErrorStream(true)
+                    .redirectOutput(logFile.toFile())
+            processBuilder.environment().remove('YANO_API_PREFIX')
+            processBuilder.environment().remove('QUARKUS_RESTEASY_PATH')
+            process = processBuilder.start()
+
+            def request = { String method, String path, Map body ->
+                java.net.HttpURLConnection connection = null
+                try {
+                    connection = (java.net.HttpURLConnection) new URL(
+                            "http://127.0.0.1:${httpPort}${path}").openConnection()
+                    connection.connectTimeout = 1000
+                    connection.readTimeout = Math.max(5000, timeoutSeconds * 1000)
+                    connection.requestMethod = method
+                    connection.setRequestProperty('Accept', 'application/json')
+                    if (body != null) {
+                        byte[] encoded = groovy.json.JsonOutput.toJson(body).getBytes(
+                                java.nio.charset.StandardCharsets.UTF_8)
+                        connection.doOutput = true
+                        connection.setRequestProperty('Content-Type', 'application/json')
+                        connection.setFixedLengthStreamingMode(encoded.length)
+                        connection.outputStream.withCloseable { it.write(encoded) }
+                    }
+                    int status = connection.responseCode
+                    def response = status >= 400 ? connection.errorStream : connection.inputStream
+                    String text = response == null ? '' : response.withCloseable {
+                        new String(it.readAllBytes(), java.nio.charset.StandardCharsets.UTF_8)
+                    }
+                    def json = text.isBlank() ? null
+                            : new groovy.json.JsonSlurper().parseText(text)
+                    return [status: status, text: text, json: json]
+                } finally {
+                    connection?.disconnect()
+                }
+            }
+            def requireResponse = { Map response, int expected, String operation ->
+                if (response.status != expected) {
+                    throw new GradleException(
+                            "${operation} returned HTTP ${response.status}: ${response.text}")
+                }
+                return response.json
+            }
+
+            long startupDeadlineMillis = System.currentTimeMillis() + timeoutSeconds * 1000L
+            boolean live = false
+            Map coverage = null
+            while (System.currentTimeMillis() < startupDeadlineMillis && process.isAlive()) {
+                try {
+                    def liveResponse = request('GET', '/q/health/live', null)
+                    live = liveResponse.status == 200
+                    if (live) {
+                        def coverageResponse = request(
+                                'GET', "${apiPrefix}/history/coverage", null)
+                        if (coverageResponse.status == 200
+                                && coverageResponse.json instanceof Map
+                                && coverageResponse.json.enabled == true
+                                && coverageResponse.json.sinkHealth == 'READY') {
+                            coverage = coverageResponse.json as Map
+                            break
+                        }
+                    }
+                } catch (IOException ignored) {
+                    // The native HTTP listener or projection service is not ready yet.
+                }
+                Thread.sleep(250)
+            }
+            if (coverage == null) {
+                def state = process.isAlive()
+                        ? "did not become projection-ready within ${timeoutSeconds}s"
+                        : "exited with code ${process.exitValue()} before projection became ready"
+                throw new GradleException(
+                        "Native projection history smoke ${state}."
+                                + System.lineSeparator() + logTail())
+            }
+
+            def expectedSections = [
+                    'account-events:v1', 'address-transaction:v1',
+                    'transaction:v1', 'utxo-history:v1'
+            ] as Set
+            if ((coverage.sections as Collection)?.toSet() != expectedSections) {
+                throw new GradleException(
+                        "Native projection sections differ: ${coverage.sections}")
+            }
+            if (coverage.identity == null || coverage.identity.toString().isBlank()) {
+                throw new GradleException('Native projection coverage has no identity')
+            }
+            if (coverage.error != null) {
+                throw new GradleException(
+                        "Native projection coverage reports an error: ${coverage.error}")
+            }
+
+            def advance = requireResponse(
+                    request('POST', "${apiPrefix}/devnet/time/advance", [epochs: 2]),
+                    200, 'devnet 0→1→2 advance') as Map
+            if ((advance.blocks_produced as Number).longValue() < epochLength * 2L) {
+                throw new GradleException(
+                        "Devnet advance produced too few blocks: ${advance}")
+            }
+            def finalityAdvance = requireResponse(
+                    request('POST', "${apiPrefix}/devnet/time/advance",
+                            [slots: finalityBlocks]),
+                    200, 'devnet epoch-artifact finality advance') as Map
+            if ((finalityAdvance.blocks_produced as Number).longValue() != finalityBlocks) {
+                throw new GradleException(
+                        "Devnet finality advance produced an unexpected block count: "
+                                + finalityAdvance)
+            }
+
+            // Lazy production leaves the tip stable. Add one block at a time only while a
+            // finalized near-tip batch is waiting below its normal minimum. This lands on a real
+            // commit boundary without changing the production batching policy or waiting for its
+            // 15-minute linger. The correctness target itself is always derived from k.
+            long convergenceDeadlineMillis = System.currentTimeMillis() + timeoutSeconds * 1000L
+            long nudgeSlots = 0
+            long finalizedTarget = -1
+            while (System.currentTimeMillis() < convergenceDeadlineMillis && process.isAlive()) {
+                coverage = requireResponse(
+                        request('GET', "${apiPrefix}/history/coverage", null),
+                        200, 'projection coverage') as Map
+                if (coverage.sinkHealth != 'READY' || coverage.genesisCaptured != true) {
+                    throw new GradleException(
+                            "Projection became unhealthy while converging: ${coverage}")
+                }
+                long tip = (coverage.tipBlock as Number).longValue()
+                long queryable = (coverage.queryableThroughBlock as Number).longValue()
+                finalizedTarget = Math.max(-1L, tip - finalityBlocks)
+                if (queryable > finalizedTarget) {
+                    throw new GradleException(
+                            "Projection committed beyond finalized target: tip=${tip}, "
+                                    + "k=${securityParam}, finality=${finalityBlocks}, "
+                                    + "queryable=${queryable}, target=${finalizedTarget}")
+                }
+                if (queryable == finalizedTarget && finalizedTarget >= 0) {
+                    break
+                }
+                if (nudgeSlots >= epochLength - 1L) {
+                    throw new GradleException(
+                            "Projection did not converge before the next epoch boundary: "
+                                    + "tip=${tip}, queryable=${queryable}, "
+                                    + "target=${finalizedTarget}, nudges=${nudgeSlots}")
+                }
+                requireResponse(request('POST', "${apiPrefix}/devnet/time/advance", [slots: 1]),
+                        200, 'devnet convergence nudge')
+                nudgeSlots++
+                Thread.sleep(250)
+            }
+            if (!process.isAlive()) {
+                throw new GradleException(
+                        "Native process exited with code ${process.exitValue()} during convergence."
+                                + System.lineSeparator() + logTail())
+            }
+            long convergedTip = (coverage.tipBlock as Number).longValue()
+            long convergedThrough = (coverage.queryableThroughBlock as Number).longValue()
+            if (convergedThrough != finalizedTarget) {
+                throw new GradleException(
+                        "Projection did not converge within ${timeoutSeconds}s: tip=${convergedTip}, "
+                                + "k=${securityParam}, finality=${finalityBlocks}, "
+                                + "queryable=${convergedThrough}, target=${finalizedTarget}")
+            }
+
+            def rangeCovers = { Map artifact, long epoch ->
+                (artifact.completeRanges as Collection)?.any { range ->
+                    (range.from as Number).longValue() <= epoch
+                            && (range.through as Number).longValue() >= epoch
+                } == true
+            }
+            def artifactEntries = (coverage.epochArtifacts as Collection).collectEntries {
+                [(it.dataset.toString()): it as Map]
+            }
+            def expectedArtifacts = [
+                    'ada_pot', 'drep_distribution', 'epoch_stake',
+                    'governance_proposal_status', 'reward'
+            ] as Set
+            if (artifactEntries.keySet() != expectedArtifacts
+                    || artifactEntries.values().any { it.selected != true }) {
+                throw new GradleException(
+                        "Native epoch-artifact selection differs: ${artifactEntries}")
+            }
+            long artifactDeadlineMillis = System.currentTimeMillis() + timeoutSeconds * 1000L
+            while (System.currentTimeMillis() < artifactDeadlineMillis
+                    && process.isAlive()
+                    && (!rangeCovers(artifactEntries.epoch_stake, 0L)
+                    || !rangeCovers(artifactEntries.epoch_stake, 1L)
+                    || !rangeCovers(artifactEntries.ada_pot, 2L))) {
+                Thread.sleep(250)
+                coverage = requireResponse(
+                        request('GET', "${apiPrefix}/history/coverage", null),
+                        200, 'epoch-artifact coverage') as Map
+                artifactEntries = (coverage.epochArtifacts as Collection).collectEntries {
+                    [(it.dataset.toString()): it as Map]
+                }
+            }
+            if (!rangeCovers(artifactEntries.epoch_stake, 0L)
+                    || !rangeCovers(artifactEntries.epoch_stake, 1L)
+                    || !rangeCovers(artifactEntries.ada_pot, 2L)) {
+                throw new GradleException(
+                        'Native producer-mode epoch artifacts did not complete the supported '
+                                + "devnet ranges: ${artifactEntries}")
+            }
+            ['epoch_stake', 'ada_pot'].each { dataset ->
+                def artifact = artifactEntries[dataset]
+                if (!(artifact.gapRanges as Collection).isEmpty()
+                        || !(artifact.pendingEpochs as Collection).isEmpty()
+                        || artifact.coverageState != 'ACTIVE') {
+                    throw new GradleException(
+                            "Native ${dataset} coverage is incomplete: ${artifact}")
+                }
+            }
+            def excludedArtifacts = [
+                    'reward', 'drep_distribution', 'governance_proposal_status'
+            ]
+            if (coverage.epochStagingFailureActive == true
+                    && !(coverage.epochStagingError?.toString()
+                    ?.contains('canonical boundary is unavailable'))) {
+                throw new GradleException(
+                        "Unexpected producer-mode staging failure: ${coverage.epochStagingError}")
+            }
+            logger.lifecycle(
+                    'Native devnet producer-mode exclusions (pre-existing boundary ordering '
+                            + "defect; fetched-block Gate D owns coverage): ${excludedArtifacts}")
+
+            requireResponse(request('POST', "${apiPrefix}/node/stop", null),
+                    200, 'node stop')
+            coverage = requireResponse(
+                    request('GET', "${apiPrefix}/history/coverage", null),
+                    200, 'post-stop projection coverage') as Map
+            long stoppedTip = (coverage.tipBlock as Number).longValue()
+            long stoppedThrough = (coverage.queryableThroughBlock as Number).longValue()
+            long stoppedTarget = Math.max(-1L, stoppedTip - finalityBlocks)
+            if (stoppedTip != convergedTip || stoppedThrough != stoppedTarget) {
+                throw new GradleException(
+                        "Projection did not retain finalized convergence after production stopped: "
+                                + "beforeTip=${convergedTip}, stoppedTip=${stoppedTip}, "
+                                + "queryable=${stoppedThrough}, target=${stoppedTarget}")
+            }
+
+            def expectedVersions = [
+                    account_event: 1, address_transaction: 1,
+                    transaction: 1, utxo_history: 1
+            ]
+            expectedVersions.keySet().each { dataset ->
+                def watermark = requireResponse(request('GET',
+                        "${apiPrefix}/history/watermark?datasets=${dataset}", null),
+                        200, "${dataset} watermark") as Map
+                if (watermark.available != true
+                        || (watermark.fromBlock as Number).longValue() != 0L
+                        || (watermark.toBlock as Number).longValue() != stoppedTarget
+                        || watermark.projectionVersions != expectedVersions) {
+                    throw new GradleException(
+                            "Native ${dataset} is not queryable through the finalized target: "
+                                    + watermark)
+                }
+            }
+
+            String unusedAddress = ('addr_test1qz2fxv2umyhttkxyxp8x0dlpdt3k6cwng5pxj3jhsydz'
+                    + 'er3jcu5d8ps7zex2k2xt3uqxgjqnnj83ws8lhrn648jjxtwq2ytjqp')
+            def readSide = requireResponse(request('GET',
+                    "${apiPrefix}/addresses/${unusedAddress}/transactions", null),
+                    200, 'projection-backed address-transaction lookup')
+            if (!(readSide instanceof Collection) || !readSide.isEmpty()) {
+                throw new GradleException(
+                        "Projection-backed address-transaction lookup returned unexpected data: "
+                                + readSide)
+            }
+
+            String output = java.nio.file.Files.readString(
+                    logFile, java.nio.charset.StandardCharsets.UTF_8)
+            def genesisMatch = output =~ /ADR-039 genesis captured: (\d+) rows, .* digest ([0-9a-f]{64})/
+            if (!genesisMatch.find()
+                    || Integer.parseInt(genesisMatch.group(1)) != genesisRows) {
+                throw new GradleException(
+                        "Native log has no matching genesis row-count/digest evidence."
+                                + System.lineSeparator() + logTail())
+            }
+            def forbidden = [
+                    'ServiceConfigurationError', 'UnsatisfiedLinkError',
+                    'No suitable driver', 'projection sink initialization failed',
+                    'packaged DuckDB extension resource is missing',
+                    'DuckDB extension checksum mismatch'
+            ]
+            def observedForbidden = forbidden.findAll { output.contains(it) }
+            if (!observedForbidden.isEmpty()) {
+                throw new GradleException(
+                        "Native projection smoke observed startup/runtime failures "
+                                + observedForbidden + System.lineSeparator() + logTail())
+            }
+
+            def digest = MessageDigest.getInstance('SHA-256')
+            java.nio.file.Files.newInputStream(binary).withCloseable { input ->
+                byte[] buffer = new byte[64 * 1024]
+                for (int read = input.read(buffer); read >= 0; read = input.read(buffer)) {
+                    if (read > 0) digest.update(buffer, 0, read)
+                }
+            }
+            logger.lifecycle(
+                    "Native projection history smoke passed: binary=${binary}, "
+                            + "sha256=${digest.digest().encodeHex()}, tip=${stoppedTip}, "
+                            + "k=${securityParam}, finality=${finalityBlocks}, "
+                            + "queryableThrough=${stoppedThrough}, nudges=${nudgeSlots}, "
+                            + "includedEpochArtifacts=[epoch_stake:0..1, ada_pot:2], "
+                            + "excludedEpochArtifacts=${excludedArtifacts}")
+        } catch (Throwable failure) {
+            primaryFailure = failure
+            throw failure
+        } finally {
+            try {
+                if (process != null && process.isAlive()) {
+                    process.destroy()
+                    if (!process.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)) {
+                        process.destroyForcibly()
+                        if (!process.waitFor(10, java.util.concurrent.TimeUnit.SECONDS)) {
+                            throw new GradleException(
+                                    "Native projection smoke process did not terminate: "
+                                            + process.pid())
+                        }
+                        throw new GradleException(
+                                "Native projection smoke process required forcible termination: "
+                                        + process.pid())
+                    }
+                }
+            } catch (Throwable cleanupFailure) {
+                if (primaryFailure != null) {
+                    primaryFailure.addSuppressed(cleanupFailure)
+                } else {
+                    throw cleanupFailure
+                }
+            } finally {
+                try {
+                    if (primaryFailure == null) {
+                        project.delete(smokeRoot.toFile())
+                    } else {
+                        logger.lifecycle(
+                                "Preserved failed native projection smoke at ${smokeRoot}")
+                    }
+                } catch (Throwable cleanupFailure) {
+                    if (primaryFailure != null) {
+                        primaryFailure.addSuppressed(cleanupFailure)
+                    } else {
+                        throw cleanupFailure
+                    }
+                }
+            }
+        }
+    }
+}
+
 def getNativeBuilderImage = {
     def raw = System.getProperty('quarkus.native.builder-image')
     if (raw == null || raw.isBlank()) {
@@ -2126,7 +2829,7 @@ gradle.taskGraph.whenReady { graph ->
 
 tasks.register('yanoNativeDistZip', Zip) {
     dependsOn 'quarkusBuild', 'generateCoreDistributionManifests',
-            tasks.named('normalizeYanoReleaseSbom')
+            tasks.named('normalizeYanoReleaseSbom'), duckDbNativeSidecarTask
     group = 'distribution'
     description = 'Builds the native binary and creates a distributable zip'
 
@@ -2141,6 +2844,7 @@ tasks.register('yanoNativeDistZip', Zip) {
                 "Native binary not found at ${binary.path}. The native build may have failed."
             )
         }
+        verifyDuckDbSidecarMatchesNativeBinary(binary)
     }
 
     into("yano-native-${distVersion}-${platform}") {
@@ -2153,6 +2857,7 @@ tasks.register('yanoNativeDistZip', Zip) {
                 filePermissions { unix('755') }
             }
         }
+        from(duckDbNativeSidecarDir)
         from(nativeDistributionManifest)
         if (!isWindowsHost()) {
             from('bin/yano.sh') {
@@ -2189,6 +2894,28 @@ tasks.register('verifyCoreNativeDistribution') {
                 .archiveFile.get().asFile
         def root = distribution.name.replaceFirst(/\.zip$/, '')
         def expectedSbom = new groovy.json.JsonSlurper().parse(releaseSbom.get().asFile)
+        def nativeBinary = layout.buildDirectory.file(nativeBinaryFileName()).get().asFile
+        def expectedSidecarName = verifyDuckDbSidecarMatchesNativeBinary(nativeBinary)
+        def sidecarFiles = duckDbNativeSidecarDir.get().asFile.listFiles()
+                .findAll { it.isFile() }
+        def sidecarLibraries = sidecarFiles.findAll { !it.name.endsWith('.sha256') }
+        if (sidecarLibraries.size() != 1) {
+            throw new GradleException(
+                    "Expected exactly one platform DuckDB JNI sidecar, found ${sidecarLibraries*.name}")
+        }
+        def sidecarLibrary = sidecarLibraries[0]
+        if (sidecarLibrary.name != expectedSidecarName) {
+            throw new GradleException(
+                    "DuckDB JNI sidecar ${sidecarLibrary.name} does not match native image " +
+                            "target ${expectedSidecarName}")
+        }
+        def sidecarChecksum = new File(
+                sidecarLibrary.parentFile, "${sidecarLibrary.name}.sha256")
+        if (!sidecarChecksum.isFile()) {
+            throw new GradleException(
+                    "DuckDB JNI sidecar checksum is missing for ${sidecarLibrary.name}")
+        }
+        def expectedSidecarSha256 = sidecarChecksum.getText('UTF-8').trim()
         new java.util.zip.ZipFile(distribution).withCloseable { archive ->
             def manifestEntry = archive.getEntry("${root}/yano-distribution-v1.json")
             if (manifestEntry == null) {
@@ -2212,6 +2939,43 @@ tasks.register('verifyCoreNativeDistribution') {
             }
             if (archive.getEntry("${root}/LICENSE") == null) {
                 throw new GradleException('Yano native distribution is missing LICENSE')
+            }
+            def packagedSidecars = archive.entries().findAll {
+                it.name.startsWith("${root}/libduckdb_java") && !it.isDirectory()
+            }
+            def expectedSidecarEntries = [
+                    "${root}/${sidecarLibrary.name}",
+                    "${root}/${sidecarChecksum.name}"
+            ]
+            if (packagedSidecars*.name.toSet() != expectedSidecarEntries.toSet()) {
+                throw new GradleException(
+                        "Yano native distribution DuckDB JNI sidecar mismatch: "
+                                + packagedSidecars*.name)
+            }
+            def packagedLibrary = archive.getEntry("${root}/${sidecarLibrary.name}")
+            if (packagedLibrary.size != sidecarLibrary.length()) {
+                throw new GradleException(
+                        "Packaged DuckDB JNI sidecar size mismatch for ${sidecarLibrary.name}")
+            }
+            def digest = MessageDigest.getInstance('SHA-256')
+            archive.getInputStream(packagedLibrary).withCloseable { input ->
+                byte[] buffer = new byte[64 * 1024]
+                for (int read = input.read(buffer); read >= 0; read = input.read(buffer)) {
+                    if (read > 0) digest.update(buffer, 0, read)
+                }
+            }
+            def packagedSidecarSha256 = digest.digest().encodeHex().toString()
+            if (packagedSidecarSha256 != expectedSidecarSha256) {
+                throw new GradleException(
+                        "Packaged DuckDB JNI sidecar checksum mismatch for ${sidecarLibrary.name}")
+            }
+            def packagedChecksum = archive.getInputStream(
+                    archive.getEntry("${root}/${sidecarChecksum.name}")).withCloseable { stream ->
+                stream.getText('UTF-8').trim()
+            }
+            if (packagedChecksum != expectedSidecarSha256) {
+                throw new GradleException(
+                        "Packaged DuckDB JNI checksum record mismatch for ${sidecarLibrary.name}")
             }
             def sbomEntry = archive.getEntry("${root}/sbom/yano.cdx.json")
             def packagedSbom = sbomEntry == null ? null

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,6 @@ import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ResolvedDependencyResult
 
-import java.io.RandomAccessFile
 import java.security.MessageDigest
 
 plugins {
@@ -11,8 +10,11 @@ plugins {
     id 'io.quarkus' version "${quarkusPluginVersion}"
 }
 
+apply from: rootProject.file('gradle/native-target.gradle')
+
 def duckDbJdbcVersion = libs.duckdb.jdbc.get().version.toString()
 def duckDbNativeSidecarDir = layout.buildDirectory.dir('generated/duckdb-native-sidecar')
+def nativeBuildTarget = providers.provider { yanoNativeTarget() }
 
 def jacksonPatchVersion = libs.versions.jackson.get()
 def jacksonAnnotationsVersion = jacksonPatchVersion.replaceFirst(/\.\d+$/, '')
@@ -460,31 +462,9 @@ tasks.register('cleanupLegacyAccountHistory', JavaExec) {
 
 // --- Distribution packaging tasks ---
 
-def detectPlatform() {
-    def osName = System.getProperty('os.name').toLowerCase()
-    def osArch = System.getProperty('os.arch').toLowerCase()
-
-    def os
-    if (osName.contains('linux')) {
-        os = 'linux'
-    } else if (osName.contains('mac') || osName.contains('darwin')) {
-        os = 'macos'
-    } else if (osName.contains('windows')) {
-        os = 'windows'
-    } else {
-        os = osName.replaceAll('[^a-z0-9]', '')
-    }
-
-    def arch
-    if (osArch == 'amd64' || osArch == 'x86_64') {
-        arch = 'x64'
-    } else if (osArch == 'aarch64' || osArch == 'arm64') {
-        arch = 'arm64'
-    } else {
-        arch = osArch.replaceAll('[^a-z0-9]', '')
-    }
-
-    return "${os}-${arch}"
+def detectPlatform = {
+    def target = nativeBuildTarget.get()
+    "${target.os}-${target.distributionArch}"
 }
 
 def distVersion = rootProject.version.toString().replaceAll('-SNAPSHOT', '')
@@ -703,8 +683,7 @@ def isNativeBuildRequested = {
 }
 
 def isNativeContainerBuildRequested = {
-    System.getProperty('quarkus.native.container-build', '').equalsIgnoreCase('true') ||
-            System.getProperty('quarkus.native.remote-container-build', '').equalsIgnoreCase('true')
+    yanoNativeContainerBuildRequested()
 }
 
 def isLinuxHost = {
@@ -716,117 +695,11 @@ def isWindowsHost = {
 }
 
 def nativeBinaryFileName = {
-    isWindowsHost() ? 'yano.exe' : 'yano'
+    nativeBuildTarget.get().binaryFileName
 }
 
-def readNativeUnsignedShort = { RandomAccessFile binary, boolean littleEndian ->
-    int first = binary.readUnsignedByte()
-    int second = binary.readUnsignedByte()
-    littleEndian ? first | (second << 8) : (first << 8) | second
-}
-
-def readNativeUnsignedInt = { RandomAccessFile binary, boolean littleEndian ->
-    long first = binary.readUnsignedByte()
-    long second = binary.readUnsignedByte()
-    long third = binary.readUnsignedByte()
-    long fourth = binary.readUnsignedByte()
-    littleEndian
-            ? first | (second << 8) | (third << 16) | (fourth << 24)
-            : (first << 24) | (second << 16) | (third << 8) | fourth
-}
-
-def duckDbTargetForNativeBinary = { File executable ->
-    new RandomAccessFile(executable, 'r').withCloseable { binary ->
-        if (binary.length() < 20) {
-            throw new GradleException(
-                    "Native binary at ${executable.path} is too small to identify its target")
-        }
-
-        byte[] magic = new byte[4]
-        binary.readFully(magic)
-        int first = magic[0] & 0xff
-        int second = magic[1] & 0xff
-        int third = magic[2] & 0xff
-        int fourth = magic[3] & 0xff
-
-        if (first == 0x7f && second == 0x45 && third == 0x4c && fourth == 0x46) {
-            binary.seek(5)
-            int encoding = binary.readUnsignedByte()
-            if (encoding != 1 && encoding != 2) {
-                throw new GradleException(
-                        "Unsupported ELF byte order ${encoding} in ${executable.path}")
-            }
-            binary.seek(18)
-            int machine = readNativeUnsignedShort(binary, encoding == 1)
-            if (machine == 0x3e) {
-                return [sidecarName: 'libduckdb_java.so_linux_amd64',
-                        extensionPlatform: 'linux_amd64']
-            }
-            if (machine == 0xb7) {
-                return [sidecarName: 'libduckdb_java.so_linux_arm64',
-                        extensionPlatform: 'linux_arm64']
-            }
-            throw new GradleException(
-                    "Unsupported ELF machine 0x${Integer.toHexString(machine)} in ${executable.path}")
-        }
-
-        boolean littleEndianMachO = first == 0xcf && second == 0xfa &&
-                third == 0xed && fourth == 0xfe
-        boolean bigEndianMachO = first == 0xfe && second == 0xed &&
-                third == 0xfa && fourth == 0xcf
-        if (littleEndianMachO || bigEndianMachO) {
-            binary.seek(4)
-            long cpuType = readNativeUnsignedInt(binary, littleEndianMachO)
-            if (cpuType == 0x01000007L) {
-                return [sidecarName: 'libduckdb_java.so_osx_universal',
-                        extensionPlatform: 'osx_amd64']
-            }
-            if (cpuType == 0x0100000cL) {
-                return [sidecarName: 'libduckdb_java.so_osx_universal',
-                        extensionPlatform: 'osx_arm64']
-            }
-            throw new GradleException(
-                    "Unsupported Mach-O CPU type 0x${Long.toHexString(cpuType)} " +
-                            "in ${executable.path}")
-        }
-
-        if (first == 0x4d && second == 0x5a) {
-            if (binary.length() < 64) {
-                throw new GradleException(
-                        "PE binary at ${executable.path} is too small to identify its target")
-            }
-            binary.seek(0x3c)
-            long peOffset = readNativeUnsignedInt(binary, true)
-            if (peOffset < 0 || peOffset + 6 > binary.length()) {
-                throw new GradleException(
-                        "Invalid PE header offset ${peOffset} in ${executable.path}")
-            }
-            binary.seek(peOffset)
-            if (binary.readUnsignedByte() != 0x50 || binary.readUnsignedByte() != 0x45 ||
-                    binary.readUnsignedByte() != 0 || binary.readUnsignedByte() != 0) {
-                throw new GradleException("Invalid PE signature in ${executable.path}")
-            }
-            int machine = readNativeUnsignedShort(binary, true)
-            if (machine == 0x8664) {
-                return [sidecarName: 'libduckdb_java.so_windows_amd64',
-                        extensionPlatform: 'windows_amd64']
-            }
-            if (machine == 0xaa64) {
-                return [sidecarName: 'libduckdb_java.so_windows_arm64',
-                        extensionPlatform: 'windows_arm64']
-            }
-            throw new GradleException(
-                    "Unsupported PE machine 0x${Integer.toHexString(machine)} in ${executable.path}")
-        }
-
-        throw new GradleException(
-                "Unsupported native binary format at ${executable.path}; " +
-                        'cannot select a safe DuckDB JNI sidecar')
-    }
-}
-
-def duckDbSidecarNameForNativeBinary = { File executable ->
-    duckDbTargetForNativeBinary(executable).sidecarName
+def isWindowsNativeTarget = {
+    nativeBuildTarget.get().os == 'windows'
 }
 
 def duckDbExtensionArchive = {
@@ -843,8 +716,8 @@ def duckDbExtensionArchive = {
     artifact.file
 }
 
-def verifyDuckDbExtensionsMatchNativeBinary = { File executable ->
-    def expectedPlatform = duckDbTargetForNativeBinary(executable).extensionPlatform
+def verifyDuckDbExtensionsMatchNativeTarget = {
+    def expectedPlatform = nativeBuildTarget.get().extensionPlatform
     def extensionVersion = duckDbJdbcVersion.endsWith('.0')
             ? duckDbJdbcVersion.substring(0, duckDbJdbcVersion.length() - 2)
             : duckDbJdbcVersion
@@ -886,27 +759,23 @@ def verifyDuckDbExtensionsMatchNativeBinary = { File executable ->
     expectedPlatform
 }
 
-def verifyDuckDbSidecarMatchesNativeBinary = { File executable ->
-    def expectedName = duckDbSidecarNameForNativeBinary(executable)
+def verifyDuckDbSidecarMatchesNativeTarget = {
+    def expectedName = nativeBuildTarget.get().sidecarName
     def packagedNames = duckDbNativeSidecarDir.get().asFile.listFiles()
             .findAll { it.isFile() && !it.name.endsWith('.sha256') }
             *.name
     if (packagedNames != [expectedName]) {
         throw new GradleException(
-                "DuckDB JNI sidecar does not match native image target: " +
-                        "${executable.name} requires ${expectedName}, found ${packagedNames}. " +
-                        'Cross-target native distributions must derive the sidecar from the ' +
-                        'built image target, not the Gradle host.')
+                "DuckDB JNI sidecar does not match native build target: " +
+                        "expected ${expectedName}, found ${packagedNames}")
     }
     expectedName
 }
 
 def duckDbNativeSidecarTask = tasks.register('bundleDuckDbNativeSidecar', Sync) {
-    dependsOn tasks.named('quarkusBuild')
-    description = 'Extracts the native-image-target DuckDB JNI library for distribution packaging.'
-    def executable = layout.buildDirectory.file(nativeBinaryFileName())
-    inputs.file(executable)
+    description = 'Extracts the native-build-target DuckDB JNI library for distribution packaging.'
     inputs.files(configurations.runtimeClasspath)
+    inputs.property('nativeLibraryName', nativeBuildTarget.map { it.sidecarName })
     outputs.dir(duckDbNativeSidecarDir)
 
     from({
@@ -919,13 +788,13 @@ def duckDbNativeSidecarTask = tasks.register('bundleDuckDbNativeSidecar', Sync) 
         zipTree(jdbcJar)
     }) {
         include { details ->
-            details.path == duckDbSidecarNameForNativeBinary(executable.get().asFile)
+            details.path == nativeBuildTarget.get().sidecarName
         }
     }
     into(duckDbNativeSidecarDir)
 
     doLast {
-        def libraryName = duckDbSidecarNameForNativeBinary(executable.get().asFile)
+        def libraryName = nativeBuildTarget.get().sidecarName
         def library = duckDbNativeSidecarDir.get().file(libraryName).asFile
         if (!library.isFile()) {
             throw new GradleException(
@@ -940,7 +809,7 @@ def duckDbNativeSidecarTask = tasks.register('bundleDuckDbNativeSidecar', Sync) 
         }
         duckDbNativeSidecarDir.get().file("${libraryName}.sha256").asFile
                 .setText(digest.digest().encodeHex().toString() + System.lineSeparator(), 'UTF-8')
-        verifyDuckDbExtensionsMatchNativeBinary(executable.get().asFile)
+        verifyDuckDbExtensionsMatchNativeTarget()
     }
 }
 
@@ -2844,7 +2713,7 @@ tasks.register('yanoNativeDistZip', Zip) {
                 "Native binary not found at ${binary.path}. The native build may have failed."
             )
         }
-        verifyDuckDbSidecarMatchesNativeBinary(binary)
+        verifyDuckDbSidecarMatchesNativeTarget()
     }
 
     into("yano-native-${distVersion}-${platform}") {
@@ -2853,13 +2722,13 @@ tasks.register('yanoNativeDistZip', Zip) {
             into 'sbom'
         }
         from(layout.buildDirectory.file(nativeBinaryFileName())) {
-            if (!isWindowsHost()) {
+            if (!isWindowsNativeTarget()) {
                 filePermissions { unix('755') }
             }
         }
         from(duckDbNativeSidecarDir)
         from(nativeDistributionManifest)
-        if (!isWindowsHost()) {
+        if (!isWindowsNativeTarget()) {
             from('bin/yano.sh') {
                 filePermissions { unix('755') }
             }
@@ -2894,8 +2763,7 @@ tasks.register('verifyCoreNativeDistribution') {
                 .archiveFile.get().asFile
         def root = distribution.name.replaceFirst(/\.zip$/, '')
         def expectedSbom = new groovy.json.JsonSlurper().parse(releaseSbom.get().asFile)
-        def nativeBinary = layout.buildDirectory.file(nativeBinaryFileName()).get().asFile
-        def expectedSidecarName = verifyDuckDbSidecarMatchesNativeBinary(nativeBinary)
+        def expectedSidecarName = verifyDuckDbSidecarMatchesNativeTarget()
         def sidecarFiles = duckDbNativeSidecarDir.get().asFile.listFiles()
                 .findAll { it.isFile() }
         def sidecarLibraries = sidecarFiles.findAll { !it.name.endsWith('.sha256') }

--- a/archive-modules/archive-store-ducklake/build.gradle
+++ b/archive-modules/archive-store-ducklake/build.gradle
@@ -7,6 +7,8 @@ plugins {
     id 'java-library'
 }
 
+apply from: rootProject.file('gradle/native-target.gradle')
+
 dependencies {
     api project(':archive-modules:archive-api')
     implementation libs.duckdb.jdbc
@@ -24,68 +26,9 @@ def duckDbExtensionNames = ['ducklake', 'sqlite_scanner']
 def duckDbExtensionMetadataPath =
         'META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake-extensions/resource-config.json'
 
-def normalizedDuckDbCpuArch = { String arch ->
-    def normalized = arch.toLowerCase(Locale.ROOT).trim()
-    if (normalized in ['x86_64', 'amd64']) return 'amd64'
-    if (normalized in ['aarch64', 'arm64']) return 'arm64'
-    throw new GradleException("Unsupported DuckDB CPU architecture: ${arch}")
-}
-
-def duckDbExtensionPlatform = providers.provider {
-    def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT).trim()
-    def cpuArch = normalizedDuckDbCpuArch(System.getProperty('os.arch'))
-    boolean containerBuild =
-            System.getProperty('quarkus.native.container-build', '').equalsIgnoreCase('true') ||
-                    System.getProperty('quarkus.native.remote-container-build', '')
-                            .equalsIgnoreCase('true')
-
-    if (containerBuild) {
-        def options = System.getProperty('quarkus.native.container-runtime-options', '')
-                .split(',')
-                .collect { it.trim() }
-                .findAll { !it.isBlank() }
-        String platformOption = null
-        for (int i = 0; i < options.size(); i++) {
-            if (options[i].startsWith('--platform=')) {
-                platformOption = options[i].substring('--platform='.length())
-                break
-            }
-            if (options[i] == '--platform' && i + 1 < options.size()) {
-                platformOption = options[i + 1]
-                break
-            }
-        }
-        if (platformOption != null) {
-            def target = platformOption.toLowerCase(Locale.ROOT).split('/')
-            if (target.length != 2 || target[0] != 'linux') {
-                throw new GradleException(
-                        "Unsupported DuckDB native container platform: ${platformOption}")
-            }
-            cpuArch = normalizedDuckDbCpuArch(target[1])
-        }
-        return "linux_${cpuArch}"
-    }
-
-    if (osName.startsWith('mac')) return "osx_${cpuArch}"
-    if (osName.startsWith('linux')) return "linux_${cpuArch}"
-    if (osName.startsWith('windows')) return "windows_${cpuArch}"
-    throw new GradleException("Unsupported DuckDB extension operating system: ${osName}")
-}
-def duckDbNativeLibraryName = providers.provider {
-    def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT).trim()
-    def arch = System.getProperty('os.arch').toLowerCase(Locale.ROOT).trim()
-    def cpuArch
-    if (arch in ['x86_64', 'amd64']) cpuArch = 'amd64'
-    else if (arch in ['aarch64', 'arm64']) cpuArch = 'arm64'
-    else cpuArch = arch.replaceAll('[^a-z0-9_\\-.]', '')
-
-    def suffix
-    if (osName.startsWith('mac')) suffix = 'osx_universal'
-    else if (osName.startsWith('linux')) suffix = "linux_${cpuArch}"
-    else if (osName.startsWith('windows')) suffix = "windows_${cpuArch}"
-    else suffix = "${osName.replaceAll('[^a-z0-9_\\-.]', '')}_${cpuArch}"
-    "libduckdb_java.so_${suffix}"
-}
+def nativeBuildTarget = providers.provider { yanoNativeTarget() }
+def duckDbExtensionPlatform = nativeBuildTarget.map { it.extensionPlatform }
+def duckDbNativeLibraryName = nativeBuildTarget.map { it.sidecarName }
 
 sourceSets.main.resources.srcDir(generatedExtensions)
 
@@ -138,7 +81,7 @@ tasks.register('bundleDuckDbExtensions') {
 }
 
 tasks.register('bundleDuckDbNativeSidecar', Sync) {
-    description = 'Extracts the build-platform DuckDB JNI library for native distribution packaging.'
+    description = 'Extracts the native-build-target DuckDB JNI library for distribution packaging.'
     inputs.files(configurations.runtimeClasspath)
     inputs.property('nativeLibraryName', duckDbNativeLibraryName)
     outputs.dir(generatedNativeSidecar)

--- a/archive-modules/archive-store-ducklake/build.gradle
+++ b/archive-modules/archive-store-ducklake/build.gradle
@@ -1,3 +1,8 @@
+import java.security.MessageDigest
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
+import java.util.zip.GZIPInputStream
+
 plugins {
     id 'java-library'
 }
@@ -6,6 +11,7 @@ dependencies {
     api project(':archive-modules:archive-api')
     implementation libs.duckdb.jdbc
     implementation libs.sqlite.jdbc
+    testImplementation libs.jackson.databind
 }
 
 def duckDbJdbcVersion = libs.duckdb.jdbc.get().version.toString()
@@ -13,51 +19,172 @@ def duckDbVersion = duckDbJdbcVersion.endsWith('.0')
         ? duckDbJdbcVersion.substring(0, duckDbJdbcVersion.length() - 2)
         : duckDbJdbcVersion
 def generatedExtensions = layout.buildDirectory.dir('generated/duckdb-extensions')
+def generatedNativeSidecar = layout.buildDirectory.dir('generated/duckdb-native-sidecar')
+def duckDbExtensionNames = ['ducklake', 'sqlite_scanner']
+def duckDbExtensionMetadataPath =
+        'META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake-extensions/resource-config.json'
+
+def normalizedDuckDbCpuArch = { String arch ->
+    def normalized = arch.toLowerCase(Locale.ROOT).trim()
+    if (normalized in ['x86_64', 'amd64']) return 'amd64'
+    if (normalized in ['aarch64', 'arm64']) return 'arm64'
+    throw new GradleException("Unsupported DuckDB CPU architecture: ${arch}")
+}
+
+def duckDbExtensionPlatform = providers.provider {
+    def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT).trim()
+    def cpuArch = normalizedDuckDbCpuArch(System.getProperty('os.arch'))
+    boolean containerBuild =
+            System.getProperty('quarkus.native.container-build', '').equalsIgnoreCase('true') ||
+                    System.getProperty('quarkus.native.remote-container-build', '')
+                            .equalsIgnoreCase('true')
+
+    if (containerBuild) {
+        def options = System.getProperty('quarkus.native.container-runtime-options', '')
+                .split(',')
+                .collect { it.trim() }
+                .findAll { !it.isBlank() }
+        String platformOption = null
+        for (int i = 0; i < options.size(); i++) {
+            if (options[i].startsWith('--platform=')) {
+                platformOption = options[i].substring('--platform='.length())
+                break
+            }
+            if (options[i] == '--platform' && i + 1 < options.size()) {
+                platformOption = options[i + 1]
+                break
+            }
+        }
+        if (platformOption != null) {
+            def target = platformOption.toLowerCase(Locale.ROOT).split('/')
+            if (target.length != 2 || target[0] != 'linux') {
+                throw new GradleException(
+                        "Unsupported DuckDB native container platform: ${platformOption}")
+            }
+            cpuArch = normalizedDuckDbCpuArch(target[1])
+        }
+        return "linux_${cpuArch}"
+    }
+
+    if (osName.startsWith('mac')) return "osx_${cpuArch}"
+    if (osName.startsWith('linux')) return "linux_${cpuArch}"
+    if (osName.startsWith('windows')) return "windows_${cpuArch}"
+    throw new GradleException("Unsupported DuckDB extension operating system: ${osName}")
+}
+def duckDbNativeLibraryName = providers.provider {
+    def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT).trim()
+    def arch = System.getProperty('os.arch').toLowerCase(Locale.ROOT).trim()
+    def cpuArch
+    if (arch in ['x86_64', 'amd64']) cpuArch = 'amd64'
+    else if (arch in ['aarch64', 'arm64']) cpuArch = 'arm64'
+    else cpuArch = arch.replaceAll('[^a-z0-9_\\-.]', '')
+
+    def suffix
+    if (osName.startsWith('mac')) suffix = 'osx_universal'
+    else if (osName.startsWith('linux')) suffix = "linux_${cpuArch}"
+    else if (osName.startsWith('windows')) suffix = "windows_${cpuArch}"
+    else suffix = "${osName.replaceAll('[^a-z0-9_\\-.]', '')}_${cpuArch}"
+    "libduckdb_java.so_${suffix}"
+}
 
 sourceSets.main.resources.srcDir(generatedExtensions)
 
 tasks.register('bundleDuckDbExtensions') {
-    description = 'Bundles signed DuckLake/SQLite extensions for the build host; runtime never downloads extensions.'
+    description = 'Bundles exact DuckLake/SQLite resources for the native-image target; runtime never downloads extensions.'
+    inputs.property('duckDbVersion', duckDbVersion)
+    inputs.property('extensionPlatform', duckDbExtensionPlatform)
     outputs.dir(generatedExtensions)
     doLast {
-        def osName = System.getProperty('os.name').toLowerCase(Locale.ROOT)
-        def arch = System.getProperty('os.arch').toLowerCase(Locale.ROOT)
-        def arm = arch in ['aarch64', 'arm64']
-        def platform
-        if (osName.contains('mac')) platform = arm ? 'osx_arm64' : 'osx_amd64'
-        else if (osName.contains('linux')) platform = arm ? 'linux_arm64' : 'linux_amd64'
-        else if (osName.contains('win')) platform = arm ? 'windows_arm64' : 'windows_amd64'
-        else throw new GradleException("Unsupported DuckDB extension platform: ${osName}/${arch}")
+        def platform = duckDbExtensionPlatform.get()
+        project.delete(generatedExtensions)
 
         def cacheRoot = new File(gradle.gradleUserHomeDir, "caches/yano-duckdb-extensions/${duckDbVersion}/${platform}")
         cacheRoot.mkdirs()
         def targetRoot = generatedExtensions.get().dir("duckdb-extensions/${duckDbVersion}/${platform}").asFile
         targetRoot.mkdirs()
-        ['ducklake', 'sqlite_scanner'].each { extensionName ->
+        duckDbExtensionNames.each { extensionName ->
             def cached = new File(cacheRoot, "${extensionName}.duckdb_extension")
             if (!cached.exists()) {
                 def download = new URL("https://extensions.duckdb.org/v${duckDbVersion}/${platform}/${extensionName}.duckdb_extension.gz")
                 def temporary = new File(cacheRoot, "${extensionName}.download")
                 download.openStream().withCloseable { input ->
-                    new java.util.zip.GZIPInputStream(input).withCloseable { gzip ->
+                    new GZIPInputStream(input).withCloseable { gzip ->
                         temporary.withOutputStream { output -> gzip.transferTo(output) }
                     }
                 }
-                java.nio.file.Files.move(temporary.toPath(), cached.toPath(),
-                        java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-                        java.nio.file.StandardCopyOption.ATOMIC_MOVE)
+                Files.move(temporary.toPath(), cached.toPath(),
+                        StandardCopyOption.REPLACE_EXISTING,
+                        StandardCopyOption.ATOMIC_MOVE)
             }
             def target = new File(targetRoot, cached.name)
-            java.nio.file.Files.copy(cached.toPath(), target.toPath(),
-                    java.nio.file.StandardCopyOption.REPLACE_EXISTING)
-            def digest = java.security.MessageDigest.getInstance('SHA-256').digest(target.bytes).encodeHex().toString()
+            Files.copy(cached.toPath(), target.toPath(),
+                    StandardCopyOption.REPLACE_EXISTING)
+            def digest = MessageDigest.getInstance('SHA-256').digest(target.bytes)
+                    .encodeHex().toString()
             new File(targetRoot, "${extensionName}.sha256").text = digest + System.lineSeparator()
         }
+
+        def includes = duckDbExtensionNames.collectMany { extensionName ->
+            ["${extensionName}.duckdb_extension", "${extensionName}.sha256"]
+        }.collect { fileName ->
+            [pattern: "\\Qduckdb-extensions/${duckDbVersion}/${platform}/${fileName}\\E"]
+        }
+        def metadata = generatedExtensions.get().file(duckDbExtensionMetadataPath).asFile
+        metadata.parentFile.mkdirs()
+        metadata.setText(groovy.json.JsonOutput.prettyPrint(
+                groovy.json.JsonOutput.toJson([resources: [includes: includes]]))
+                + System.lineSeparator(), 'UTF-8')
+    }
+}
+
+tasks.register('bundleDuckDbNativeSidecar', Sync) {
+    description = 'Extracts the build-platform DuckDB JNI library for native distribution packaging.'
+    inputs.files(configurations.runtimeClasspath)
+    inputs.property('nativeLibraryName', duckDbNativeLibraryName)
+    outputs.dir(generatedNativeSidecar)
+
+    from({
+        def jdbcJar = configurations.runtimeClasspath.files.find {
+            it.name == "duckdb_jdbc-${duckDbJdbcVersion}.jar"
+        }
+        if (jdbcJar == null) {
+            throw new GradleException("DuckDB JDBC ${duckDbJdbcVersion} jar not found")
+        }
+        zipTree(jdbcJar)
+    }) {
+        include { details -> details.path == duckDbNativeLibraryName.get() }
+    }
+    into(generatedNativeSidecar)
+
+    doLast {
+        def libraryName = duckDbNativeLibraryName.get()
+        def library = generatedNativeSidecar.get().file(libraryName).asFile
+        if (!library.isFile()) {
+            throw new GradleException(
+                    "DuckDB JDBC ${duckDbJdbcVersion} does not contain ${libraryName}")
+        }
+        def digest = MessageDigest.getInstance('SHA-256')
+        library.withInputStream { input ->
+            byte[] buffer = new byte[64 * 1024]
+            for (int read = input.read(buffer); read >= 0; read = input.read(buffer)) {
+                if (read > 0) digest.update(buffer, 0, read)
+            }
+        }
+        generatedNativeSidecar.get().file("${libraryName}.sha256").asFile
+                .setText(digest.digest().encodeHex().toString() + System.lineSeparator(), 'UTF-8')
     }
 }
 
 tasks.named('processResources') {
     dependsOn tasks.named('bundleDuckDbExtensions')
+}
+
+tasks.named('test') {
+    dependsOn tasks.named('bundleDuckDbNativeSidecar')
+    systemProperty 'yano.duckdb.native-sidecar-dir',
+            generatedNativeSidecar.get().asFile.absolutePath
+    systemProperty 'yano.duckdb.extension-platform', duckDbExtensionPlatform.get()
+    systemProperty 'yano.duckdb.version', duckDbVersion
 }
 
 publishing {

--- a/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckDbManager.java
+++ b/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckDbManager.java
@@ -5,7 +5,9 @@ import com.bloxbean.cardano.yano.archive.api.ArchiveResourceGate;
 import com.bloxbean.cardano.yano.archive.api.ArchiveStoreException;
 import com.bloxbean.cardano.yano.archive.api.ArchiveStuckOperationException;
 import com.bloxbean.cardano.yano.archive.api.ArchiveWaitPolicy;
+import org.duckdb.DuckDBDriver;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.sql.Connection;
@@ -16,6 +18,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -25,9 +28,11 @@ import java.util.concurrent.atomic.AtomicBoolean;
  */
 public final class DuckDbManager implements AutoCloseable {
     private static final System.Logger LOG = System.getLogger(DuckDbManager.class.getName());
+    private static final String JDBC_URL = "jdbc:duckdb:";
 
     private final DuckDbManagerConfig config;
     private final DuckDbExtensionLoader extensionLoader;
+    private final DuckDBDriver driver;
     // The fair semaphores remain the FIFO mechanism; the gates only add wait
     // diagnostics and the warn-versus-stuck distinction around them.
     private final Semaphore totalPermits;
@@ -43,20 +48,21 @@ public final class DuckDbManager implements AutoCloseable {
 
     public DuckDbManager(DuckDbManagerConfig config, DuckDbExtensionLoader extensionLoader,
                          ArchiveWaitPolicy waitPolicy) {
+        this(config, extensionLoader, waitPolicy, loadDriver());
+    }
+
+    DuckDbManager(DuckDbManagerConfig config, DuckDbExtensionLoader extensionLoader,
+                  ArchiveWaitPolicy waitPolicy, DuckDBDriver driver) {
         this.config = Objects.requireNonNull(config, "config");
         this.extensionLoader = Objects.requireNonNull(extensionLoader, "extensionLoader");
         this.waitPolicy = Objects.requireNonNull(waitPolicy, "waitPolicy");
+        this.driver = Objects.requireNonNull(driver, "driver");
         this.totalPermits = new Semaphore(config.maxConcurrentQueries(), true);
         this.bulkPermits = new Semaphore(config.maxConcurrentBulkJobs(), true);
         this.totalGate = new ArchiveResourceGate("duckdb-total", config.maxConcurrentQueries(),
                 totalPermits, waitPolicy, DuckDbManager::logWait);
         this.bulkGate = new ArchiveResourceGate("duckdb-bulk", config.maxConcurrentBulkJobs(),
                 bulkPermits, waitPolicy, DuckDbManager::logWait);
-        try {
-            Class.forName("org.duckdb.DuckDBDriver");
-        } catch (ClassNotFoundException e) {
-            throw new ArchiveStoreException("DuckDB driver unavailable", e);
-        }
         try {
             Files.createDirectories(config.tempDirectory());
         } catch (IOException e) {
@@ -113,7 +119,28 @@ public final class DuckDbManager implements AutoCloseable {
             totalTicket = totalGate.acquire(operation, remainingPolicy(policy, deadline, operation));
             if (closed.get()) throw new IllegalStateException("DuckDbManager is closed");
 
-            Connection connection = DriverManager.getConnection("jdbc:duckdb:");
+            if (LOG.isLoggable(System.Logger.Level.DEBUG)) {
+                long registeredDriverCount = DriverManager.drivers().count();
+                LOG.log(System.Logger.Level.DEBUG,
+                        "Opening DuckDB connection through explicit DuckDBDriver.connect; "
+                                + "DriverManager registered-driver count={0}",
+                        registeredDriverCount);
+            }
+            Connection connection;
+            try {
+                connection = driver.connect(JDBC_URL, new Properties());
+            } catch (LinkageError failure) {
+                FileNotFoundException missingLibrary = missingNativeLibrary(failure);
+                if (missingLibrary == null) throw failure;
+                throw new ArchiveStoreException(
+                        "DuckDB native library unavailable. Start Yano from the complete native "
+                                + "distribution so its platform JNI sidecar is beside the executable; "
+                                + missingLibrary.getMessage(),
+                        failure);
+            }
+            if (connection == null) {
+                throw new SQLException("DuckDB driver declined JDBC URL: " + JDBC_URL);
+            }
             try {
                 configure(connection, workload);
                 extensionLoader.load(connection);
@@ -169,6 +196,25 @@ public final class DuckDbManager implements AutoCloseable {
         LOG.log(System.Logger.Level.WARNING,
                 "Archive still waiting for {0} after {1}s while running {2}; {3}",
                 gate, waited.toSeconds(), operation, holderDetail);
+    }
+
+    private static DuckDBDriver loadDriver() {
+        try {
+            return new DuckDBDriver();
+        } catch (RuntimeException | LinkageError e) {
+            throw new ArchiveStoreException("DuckDB driver unavailable", e);
+        }
+    }
+
+    private static FileNotFoundException missingNativeLibrary(Throwable failure) {
+        Throwable current = failure;
+        while (current != null) {
+            if (current instanceof FileNotFoundException missing) return missing;
+            Throwable cause = current.getCause();
+            if (cause == current) return null;
+            current = cause;
+        }
+        return null;
     }
 
     private void configure(Connection connection, DuckDbWorkload workload) throws SQLException {

--- a/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeTransactionLocator.java
+++ b/archive-modules/archive-store-ducklake/src/main/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeTransactionLocator.java
@@ -1,10 +1,21 @@
 package com.bloxbean.cardano.yano.archive.ducklake;
 
 import com.bloxbean.cardano.yano.archive.api.ArchiveStoreException;
+import org.sqlite.JDBC;
 
 import java.nio.file.Path;
-import java.sql.*;
-import java.util.*;
+import java.sql.Connection;
+import java.sql.Driver;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.Objects;
+import java.util.OptionalLong;
+import java.util.Properties;
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -30,13 +41,17 @@ final class DuckLakeTransactionLocator implements AutoCloseable {
     private static final System.Logger LOG = System.getLogger(DuckLakeTransactionLocator.class.getName());
 
     private final String jdbcUrl;
+    private final Driver driver;
     private final AtomicLong fullRebuilds = new AtomicLong();
 
     DuckLakeTransactionLocator(Path catalogPath) {
+        this(catalogPath, loadDriver());
+    }
+
+    DuckLakeTransactionLocator(Path catalogPath, Driver driver) {
         Path path = catalogPath.resolveSibling(catalogPath.getFileName() + ".tx-locator.sqlite");
         jdbcUrl = "jdbc:sqlite:" + path.toAbsolutePath().normalize();
-        try { Class.forName("org.sqlite.JDBC"); }
-        catch (ClassNotFoundException e) { throw new ArchiveStoreException("SQLite locator driver unavailable", e); }
+        this.driver = Objects.requireNonNull(driver, "driver");
         try (Connection connection = open(); Statement sql = connection.createStatement()) {
             sql.execute("CREATE TABLE IF NOT EXISTS tx_locator(tx_hash BLOB PRIMARY KEY, block_number INTEGER NOT NULL, job_id TEXT NOT NULL)");
             sql.execute("CREATE INDEX IF NOT EXISTS idx_tx_locator_job ON tx_locator(job_id)");
@@ -180,12 +195,30 @@ final class DuckLakeTransactionLocator implements AutoCloseable {
     }
 
     private Connection open() throws SQLException {
-        Connection connection = DriverManager.getConnection(jdbcUrl);
+        if (LOG.isLoggable(System.Logger.Level.DEBUG)) {
+            long registeredDriverCount = DriverManager.drivers().count();
+            LOG.log(System.Logger.Level.DEBUG,
+                    "Opening SQLite locator connection through explicit JDBC.connect; "
+                            + "DriverManager registered-driver count={0}",
+                    registeredDriverCount);
+        }
+        Connection connection = driver.connect(jdbcUrl, new Properties());
+        if (connection == null) {
+            throw new SQLException("SQLite driver declined JDBC URL: " + jdbcUrl);
+        }
         try (Statement sql = connection.createStatement()) {
             sql.execute("PRAGMA journal_mode=WAL"); sql.execute("PRAGMA synchronous=FULL");
             sql.execute("PRAGMA busy_timeout=5000");
         }
         return connection;
+    }
+
+    private static JDBC loadDriver() {
+        try {
+            return new JDBC();
+        } catch (RuntimeException | LinkageError e) {
+            throw new ArchiveStoreException("SQLite locator driver unavailable", e);
+        }
     }
     private long generation(Connection connection) throws SQLException {
         try (Statement sql = connection.createStatement(); ResultSet row = sql.executeQuery(

--- a/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/jni-config.json
+++ b/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/jni-config.json
@@ -1,0 +1,237 @@
+[
+  { "name": "byte[]" },
+  {
+    "name": "java.lang.Boolean",
+    "methods": [{ "name": "booleanValue", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.Byte",
+    "methods": [{ "name": "byteValue", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.Double",
+    "methods": [{ "name": "doubleValue", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.Float",
+    "methods": [{ "name": "floatValue", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.Integer",
+    "methods": [{ "name": "intValue", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.Long",
+    "methods": [{ "name": "longValue", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.Object",
+    "methods": [{ "name": "toString", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.Short",
+    "methods": [{ "name": "shortValue", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.lang.String",
+    "methods": [{ "name": "getBytes", "parameterTypes": ["java.nio.charset.Charset"] }]
+  },
+  {
+    "name": "java.lang.Throwable",
+    "methods": [{ "name": "getMessage", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.math.BigDecimal",
+    "methods": [
+      { "name": "longValue", "parameterTypes": [] },
+      { "name": "precision", "parameterTypes": [] },
+      { "name": "scale", "parameterTypes": [] },
+      { "name": "scaleByPowerOfTen", "parameterTypes": ["int"] },
+      { "name": "toPlainString", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "java.nio.ByteBuffer",
+    "methods": [{ "name": "order", "parameterTypes": ["java.nio.ByteOrder"] }]
+  },
+  {
+    "name": "java.nio.ByteOrder",
+    "methods": [{ "name": "nativeOrder", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.nio.CharBuffer",
+    "methods": [{ "name": "toString", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.nio.charset.Charset",
+    "methods": [{ "name": "decode", "parameterTypes": ["java.nio.ByteBuffer"] }]
+  },
+  {
+    "name": "java.nio.charset.StandardCharsets",
+    "fields": [{ "name": "UTF_8" }]
+  },
+  {
+    "name": "java.sql.Array",
+    "methods": [
+      { "name": "getArray", "parameterTypes": [] },
+      { "name": "getBaseTypeName", "parameterTypes": [] }
+    ]
+  },
+  { "name": "java.sql.SQLException" },
+  { "name": "java.sql.SQLTimeoutException" },
+  {
+    "name": "java.sql.Struct",
+    "methods": [
+      { "name": "getAttributes", "parameterTypes": [] },
+      { "name": "getSQLTypeName", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "java.util.Iterator",
+    "methods": [
+      { "name": "hasNext", "parameterTypes": [] },
+      { "name": "next", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "java.util.List",
+    "methods": [{ "name": "iterator", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.util.Map",
+    "methods": [{ "name": "entrySet", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.util.Map$Entry",
+    "methods": [
+      { "name": "getKey", "parameterTypes": [] },
+      { "name": "getValue", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "java.util.Set",
+    "methods": [{ "name": "iterator", "parameterTypes": [] }]
+  },
+  {
+    "name": "java.util.UUID",
+    "methods": [
+      { "name": "getLeastSignificantBits", "parameterTypes": [] },
+      { "name": "getMostSignificantBits", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "org.duckdb.DuckDBArray",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": ["org.duckdb.DuckDBVector", "int", "int"]
+      }
+    ]
+  },
+  {
+    "name": "org.duckdb.DuckDBDate",
+    "methods": [{ "name": "getDaysSinceEpoch", "parameterTypes": [] }]
+  },
+  {
+    "name": "org.duckdb.DuckDBHugeInt",
+    "fields": [{ "name": "lower" }, { "name": "upper" }],
+    "methods": [
+      { "name": "toBigDecimal", "parameterTypes": ["long", "long", "int"] },
+      { "name": "toBigInteger", "parameterTypes": ["long", "long"] }
+    ]
+  },
+  {
+    "name": "org.duckdb.DuckDBResultSetMetaData",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "int",
+          "int",
+          "java.lang.String[]",
+          "java.lang.String[]",
+          "java.lang.String[]",
+          "java.lang.String",
+          "java.lang.String[]",
+          "java.lang.String[]"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.duckdb.DuckDBScalarFunctionWrapper",
+    "methods": [
+      {
+        "name": "execute",
+        "parameterTypes": ["java.nio.ByteBuffer", "java.nio.ByteBuffer", "java.nio.ByteBuffer"]
+      }
+    ]
+  },
+  {
+    "name": "org.duckdb.DuckDBStruct",
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": [
+          "java.lang.String[]",
+          "org.duckdb.DuckDBVector[]",
+          "int",
+          "java.lang.String"
+        ]
+      }
+    ]
+  },
+  {
+    "name": "org.duckdb.DuckDBTableFunctionWrapper",
+    "methods": [
+      { "name": "executeBind", "parameterTypes": ["java.nio.ByteBuffer"] },
+      {
+        "name": "executeFunction",
+        "parameterTypes": ["java.nio.ByteBuffer", "java.nio.ByteBuffer"]
+      },
+      { "name": "executeGlobalInit", "parameterTypes": ["java.nio.ByteBuffer"] },
+      { "name": "executeLocalInit", "parameterTypes": ["java.nio.ByteBuffer"] }
+    ]
+  },
+  { "name": "org.duckdb.DuckDBTime" },
+  {
+    "name": "org.duckdb.DuckDBTimestamp",
+    "methods": [
+      { "name": "getMicrosEpoch", "parameterTypes": [] },
+      { "name": "valueOf", "parameterTypes": ["java.lang.Object"] }
+    ]
+  },
+  { "name": "org.duckdb.DuckDBTimestampTZ" },
+  {
+    "name": "org.duckdb.DuckDBVector",
+    "fields": [{ "name": "constlen_data" }, { "name": "varlen_data" }],
+    "methods": [
+      {
+        "name": "<init>",
+        "parameterTypes": ["java.lang.String", "int", "boolean[]"]
+      },
+      { "name": "retainConstlenData", "parameterTypes": [] }
+    ]
+  },
+  {
+    "name": "org.duckdb.ProfilerPrintFormat",
+    "fields": [
+      { "name": "GRAPHVIZ" },
+      { "name": "HTML" },
+      { "name": "JSON" },
+      { "name": "NO_OUTPUT" },
+      { "name": "QUERY_TREE" },
+      { "name": "QUERY_TREE_OPTIMIZER" }
+    ]
+  },
+  {
+    "name": "org.duckdb.QueryProgress",
+    "methods": [
+      { "name": "<init>", "parameterTypes": ["double", "long", "long"] }
+    ]
+  },
+  {
+    "name": "org.duckdb.user.DuckDBMap",
+    "methods": [{ "name": "getSQLTypeName", "parameterTypes": [] }]
+  }
+]

--- a/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/native-image.properties
+++ b/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/native-image.properties
@@ -1,0 +1,1 @@
+Args = --initialize-at-run-time=org.duckdb.DuckDBDriver --initialize-at-run-time=org.duckdb.DuckDBNative

--- a/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/reflect-config.json
+++ b/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/reflect-config.json
@@ -1,0 +1,10 @@
+[
+  {
+    "name": "com.bloxbean.cardano.yano.archive.ducklake.DuckLakeProjectionSinkProvider",
+    "allDeclaredConstructors": true
+  },
+  {
+    "name": "com.bloxbean.cardano.yano.archive.ducklake.DuckLakeArchiveBackendProvider",
+    "allDeclaredConstructors": true
+  }
+]

--- a/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/resource-config.json
+++ b/archive-modules/archive-store-ducklake/src/main/resources/META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/resource-config.json
@@ -1,0 +1,12 @@
+{
+  "resources": {
+    "includes": [
+      {
+        "pattern": "\\QMETA-INF/services/com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkProvider\\E"
+      },
+      {
+        "pattern": "\\QMETA-INF/services/com.bloxbean.cardano.yano.archive.api.ArchiveBackendProvider\\E"
+      }
+    ]
+  }
+}

--- a/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckDbManagerTest.java
+++ b/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckDbManagerTest.java
@@ -1,12 +1,19 @@
 package com.bloxbean.cardano.yano.archive.ducklake;
 
+import com.bloxbean.cardano.yano.archive.api.ArchiveStoreException;
+import com.bloxbean.cardano.yano.archive.api.ArchiveWaitPolicy;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.duckdb.DuckDBDriver;
 
+import java.io.FileNotFoundException;
 import java.nio.file.Path;
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.time.Duration;
+import java.util.Properties;
 import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -51,6 +58,64 @@ class DuckDbManagerTest {
             assertThat(result.next()).isTrue();
             assertThat(result.getString(1)).isEqualTo("sqlite_scanner");
             assertThat(result.next()).isFalse();
+        }
+    }
+
+    @Test
+    void acquisitionUsesTheManagersExplicitDriverInstance() throws Exception {
+        AtomicInteger directConnectCalls = new AtomicInteger();
+        DuckDBDriver driver = new DuckDBDriver() {
+            @Override
+            public Connection connect(String url, Properties properties) throws SQLException {
+                directConnectCalls.incrementAndGet();
+                return super.connect(url, properties);
+            }
+        };
+
+        try (var manager = new DuckDbManager(DuckDbManagerConfig.defaults(temp.resolve("direct")),
+                DuckDbExtensionLoader.none(), ArchiveWaitPolicy.defaults(), driver);
+             var lease = manager.acquire(DuckDbWorkload.STEADY, Duration.ofSeconds(2))) {
+            assertThat(lease.connection()).isNotNull();
+            assertThat(directConnectCalls).hasValue(1);
+        }
+    }
+
+    @Test
+    void driverDecliningTheDuckDbUrlFailsExplicitly() {
+        DuckDBDriver decliningDriver = new DuckDBDriver() {
+            @Override
+            public Connection connect(String url, Properties properties) {
+                return null;
+            }
+        };
+        try (var manager = new DuckDbManager(DuckDbManagerConfig.defaults(temp.resolve("declined")),
+                DuckDbExtensionLoader.none(), ArchiveWaitPolicy.defaults(), decliningDriver)) {
+            assertThatThrownBy(() -> manager.acquire(DuckDbWorkload.STEADY,
+                    Duration.ofSeconds(2)))
+                    .isInstanceOf(SQLException.class)
+                    .hasMessage("DuckDB driver declined JDBC URL: jdbc:duckdb:");
+        }
+    }
+
+    @Test
+    void missingNativeSidecarNamesTheExpectedFileAndCompleteDistributionRemedy() {
+        Path expected = temp.resolve("distribution/libduckdb_java.so_osx_universal")
+                .toAbsolutePath();
+        DuckDBDriver missingSidecarDriver = new DuckDBDriver() {
+            @Override
+            public Connection connect(String url, Properties properties) {
+                FileNotFoundException missing = new FileNotFoundException(
+                        "DuckDB JNI library not found, path: '" + expected + "'");
+                throw new ExceptionInInitializerError(new RuntimeException(missing));
+            }
+        };
+        try (var manager = new DuckDbManager(DuckDbManagerConfig.defaults(temp.resolve("missing")),
+                DuckDbExtensionLoader.none(), ArchiveWaitPolicy.defaults(), missingSidecarDriver)) {
+            assertThatThrownBy(() -> manager.acquire(DuckDbWorkload.STEADY,
+                    Duration.ofSeconds(2)))
+                    .isInstanceOf(ArchiveStoreException.class)
+                    .hasMessageContaining("Start Yano from the complete native distribution")
+                    .hasMessageContaining(expected.toString());
         }
     }
 

--- a/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckDbNativeSidecarTest.java
+++ b/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckDbNativeSidecarTest.java
@@ -1,0 +1,58 @@
+package com.bloxbean.cardano.yano.archive.ducklake;
+
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Method;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.MessageDigest;
+import java.util.HexFormat;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DuckDbNativeSidecarTest {
+
+    @Test
+    void generatedSidecarExactlyMatchesDuckDbLoadersPlatformNameAndChecksum() throws Exception {
+        Path sidecarDirectory = Path.of(
+                System.getProperty("yano.duckdb.native-sidecar-dir"));
+        String expectedLibraryName = duckDbNativeLibraryName();
+        String expectedExtensionPlatform =
+                System.getProperty("yano.duckdb.extension-platform");
+        Path library = sidecarDirectory.resolve(expectedLibraryName);
+        Path checksum = sidecarDirectory.resolve(expectedLibraryName + ".sha256");
+
+        try (var files = Files.list(sidecarDirectory)) {
+            assertThat(files.map(path -> path.getFileName().toString()).sorted().toList())
+                    .containsExactly(expectedLibraryName, expectedLibraryName + ".sha256");
+        }
+        assertThat(Files.size(library)).isPositive();
+        assertThat(Files.readString(checksum).trim()).isEqualTo(sha256(library));
+        assertThat(expectedExtensionPlatform).isEqualTo(PackagedDuckDbExtensionLoader.platform());
+        if (expectedLibraryName.endsWith("_osx_universal")) {
+            assertThat(expectedExtensionPlatform)
+                    .startsWith("osx_")
+                    .doesNotContain("universal");
+        }
+    }
+
+    private static String duckDbNativeLibraryName() throws Exception {
+        Class<?> nativeClass = Class.forName(
+                "org.duckdb.DuckDBNative", false,
+                DuckDbNativeSidecarTest.class.getClassLoader());
+        Method nativeLibName = nativeClass.getDeclaredMethod("nativeLibName");
+        nativeLibName.setAccessible(true);
+        return (String) nativeLibName.invoke(null);
+    }
+
+    private static String sha256(Path path) throws Exception {
+        MessageDigest digest = MessageDigest.getInstance("SHA-256");
+        try (var input = Files.newInputStream(path)) {
+            byte[] buffer = new byte[64 * 1024];
+            for (int read = input.read(buffer); read >= 0; read = input.read(buffer)) {
+                if (read > 0) digest.update(buffer, 0, read);
+            }
+        }
+        return HexFormat.of().formatHex(digest.digest());
+    }
+}

--- a/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeNativeImageMetadataTest.java
+++ b/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeNativeImageMetadataTest.java
@@ -1,0 +1,318 @@
+package com.bloxbean.cardano.yano.archive.ducklake;
+
+import com.bloxbean.cardano.yano.archive.api.ArchiveBackendProvider;
+import com.bloxbean.cardano.yano.archive.api.projection.ProjectionSinkProvider;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.StringReader;
+import java.lang.reflect.Modifier;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DuckLakeNativeImageMetadataTest {
+    private static final String PROJECTION_SERVICE = ProjectionSinkProvider.class.getName();
+    private static final String BACKEND_SERVICE = ArchiveBackendProvider.class.getName();
+    private static final String PROJECTION_PROVIDER = DuckLakeProjectionSinkProvider.class.getName();
+    private static final String BACKEND_PROVIDER = DuckLakeArchiveBackendProvider.class.getName();
+    private static final String NATIVE_METADATA_ROOT =
+            "META-INF/native-image/com.bloxbean.cardano/yano-archive-store-ducklake/";
+    private static final String EXTENSION_METADATA_ROOT =
+            "META-INF/native-image/com.bloxbean.cardano/"
+                    + "yano-archive-store-ducklake-extensions/";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+
+    @Test
+    void providerDescriptorsAndNativeMetadataStayInExactLockstep() throws Exception {
+        Map<String, String> providersByService = Map.of(
+                PROJECTION_SERVICE, PROJECTION_PROVIDER,
+                BACKEND_SERVICE, BACKEND_PROVIDER);
+
+        providersByService.forEach((service, provider) ->
+                assertThat(serviceEntries(service)).containsExactly(provider));
+        providersByService.forEach(DuckLakeNativeImageMetadataTest::assertServiceProviderContract);
+
+        assertThat(reflectionEntries()).containsExactlyInAnyOrderEntriesOf(Map.of(
+                PROJECTION_PROVIDER, Set.of("name", "allDeclaredConstructors"),
+                BACKEND_PROVIDER, Set.of("name", "allDeclaredConstructors")));
+        assertThat(resourcePatterns()).containsExactlyInAnyOrder(
+                quotedResource("META-INF/services/" + PROJECTION_SERVICE),
+                quotedResource("META-INF/services/" + BACKEND_SERVICE));
+        String duckDbVersion = System.getProperty("yano.duckdb.version");
+        String extensionPlatform = System.getProperty("yano.duckdb.extension-platform");
+        String extensionRoot = "duckdb-extensions/" + duckDbVersion + "/"
+                + extensionPlatform + "/";
+        assertThat(resourcePatterns(EXTENSION_METADATA_ROOT + "resource-config.json"))
+                .containsExactlyInAnyOrder(
+                        quotedResource(extensionRoot + "ducklake.duckdb_extension"),
+                        quotedResource(extensionRoot + "ducklake.sha256"),
+                        quotedResource(extensionRoot + "sqlite_scanner.duckdb_extension"),
+                        quotedResource(extensionRoot + "sqlite_scanner.sha256"));
+        assertThat(jniEntries()).containsExactlyInAnyOrderEntriesOf(expectedJniEntries());
+        assertThat(nativeImageArgs())
+                .containsExactlyInAnyOrder(
+                        "--initialize-at-run-time=org.duckdb.DuckDBDriver",
+                        "--initialize-at-run-time=org.duckdb.DuckDBNative");
+    }
+
+    private static Set<String> serviceEntries(String service) {
+        Set<String> entries = new LinkedHashSet<>();
+        for (String line : resourceText("META-INF/services/" + service).lines().toList()) {
+            String entry = line.substring(0, commentStart(line)).trim();
+            if (!entry.isEmpty()) {
+                assertThat(entries.add(entry)).as("duplicate provider in %s", service).isTrue();
+            }
+        }
+        return entries;
+    }
+
+    private static int commentStart(String line) {
+        int comment = line.indexOf('#');
+        return comment < 0 ? line.length() : comment;
+    }
+
+    private static void assertServiceProviderContract(String serviceName, String providerName) {
+        try {
+            Class<?> service = Class.forName(serviceName);
+            Class<?> provider = Class.forName(providerName);
+
+            assertThat(service.isAssignableFrom(provider)).isTrue();
+            assertThat(Modifier.isPublic(provider.getModifiers())).isTrue();
+            assertThat(Modifier.isPublic(provider.getDeclaredConstructor().getModifiers())).isTrue();
+        } catch (ReflectiveOperationException e) {
+            throw new AssertionError("invalid ServiceLoader provider " + providerName, e);
+        }
+    }
+
+    private static Map<String, Set<String>> reflectionEntries() {
+        JsonNode entriesNode = jsonResource(NATIVE_METADATA_ROOT + "reflect-config.json");
+        assertThat(entriesNode.isArray()).as("native reflection config is an array").isTrue();
+
+        Map<String, Set<String>> entries = new LinkedHashMap<>();
+        for (JsonNode entry : entriesNode) {
+            assertThat(entry.isObject()).as("reflection entry %s", entry).isTrue();
+            String name = entry.path("name").asText();
+            assertThat(name).as("reflection entry name in %s", entry).isNotBlank();
+            Set<String> properties = new LinkedHashSet<>();
+            entry.properties().forEach(property -> properties.add(property.getKey()));
+            assertThat(entry.path("allDeclaredConstructors").asBoolean())
+                    .as("declared constructors for %s", name)
+                    .isTrue();
+            assertThat(entries.put(name, Set.copyOf(properties)))
+                    .as("duplicate reflection entry for %s", name)
+                    .isNull();
+        }
+        return entries;
+    }
+
+    private static Set<String> resourcePatterns() {
+        return resourcePatterns(NATIVE_METADATA_ROOT + "resource-config.json");
+    }
+
+    private static Set<String> resourcePatterns(String path) {
+        JsonNode config = jsonResource(path);
+        assertThat(config.properties()).extracting(Map.Entry::getKey)
+                .containsExactly("resources");
+        JsonNode resources = config.path("resources");
+        assertThat(resources.properties()).extracting(Map.Entry::getKey)
+                .containsExactly("includes");
+        JsonNode includes = resources.path("includes");
+        assertThat(includes.isArray()).as("native resource includes is an array").isTrue();
+
+        Set<String> patterns = new LinkedHashSet<>();
+        for (JsonNode entry : includes) {
+            assertThat(entry.properties()).extracting(Map.Entry::getKey)
+                    .containsExactly("pattern");
+            String pattern = entry.path("pattern").asText();
+            assertThat(patterns.add(pattern))
+                    .as("duplicate native resource pattern %s", pattern)
+                    .isTrue();
+        }
+        return patterns;
+    }
+
+    private static String quotedResource(String resource) {
+        return "\\Q" + resource + "\\E";
+    }
+
+    private static Map<String, Set<String>> expectedJniEntries() {
+        return Map.ofEntries(
+                Map.entry("byte[]", Set.of()),
+                Map.entry("java.lang.Boolean", Set.of("method:booleanValue()")),
+                Map.entry("java.lang.Byte", Set.of("method:byteValue()")),
+                Map.entry("java.lang.Double", Set.of("method:doubleValue()")),
+                Map.entry("java.lang.Float", Set.of("method:floatValue()")),
+                Map.entry("java.lang.Integer", Set.of("method:intValue()")),
+                Map.entry("java.lang.Long", Set.of("method:longValue()")),
+                Map.entry("java.lang.Object", Set.of("method:toString()")),
+                Map.entry("java.lang.Short", Set.of("method:shortValue()")),
+                Map.entry("java.lang.String", Set.of(
+                        "method:getBytes(java.nio.charset.Charset)")),
+                Map.entry("java.lang.Throwable", Set.of("method:getMessage()")),
+                Map.entry("java.math.BigDecimal", Set.of(
+                        "method:longValue()",
+                        "method:precision()",
+                        "method:scale()",
+                        "method:scaleByPowerOfTen(int)",
+                        "method:toPlainString()")),
+                Map.entry("java.nio.ByteBuffer", Set.of(
+                        "method:order(java.nio.ByteOrder)")),
+                Map.entry("java.nio.ByteOrder", Set.of("method:nativeOrder()")),
+                Map.entry("java.nio.CharBuffer", Set.of("method:toString()")),
+                Map.entry("java.nio.charset.Charset", Set.of(
+                        "method:decode(java.nio.ByteBuffer)")),
+                Map.entry("java.nio.charset.StandardCharsets", Set.of("field:UTF_8")),
+                Map.entry("java.sql.Array", Set.of(
+                        "method:getArray()", "method:getBaseTypeName()")),
+                Map.entry("java.sql.SQLException", Set.of()),
+                Map.entry("java.sql.SQLTimeoutException", Set.of()),
+                Map.entry("java.sql.Struct", Set.of(
+                        "method:getAttributes()", "method:getSQLTypeName()")),
+                Map.entry("java.util.Iterator", Set.of(
+                        "method:hasNext()", "method:next()")),
+                Map.entry("java.util.List", Set.of("method:iterator()")),
+                Map.entry("java.util.Map", Set.of("method:entrySet()")),
+                Map.entry("java.util.Map$Entry", Set.of(
+                        "method:getKey()", "method:getValue()")),
+                Map.entry("java.util.Set", Set.of("method:iterator()")),
+                Map.entry("java.util.UUID", Set.of(
+                        "method:getLeastSignificantBits()",
+                        "method:getMostSignificantBits()")),
+                Map.entry("org.duckdb.DuckDBArray", Set.of(
+                        "method:<init>(org.duckdb.DuckDBVector,int,int)")),
+                Map.entry("org.duckdb.DuckDBDate", Set.of(
+                        "method:getDaysSinceEpoch()")),
+                Map.entry("org.duckdb.DuckDBHugeInt", Set.of(
+                        "field:lower",
+                        "field:upper",
+                        "method:toBigDecimal(long,long,int)",
+                        "method:toBigInteger(long,long)")),
+                Map.entry("org.duckdb.DuckDBResultSetMetaData", Set.of(
+                        "method:<init>(int,int,java.lang.String[],java.lang.String[],"
+                                + "java.lang.String[],java.lang.String,java.lang.String[],"
+                                + "java.lang.String[])")),
+                Map.entry("org.duckdb.DuckDBScalarFunctionWrapper", Set.of(
+                        "method:execute(java.nio.ByteBuffer,java.nio.ByteBuffer,"
+                                + "java.nio.ByteBuffer)")),
+                Map.entry("org.duckdb.DuckDBStruct", Set.of(
+                        "method:<init>(java.lang.String[],org.duckdb.DuckDBVector[],int,"
+                                + "java.lang.String)")),
+                Map.entry("org.duckdb.DuckDBTableFunctionWrapper", Set.of(
+                        "method:executeBind(java.nio.ByteBuffer)",
+                        "method:executeFunction(java.nio.ByteBuffer,java.nio.ByteBuffer)",
+                        "method:executeGlobalInit(java.nio.ByteBuffer)",
+                        "method:executeLocalInit(java.nio.ByteBuffer)")),
+                Map.entry("org.duckdb.DuckDBTime", Set.of()),
+                Map.entry("org.duckdb.DuckDBTimestamp", Set.of(
+                        "method:getMicrosEpoch()", "method:valueOf(java.lang.Object)")),
+                Map.entry("org.duckdb.DuckDBTimestampTZ", Set.of()),
+                Map.entry("org.duckdb.DuckDBVector", Set.of(
+                        "field:constlen_data",
+                        "field:varlen_data",
+                        "method:<init>(java.lang.String,int,boolean[])",
+                        "method:retainConstlenData()")),
+                Map.entry("org.duckdb.ProfilerPrintFormat", Set.of(
+                        "field:GRAPHVIZ",
+                        "field:HTML",
+                        "field:JSON",
+                        "field:NO_OUTPUT",
+                        "field:QUERY_TREE",
+                        "field:QUERY_TREE_OPTIMIZER")),
+                Map.entry("org.duckdb.QueryProgress", Set.of(
+                        "method:<init>(double,long,long)")),
+                Map.entry("org.duckdb.user.DuckDBMap", Set.of(
+                        "method:getSQLTypeName()")));
+    }
+
+    private static Map<String, Set<String>> jniEntries() {
+        JsonNode entriesNode = jsonResource(NATIVE_METADATA_ROOT + "jni-config.json");
+        assertThat(entriesNode.isArray()).as("native JNI config is an array").isTrue();
+
+        Map<String, Set<String>> entries = new LinkedHashMap<>();
+        for (JsonNode entry : entriesNode) {
+            assertThat(entry.isObject()).as("JNI entry %s", entry).isTrue();
+            assertThat(entry.properties()).extracting(Map.Entry::getKey)
+                    .contains("name")
+                    .isSubsetOf("name", "fields", "methods");
+            String name = entry.path("name").asText();
+            assertThat(name).as("JNI entry name in %s", entry).isNotBlank();
+
+            Set<String> members = new LinkedHashSet<>();
+            for (JsonNode field : entry.path("fields")) {
+                assertThat(field.properties()).extracting(Map.Entry::getKey)
+                        .containsExactly("name");
+                assertThat(members.add("field:" + field.path("name").asText()))
+                        .as("duplicate JNI field in %s", name)
+                        .isTrue();
+            }
+            for (JsonNode method : entry.path("methods")) {
+                assertThat(method.properties()).extracting(Map.Entry::getKey)
+                        .containsExactlyInAnyOrder("name", "parameterTypes");
+                assertThat(method.path("parameterTypes").isArray())
+                        .as("JNI method parameters in %s", method)
+                        .isTrue();
+                List<String> parameters = new ArrayList<>();
+                method.path("parameterTypes").forEach(parameter ->
+                        parameters.add(parameter.asText()));
+                String signature = "method:" + method.path("name").asText()
+                        + "(" + String.join(",", parameters) + ")";
+                assertThat(members.add(signature))
+                        .as("duplicate JNI method in %s", name)
+                        .isTrue();
+            }
+            assertThat(entries.put(name, Set.copyOf(members)))
+                    .as("duplicate JNI entry for %s", name)
+                    .isNull();
+        }
+        return entries;
+    }
+
+    private static Set<String> nativeImageArgs() {
+        String propertiesText = resourceText(NATIVE_METADATA_ROOT + "native-image.properties");
+        List<String> propertyLines = propertiesText.lines()
+                .map(String::trim)
+                .filter(line -> !line.isEmpty() && !line.startsWith("#"))
+                .toList();
+        assertThat(propertyLines).as("native-image.properties exact property lines").hasSize(1);
+
+        Properties properties = new Properties();
+        try {
+            properties.load(new StringReader(propertiesText));
+        } catch (IOException e) {
+            throw new AssertionError("failed to parse native-image.properties", e);
+        }
+        assertThat(properties.stringPropertyNames()).containsExactly("Args");
+        return Set.of(properties.getProperty("Args").trim().split("\\s+"));
+    }
+
+    private static JsonNode jsonResource(String path) {
+        ClassLoader loader = DuckLakeNativeImageMetadataTest.class.getClassLoader();
+        try (InputStream input = loader.getResourceAsStream(path)) {
+            assertThat(input).as("classpath resource %s", path).isNotNull();
+            return OBJECT_MAPPER.readTree(input);
+        } catch (IOException e) {
+            throw new AssertionError("failed to parse classpath JSON resource " + path, e);
+        }
+    }
+
+    private static String resourceText(String path) {
+        ClassLoader loader = DuckLakeNativeImageMetadataTest.class.getClassLoader();
+        try (InputStream input = loader.getResourceAsStream(path)) {
+            assertThat(input).as("classpath resource %s", path).isNotNull();
+            return new String(input.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new AssertionError("failed to read classpath resource " + path, e);
+        }
+    }
+}

--- a/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeTransactionLocatorTest.java
+++ b/archive-modules/archive-store-ducklake/src/test/java/com/bloxbean/cardano/yano/archive/ducklake/DuckLakeTransactionLocatorTest.java
@@ -3,20 +3,24 @@ package com.bloxbean.cardano.yano.archive.ducklake;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.sqlite.JDBC;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
+import java.sql.SQLException;
 import java.sql.Statement;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.OptionalLong;
+import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +41,16 @@ class DuckLakeTransactionLocatorTest {
     private Connection duckLake;
     private DuckLakeTransactionLocator locator;
     private Path catalog;
+
+    private static final class CountingSqliteDriver extends JDBC {
+        private final AtomicInteger connections = new AtomicInteger();
+
+        @Override
+        public Connection connect(String url, Properties properties) throws SQLException {
+            connections.incrementAndGet();
+            return super.connect(url, properties);
+        }
+    }
 
     @BeforeEach
     void setUp() throws Exception {
@@ -64,6 +78,17 @@ class DuckLakeTransactionLocatorTest {
         byte[] value = new byte[32];
         value[0] = (byte) id; value[1] = (byte) (id >>> 8);
         return value;
+    }
+
+    @Test
+    void locatorConnectsThroughItsExplicitSqliteDriver() {
+        CountingSqliteDriver driver = new CountingSqliteDriver();
+        try (DuckLakeTransactionLocator direct = new DuckLakeTransactionLocator(
+                temp.resolve("explicit-catalog.sqlite"), driver)) {
+            assertThat(driver.connections).hasValue(1);
+            assertThat(direct.currentGeneration()).isEqualTo(-1);
+            assertThat(driver.connections).hasValue(2);
+        }
     }
 
     /** Inserts into the authoritative table, as a TRANSACTION commit would. */

--- a/gradle/native-target.gradle
+++ b/gradle/native-target.gradle
@@ -1,0 +1,73 @@
+import java.util.Locale
+
+def normalizeNativeCpuArch = { String value ->
+    def arch = value.toLowerCase(Locale.ROOT).trim()
+    if (arch in ['x86_64', 'amd64']) return 'amd64'
+    if (arch in ['aarch64', 'arm64']) return 'arm64'
+    throw new GradleException("Unsupported native CPU architecture: ${value}")
+}
+
+def nativeContainerPlatform = {
+    def options = System.getProperty('quarkus.native.container-runtime-options', '')
+            .split(',')
+            .collect { it.trim() }
+            .findAll { !it.isBlank() }
+    for (int i = 0; i < options.size(); i++) {
+        if (options[i].startsWith('--platform=')) {
+            return options[i].substring('--platform='.length())
+        }
+        if (options[i] == '--platform' && i + 1 < options.size()) {
+            return options[i + 1]
+        }
+    }
+    return null
+}
+
+def nativeContainerBuildRequested = {
+    System.getProperty('quarkus.native.container-build', '').equalsIgnoreCase('true') ||
+            System.getProperty('quarkus.native.remote-container-build', '')
+                    .equalsIgnoreCase('true')
+}
+
+ext.yanoNativeContainerBuildRequested = nativeContainerBuildRequested
+
+ext.yanoNativeTarget = {
+    def hostCpuArch = normalizeNativeCpuArch(System.getProperty('os.arch', ''))
+
+    String targetOs
+    if (nativeContainerBuildRequested()) {
+        targetOs = 'linux'
+        def requestedPlatform = nativeContainerPlatform()
+        if (requestedPlatform != null) {
+            def parts = requestedPlatform.toLowerCase(Locale.ROOT).split('/')
+            if (parts.length != 2 || parts[0] != 'linux') {
+                throw new GradleException(
+                        "Unsupported native container platform: ${requestedPlatform}")
+            }
+            def requestedCpuArch = normalizeNativeCpuArch(parts[1])
+            if (requestedCpuArch != hostCpuArch) {
+                throw new GradleException(
+                        "Cross-CPU native builds are not supported: host is ${hostCpuArch}, " +
+                                "requested ${requestedPlatform}")
+            }
+        }
+    } else {
+        def hostOs = System.getProperty('os.name', '').toLowerCase(Locale.ROOT)
+        if (hostOs.contains('linux')) targetOs = 'linux'
+        else if (hostOs.contains('mac') || hostOs.contains('darwin')) targetOs = 'macos'
+        else if (hostOs.contains('windows')) targetOs = 'windows'
+        else throw new GradleException("Unsupported native operating system: ${hostOs}")
+    }
+
+    def extensionOs = targetOs == 'macos' ? 'osx' : targetOs
+    [
+            os: targetOs,
+            cpuArch: hostCpuArch,
+            distributionArch: hostCpuArch == 'amd64' ? 'x64' : 'arm64',
+            extensionPlatform: "${extensionOs}_${hostCpuArch}",
+            sidecarName: targetOs == 'macos'
+                    ? 'libduckdb_java.so_osx_universal'
+                    : "libduckdb_java.so_${targetOs}_${hostCpuArch}",
+            binaryFileName: targetOs == 'windows' ? 'yano.exe' : 'yano'
+    ]
+}


### PR DESCRIPTION
## Summary

Addresses #105 by making the built-in DuckLake projection-history providers and their native dependencies reachable from the Yano native distribution.

- Retains the DuckLake ServiceLoader providers and descriptors in Native Image metadata.
- Uses explicit DuckDB and SQLite driver instances at module boundaries.
- Runtime-initializes the required DuckDB classes.
- Packages the checksum-verified DuckDB JNI sidecar and the target-specific `ducklake` and `sqlite_scanner` extensions.
- Adds native distribution, runtime, and devnet projection-history checks.
- Centralizes native target selection in one readable Gradle helper shared by the app and DuckLake archive module.

The PR does not change projection schemas, history APIs, chainstate formats, public-network sync behavior, or projection defaults.

## Native build target contract

Target selection now follows the build mode instead of parsing ELF, Mach-O, or PE headers:

- A local native build targets the host OS and host CPU.
- A container native build targets Linux on the host CPU.
- An explicit container `--platform` is accepted only for Linux on the host CPU.
- Unsupported host CPUs and cross-CPU requests fail early with a clear error.

This covers the project workflows: local macOS, Linux, and Windows builds; Linux container builds on Linux or Windows; and macOS-to-Linux container builds using the Mac host CPU. GitHub Actions already uses architecture-matched x64 and ARM runners, so it does not depend on cross-CPU compilation.

## Validation

- `./gradlew :archive-modules:archive-store-ducklake:test :app:test :app:quarkusBuild`
- `./gradlew :app:verifyCoreNativeDistribution -Dquarkus.native.enabled=true -Dquarkus.package.jar.enabled=false -PskipSigning=true`
  - Oracle GraalVM 25.3.4.1
  - macOS ARM64 native executable
  - macOS ARM64 distribution ZIP and checksum-verified DuckDB sidecar
- Linux ARM64 container target selection produces the Linux ARM64 DuckDB sidecar and extension resources.
- A Linux AMD64 container target request on an ARM64 host fails early as unsupported cross-CPU compilation.
- The native devnet projection smoke crossed epochs 0 → 1 → 2, reached the exact finality frontier, and exercised projection-backed reads without provider, driver, JNI, extension, checksum, or archive-degradation failures.

## ADR and stack

- ADR-052 records the native projection-history packaging and host-CPU target-selection decisions.
- PR #108 has merged; this PR now targets `main`.
