### PR TITLE
Fix L1 epoch observations across Byron-era networks

### DIFF
--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/l1view/L1EpochState.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/l1view/L1EpochState.java
@@ -11,8 +11,13 @@ public interface L1EpochState extends AutoCloseable {
 
     long newEpoch();
 
+    /**
+     * Parameters effective in {@link #newEpoch()}. Hosts may reject any other epoch;
+     * observers must not use this method to infer the era of a previous-epoch dataset.
+     */
     ProtocolParamsView protocolParams(long effectiveEpoch);
 
+    /** Whether the previous-epoch snapshot is available, including a completed empty snapshot. */
     boolean hasStakeSnapshot(long snapshotEpoch);
 
     void forEachStakeEntry(long snapshotEpoch, StakeEntryConsumer consumer);

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/l1view/L1EpochStateProvider.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/l1view/L1EpochStateProvider.java
@@ -15,6 +15,16 @@ public interface L1EpochStateProvider {
     /** Pure slot-to-epoch calculation used by the non-blocking event callback. */
     long epochAtSlot(long slot);
 
+    /**
+     * First epoch transition for which this source can expose observer datasets.
+     *
+     * <p>The default matches networks whose ledger-state datasets start at genesis. Hosts with
+     * a Byron era override this with the first post-Byron epoch.</p>
+     */
+    default long firstObservableEpoch() {
+        return 1;
+    }
+
     /** Return completed boundaries after {@code afterNewEpoch}, ascending. */
     List<L1EpochBoundary> completedBoundaries(long afterNewEpoch, int limit);
 

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/l1view/L1EpochStateProvider.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/appchain/l1view/L1EpochStateProvider.java
@@ -19,7 +19,8 @@ public interface L1EpochStateProvider {
      * First epoch transition for which this source can expose observer datasets.
      *
      * <p>The default matches networks whose ledger-state datasets start at genesis. Hosts with
-     * a Byron era override this with the first post-Byron epoch.</p>
+     * a Byron era override this with the first post-Byron epoch. Every member must derive
+     * the same value from deterministic network configuration, never local dataset availability.</p>
      */
     default long firstObservableEpoch() {
         return 1;

--- a/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/HistoricalEpochStateView.java
+++ b/ledger-state/src/main/java/com/bloxbean/cardano/yano/ledgerstate/HistoricalEpochStateView.java
@@ -8,6 +8,7 @@ import com.bloxbean.cardano.yano.ledgerstate.governance.GovernanceCborCodec;
 import org.rocksdb.ColumnFamilyHandle;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
+import org.rocksdb.RocksDBException;
 import org.rocksdb.RocksIterator;
 import org.rocksdb.Snapshot;
 
@@ -38,6 +39,17 @@ public final class HistoricalEpochStateView implements AutoCloseable {
     public boolean hasStakeSnapshot(int epoch) {
         requireOpen();
         byte[] prefix = epochPrefix(epoch);
+        try {
+            byte[] marker = db.get(state, reads, DefaultAccountStateStore.snapshotGenerationKey(epoch));
+            if (marker != null) {
+                // A completed generation can contain zero rows. BUILDING generations
+                // must remain unavailable even when some rows have already been flushed.
+                return marker.length >= 2 && marker[0] == 1 && marker[1] == 1;
+            }
+        } catch (RocksDBException e) {
+            throw new IllegalStateException("historical stake snapshot marker read failed", e);
+        }
+        // Legacy snapshots predate generation markers and require at least one row.
         try (RocksIterator iterator = db.newIterator(stakeSnapshots, reads)) {
             iterator.seek(prefix);
             return iterator.isValid() && keyEpoch(iterator.key()) == epoch;
@@ -128,7 +140,7 @@ public final class HistoricalEpochStateView implements AutoCloseable {
         requireOpen();
         try {
             return db.get(state, reads, stateEpochPrefix(markerPrefix, epoch)) != null;
-        } catch (org.rocksdb.RocksDBException e) {
+        } catch (RocksDBException e) {
             throw new IllegalStateException("historical epoch marker read failed", e);
         }
     }

--- a/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/HistoricalEpochStateViewTest.java
+++ b/ledger-state/src/test/java/com/bloxbean/cardano/yano/ledgerstate/HistoricalEpochStateViewTest.java
@@ -47,6 +47,62 @@ class HistoricalEpochStateViewTest {
     }
 
     @Test
+    void completedEmptyStakeSnapshotIsPinnedAndRemovedOnRollback() throws Exception {
+        try (var rocks = TestRocksDBHelper.create(tempDir)) {
+            var store = new DefaultAccountStateStore(rocks.db(), rocks.cfSupplier(),
+                    LoggerFactory.getLogger(getClass()), true);
+            try (HistoricalEpochStateView before = store.openHistoricalEpochStateView()) {
+                store.createAndCommitDelegationSnapshot(3);
+                assertThat(before.hasStakeSnapshot(3)).isFalse();
+                try (HistoricalEpochStateView completed = store.openHistoricalEpochStateView()) {
+                    assertThat(completed.hasStakeSnapshot(3)).isTrue();
+                    List<String> entries = new ArrayList<>();
+                    completed.forEachStakeEntry(3, (type, hash, coin, pool) -> entries.add("unexpected"));
+                    assertThat(entries).isEmpty();
+                    store.rollbackToSlot(store.slotForEpochStart(3));
+                    assertThat(completed.hasStakeSnapshot(3)).isTrue();
+                    try (HistoricalEpochStateView rolledBack = store.openHistoricalEpochStateView()) {
+                        assertThat(rolledBack.hasStakeSnapshot(3)).isFalse();
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    void pruningRemovesCompletedEmptyStakeSnapshotPresence() throws Exception {
+        try (var rocks = TestRocksDBHelper.create(tempDir)) {
+            var store = new DefaultAccountStateStore(rocks.db(), rocks.cfSupplier(),
+                    LoggerFactory.getLogger(getClass()), true);
+            store.createAndCommitDelegationSnapshot(207);
+            try (HistoricalEpochStateView retained = store.openHistoricalEpochStateView()) {
+                assertThat(retained.hasStakeSnapshot(207)).isTrue();
+                int newEpoch = 208 + store.snapshotRetentionEpochs();
+                store.handleEpochTransitionSnapshot(newEpoch - 1, newEpoch);
+                assertThat(retained.hasStakeSnapshot(207)).isTrue();
+                try (HistoricalEpochStateView pruned = store.openHistoricalEpochStateView()) {
+                    assertThat(pruned.hasStakeSnapshot(207)).isFalse();
+                }
+            }
+        }
+    }
+
+    @Test
+    void incompleteOrUnknownStakeGenerationIsUnavailableEvenWithRows() throws Exception {
+        try (var rocks = TestRocksDBHelper.create(tempDir)) {
+            var store = new DefaultAccountStateStore(rocks.db(), rocks.cfSupplier(),
+                    LoggerFactory.getLogger(getClass()), true);
+            put(rocks, 42, 0, 1, 10);
+            for (byte[] marker : List.of(new byte[]{1, 0}, new byte[]{2, 1}, new byte[]{1})) {
+                rocks.db().put(rocks.cfState(), DefaultAccountStateStore.snapshotGenerationKey(42), marker);
+                try (HistoricalEpochStateView view = store.openHistoricalEpochStateView()) {
+                    assertThat(view.hasStakeSnapshot(42)).isFalse();
+                }
+            }
+        }
+    }
+
+    @Test
     void heldRocksSnapshotIsStableAndCloseGuarded() throws Exception {
         try (var rocks = TestRocksDBHelper.create(tempDir)) {
             put(rocks, 42, 0, 1, 10);

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinator.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinator.java
@@ -181,6 +181,7 @@ final class L1EpochObservationCoordinator implements AutoCloseable {
         latestAppliedBlockNumber.accumulateAndGet(blockNumber, Math::max);
         if (epoch < firstObservableEpoch) {
             lastObservedEpoch.set(-1);
+            wake();
             return;
         }
         long previous = lastObservedEpoch.getAndSet(epoch);

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinator.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinator.java
@@ -43,6 +43,7 @@ final class L1EpochObservationCoordinator implements AutoCloseable {
     private final int stabilityDepth;
     private final int maxMessagesPerOffer;
     private final long maxBytesPerOffer;
+    private final long firstObservableEpoch;
     private final BooleanSupplier scheduledProposer;
     private final Function<L1Observation, Boolean> injector;
     private final Logger log;
@@ -94,6 +95,11 @@ final class L1EpochObservationCoordinator implements AutoCloseable {
         if (stateProvider.snapshotRetentionEpochs() < MINIMUM_RETENTION_EPOCHS) {
             throw new IllegalArgumentException("L1 epoch observers require snapshot retention of at least "
                     + MINIMUM_RETENTION_EPOCHS + " epochs");
+        }
+        this.firstObservableEpoch = stateProvider.firstObservableEpoch();
+        if (firstObservableEpoch < 1) {
+            throw new IllegalArgumentException(
+                    "L1 epoch observer first observable epoch must be positive");
         }
         if (stabilityDepth <= 0) {
             throw new IllegalArgumentException(
@@ -173,6 +179,10 @@ final class L1EpochObservationCoordinator implements AutoCloseable {
             return;
         }
         latestAppliedBlockNumber.accumulateAndGet(blockNumber, Math::max);
+        if (epoch < firstObservableEpoch) {
+            lastObservedEpoch.set(-1);
+            return;
+        }
         long previous = lastObservedEpoch.getAndSet(epoch);
         if (previous >= 0 && epoch > previous) {
             for (long next = previous + 1; next <= epoch; next++) {
@@ -188,7 +198,8 @@ final class L1EpochObservationCoordinator implements AutoCloseable {
         pendingRollbackSlot.accumulateAndGet(rollbackToSlot, Math::min);
         pendingBoundaries.entrySet().removeIf(
                 entry -> entry.getValue().boundarySlot() > rollbackToSlot);
-        lastObservedEpoch.set(stateProvider.epochAtSlot(rollbackToSlot));
+        long rollbackEpoch = stateProvider.epochAtSlot(rollbackToSlot);
+        lastObservedEpoch.set(rollbackEpoch >= firstObservableEpoch ? rollbackEpoch : -1);
         latestAppliedBlockNumber.set(-1);
         wake();
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/hostbridge/DefaultL1EpochStateProvider.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/appchain/hostbridge/DefaultL1EpochStateProvider.java
@@ -9,6 +9,7 @@ import com.bloxbean.cardano.yano.api.appchain.l1view.L1EpochState;
 import com.bloxbean.cardano.yano.api.appchain.l1view.L1EpochStateProvider;
 import com.bloxbean.cardano.yano.api.appchain.l1view.ProtocolParamsCanonicalCodec;
 import com.bloxbean.cardano.yano.api.appchain.l1view.ProtocolParamsView;
+import com.bloxbean.cardano.yano.api.util.EpochSlotCalc;
 import com.bloxbean.cardano.yano.ledgerstate.DefaultAccountStateStore;
 import com.bloxbean.cardano.yano.ledgerstate.EpochBoundaryProcessor;
 import com.bloxbean.cardano.yano.ledgerstate.HistoricalEpochStateView;
@@ -40,6 +41,10 @@ public final class DefaultL1EpochStateProvider implements L1EpochStateProvider {
         return epochParams.getEpochSlotCalc().slotToEpoch(slot);
     }
 
+    @Override public long firstObservableEpoch() {
+        return firstObservableEpoch(epochParams.getEpochSlotCalc());
+    }
+
     @Override
     public List<L1EpochBoundary> completedBoundaries(long afterNewEpoch, int limit) {
         if (limit <= 0) return List.of();
@@ -49,8 +54,8 @@ public final class DefaultL1EpochStateProvider implements L1EpochStateProvider {
             return List.of();
         }
         long latestNewEpoch = state[0];
-        long first = Math.max(afterNewEpoch + 1,
-                Math.max(1, latestNewEpoch - store.snapshotRetentionEpochs() + 1));
+        long first = firstBoundaryToScan(afterNewEpoch, latestNewEpoch,
+                store.snapshotRetentionEpochs(), firstObservableEpoch());
         List<L1EpochBoundary> result = new ArrayList<>();
         for (long newEpoch = first; newEpoch <= latestNewEpoch && result.size() < limit; newEpoch++) {
             long startSlot = epochParams.getEpochSlotCalc().epochToStartSlot((int) newEpoch);
@@ -64,6 +69,16 @@ public final class DefaultL1EpochStateProvider implements L1EpochStateProvider {
                     point.getSlot(), hash, blockNumber));
         }
         return List.copyOf(result);
+    }
+
+    static long firstObservableEpoch(EpochSlotCalc epochSlotCalc) {
+        return Math.max(1, epochSlotCalc.firstNonByronEpoch());
+    }
+
+    static long firstBoundaryToScan(long afterNewEpoch, long latestNewEpoch,
+                                    int retentionEpochs, long firstObservableEpoch) {
+        return Math.max(afterNewEpoch + 1,
+                Math.max(firstObservableEpoch, latestNewEpoch - retentionEpochs + 1));
     }
 
     @Override

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinatorTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinatorTest.java
@@ -341,20 +341,39 @@ class L1EpochObservationCoordinatorTest {
     @Test
     void ignoresPreLedgerStateEpochsAndReconcilesTheFirstObservableBoundary(
             @TempDir Path dir) throws Exception {
+        assertFirstObservableBoundary(dir, false);
+    }
+
+    @Test
+    void rollbackIntoByronReconcilesOnlyTheFirstObservableBoundary(@TempDir Path dir)
+            throws Exception {
+        assertFirstObservableBoundary(dir, true);
+    }
+
+    private void assertFirstObservableBoundary(Path dir, boolean rollback) throws Exception {
         L1EpochBoundary boundary = new L1EpochBoundary(3, 4, 86_400,
                 bytes(0x04), 100);
         AtomicBoolean completed = new AtomicBoolean();
+        AtomicBoolean failStartup = new AtomicBoolean(true);
+        List<L1EpochBoundary> opened = new CopyOnWriteArrayList<>();
         L1EpochStateProvider provider = new L1EpochStateProvider() {
             @Override public boolean persistent() { return true; }
             @Override public int snapshotRetentionEpochs() { return 8; }
-            @Override public long epochAtSlot(long slot) { return slot < 86_400 ? 3 : 4; }
+            @Override public long epochAtSlot(long slot) { return slot / 21_600; }
             @Override public long firstObservableEpoch() { return 4; }
             @Override public List<L1EpochBoundary> completedBoundaries(long after, int limit) {
+                if (failStartup.getAndSet(false)) {
+                    throw new IllegalStateException("transient startup failure");
+                }
                 return completed.get() && boundary.newEpoch() > after
                         ? List.of(boundary) : List.of();
             }
-            @Override public Optional<L1EpochState> open(L1EpochBoundary ignored) {
-                return Optional.of(new EmptyState(boundary));
+            @Override public Optional<L1EpochState> open(L1EpochBoundary requested) {
+                opened.add(requested);
+                if (!requested.equals(boundary)) {
+                    throw new IllegalArgumentException("Unexpected boundary: " + requested);
+                }
+                return Optional.of(new EmptyState(requested));
             }
         };
 
@@ -365,21 +384,32 @@ class L1EpochObservationCoordinatorTest {
                      () -> false, ignored -> false, ignored -> { }, "pre-ledger-state",
                      LoggerFactory.getLogger("epoch-test"))) {
             coordinator.start();
+            await(() -> !coordinator.healthy());
+            coordinator.onBlockApplied(43_200, 80, bytes(0x02));
+            await(coordinator::healthy, coordinator::status);
             coordinator.onBlockApplied(64_800, 90, bytes(0x03));
             await(() -> Long.valueOf(90L).equals(
                     coordinator.status().get("latestAppliedBlockNumber")));
 
             assertThat(coordinator.healthy()).isTrue();
-            assertThat(coordinator.status()).containsEntry("failures", 0L);
+            assertThat(coordinator.status()).containsEntry("failures", 1L);
             assertThat(coordinator.status().toString()).contains("ready=0");
+            assertThat(opened).isEmpty();
 
+            if (rollback) {
+                // Re-enter Shelley directly from epoch 2: without the rollback clamp
+                // the event path incorrectly enqueues the Byron 2 -> 3 boundary.
+                coordinator.onRollback(43_200);
+            }
             completed.set(true);
             coordinator.onBlockApplied(86_400, 100, bytes(0x04));
             await(() -> coordinator.status().toString().contains("ready=1"),
                     coordinator::status);
 
             assertThat(coordinator.healthy()).isTrue();
-            assertThat(coordinator.status()).containsEntry("completedJobs", 1L);
+            assertThat(coordinator.status()).containsEntry("completedJobs", 1L)
+                    .containsEntry("failures", 1L);
+            assertThat(opened).isNotEmpty().allMatch(boundary::equals);
         }
     }
 

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinatorTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/L1EpochObservationCoordinatorTest.java
@@ -339,6 +339,51 @@ class L1EpochObservationCoordinatorTest {
     }
 
     @Test
+    void ignoresPreLedgerStateEpochsAndReconcilesTheFirstObservableBoundary(
+            @TempDir Path dir) throws Exception {
+        L1EpochBoundary boundary = new L1EpochBoundary(3, 4, 86_400,
+                bytes(0x04), 100);
+        AtomicBoolean completed = new AtomicBoolean();
+        L1EpochStateProvider provider = new L1EpochStateProvider() {
+            @Override public boolean persistent() { return true; }
+            @Override public int snapshotRetentionEpochs() { return 8; }
+            @Override public long epochAtSlot(long slot) { return slot < 86_400 ? 3 : 4; }
+            @Override public long firstObservableEpoch() { return 4; }
+            @Override public List<L1EpochBoundary> completedBoundaries(long after, int limit) {
+                return completed.get() && boundary.newEpoch() > after
+                        ? List.of(boundary) : List.of();
+            }
+            @Override public Optional<L1EpochState> open(L1EpochBoundary ignored) {
+                return Optional.of(new EmptyState(boundary));
+            }
+        };
+
+        try (AppLedgerStore ledger = ledger(dir.resolve("pre-ledger-state"));
+             L1EpochObservationCoordinator coordinator = new L1EpochObservationCoordinator(
+                     List.of(observer(null, null)), provider,
+                     new EpochObservationSpool(ledger, 1_000_000), 2, 1, 65_536,
+                     () -> false, ignored -> false, ignored -> { }, "pre-ledger-state",
+                     LoggerFactory.getLogger("epoch-test"))) {
+            coordinator.start();
+            coordinator.onBlockApplied(64_800, 90, bytes(0x03));
+            await(() -> Long.valueOf(90L).equals(
+                    coordinator.status().get("latestAppliedBlockNumber")));
+
+            assertThat(coordinator.healthy()).isTrue();
+            assertThat(coordinator.status()).containsEntry("failures", 0L);
+            assertThat(coordinator.status().toString()).contains("ready=0");
+
+            completed.set(true);
+            coordinator.onBlockApplied(86_400, 100, bytes(0x04));
+            await(() -> coordinator.status().toString().contains("ready=1"),
+                    coordinator::status);
+
+            assertThat(coordinator.healthy()).isTrue();
+            assertThat(coordinator.status()).containsEntry("completedJobs", 1L);
+        }
+    }
+
+    @Test
     void restartResumesGeneratingJobOutsideTheCurrentBoundaryScan(@TempDir Path dir)
             throws Exception {
         L1EpochBoundary boundary = new L1EpochBoundary(90, 91, 9_000,

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/hostbridge/DefaultL1EpochStateProviderTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/appchain/hostbridge/DefaultL1EpochStateProviderTest.java
@@ -1,0 +1,29 @@
+package com.bloxbean.cardano.yano.runtime.appchain.hostbridge;
+
+import com.bloxbean.cardano.yano.api.util.EpochSlotCalc;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class DefaultL1EpochStateProviderTest {
+
+    @Test
+    void derivesTheFirstObservableEpochFromNetworkEraConfiguration() {
+        assertThat(DefaultL1EpochStateProvider.firstObservableEpoch(
+                new EpochSlotCalc(432_000, 21_600, 4_492_800))).isEqualTo(208);
+        assertThat(DefaultL1EpochStateProvider.firstObservableEpoch(
+                new EpochSlotCalc(432_000, 21_600, 86_400))).isEqualTo(4);
+        assertThat(DefaultL1EpochStateProvider.firstObservableEpoch(
+                new EpochSlotCalc(86_400, 21_600, 0))).isEqualTo(1);
+    }
+
+    @Test
+    void completedBoundaryScanDoesNotEnumerateByronEpochs() {
+        assertThat(DefaultL1EpochStateProvider.firstBoundaryToScan(
+                -1, 4, 50, 4)).isEqualTo(4);
+        assertThat(DefaultL1EpochStateProvider.firstBoundaryToScan(
+                -1, 211, 50, 208)).isEqualTo(208);
+        assertThat(DefaultL1EpochStateProvider.firstBoundaryToScan(
+                -1, 311, 50, 4)).isEqualTo(262);
+    }
+}


### PR DESCRIPTION
## Summary

A fresh sync on a Byron network previously queued epoch boundaries whose protocol parameters do not exist. Derive a deterministic first observable boundary from genesis configuration: mainnet 208, preprod 4, and epoch 1 for networks without Byron. Apply the same floor to event tracking, rollback tracking, and the retained canonical boundary scan.

At the first Shelley boundary, the stake dataset belongs to the preceding epoch and can be empty. The historical view now reads the existing snapshot-generation completion marker through its pinned RocksDB snapshot, so a completed empty dataset is available and can produce an empty stake manifest. BUILDING or unknown marker versions remain unavailable even when partial rows exist. Legacy nonempty snapshots without markers remain readable; markerless empty snapshots are not inferred to be complete.

Pre-floor blocks still wake reconciliation, allowing transient startup failures to recover during Byron sync. SPI documentation states that all members must derive the same floor and that protocol parameters are pinned to the new epoch.

This implements the host/network floor discussed in ADR-037, **Observer profile epochs, late activation, and bounded backfill**, section 6.1. Per-observer committed coverage floors remain separate work; missing datasets at or above the applicable floor still fail closed.

## Validation

- `./gradlew :core-api:check :ledger-state:check :runtime:check --no-parallel`: core-api passed 284 tests; ledger-state passed 370 tests; runtime ran 1,473 tests with one failure and three skips. The failure was the existing `proposerRotationDoesNotLetANonProposerDiscardVerificationRecords` timeout; all new regressions passed. Runtime plugin-catalog semantics checks also passed.
- Uncached retry passed: `./gradlew :runtime:test --tests '*L1EpochObservationCoordinatorTest' --tests '*DefaultL1EpochStateProviderTest' --no-parallel --rerun-tasks`, including the proposer-rotation test. The full-suite timeout remains recorded above.
- Historical-view tests cover completed empty snapshots, missing/incomplete/unknown generations, legacy rows, pinned visibility across completion, and actual rollback/pruning removal.
- Coordinator tests apply epoch 2 → 3 → 4, reject every unexpected boundary opened, recover from a startup failure on a pre-floor block, and roll back into Byron before applying the first Shelley block.
- Mutation checks: removing the pre-floor event guard fails the strengthened event test; removing the rollback clamp fails the rollback test. Both guards were restored before the final checks.

These are local regression checks, not a new mainnet/preprod full-sync run.

## Cross-repository contract

The uncommitted yano-x `EpochStakeObserver.stakeEra()` change calls `protocolParams(previousEpoch)`, which this provider rejects. That change must be corrected before it lands: stake availability comes from the previous-epoch snapshot, including its explicit empty completion marker, rather than a previous-epoch protocol-parameter lookup. This PR documents the existing SPI contract; it does not modify the separate yano-x working tree.
