### PR TITLE
devnet: make the empty-block backfill interval configurable

### DIFF
--- a/app/docs/devnet-modes.md
+++ b/app/docs/devnet-modes.md
@@ -48,6 +48,7 @@ All config is in `application.yml` under the `%devnet` profile. Key properties:
 | `yano.block-producer.lazy` | false | If true, skip empty blocks |
 | `yano.block-producer.genesis-timestamp` | 0 (auto) | Genesis time; 0 = use current time |
 | `yano.block-producer.slot-length-millis` | 0 (auto) | Slot length; 0 = derive from genesis |
+| `yano.block-producer.backfill-block-interval-slots` | 1 | Empty-block backfills (catch-up, time advance, epoch fast-forward) place one block every N slots instead of every slot; the first slot of each epoch and the target slot always get a block. Keep N below the stability window (3k/f) so a Haskell relay can validate the chain |
 | `yano.dev-mode` | true | Enables devnet REST APIs |
 
 Genesis files are at `config/network/devnet/`.

--- a/app/docs/devnet-modes.md
+++ b/app/docs/devnet-modes.md
@@ -48,7 +48,7 @@ All config is in `application.yml` under the `%devnet` profile. Key properties:
 | `yano.block-producer.lazy` | false | If true, skip empty blocks |
 | `yano.block-producer.genesis-timestamp` | 0 (auto) | Genesis time; 0 = use current time |
 | `yano.block-producer.slot-length-millis` | 0 (auto) | Slot length; 0 = derive from genesis |
-| `yano.block-producer.backfill-block-interval-slots` | 1 | Empty-block backfills (catch-up, time advance, epoch fast-forward) place one block every N slots instead of every slot; the first slot of each epoch and the target slot always get a block. Keep N below the stability window (3k/f) so a Haskell relay can validate the chain |
+| `yano.block-producer.backfill-block-interval-slots` | 1 | Backfills place one block every N slots instead of every slot. Empty-block backfills (catch-up, time advance, epoch fast-forward) always add the first slot of each epoch and the target slot; the slot-leader catch-up forges the first eligible slot after each interval and after each epoch start, skipping leadership checks in between. Keep N below the stability window (3k/f) so a Haskell relay can validate the chain |
 | `yano.dev-mode` | true | Enables devnet REST APIs |
 
 Genesis files are at `config/network/devnet/`.

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
@@ -467,6 +467,9 @@ public class YanoProducer {
     @ConfigProperty(name = YanoPropertyKeys.BlockProducer.PAST_TIME_TRAVEL_SLOT_LEADER_MODE, defaultValue = "false")
     boolean pastTimeTravelSlotLeaderMode;
 
+    @ConfigProperty(name = YanoPropertyKeys.BlockProducer.BACKFILL_BLOCK_INTERVAL_SLOTS, defaultValue = "1")
+    int backfillBlockIntervalSlots;
+
     // Bootstrap config
     @ConfigProperty(name = YanoPropertyKeys.Bootstrap.ENABLED, defaultValue = "false")
     boolean bootstrapEnabled;
@@ -579,6 +582,7 @@ public class YanoProducer {
                 .startEpoch(startEpoch)
                 .pastTimeTravelMode(pastTimeTravelMode)
                 .pastTimeTravelSlotLeaderMode(pastTimeTravelSlotLeaderMode)
+                .backfillBlockIntervalSlots(backfillBlockIntervalSlots)
                 .shelleyGenesisHash(shelleyGenesisHash.orElse(null))
                 .shelleyGenesisFile(resolvedShelleyGenesis)
                 .byronGenesisFile(resolvedByronGenesis)

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoConfig.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoConfig.java
@@ -106,6 +106,13 @@ public class YanoConfig implements NodeConfig {
     @Builder.Default
     private boolean pastTimeTravelSlotLeaderMode = false;
 
+    // Empty-block backfills (catch-up, time advance, epoch fast-forward) place one block every
+    // this many slots instead of every slot. The first slot of every epoch and the target slot
+    // always get a block. Keep it below the stability window (3k/f) so a Haskell relay can
+    // still validate the chain. 1 = one block per slot (default).
+    @Builder.Default
+    private int backfillBlockIntervalSlots = 1;
+
     // Epoch/slot config — set from genesis at runtime via propagateGenesisToConfig().
     // No defaults: fail fast if not initialized from genesis.
     private Long epochLength;           // From shelley-genesis.json epochLength
@@ -571,6 +578,11 @@ public class YanoConfig implements NodeConfig {
             if (!enableBlockProducer) {
                 throw new IllegalArgumentException("Past time travel mode requires block producer to be enabled");
             }
+        }
+
+        if (backfillBlockIntervalSlots < 1) {
+            throw new IllegalArgumentException("Backfill block interval must be at least 1 slot, got: "
+                    + backfillBlockIntervalSlots);
         }
 
         if (pastTimeTravelSlotLeaderMode) {

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
@@ -525,6 +525,8 @@ public final class YanoPropertyKeys {
                 "yano.block-producer.past-time-travel-slot-leader-mode";
         public static final String PROCESS_SKIPPED_EPOCHS =
                 "yano.block-producer.process-skipped-epochs";
+        public static final String BACKFILL_BLOCK_INTERVAL_SLOTS =
+                "yano.block-producer.backfill-block-interval-slots";
 
         private BlockProducer() {
         }

--- a/core-api/src/test/java/com/bloxbean/cardano/yano/api/config/YanoConfigTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/yano/api/config/YanoConfigTest.java
@@ -351,6 +351,50 @@ class YanoConfigTest {
     }
 
     @Test
+    void validate_backfillBlockIntervalSlots_defaultsToOneBlockPerSlot() {
+        YanoConfig config = YanoConfig.builder()
+                .enableClient(false)
+                .enableServer(true)
+                .serverPort(13337)
+                .enableBlockProducer(true)
+                .devMode(true)
+                .pastTimeTravelMode(true)
+                .protocolMagic(42)
+                .build();
+
+        assertThat(config.getBackfillBlockIntervalSlots()).isEqualTo(1);
+        assertThatCode(config::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_backfillBlockIntervalSlots_acceptsSparseIntervalAndRejectsZero() {
+        YanoConfig sparse = YanoConfig.builder()
+                .enableClient(false)
+                .enableServer(true)
+                .serverPort(13337)
+                .enableBlockProducer(true)
+                .devMode(true)
+                .pastTimeTravelMode(true)
+                .backfillBlockIntervalSlots(900)
+                .protocolMagic(42)
+                .build();
+        assertThatCode(sparse::validate).doesNotThrowAnyException();
+
+        YanoConfig zero = YanoConfig.builder()
+                .enableClient(false)
+                .enableServer(true)
+                .serverPort(13337)
+                .enableBlockProducer(true)
+                .devMode(true)
+                .backfillBlockIntervalSlots(0)
+                .protocolMagic(42)
+                .build();
+        assertThatThrownBy(zero::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Backfill block interval");
+    }
+
+    @Test
     void validate_pastTimeTravelMode_shouldThrowWhenDevModeDisabled() {
         YanoConfig config = YanoConfig.builder()
                 .enableClient(false)

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProducerHelper.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProducerHelper.java
@@ -253,4 +253,14 @@ public final class BlockProducerHelper {
         if (epochProvider == null) return -1;
         return epochProvider.getEpochSlotCalc().slotToEpoch(slot);
     }
+
+    /**
+     * First slot of the epoch after the one containing {@code slot}, or -1 when no epoch
+     * provider is installed. Used by sparse backfills so every epoch starts with a block.
+     */
+    public static long firstSlotOfNextEpoch(long slot) {
+        if (epochProvider == null || slot < 0) return -1;
+        var calc = epochProvider.getEpochSlotCalc();
+        return calc.epochToStartSlot(calc.slotToEpoch(slot) + 1);
+    }
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
@@ -44,6 +44,7 @@ public class DevnetBlockProducer implements BlockProducerService {
     private long lastUsedSlot = -1;
     private volatile boolean running;
     private volatile boolean forceSequentialSlots = false;
+    private volatile int backfillBlockIntervalSlots = 1;
 
     public DevnetBlockProducer(ChainState chainState, MemPool memPool, NodeServer nodeServer,
                          EventBus eventBus, ScheduledExecutorService scheduler,
@@ -351,8 +352,44 @@ public class DevnetBlockProducer implements BlockProducerService {
     }
 
     /**
+     * Set how many slots apart empty-block backfills place their blocks. 1 (default) places a block
+     * in every slot. Larger values thin the backfill; the first slot of every epoch and the target
+     * slot always get a block. Keep it below the stability window (3k/f) so a Haskell relay can
+     * still validate the chain.
+     */
+    public void setBackfillBlockIntervalSlots(int backfillBlockIntervalSlots) {
+        if (backfillBlockIntervalSlots < 1) {
+            throw new IllegalArgumentException("backfillBlockIntervalSlots must be at least 1, got "
+                    + backfillBlockIntervalSlots);
+        }
+        this.backfillBlockIntervalSlots = backfillBlockIntervalSlots;
+    }
+
+    public int getBackfillBlockIntervalSlots() {
+        return backfillBlockIntervalSlots;
+    }
+
+    /**
+     * Slot of the next backfill block after {@code fromSlot}: {@code fromSlot + interval}, pulled back
+     * to the first slot of the next epoch when the step would cross an epoch boundary, and never past
+     * {@code targetSlot}. With interval 1 this is always {@code fromSlot + 1}.
+     */
+    long nextBackfillSlot(long fromSlot, long targetSlot) {
+        long next = Math.min(fromSlot + backfillBlockIntervalSlots, targetSlot);
+        if (backfillBlockIntervalSlots > 1) {
+            long epochStart = BlockProducerHelper.firstSlotOfNextEpoch(fromSlot);
+            if (epochStart > fromSlot && epochStart < next) {
+                next = epochStart;
+            }
+        }
+        return next;
+    }
+
+    /**
      * Produce empty blocks rapidly from the current tip slot up to (and including) targetSlot.
-     * Each block advances by one slot step. Used for time/slot advance in devnet mode.
+     * By default each block advances by one slot; with a backfill block interval above 1, blocks are
+     * placed every interval slots plus the first slot of each epoch and the target slot.
+     * Used for time/slot advance and catch-up in devnet mode.
      *
      * @param targetSlot the slot to advance to
      * @return number of blocks produced
@@ -364,7 +401,11 @@ public class DevnetBlockProducer implements BlockProducerService {
         }
 
         int blocksProduced = 0;
-        long currentSlot = lastUsedSlot + 1;
+        long currentSlot = nextBackfillSlot(lastUsedSlot, targetSlot);
+        if (backfillBlockIntervalSlots > 1) {
+            log.info("Sparse backfill: one block every {} slots from slot {} to {}",
+                    backfillBlockIntervalSlots, lastUsedSlot + 1, targetSlot);
+        }
 
         while (currentSlot <= targetSlot) {
             BlockProducerHelper.prepareEpochTransitionBeforeBlock(
@@ -385,7 +426,10 @@ public class DevnetBlockProducer implements BlockProducerService {
                 log.info("Time advance progress: {} blocks produced, current slot={}", blocksProduced, currentSlot);
             }
 
-            currentSlot++;
+            if (currentSlot >= targetSlot) {
+                break;
+            }
+            currentSlot = nextBackfillSlot(currentSlot, targetSlot);
         }
 
         // Notify server once at the end

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -47,6 +47,7 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
     private ScheduledFuture<?> scheduledTask;
     private volatile boolean running;
     private volatile boolean forceSequentialSlots = true;
+    private volatile int backfillBlockIntervalSlots = 1;
     private long lastCheckedSlot = -1;
     private int lastStakeEpoch = -1;
     private BigDecimal sigma = BigDecimal.ZERO;
@@ -189,8 +190,50 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         this.forceSequentialSlots = forceSequentialSlots;
     }
 
+    /**
+     * Catch-up entry point: scan from the last checked slot to {@code targetSlot} and forge every
+     * eligible slot, or, with a backfill block interval above 1, only the first eligible slot at or
+     * after each interval and after each epoch start (see {@link #setBackfillBlockIntervalSlots(int)}).
+     */
     public synchronized int produceToSlot(long targetSlot) {
-        return produceToSlot(targetSlot, false);
+        return produceToSlot(targetSlot, false, true);
+    }
+
+    /**
+     * Set how many slots apart the catch-up backfill places its blocks. 1 (default) forges every
+     * eligible slot. Above 1, after each block the scan jumps to the earlier of {@code block + interval}
+     * and the next epoch start, and forges the first eligible slot from there. Leadership checks are
+     * skipped for the slots jumped over, so a multi-day catch-up costs a few dozen VRF evaluations.
+     * Keep it below the stability window (3k/f) so a Haskell relay can still validate the chain.
+     * Scheduled (wall-clock and sequential-scan) production is not affected.
+     */
+    public void setBackfillBlockIntervalSlots(int backfillBlockIntervalSlots) {
+        if (backfillBlockIntervalSlots < 1) {
+            throw new IllegalArgumentException("backfillBlockIntervalSlots must be at least 1, got "
+                    + backfillBlockIntervalSlots);
+        }
+        this.backfillBlockIntervalSlots = backfillBlockIntervalSlots;
+    }
+
+    public int getBackfillBlockIntervalSlots() {
+        return backfillBlockIntervalSlots;
+    }
+
+    /**
+     * First slot worth a leadership check after a block at {@code lastBlockSlot}, given the interval:
+     * {@code lastBlockSlot + interval}, pulled back to the next epoch start when that comes first, and
+     * never before {@code slot} itself. Package-private for tests.
+     */
+    static long nextSparseCandidateSlot(long slot, long lastBlockSlot, int interval) {
+        if (interval <= 1 || lastBlockSlot < 0) {
+            return slot;
+        }
+        long earliest = lastBlockSlot + interval;
+        long epochStart = BlockProducerHelper.firstSlotOfNextEpoch(lastBlockSlot);
+        if (epochStart > lastBlockSlot && epochStart < earliest) {
+            earliest = epochStart;
+        }
+        return Math.max(slot, earliest);
     }
 
     public long getLastCheckedSlot() {
@@ -208,7 +251,7 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
                 return;
             }
             long fromSlot = lastCheckedSlot + 1;
-            int produced = produceToSlot(targetSlot, true);
+            int produced = produceToSlot(targetSlot, true, false);
             if (produced == 0) {
                 log.debug("No eligible slot found while scanning slots {}..{}", fromSlot, targetSlot);
             }
@@ -216,17 +259,33 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         }
 
         long wallClockSlot = calculateWallClockSlot();
-        produceToSlot(wallClockSlot, false);
+        produceToSlot(wallClockSlot, false, false);
     }
 
-    private int produceToSlot(long targetSlot, boolean stopAfterFirstBlock) {
+    private int produceToSlot(long targetSlot, boolean stopAfterFirstBlock, boolean sparse) {
         if (targetSlot <= lastCheckedSlot) {
             return 0;
+        }
+
+        int interval = sparse ? backfillBlockIntervalSlots : 1;
+        if (interval > 1) {
+            log.info("Sparse slot-leader backfill: first eligible slot every {} slots from slot {} to {}",
+                    interval, lastCheckedSlot + 1, targetSlot);
         }
 
         int blocksProduced = 0;
         long slot = lastCheckedSlot + 1;
         while (slot <= targetSlot) {
+            if (interval > 1) {
+                ChainTip tip = chainState.getTip();
+                long candidate = nextSparseCandidateSlot(slot, tip != null ? tip.getSlot() : -1, interval);
+                if (candidate > targetSlot) {
+                    // Nothing more to forge before the target: count the rest as checked.
+                    lastCheckedSlot = targetSlot;
+                    break;
+                }
+                slot = candidate;
+            }
             lastCheckedSlot = slot;
             int epoch = epochNonceState.epochForSlot(slot);
             refreshStakeData(epoch);

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -2591,7 +2591,8 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
                     resolvedGenesisTimestamp,
                     config.getSlotLengthMillis(),
                     config.getBlockTimeMillis(),
-                    sequentialScanLimitSlots);
+                    sequentialScanLimitSlots,
+                    config.getBackfillBlockIntervalSlots());
         } catch (Exception e) {
             throw new RuntimeException("Failed to create past-time-travel slot-leader block producer", e);
         }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -2471,7 +2471,8 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
                 config.isLazyBlockProduction(),
                 resolvedGenesisTimestamp,
                 config.getSlotLengthMillis(),
-                genesisConfig);
+                genesisConfig,
+                config.getBackfillBlockIntervalSlots());
     }
 
     private DevnetBlockBuilderFactory devnetBlockBuilderFactory() {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactory.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactory.java
@@ -46,6 +46,7 @@ public final class DevnetProducerFactory {
                 settings.resolvedGenesisTimestamp(),
                 settings.slotLengthMillis(),
                 settings.genesisConfig());
+        producer.setBackfillBlockIntervalSlots(settings.backfillBlockIntervalSlots());
         dependencies.producerSubsystem().installDevnet(producer, timeTravel);
         return producer;
     }
@@ -58,7 +59,22 @@ public final class DevnetProducerFactory {
             boolean lazyBlockProduction,
             long resolvedGenesisTimestamp,
             int slotLengthMillis,
-            GenesisConfig genesisConfig) {
+            GenesisConfig genesisConfig,
+            int backfillBlockIntervalSlots) {
+        public Settings {
+            if (backfillBlockIntervalSlots < 1) {
+                throw new IllegalArgumentException(
+                        "backfillBlockIntervalSlots must be at least 1, got " + backfillBlockIntervalSlots);
+            }
+        }
+
+        public Settings(int blockTimeMillis,
+                        boolean lazyBlockProduction,
+                        long resolvedGenesisTimestamp,
+                        int slotLengthMillis,
+                        GenesisConfig genesisConfig) {
+            this(blockTimeMillis, lazyBlockProduction, resolvedGenesisTimestamp, slotLengthMillis, genesisConfig, 1);
+        }
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/SlotLeaderProducerFactory.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/SlotLeaderProducerFactory.java
@@ -62,6 +62,20 @@ public final class SlotLeaderProducerFactory {
                                                               int slotLengthMillis,
                                                               int blockTimeMillis,
                                                               long sequentialScanLimitSlots) {
+        return createTimeTravel(signedBlockBuilder, epochNonceState, slotLeaderCheck, stakeDataProvider, poolHash,
+                resolvedGenesisTimestamp, slotLengthMillis, blockTimeMillis, sequentialScanLimitSlots, 1);
+    }
+
+    public SlotLeaderTimeTravelBlockProducer createTimeTravel(SignedBlockBuilder signedBlockBuilder,
+                                                              EpochNonceState epochNonceState,
+                                                              SlotLeaderCheck slotLeaderCheck,
+                                                              StakeDataProvider stakeDataProvider,
+                                                              String poolHash,
+                                                              long resolvedGenesisTimestamp,
+                                                              int slotLengthMillis,
+                                                              int blockTimeMillis,
+                                                              long sequentialScanLimitSlots,
+                                                              int backfillBlockIntervalSlots) {
         var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
                 dependencies.chainState(),
                 dependencies.transactions(),
@@ -77,6 +91,7 @@ public final class SlotLeaderProducerFactory {
                 slotLengthMillis,
                 blockTimeMillis,
                 sequentialScanLimitSlots);
+        producer.setBackfillBlockIntervalSlots(backfillBlockIntervalSlots);
         dependencies.producerSubsystem().installSlotLeaderTimeTravel(producer);
         return producer;
     }

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducerTest.java
@@ -450,6 +450,100 @@ class DevnetBlockProducerTest {
         assertThat(chainState.getTip().getBlockNumber()).isEqualTo(0);
     }
 
+    @Test
+    void produceEmptyBlocksToSlot_defaultIntervalPlacesABlockInEverySlot() {
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+
+        int produced = blockProducer.produceEmptyBlocksToSlot(20);
+
+        assertThat(produced).isEqualTo(20);
+        assertThat(chainState.getTip().getSlot()).isEqualTo(20);
+        assertThat(chainState.getTip().getBlockNumber()).isEqualTo(20);
+        assertThat(producedSlots(eventBus)).hasSize(20).startsWith(1L, 2L, 3L).endsWith(19L, 20L);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_sparseIntervalPlacesBlocksEveryNSlotsAndAtTheTarget() {
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+        blockProducer.setBackfillBlockIntervalSlots(100);
+
+        int produced = blockProducer.produceEmptyBlocksToSlot(1_050);
+
+        assertThat(produced).isEqualTo(11);
+        assertThat(producedSlots(eventBus)).containsExactly(
+                100L, 200L, 300L, 400L, 500L, 600L, 700L, 800L, 900L, 1_000L, 1_050L);
+        assertThat(chainState.getTip().getSlot()).isEqualTo(1_050);
+        assertThat(chainState.getTip().getBlockNumber()).isEqualTo(11);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_sparseIntervalStillStartsEveryEpochWithABlock() {
+        BlockProducerHelper.setEpochParamProvider(new TestEpochParamProvider(250));
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+        blockProducer.setBackfillBlockIntervalSlots(100);
+
+        int produced = blockProducer.produceEmptyBlocksToSlot(620);
+
+        assertThat(produced).isEqualTo(8);
+        assertThat(producedSlots(eventBus)).containsExactly(100L, 200L, 250L, 350L, 450L, 500L, 600L, 620L);
+        assertThat(eventBus.events().stream().filter(EpochTransitionEvent.class::isInstance).count()).isEqualTo(2);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_intervalLongerThanAnEpochStillVisitsEveryEpoch() {
+        BlockProducerHelper.setEpochParamProvider(new TestEpochParamProvider(50));
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+        blockProducer.setBackfillBlockIntervalSlots(1_000);
+
+        blockProducer.produceEmptyBlocksToSlot(175);
+
+        assertThat(producedSlots(eventBus)).containsExactly(50L, 100L, 150L, 175L);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_afterSparseBackfillLiveProductionContinuesFromTheTip() {
+        // Running producer with a one-minute schedule, so only the explicit produceBlock() call below forges.
+        var existing = new DevnetBlockBuilder().buildBlock(0, 0, null, List.of());
+        chainState.storeBlock(existing.blockHash(), 0L, 0L, existing.blockCbor());
+        chainState.storeBlockHeader(existing.blockHash(), 0L, 0L, existing.wrappedHeaderCbor());
+        blockProducer = new DevnetBlockProducer(
+                chainState, memPool, null, new NoopEventBus(), scheduler, new DevnetBlockBuilder(),
+                60_000, false, System.currentTimeMillis(), 1000, null,
+                new DummyTransactionValidationService(null, null), null);
+        blockProducer.setForceSequentialSlots(true);
+        blockProducer.start();
+        blockProducer.setBackfillBlockIntervalSlots(40);
+        blockProducer.produceEmptyBlocksToSlot(90);
+
+        blockProducer.produceBlock();
+
+        assertThat(chainState.getTip().getSlot()).isEqualTo(91);
+        assertThat(chainState.getTip().getBlockNumber()).isEqualTo(4);
+    }
+
+    @Test
+    void setBackfillBlockIntervalSlots_rejectsValuesBelowOne() {
+        blockProducer = createDevnetBlockProducer(1000, false);
+
+        assertThrows(IllegalArgumentException.class, () -> blockProducer.setBackfillBlockIntervalSlots(0));
+        assertThat(blockProducer.getBackfillBlockIntervalSlots()).isEqualTo(1);
+    }
+
+    private static List<Long> producedSlots(RecordingEventBus eventBus) {
+        return eventBus.events().stream()
+                .filter(BlockProducedEvent.class::isInstance)
+                .map(event -> ((BlockProducedEvent) event).slot())
+                .toList();
+    }
+
     private DevnetBlockProducer createDevnetBlockProducer(int blockTimeMillis, boolean lazy) {
         return new DevnetBlockProducer(
                 chainState, memPool, null, new NoopEventBus(), scheduler,

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -17,6 +18,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SlotLeaderTimeTravelBlockProducerTest {
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -90,6 +92,112 @@ class SlotLeaderTimeTravelBlockProducerTest {
         } finally {
             releaseStakeRead.countDown();
             producer.stop();
+        }
+    }
+
+    @Test
+    void nextSparseCandidateSlot_stepsByIntervalButNeverPastAnEpochStart() {
+        BlockProducerHelper.setEpochParamProvider(new EpochLengthProvider(250));
+        try {
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(1, 0, 100)).isEqualTo(100);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(201, 200, 100)).isEqualTo(250);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(251, 250, 100)).isEqualTo(350);
+            // an interval longer than an epoch still visits every epoch start
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(1, 0, 1_000)).isEqualTo(250);
+            // never earlier than the slot being scanned, and interval 1 or no tip means no skipping
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(400, 0, 100)).isEqualTo(400);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(7, 6, 1)).isEqualTo(7);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(7, -1, 100)).isEqualTo(7);
+        } finally {
+            BlockProducerHelper.setEpochParamProvider(null);
+        }
+    }
+
+    @Test
+    void catchUpSkipsLeadershipChecksInsideTheIntervalButScheduledScanDoesNot() {
+        InMemoryChainState chainState = new InMemoryChainState();
+        var existing = new DevnetBlockBuilder().buildBlock(0, 0, null, List.of());
+        chainState.storeBlock(existing.blockHash(), 0L, 0L, existing.blockCbor());
+        chainState.storeBlockHeader(existing.blockHash(), 0L, 0L, existing.wrappedHeaderCbor());
+
+        List<Long> checkedSlots = new ArrayList<>();
+        SlotLeaderCheck countingNeverLeader = new SlotLeaderCheck(new byte[64], BigDecimal.ONE, null) {
+            @Override
+            public BlockSigner.VrfSignResult checkAndProve(long slot, byte[] epochNonce, BigDecimal sigma) {
+                checkedSlots.add(slot);
+                return null;
+            }
+        };
+        StakeDataProvider fullStake = new StakeDataProvider() {
+            @Override
+            public BigInteger getPoolStake(String poolHash, int epoch) {
+                return BigInteger.ONE;
+            }
+
+            @Override
+            public BigInteger getTotalStake(int epoch) {
+                return BigInteger.ONE;
+            }
+        };
+        EpochNonceState nonceState = new EpochNonceState(10_000, 1, 1.0);
+        nonceState.initFromGenesisHash(new byte[32]);
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
+                chainState, emptyTransactions(), () -> null, new NoopEventBus(), scheduler,
+                null, nonceState, countingNeverLeader, fullStake,
+                "pool", System.currentTimeMillis() - 60_000, 1000, 1, 1);
+        producer.setBackfillBlockIntervalSlots(100);
+
+        producer.produceToSlot(1_000);
+
+        assertThat(checkedSlots).isNotEmpty();
+        assertThat(checkedSlots.get(0)).isEqualTo(100L);
+        assertThat(checkedSlots).hasSize(901);
+        assertThat(producer.getLastCheckedSlot()).isEqualTo(1_000);
+
+        // a catch-up that ends inside the interval forges nothing and lands on the target
+        checkedSlots.clear();
+        producer.setBackfillBlockIntervalSlots(5_000);
+        producer.produceToSlot(1_500);
+        assertThat(checkedSlots).isEmpty();
+        assertThat(producer.getLastCheckedSlot()).isEqualTo(1_500);
+    }
+
+    @Test
+    void setBackfillBlockIntervalSlots_rejectsValuesBelowOne() {
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
+                new InMemoryChainState(), emptyTransactions(), () -> null, new NoopEventBus(), scheduler,
+                null, new EpochNonceState(10, 1, 1.0), null, null,
+                "pool", System.currentTimeMillis() - 60_000, 1000, 1, 1);
+        assertThatThrownBy(() -> producer.setBackfillBlockIntervalSlots(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(producer.getBackfillBlockIntervalSlots()).isEqualTo(1);
+    }
+
+    private static final class EpochLengthProvider implements com.bloxbean.cardano.yano.api.EpochParamProvider {
+        private final long epochLength;
+
+        private EpochLengthProvider(long epochLength) {
+            this.epochLength = epochLength;
+        }
+
+        @Override
+        public BigInteger getKeyDeposit(long epoch) {
+            return BigInteger.ZERO;
+        }
+
+        @Override
+        public BigInteger getPoolDeposit(long epoch) {
+            return BigInteger.ZERO;
+        }
+
+        @Override
+        public long getEpochLength() {
+            return epochLength;
+        }
+
+        @Override
+        public long getByronSlotsPerEpoch() {
+            return epochLength;
         }
     }
 

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactoryTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactoryTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DevnetProducerFactoryTest {
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -51,6 +52,25 @@ class DevnetProducerFactoryTest {
         assertThat(producerSubsystem.modeOrNull()).isEqualTo(ProducerMode.DEVNET_TIME_TRAVEL);
         assertThat(producerSubsystem.isRunning()).isFalse();
         assertThat(producerSubsystem.slotLengthMillis("test")).isEqualTo(1000);
+    }
+
+    @Test
+    void settingsCarryTheBackfillBlockIntervalToTheProducer() {
+        ProducerSubsystem producerSubsystem = new ProducerSubsystem();
+        var sparse = new DevnetProducerFactory.Settings(60_000, true, System.currentTimeMillis(), 1000, null, 7);
+
+        var producer = factory(producerSubsystem).createTimeTravel(new DevnetBlockBuilder(), sparse);
+
+        assertThat(producer.getBackfillBlockIntervalSlots()).isEqualTo(7);
+        assertThat(factory(new ProducerSubsystem()).createLive(new DevnetBlockBuilder(), settings())
+                .getBackfillBlockIntervalSlots()).isEqualTo(1);
+    }
+
+    @Test
+    void settingsRejectABackfillBlockIntervalBelowOne() {
+        assertThatThrownBy(() -> new DevnetProducerFactory.Settings(60_000, true, System.currentTimeMillis(), 1000, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("backfillBlockIntervalSlots");
     }
 
     private DevnetProducerFactory factory(ProducerSubsystem producerSubsystem) {


### PR DESCRIPTION
Catch-up placed one block in every slot from the shifted genesis to wall clock, so create time grew with epoch length and a Haskell relay had to copy the whole chain. A relay only needs one block per stability window (3k/f) to validate the history.

- add yano.block-producer.backfill-block-interval-slots (default 1, the old one-block-per-slot behaviour)
- with an interval above 1, produceEmptyBlocksToSlot places blocks every interval slots plus the first slot of each epoch and the target slot, so every epoch still gets its boundary processing and the tip lands at the target
- carry the interval through YanoConfig and DevnetProducerFactory.Settings