### PR TITLE
devnet: forge the first slot-leader block before storing genesis UTXOs

### DIFF
--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -193,6 +193,22 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         return produceToSlot(targetSlot, false);
     }
 
+    /**
+     * Forge the chain's first block right now instead of waiting for the first scheduled tick:
+     * scan from the last checked slot for the first eligible slot (bounded by the sequential scan
+     * limit and wall clock) and forge it. A fresh past-time-travel chain has no block until an
+     * eligible slot is found, and genesis UTXOs must bind to a real block, so the shift path calls
+     * this before storing them. Returns the number of blocks forged (0 when a tip already exists
+     * or no eligible slot was found in range).
+     */
+    public synchronized int forgeFirstBlockNow() {
+        if (chainState.getTip() != null) {
+            return 0;
+        }
+        long targetSlot = Math.min(lastCheckedSlot + sequentialScanLimitSlots, calculateWallClockSlot());
+        return produceToSlot(targetSlot, true);
+    }
+
     public long getLastCheckedSlot() {
         return lastCheckedSlot;
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftService.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftService.java
@@ -129,11 +129,12 @@ public final class DevnetGenesisShiftService {
 
             switch (plan.mode()) {
                 case SLOT_LEADER_TIME_TRAVEL -> {
-                    // Slot-leader deployments normally restore an existing genesis tip.
-                    // Preserve that ordering until the deferred producer owns fresh-genesis
-                    // creation itself.
-                    actions.storeGenesisUtxosIfNeeded(freshStart);
+                    // On a fresh start the producer forges the first eligible block
+                    // synchronously, so the genesis UTXOs stored next bind their indexes to a
+                    // real block hash (the pointer index marker rejects an empty one). A restart
+                    // restores the existing tip and stores nothing.
                     actions.startSlotLeaderTimeTravel(freshStart);
+                    actions.storeGenesisUtxosIfNeeded(freshStart);
                 }
                 case DEVNET_TIME_TRAVEL -> {
                     // DevnetBlockProducer.start() creates and stores block zero

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -3651,6 +3651,16 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
         SlotLeaderTimeTravelBlockProducer producer = createSlotLeaderTimeTravelProducer(freshStart);
         producerSubsystem.setForceSequentialSlots(true, "Past time travel");
         producer.start();
+        if (freshStart) {
+            // A fresh chain has no block zero until the first eligible slot is forged. Do it now so
+            // the genesis UTXOs stored right after this bind to a real block hash.
+            int forged = producer.forgeFirstBlockNow();
+            if (chainState.getTip() == null) {
+                throw new IllegalStateException(
+                        "Past-time-travel slot-leader producer found no eligible slot for the first block");
+            }
+            log.info("First slot-leader time-travel block forged during epoch shift (blocks={})", forged);
+        }
     }
 
     private void startShiftedDevnetTimeTravelProducer(boolean freshStart) {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -91,6 +92,42 @@ class SlotLeaderTimeTravelBlockProducerTest {
             releaseStakeRead.countDown();
             producer.stop();
         }
+    }
+
+    @Test
+    void forgeFirstBlockNowScansForTheFirstEligibleSlotWithoutWaitingForATick() {
+        List<Long> checkedSlots = new ArrayList<>();
+        SlotLeaderCheck countingNeverLeader = new SlotLeaderCheck(new byte[64], BigDecimal.ONE, null) {
+            @Override
+            public BlockSigner.VrfSignResult checkAndProve(long slot, byte[] epochNonce, BigDecimal sigma) {
+                checkedSlots.add(slot);
+                return null;
+            }
+        };
+        StakeDataProvider fullStake = new StakeDataProvider() {
+            @Override
+            public BigInteger getPoolStake(String poolHash, int epoch) {
+                return BigInteger.ONE;
+            }
+
+            @Override
+            public BigInteger getTotalStake(int epoch) {
+                return BigInteger.ONE;
+            }
+        };
+        EpochNonceState nonceState = new EpochNonceState(10_000, 1, 1.0);
+        nonceState.initFromGenesisHash(new byte[32]);
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
+                new InMemoryChainState(), emptyTransactions(), () -> null, new NoopEventBus(), scheduler,
+                null, nonceState, countingNeverLeader, fullStake,
+                "pool", System.currentTimeMillis() - 3_600_000, 1000, 60_000, 50);
+
+        int forged = producer.forgeFirstBlockNow();
+
+        // no eligible slot in the 50-slot scan window: nothing forged, but the scan happened at once
+        assertThat(forged).isEqualTo(0);
+        assertThat(checkedSlots).containsExactly(java.util.stream.LongStream.rangeClosed(0, 49).boxed().toArray(Long[]::new));
+        assertThat(producer.getLastCheckedSlot()).isEqualTo(49);
     }
 
     private static BlockTransactionSelector emptyTransactions() {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftServiceTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftServiceTest.java
@@ -63,6 +63,23 @@ class DevnetGenesisShiftServiceTest {
     }
 
     @Test
+    void freshSlotLeaderTimeTravelShiftForgesBeforeStoringGenesisUtxos() {
+        FakeActions actions = new FakeActions(genesisConfig(shelleyGenesis(5, 1.0)), true);
+
+        service(
+                true,
+                new ProducerStartupPlan(ProducerMode.SLOT_LEADER_TIME_TRAVEL, true),
+                false,
+                50_000,
+                actions)
+                .shiftGenesisAndStartProducer(3);
+
+        assertTrue(actions.slotLeaderTimeTravelStarted);
+        assertTrue(actions.genesisUtxosStoredForFreshStart);
+        assertEquals("start-slot-leader,store-utxos", actions.startupOrder.toString());
+    }
+
+    @Test
     void preservesValidationOrderAndMessages() {
         FakeActions actions = new FakeActions(genesisConfig(shelleyGenesis(10, 1.0)), true);
 


### PR DESCRIPTION
A fresh past-time-travel shift in slot-leader mode stored the genesis UTXOs before any block existed. Since the pointer index marker started requiring a canonical block hash, that store failed with "Canonical block hash is required" and the shift returned HTTP 500, so a companion bootstrap at activeSlotsCoeff below 1 could not start at all.

- start the slot-leader time-travel producer first and have it forge the first eligible block synchronously (forgeFirstBlockNow), then store the genesis UTXOs against that block, the same order the dense path uses
- fail the shift loudly when no eligible slot is found in the scan window