### PR TITLE
devnet: integrate and validate sparse backfill

### DIFF
--- a/.agents/skills/test-sparse-backfill/SKILL.md
+++ b/.agents/skills/test-sparse-backfill/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: test-sparse-backfill
+description: Regression test - Validate fast devnet backfill across yano.block-producer.backfill-block-interval-slots values (dense, explicit, automatic, 1000 ms slots, rejections) and prove a downstream Haskell cardano-node syncs the resulting history from genesis and keeps following live blocks
+---
+
+# Test: Sparse Devnet Backfill + Haskell Sync
+
+End-to-end regression for `yano.block-producer.backfill-block-interval-slots`: start a
+regular devnet producer (NOT slot-leader) with genesis shifted three epochs into the
+past, catch up to wall-clock, verify the backfilled history block by block, then prove a
+Haskell `cardano-node` accepts that history from genesis and follows subsequent live
+blocks.
+
+## Run it
+
+```bash
+./scripts/sparse-backfill/run-sparse-backfill-test.sh                 # devkit matrix (default)
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --cases auto    # one interval
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --no-haskell    # Yano-side only, fast
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --slot-leader   # + optional slot-leader scenario
+```
+
+Default cases: `dense,interval2,auto,auto-1s,reject`. The runner prints a combined
+report and exits non-zero if any case is FAIL or BLOCKED.
+
+| case | `backfill-block-interval-slots` | genesis `slotLength` | what it proves |
+|---|---|---|---|
+| `dense` | 1 | 0.3 s | original dense behaviour, one block per slot — the speed baseline |
+| `interval2` | 2 | 0.3 s | explicit two-slot spacing |
+| `auto` | 0 | 0.3 s | automatic sparse spacing (+ graceful restart and continued live production) |
+| `auto-1s` | 0 | 1.0 s | spacing is slot-based; the wall-clock conversion respects slot duration |
+| `reject` | −1 and `3k/f` | 0.3 s | negative interval and forecast-window-limit interval are rejected with a useful error |
+| `slot-leader` (opt-in) | 0, `f<1` | 0.3 s | Praos-eligible sparse backfill; see the caveat below |
+
+## Scenario
+
+Each case copies `app/config/network/devnet/pv10/` into its own directory and patches the
+Shelley genesis to `epochLength=1200`, `securityParam=100`, `activeSlotsCoeff=1`,
+`slotLength=0.3` (`1.0` for `auto-1s`). Three epochs are therefore
+`3 × 1200 × 0.3 s = 1,080,000 ms` (`3,600,000 ms` at 1 s slots), and the wall-clock target
+lands just past slot 3600. Slot and live block timers both resolve to 300 ms
+(1000 ms for `auto-1s`) straight from the genesis — nothing is set explicitly.
+
+`pv10/` is used because cardano-node 11.0.x enforces strict cost-model lengths (alonzo
+166 PlutusV1 entries, conway 251 PlutusV3); the PV11 folder at
+`app/config/network/devnet/` is rejected. See `test-past-time-travel` for the background.
+
+With `k=100` and `f=1` the forecast window is `floor(3k/f) = 300` slots and automatic
+empty-block spacing is `299` slots. Starting exactly at slot 0 and targeting exactly slot
+3600 yields **15 backfill blocks plus genesis** — that vector is asserted in the helper's
+self-test, never against a live API call (see below).
+
+## No hardcoded block counts on live calls
+
+A live `/epochs/catch-up` never starts at slot 0: the past-time-travel scheduler forges
+sequential blocks (slot *i* = block *i*) while the test issues its HTTP calls, and the
+target is `(now − genesisTimestamp) / slotLength` at the moment of the call. The runner
+therefore records the real values after the fact and derives the expectation, from three
+sources that must agree:
+
+1. runtime log — `Catching up to wall-clock: N slots (current=S0, target=T)`
+2. runtime log — `Sparse backfill: one block every I slots from slot S0+1 to T`
+   (absent when the resolved interval is 1)
+3. arithmetic — `S0 = new_block_number − blocks_produced` from the catch-up response,
+   cross-checked against the slot of block `S0`
+
+`tools/backfill_expect.py` then reproduces `DevnetBlockProducer.nextBackfillSlot` for
+`(S0, T, resolved interval, epochLength)` — including the epoch-boundary pull-back and the
+final target block — and the produced slots must match it exactly. Nothing polls
+`/node/tip` before the call and treats that as the starting point, so scheduler races
+cannot corrupt the measurement. The pre-call tip is still captured, as observation only.
+
+## What each backfill case asserts
+
+Yano side (`tools/verify_chain.py`):
+- resolved `slotLength` / block interval match the genesis derivation
+- `/epochs/shift` returns `genesis_slot=0` and `shift_millis` equal to
+  `epochs × epochLength × slotLength × 1000`
+- resolved interval equals `BackfillPolicy.resolveInterval(requested, k, f)`
+- `blocks_produced` equals the derived expectation; every backfilled slot matches
+- past-time-travel prefix is dense (block *i* at slot *i*) up to the recorded initial tip
+- no gap exceeds the resolved interval, and the widest gap stays inside the forecast window
+- every epoch start in range carries a block, one `Epoch transition detected` line per
+  crossed boundary, no skipped-epoch batch processing, `epoch == slot / epochLength`
+- hash continuity (`previous_block` → prior `hash`) across consecutive blocks
+- the final block sits exactly on the recorded target
+- **speed**: `elapsed < blocks_produced × block_time_ms` — the only timing assertion. It
+  proves the backfill neither waited for the live block timer nor scanned intervening
+  slots. Ratios (including vs. the dense baseline) are reported, never asserted.
+- no validation / nonce / forecast / epoch-transition errors in the Yano log
+
+Haskell side (`tools/haskell_check.py`), against a **fresh database** and the **same
+genesis bytes** (sha256 compared, not assumed):
+- adopted tips parsed from `Chain extended, new tip: <hash> at slot <n>`; zero parsed
+  lines is a FAIL, not a silent pass
+- genesis (slot 0) is adopted, and every crossed epoch start plus the backfilled target
+  is **covered**: either logged directly (then hash-compared), or below the highest
+  adopted slot. The ChainDB tracer does not log a tip line for every block during bulk
+  sync — in the dense case only genesis, the epoch starts and the live blocks appear —
+  so the fallback matters. It is sound because the node starts from an empty database and
+  its tip hash matches Yano at the same block number; a Cardano chain is a hash chain, so
+  an identical tip means an identical prefix. `verify.json` records which slots were
+  verified directly and which by prefix implication.
+- every required slot that was logged, plus a spread of up to 20 other adopted tips,
+  resolves in Yano at exactly that slot (`GET /api/v1/blocks/<hash>`)
+- `cardano-cli query tip` block/slot/hash equal Yano's block at the same number, sampled
+  at the backfilled tip and again during live follow. `syncProgress` is recorded but is
+  never the evidence.
+- no rejection/validation/forecast errors in the node log
+
+`auto` additionally stops Yano with SIGTERM (60 s grace), restarts it, and requires
+`Block producer resuming from existing tip` in the **new** log, an advancing tip, and the
+still-running Haskell peer following past the pre-restart slot.
+
+Every Yano shutdown — the restart stop and the end-of-case stop — is also checked for a
+JVM crash signature (`shutdown-clean`, `final-shutdown-clean`). A SIGSEGV exits inside the
+SIGTERM grace period and would otherwise be recorded as a normal stop; see discrepancy 7.
+
+## Rejection cases (`--cases reject`)
+
+| sub-case | config | where it fails |
+|---|---|---|
+| `negative` | `-1`, past-time-travel | startup — `YanoConfig.validate`: *Backfill block interval must be non-negative (0 = automatic)* |
+| `limit-live` | `300` (= `3k/f`), regular devnet | startup — `DevnetProducerFactory` resolves the interval while creating the live producer |
+| `limit-ptt` | `300`, past-time-travel | `POST /api/v1/devnet/epochs/shift` — *Backfill interval must be below forecast window of 300 slots* |
+
+For the startup cases the runner asserts the exact message appears with
+`YANO_STARTUP_FAILURE code=RUNTIME_INITIALIZATION_FAILED`, and that no block producer ever
+starts. It does **not** assert process exit — see discrepancies 7 and 8. For the shift case it
+asserts a 4xx/5xx response whose body names the forecast window and the limit.
+
+## Code vs. the expectations this skill was written against
+
+Verified against the implementation (`runtime/.../blockproducer/BackfillPolicy.java`,
+`DevnetBlockProducer.java`, `producer/DevnetProducerFactory.java`,
+`producer/ProducerStartupCoordinator.java`, `devnet/DevnetCatchUpService.java`,
+`devnet/DevnetGenesisShiftService.java`, `core-api/.../YanoConfig.java`). Everything in the
+matrix matches; these details differ from a naive reading and are handled by the runner:
+
+1. **Genesis is authoritative for slot duration.** Epoch shift and producer timing
+   use Shelley genesis `slotLength`. The legacy
+   `yano.block-producer.slot-length-millis` property is accepted for compatibility,
+   but conflicting values are ignored with a warning. Exercise this with
+   `--cases dense,interval2,auto,auto-1s --legacy-slot-length-millis 777`;
+   the existing duration and shift checks must still pass at 300 ms and 1000 ms.
+2. **An out-of-range explicit interval is not rejected at startup in past-time-travel
+   mode.** The producer is constructed during `/epochs/shift`, so the failure surfaces on
+   that call — and `DevnetGenesisShiftService` marks the runtime degraded, so the node
+   needs a restart afterwards. Without past-time-travel the same value fails at boot.
+   Worth tightening: validate the interval against genesis `k`/`f` at startup.
+3. **`past-time-travel-mode` is a first-boot mode.** `ProducerStartupPlan.from` defers
+   production whenever the flag is set, regardless of existing chain state, and a second
+   `/epochs/shift` would re-shift genesis. The restart check therefore restarts in regular
+   devnet mode against the same chainstate and the already-shifted `systemStart`.
+4. **The runtime rewrites `systemStart` into whatever `shelley-genesis.json` it is given**
+   (`resolveAndPersistGenesisTimestamp`, `persistShiftedSystemStart`). Never point a test
+   at the tracked fixtures — this previously dirtied `app/config/network/devnet/pv10/` and
+   broke the testkit suite (`app/docs/sparse-backfill-validation.md`). The runner copies
+   first and re-checks `git status --porcelain app/config` at the end.
+5. **`0` never reaches the producer.** `DevnetBlockProducer.setBackfillBlockIntervalSlots`
+   rejects values below 1; `BackfillPolicy.resolveInterval` turns the configured `0` into
+   the automatic spacing first. Layering, not a defect — but it means unit tests of the
+   producer and of the policy must both be read to know the effective value.
+6. **`cardano-cli` cannot use a long socket path.** AF_UNIX caps paths at 104 bytes; an
+   absolute run-directory path fails with `pokeSockAddr: path is too long`. The runner runs
+   both node and CLI with a relative `db/node.socket`.
+7. **Open defect — an invalid interval can crash the JVM.** On the `limit-live` path
+   (interval `3k/f`, regular devnet, so the failure happens *after* the chain store is
+   open) the process intermittently dies with
+   `SIGSEGV … librocksdbjni…jnilib Java_org_rocksdb_RocksDB_iterator`. The crashing thread
+   is the projection drain loop, which keeps running after the failed startup and calls
+   `RocksDB.newIterator` on an already-closed handle:
+
+   ```text
+   ProjectionHistoryService.drainLoop
+     -> ProjectionHistoryService.drainEpochArtifactGaps
+     -> ProjectionOutboxStore.acknowledgeRepairsAlreadyComplete
+     -> ProjectionOutboxStore.epochArtifactGaps
+     -> org.rocksdb.RocksDB.newIterator   <-- SIGSEGV, handle closed
+   ```
+
+   Reproduced in every run where the check ran after shutdown — 4 of 4 (`0.1.0-pre14`,
+   JVM 25.0.2, macOS arm64); one earlier run checked too early to tell. `hs_err_pid*.log`
+   is preserved in the sub-case directory. A healthy node's SIGTERM does **not** crash:
+   the `shutdown-clean` / `final-shutdown-clean` stages of the backfill cases pass. The rejection message and "no block production"
+   assertions still pass — the crash is a separate teardown defect, and it is not
+   backfill-specific (any startup failure after the store opens can hit it). Because of it
+   **the `reject` case currently reports FAIL** on `limit-live-clean-failure`; that is
+   intentional — a crash must not be reported as PASS. Related: the "async drain on the
+   failed-startup path" finding from the ADR-055 review.
+
+8. **An invalid interval does not stop the process.** With `-1` the node logs
+   `YANO_STARTUP_FAILURE code=RUNTIME_INITIALIZATION_FAILED` and
+   *Backfill block interval must be non-negative (0 = automatic), got: -1*, then keeps
+   running: a `plugin-metrics-cache` thread retries `ensureYano()` about once a second and
+   re-logs `Creating Yano with network: devnet` forever. The node never produces blocks, so
+   the rejection itself is correct and useful, but a misconfigured process lingers instead
+   of exiting. This is generic Yano startup behaviour, not backfill-specific; the runner
+   records it as a NOTE (never a silent pass) and stops the process itself.
+
+## Optional slot-leader scenario (`--slot-leader`)
+
+Past-time-travel **slot-leader** backfill (`past-time-travel-slot-leader-mode=true`) with
+`f < 1`: the catch-up forges only slots the pool is eligible for, so the tip may legitimately
+sit behind the processed target and spacing is a lower bound, not an equality. The runner
+checks the `Slot-leader backfill complete: blocks=…, checks=…, processedSlot=…` line
+(blocks and leadership checks both > 0), that no gap exceeds the forecast window, and that a
+Haskell node accepts the history. Automatic slot-leader spacing is `floor(3k/f)/2` — half
+the window, leaving search headroom — not `window − 1`.
+
+Genesis for this case uses `k=50`, `f=0.5` so that both `3k/f` and `10k/f` stay within
+`epochLength=1200`; cardano-node validates the Shelley genesis against those bounds and
+refuses it otherwise. Verify the bound from the Haskell startup log if you change `k`/`f`.
+
+**Known blocker:** a fresh slot-leader devnet fails at `/epochs/shift`, before any backfill,
+with `Canonical block hash is required` — `DevnetGenesisShiftService` calls
+`storeGenesisUtxosIfNeeded` before `startSlotLeaderTimeTravel`, which does not synchronously
+create a genesis block. The runner detects this and records the case **BLOCKED**. Never
+disable UTXOs to make it pass, and never report it as PASS.
+
+## Isolation and cleanup
+
+- Per case: its own genesis copy, chainstate, history archive, app-chain store, Haskell
+  database + socket + config + topology, logs, and probed ports (never 7070 / 13337 /
+  3002 / 32000 / 12788 / 12798).
+- Only PIDs this run started are ever signalled — recorded in `<run-dir>/started-pids`, no
+  `pkill`, no port-based killing. Existing developer nodes and databases are untouched.
+- The shared `test-data-dir/haskell-node/` supplies only the **binary**;
+  `setup-haskell-test-node.sh` runs only when that binary is missing.
+- Everything is preserved under `test-data-dir/sparse-backfill/<timestamp>/` (gitignored):
+  effective genesis + sha256s, `node-config.json`, the exact `java` command, all logs,
+  `verify.json`, `haskell-*.json`, `stages.tsv`, and `report.md`.
+- Three statuses: **PASS**, **FAIL**, **BLOCKED**. A blocked or skipped scenario is never
+  reported as PASS.
+- The runner makes no commits and never modifies tracked fixtures.
+
+## Last validated
+
+Full default matrix, 2026-09-10, macOS arm64, Yano `0.1.0-pre14` uber-jar (JVM 25.0.2),
+cardano-node 11.0.1 (`macos-amd64`), `epochLength=1200`, `k=100`, `f=1`, 3-epoch shift:
+
+| case | interval → resolved | slot ms | initial → target slot | blocks | backfill | Haskell sync | result |
+|---|---|---|---|---|---|---|---|
+| dense | 1 → 1 | 300 | 10 → 3613 | 3603 | 3510 ms | 7468 ms | PASS |
+| interval2 | 2 → 2 | 300 | 9 → 3613 | 1803 | 2128 ms | 7463 ms | PASS |
+| auto | 0 → 299 | 300 | 9 → 3611 | 15 | 564 ms | 5379 ms | PASS |
+| auto-1s | 0 → 299 | 1000 | 3 → 3603 | 16 | 520 ms | 5379 ms | PASS |
+| reject | −1 / 300 | 300 | — | — | — | — | FAIL — see #7 |
+
+Notes from that run:
+- The automatic spacing stayed 299 **slots** at both 300 ms and 1000 ms slots, while the
+  epoch shift correctly scaled with slot duration (1,080,000 ms vs 3,600,000 ms) — that is
+  the slot-based-vs-wall-clock check.
+- `auto-1s` produced slots
+  `302, 601, 900, 1199, 1200, 1499, 1798, 2097, 2396, 2400, 2699, 2998, 3297, 3596, 3600, 3603`
+  — 299-slot spacing, an extra block at each epoch start, and the target.
+- Every case placed its final block exactly on the recorded target, and the Haskell node's
+  tip matched Yano by slot, block number and hash in every sample.
+- Backfill never waited for the block timer: `auto` covered ~1,080,600 ms of wall-clock
+  time in 564 ms (~1900x); dense covered the same span in 3510 ms. Sparse is ~6x faster
+  than the dense baseline here, and the gap widens with the shifted span.
+- `reject`: both messages verified (`Backfill block interval must be non-negative
+  (0 = automatic), got: -1`, and HTTP 400
+  `Backfill interval must be below forecast window of 300 slots`), no block production in
+  either — but `limit-live` hit the JVM crash in #7.
+- The optional `--slot-leader` scenario (`k=50`, `f=0.5`) reproduced the known bootstrap
+  blocker and was reported **BLOCKED**, not PASS: `POST /epochs/shift` returned
+  `{"error":"Epoch shift failed: Failed to store Shelley genesis UTXOs"}` with
+  `IllegalArgumentException: Canonical block hash is required` in the node log — the
+  failure happens before any slot-leader backfill runs, so eligible-block/search-count
+  coverage for `f < 1` remains unvalidated end to end.
+
+## Pass criteria
+
+- Every case in the requested matrix is PASS. Today the `reject` case fails on
+  `limit-live-clean-failure` (#7) — fix or track that defect rather than relaxing the check.
+- `backfill_expect.py --self-test` passes (it runs first; a failure means the runtime
+  algorithm changed and the mirror must be updated before any result is trusted).
+- `git status --porcelain app/config` is unchanged by the run.
+
+## Manual reproduction (one case, without the runner)
+
+```bash
+CASE=/tmp/sb-manual; rm -rf $CASE; mkdir -p $CASE
+python3 scripts/sparse-backfill/tools/prepare_genesis.py \
+  --source app/config/network/devnet/pv10 --dest $CASE/genesis \
+  --slot-length 0.3 --epoch-length 1200 --security-param 100 --active-slots-coeff 1.0
+cd $CASE && java -Dquarkus.profile=devnet -Dquarkus.http.port=21000 \
+  -Dyano.server.port=21001 -Dyano.storage.path=$CASE/chainstate -Dyano.history.dir=$CASE/history \
+  -Dyano.genesis.shelley-genesis-file=$CASE/genesis/shelley-genesis.json \
+  -Dyano.genesis.byron-genesis-file=$CASE/genesis/byron-genesis.json \
+  -Dyano.genesis.alonzo-genesis-file=$CASE/genesis/alonzo-genesis.json \
+  -Dyano.genesis.conway-genesis-file=$CASE/genesis/conway-genesis.json \
+  -Dyano.genesis.protocol-parameters-file=$CASE/genesis/protocol-param.json \
+  -Dyano.block-producer.vrf-skey-file=$CASE/genesis/vrf.skey \
+  -Dyano.block-producer.kes-skey-file=$CASE/genesis/kes.skey \
+  -Dyano.block-producer.opcert-file=$CASE/genesis/opcert.cert \
+  -Dyano.block-producer.past-time-travel-mode=true \
+  -Dyano.block-producer.backfill-block-interval-slots=0 \
+  -jar <repo>/app/build/yano.jar > $CASE/yano.log 2>&1 &
+curl -s -X POST localhost:21000/api/v1/devnet/epochs/shift -H 'Content-Type: application/json' -d '{"epochs":3}'
+curl -s -X POST localhost:21000/api/v1/devnet/epochs/catch-up
+grep -E "Sparse backfill|Catching up to wall-clock|Epoch transition detected" $CASE/yano.log
+```
+
+Copy `$CASE/genesis/*.json` into a fresh Haskell instance **after** the shift (that is when
+`systemStart` is rewritten), point its topology at port 21001, and start it with an empty
+`db/`.
+
+## Files
+
+- `scripts/sparse-backfill/run-sparse-backfill-test.sh` — driver and case definitions
+- `scripts/sparse-backfill/lib/{common,yano,haskell}.sh` — process/port/isolation helpers
+- `scripts/sparse-backfill/tools/backfill_expect.py` — mirror of `BackfillPolicy` +
+  `nextBackfillSlot`, with the Java test vectors as a self-test
+- `scripts/sparse-backfill/tools/prepare_genesis.py` — isolated genesis copy + patch
+- `scripts/sparse-backfill/tools/verify_chain.py` — Yano-side verification
+- `scripts/sparse-backfill/tools/haskell_check.py` — Haskell-side verification
+- `scripts/sparse-backfill/tools/render_report.py` — combined report
+
+Related: `test-past-time-travel` (dense past-time-travel + Haskell sync),
+`app/docs/devnet-modes.md`, `app/docs/sparse-backfill-validation.md`.

--- a/.claude/skills/test-sparse-backfill/SKILL.md
+++ b/.claude/skills/test-sparse-backfill/SKILL.md
@@ -1,0 +1,322 @@
+---
+name: test-sparse-backfill
+description: Regression test - Validate fast devnet backfill across yano.block-producer.backfill-block-interval-slots values (dense, explicit, automatic, 1000 ms slots, rejections) and prove a downstream Haskell cardano-node syncs the resulting history from genesis and keeps following live blocks
+---
+
+# Test: Sparse Devnet Backfill + Haskell Sync
+
+End-to-end regression for `yano.block-producer.backfill-block-interval-slots`: start a
+regular devnet producer (NOT slot-leader) with genesis shifted three epochs into the
+past, catch up to wall-clock, verify the backfilled history block by block, then prove a
+Haskell `cardano-node` accepts that history from genesis and follows subsequent live
+blocks.
+
+## Run it
+
+```bash
+./scripts/sparse-backfill/run-sparse-backfill-test.sh                 # devkit matrix (default)
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --cases auto    # one interval
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --no-haskell    # Yano-side only, fast
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --slot-leader   # + optional slot-leader scenario
+```
+
+Default cases: `dense,interval2,auto,auto-1s,reject`. The runner prints a combined
+report and exits non-zero if any case is FAIL or BLOCKED.
+
+| case | `backfill-block-interval-slots` | genesis `slotLength` | what it proves |
+|---|---|---|---|
+| `dense` | 1 | 0.3 s | original dense behaviour, one block per slot — the speed baseline |
+| `interval2` | 2 | 0.3 s | explicit two-slot spacing |
+| `auto` | 0 | 0.3 s | automatic sparse spacing (+ graceful restart and continued live production) |
+| `auto-1s` | 0 | 1.0 s | spacing is slot-based; the wall-clock conversion respects slot duration |
+| `reject` | −1 and `3k/f` | 0.3 s | negative interval and forecast-window-limit interval are rejected with a useful error |
+| `slot-leader` (opt-in) | 0, `f<1` | 0.3 s | Praos-eligible sparse backfill; see the caveat below |
+
+## Scenario
+
+Each case copies `app/config/network/devnet/pv10/` into its own directory and patches the
+Shelley genesis to `epochLength=1200`, `securityParam=100`, `activeSlotsCoeff=1`,
+`slotLength=0.3` (`1.0` for `auto-1s`). Three epochs are therefore
+`3 × 1200 × 0.3 s = 1,080,000 ms` (`3,600,000 ms` at 1 s slots), and the wall-clock target
+lands just past slot 3600. Slot and live block timers both resolve to 300 ms
+(1000 ms for `auto-1s`) straight from the genesis — nothing is set explicitly.
+
+`pv10/` is used because cardano-node 11.0.x enforces strict cost-model lengths (alonzo
+166 PlutusV1 entries, conway 251 PlutusV3); the PV11 folder at
+`app/config/network/devnet/` is rejected. See `test-past-time-travel` for the background.
+
+With `k=100` and `f=1` the forecast window is `floor(3k/f) = 300` slots and automatic
+empty-block spacing is `299` slots. Starting exactly at slot 0 and targeting exactly slot
+3600 yields **15 backfill blocks plus genesis** — that vector is asserted in the helper's
+self-test, never against a live API call (see below).
+
+## No hardcoded block counts on live calls
+
+A live `/epochs/catch-up` never starts at slot 0: the past-time-travel scheduler forges
+sequential blocks (slot *i* = block *i*) while the test issues its HTTP calls, and the
+target is `(now − genesisTimestamp) / slotLength` at the moment of the call. The runner
+therefore records the real values after the fact and derives the expectation, from three
+sources that must agree:
+
+1. runtime log — `Catching up to wall-clock: N slots (current=S0, target=T)`
+2. runtime log — `Sparse backfill: one block every I slots from slot S0+1 to T`
+   (absent when the resolved interval is 1)
+3. arithmetic — `S0 = new_block_number − blocks_produced` from the catch-up response,
+   cross-checked against the slot of block `S0`
+
+`tools/backfill_expect.py` then reproduces `DevnetBlockProducer.nextBackfillSlot` for
+`(S0, T, resolved interval, epochLength)` — including the epoch-boundary pull-back and the
+final target block — and the produced slots must match it exactly. Nothing polls
+`/node/tip` before the call and treats that as the starting point, so scheduler races
+cannot corrupt the measurement. The pre-call tip is still captured, as observation only.
+
+## What each backfill case asserts
+
+Yano side (`tools/verify_chain.py`):
+- resolved `slotLength` / block interval match the genesis derivation
+- `/epochs/shift` returns `genesis_slot=0` and `shift_millis` equal to
+  `epochs × epochLength × slotLength × 1000`
+- resolved interval equals `BackfillPolicy.resolveInterval(requested, k, f)`
+- `blocks_produced` equals the derived expectation; every backfilled slot matches
+- past-time-travel prefix is dense (block *i* at slot *i*) up to the recorded initial tip
+- no gap exceeds the resolved interval, and the widest gap stays inside the forecast window
+- every epoch start in range carries a block, one `Epoch transition detected` line per
+  crossed boundary, no skipped-epoch batch processing, `epoch == slot / epochLength`
+- hash continuity (`previous_block` → prior `hash`) across consecutive blocks
+- the final block sits exactly on the recorded target
+- **speed**: `elapsed < blocks_produced × block_time_ms` — the only timing assertion. It
+  proves the backfill neither waited for the live block timer nor scanned intervening
+  slots. Ratios (including vs. the dense baseline) are reported, never asserted.
+- no validation / nonce / forecast / epoch-transition errors in the Yano log
+
+Haskell side (`tools/haskell_check.py`), against a **fresh database** and the **same
+genesis bytes** (sha256 compared, not assumed):
+- adopted tips parsed from `Chain extended, new tip: <hash> at slot <n>`; zero parsed
+  lines is a FAIL, not a silent pass
+- genesis (slot 0) is adopted, and every crossed epoch start plus the backfilled target
+  is **covered**: either logged directly (then hash-compared), or below the highest
+  adopted slot. The ChainDB tracer does not log a tip line for every block during bulk
+  sync — in the dense case only genesis, the epoch starts and the live blocks appear —
+  so the fallback matters. It is sound because the node starts from an empty database and
+  its tip hash matches Yano at the same block number; a Cardano chain is a hash chain, so
+  an identical tip means an identical prefix. `verify.json` records which slots were
+  verified directly and which by prefix implication.
+- every required slot that was logged, plus a spread of up to 20 other adopted tips,
+  resolves in Yano at exactly that slot (`GET /api/v1/blocks/<hash>`)
+- `cardano-cli query tip` block/slot/hash equal Yano's block at the same number, sampled
+  at the backfilled tip and again during live follow. `syncProgress` is recorded but is
+  never the evidence.
+- no rejection/validation/forecast errors in the node log
+
+`auto` additionally stops Yano with SIGTERM (60 s grace), restarts it, and requires
+`Block producer resuming from existing tip` in the **new** log, an advancing tip, and the
+still-running Haskell peer following past the pre-restart slot.
+
+Every Yano shutdown — the restart stop and the end-of-case stop — is also checked for a
+JVM crash signature (`shutdown-clean`, `final-shutdown-clean`). A SIGSEGV exits inside the
+SIGTERM grace period and would otherwise be recorded as a normal stop; see discrepancy 7.
+
+## Rejection cases (`--cases reject`)
+
+| sub-case | config | where it fails |
+|---|---|---|
+| `negative` | `-1`, past-time-travel | startup — `YanoConfig.validate`: *Backfill block interval must be non-negative (0 = automatic)* |
+| `limit-live` | `300` (= `3k/f`), regular devnet | startup — `DevnetProducerFactory` resolves the interval while creating the live producer |
+| `limit-ptt` | `300`, past-time-travel | `POST /api/v1/devnet/epochs/shift` — *Backfill interval must be below forecast window of 300 slots* |
+
+For the startup cases the runner asserts the exact message appears with
+`YANO_STARTUP_FAILURE code=RUNTIME_INITIALIZATION_FAILED`, and that no block producer ever
+starts. It does **not** assert process exit — see discrepancies 7 and 8. For the shift case it
+asserts a 4xx/5xx response whose body names the forecast window and the limit.
+
+## Code vs. the expectations this skill was written against
+
+Verified against the implementation (`runtime/.../blockproducer/BackfillPolicy.java`,
+`DevnetBlockProducer.java`, `producer/DevnetProducerFactory.java`,
+`producer/ProducerStartupCoordinator.java`, `devnet/DevnetCatchUpService.java`,
+`devnet/DevnetGenesisShiftService.java`, `core-api/.../YanoConfig.java`). Everything in the
+matrix matches; these details differ from a naive reading and are handled by the runner:
+
+1. **Genesis is authoritative for slot duration.** Epoch shift and producer timing
+   use Shelley genesis `slotLength`. The legacy
+   `yano.block-producer.slot-length-millis` property is accepted for compatibility,
+   but conflicting values are ignored with a warning. Exercise this with
+   `--cases dense,interval2,auto,auto-1s --legacy-slot-length-millis 777`;
+   the existing duration and shift checks must still pass at 300 ms and 1000 ms.
+2. **An out-of-range explicit interval is not rejected at startup in past-time-travel
+   mode.** The producer is constructed during `/epochs/shift`, so the failure surfaces on
+   that call — and `DevnetGenesisShiftService` marks the runtime degraded, so the node
+   needs a restart afterwards. Without past-time-travel the same value fails at boot.
+   Worth tightening: validate the interval against genesis `k`/`f` at startup.
+3. **`past-time-travel-mode` is a first-boot mode.** `ProducerStartupPlan.from` defers
+   production whenever the flag is set, regardless of existing chain state, and a second
+   `/epochs/shift` would re-shift genesis. The restart check therefore restarts in regular
+   devnet mode against the same chainstate and the already-shifted `systemStart`.
+4. **The runtime rewrites `systemStart` into whatever `shelley-genesis.json` it is given**
+   (`resolveAndPersistGenesisTimestamp`, `persistShiftedSystemStart`). Never point a test
+   at the tracked fixtures — this previously dirtied `app/config/network/devnet/pv10/` and
+   broke the testkit suite (`app/docs/sparse-backfill-validation.md`). The runner copies
+   first and re-checks `git status --porcelain app/config` at the end.
+5. **`0` never reaches the producer.** `DevnetBlockProducer.setBackfillBlockIntervalSlots`
+   rejects values below 1; `BackfillPolicy.resolveInterval` turns the configured `0` into
+   the automatic spacing first. Layering, not a defect — but it means unit tests of the
+   producer and of the policy must both be read to know the effective value.
+6. **`cardano-cli` cannot use a long socket path.** AF_UNIX caps paths at 104 bytes; an
+   absolute run-directory path fails with `pokeSockAddr: path is too long`. The runner runs
+   both node and CLI with a relative `db/node.socket`.
+7. **Open defect — an invalid interval can crash the JVM.** On the `limit-live` path
+   (interval `3k/f`, regular devnet, so the failure happens *after* the chain store is
+   open) the process intermittently dies with
+   `SIGSEGV … librocksdbjni…jnilib Java_org_rocksdb_RocksDB_iterator`. The crashing thread
+   is the projection drain loop, which keeps running after the failed startup and calls
+   `RocksDB.newIterator` on an already-closed handle:
+
+   ```text
+   ProjectionHistoryService.drainLoop
+     -> ProjectionHistoryService.drainEpochArtifactGaps
+     -> ProjectionOutboxStore.acknowledgeRepairsAlreadyComplete
+     -> ProjectionOutboxStore.epochArtifactGaps
+     -> org.rocksdb.RocksDB.newIterator   <-- SIGSEGV, handle closed
+   ```
+
+   Reproduced in every run where the check ran after shutdown — 4 of 4 (`0.1.0-pre14`,
+   JVM 25.0.2, macOS arm64); one earlier run checked too early to tell. `hs_err_pid*.log`
+   is preserved in the sub-case directory. A healthy node's SIGTERM does **not** crash:
+   the `shutdown-clean` / `final-shutdown-clean` stages of the backfill cases pass. The rejection message and "no block production"
+   assertions still pass — the crash is a separate teardown defect, and it is not
+   backfill-specific (any startup failure after the store opens can hit it). Because of it
+   **the `reject` case currently reports FAIL** on `limit-live-clean-failure`; that is
+   intentional — a crash must not be reported as PASS. Related: the "async drain on the
+   failed-startup path" finding from the ADR-055 review.
+
+8. **An invalid interval does not stop the process.** With `-1` the node logs
+   `YANO_STARTUP_FAILURE code=RUNTIME_INITIALIZATION_FAILED` and
+   *Backfill block interval must be non-negative (0 = automatic), got: -1*, then keeps
+   running: a `plugin-metrics-cache` thread retries `ensureYano()` about once a second and
+   re-logs `Creating Yano with network: devnet` forever. The node never produces blocks, so
+   the rejection itself is correct and useful, but a misconfigured process lingers instead
+   of exiting. This is generic Yano startup behaviour, not backfill-specific; the runner
+   records it as a NOTE (never a silent pass) and stops the process itself.
+
+## Optional slot-leader scenario (`--slot-leader`)
+
+Past-time-travel **slot-leader** backfill (`past-time-travel-slot-leader-mode=true`) with
+`f < 1`: the catch-up forges only slots the pool is eligible for, so the tip may legitimately
+sit behind the processed target and spacing is a lower bound, not an equality. The runner
+checks the `Slot-leader backfill complete: blocks=…, checks=…, processedSlot=…` line
+(blocks and leadership checks both > 0), that no gap exceeds the forecast window, and that a
+Haskell node accepts the history. Automatic slot-leader spacing is `floor(3k/f)/2` — half
+the window, leaving search headroom — not `window − 1`.
+
+Genesis for this case uses `k=50`, `f=0.5` so that both `3k/f` and `10k/f` stay within
+`epochLength=1200`; cardano-node validates the Shelley genesis against those bounds and
+refuses it otherwise. Verify the bound from the Haskell startup log if you change `k`/`f`.
+
+**Known blocker:** a fresh slot-leader devnet fails at `/epochs/shift`, before any backfill,
+with `Canonical block hash is required` — `DevnetGenesisShiftService` calls
+`storeGenesisUtxosIfNeeded` before `startSlotLeaderTimeTravel`, which does not synchronously
+create a genesis block. The runner detects this and records the case **BLOCKED**. Never
+disable UTXOs to make it pass, and never report it as PASS.
+
+## Isolation and cleanup
+
+- Per case: its own genesis copy, chainstate, history archive, app-chain store, Haskell
+  database + socket + config + topology, logs, and probed ports (never 7070 / 13337 /
+  3002 / 32000 / 12788 / 12798).
+- Only PIDs this run started are ever signalled — recorded in `<run-dir>/started-pids`, no
+  `pkill`, no port-based killing. Existing developer nodes and databases are untouched.
+- The shared `test-data-dir/haskell-node/` supplies only the **binary**;
+  `setup-haskell-test-node.sh` runs only when that binary is missing.
+- Everything is preserved under `test-data-dir/sparse-backfill/<timestamp>/` (gitignored):
+  effective genesis + sha256s, `node-config.json`, the exact `java` command, all logs,
+  `verify.json`, `haskell-*.json`, `stages.tsv`, and `report.md`.
+- Three statuses: **PASS**, **FAIL**, **BLOCKED**. A blocked or skipped scenario is never
+  reported as PASS.
+- The runner makes no commits and never modifies tracked fixtures.
+
+## Last validated
+
+Full default matrix, 2026-09-10, macOS arm64, Yano `0.1.0-pre14` uber-jar (JVM 25.0.2),
+cardano-node 11.0.1 (`macos-amd64`), `epochLength=1200`, `k=100`, `f=1`, 3-epoch shift:
+
+| case | interval → resolved | slot ms | initial → target slot | blocks | backfill | Haskell sync | result |
+|---|---|---|---|---|---|---|---|
+| dense | 1 → 1 | 300 | 10 → 3613 | 3603 | 3510 ms | 7468 ms | PASS |
+| interval2 | 2 → 2 | 300 | 9 → 3613 | 1803 | 2128 ms | 7463 ms | PASS |
+| auto | 0 → 299 | 300 | 9 → 3611 | 15 | 564 ms | 5379 ms | PASS |
+| auto-1s | 0 → 299 | 1000 | 3 → 3603 | 16 | 520 ms | 5379 ms | PASS |
+| reject | −1 / 300 | 300 | — | — | — | — | FAIL — see #7 |
+
+Notes from that run:
+- The automatic spacing stayed 299 **slots** at both 300 ms and 1000 ms slots, while the
+  epoch shift correctly scaled with slot duration (1,080,000 ms vs 3,600,000 ms) — that is
+  the slot-based-vs-wall-clock check.
+- `auto-1s` produced slots
+  `302, 601, 900, 1199, 1200, 1499, 1798, 2097, 2396, 2400, 2699, 2998, 3297, 3596, 3600, 3603`
+  — 299-slot spacing, an extra block at each epoch start, and the target.
+- Every case placed its final block exactly on the recorded target, and the Haskell node's
+  tip matched Yano by slot, block number and hash in every sample.
+- Backfill never waited for the block timer: `auto` covered ~1,080,600 ms of wall-clock
+  time in 564 ms (~1900x); dense covered the same span in 3510 ms. Sparse is ~6x faster
+  than the dense baseline here, and the gap widens with the shifted span.
+- `reject`: both messages verified (`Backfill block interval must be non-negative
+  (0 = automatic), got: -1`, and HTTP 400
+  `Backfill interval must be below forecast window of 300 slots`), no block production in
+  either — but `limit-live` hit the JVM crash in #7.
+- The optional `--slot-leader` scenario (`k=50`, `f=0.5`) reproduced the known bootstrap
+  blocker and was reported **BLOCKED**, not PASS: `POST /epochs/shift` returned
+  `{"error":"Epoch shift failed: Failed to store Shelley genesis UTXOs"}` with
+  `IllegalArgumentException: Canonical block hash is required` in the node log — the
+  failure happens before any slot-leader backfill runs, so eligible-block/search-count
+  coverage for `f < 1` remains unvalidated end to end.
+
+## Pass criteria
+
+- Every case in the requested matrix is PASS. Today the `reject` case fails on
+  `limit-live-clean-failure` (#7) — fix or track that defect rather than relaxing the check.
+- `backfill_expect.py --self-test` passes (it runs first; a failure means the runtime
+  algorithm changed and the mirror must be updated before any result is trusted).
+- `git status --porcelain app/config` is unchanged by the run.
+
+## Manual reproduction (one case, without the runner)
+
+```bash
+CASE=/tmp/sb-manual; rm -rf $CASE; mkdir -p $CASE
+python3 scripts/sparse-backfill/tools/prepare_genesis.py \
+  --source app/config/network/devnet/pv10 --dest $CASE/genesis \
+  --slot-length 0.3 --epoch-length 1200 --security-param 100 --active-slots-coeff 1.0
+cd $CASE && java -Dquarkus.profile=devnet -Dquarkus.http.port=21000 \
+  -Dyano.server.port=21001 -Dyano.storage.path=$CASE/chainstate -Dyano.history.dir=$CASE/history \
+  -Dyano.genesis.shelley-genesis-file=$CASE/genesis/shelley-genesis.json \
+  -Dyano.genesis.byron-genesis-file=$CASE/genesis/byron-genesis.json \
+  -Dyano.genesis.alonzo-genesis-file=$CASE/genesis/alonzo-genesis.json \
+  -Dyano.genesis.conway-genesis-file=$CASE/genesis/conway-genesis.json \
+  -Dyano.genesis.protocol-parameters-file=$CASE/genesis/protocol-param.json \
+  -Dyano.block-producer.vrf-skey-file=$CASE/genesis/vrf.skey \
+  -Dyano.block-producer.kes-skey-file=$CASE/genesis/kes.skey \
+  -Dyano.block-producer.opcert-file=$CASE/genesis/opcert.cert \
+  -Dyano.block-producer.past-time-travel-mode=true \
+  -Dyano.block-producer.backfill-block-interval-slots=0 \
+  -jar <repo>/app/build/yano.jar > $CASE/yano.log 2>&1 &
+curl -s -X POST localhost:21000/api/v1/devnet/epochs/shift -H 'Content-Type: application/json' -d '{"epochs":3}'
+curl -s -X POST localhost:21000/api/v1/devnet/epochs/catch-up
+grep -E "Sparse backfill|Catching up to wall-clock|Epoch transition detected" $CASE/yano.log
+```
+
+Copy `$CASE/genesis/*.json` into a fresh Haskell instance **after** the shift (that is when
+`systemStart` is rewritten), point its topology at port 21001, and start it with an empty
+`db/`.
+
+## Files
+
+- `scripts/sparse-backfill/run-sparse-backfill-test.sh` — driver and case definitions
+- `scripts/sparse-backfill/lib/{common,yano,haskell}.sh` — process/port/isolation helpers
+- `scripts/sparse-backfill/tools/backfill_expect.py` — mirror of `BackfillPolicy` +
+  `nextBackfillSlot`, with the Java test vectors as a self-test
+- `scripts/sparse-backfill/tools/prepare_genesis.py` — isolated genesis copy + patch
+- `scripts/sparse-backfill/tools/verify_chain.py` — Yano-side verification
+- `scripts/sparse-backfill/tools/haskell_check.py` — Haskell-side verification
+- `scripts/sparse-backfill/tools/render_report.py` — combined report
+
+Related: `test-past-time-travel` (dense past-time-travel + Haskell sync),
+`app/docs/devnet-modes.md`, `app/docs/sparse-backfill-validation.md`.

--- a/app/config/application.yml
+++ b/app/config/application.yml
@@ -97,7 +97,7 @@ yano:
 #    block-time-millis: 0
 #    lazy: false
 #    genesis-timestamp: 0
-#    slot-length-millis: 0
+#    # Slot duration comes from Shelley genesis slotLength (legacy slot-length-millis is ignored).
 #    vrf-skey-file: config/network/devnet/vrf.skey
 #    kes-skey-file: config/network/devnet/kes.skey
 #    opcert-file: config/network/devnet/opcert.cert

--- a/app/config/network/devnet/pv10/shelley-genesis.json
+++ b/app/config/network/devnet/pv10/shelley-genesis.json
@@ -34,7 +34,7 @@
     "60ba957a0fff6816021b2afa7900beea68fd10f2d78fb5b64de0d2379c" : 3000000000000000,
     "604fb41f142d1f7b8e51dd9232a110cf72aec955275439b72870b9c20d" : 10000000000000
   },
-  "maxKESEvolutions" : 10000,
+  "maxKESEvolutions" : 62,
   "maxLovelaceSupply" : 45000000000000000,
   "networkId" : "Testnet",
   "networkMagic" : 42,
@@ -64,7 +64,7 @@
   },
   "securityParam" : 100,
   "slotLength" : 0.2,
-  "slotsPerKESPeriod" : 129600,
+  "slotsPerKESPeriod" : 10000000,
   "staking" : {
     "pools" : {
       "7301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc57" : {

--- a/app/config/network/devnet/shelley-genesis.json
+++ b/app/config/network/devnet/shelley-genesis.json
@@ -34,7 +34,7 @@
     "60ba957a0fff6816021b2afa7900beea68fd10f2d78fb5b64de0d2379c" : 3000000000000000,
     "604fb41f142d1f7b8e51dd9232a110cf72aec955275439b72870b9c20d" : 10000000000000
   },
-  "maxKESEvolutions" : 10000,
+  "maxKESEvolutions" : 62,
   "maxLovelaceSupply" : 45000000000000000,
   "networkId" : "Testnet",
   "networkMagic" : 42,
@@ -64,7 +64,7 @@
   },
   "securityParam" : 100,
   "slotLength" : 0.2,
-  "slotsPerKESPeriod" : 129600,
+  "slotsPerKESPeriod" : 10000000,
   "staking" : {
     "pools" : {
       "7301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc57" : {

--- a/app/docs/devnet-modes.md
+++ b/app/docs/devnet-modes.md
@@ -47,8 +47,34 @@ All config is in `application.yml` under the `%devnet` profile. Key properties:
 | `yano.block-producer.block-time-millis` | 0 (auto) | Block interval; 0 = derive from genesis |
 | `yano.block-producer.lazy` | false | If true, skip empty blocks |
 | `yano.block-producer.genesis-timestamp` | 0 (auto) | Genesis time; 0 = use current time |
-| `yano.block-producer.slot-length-millis` | 0 (auto) | Slot length; 0 = derive from genesis |
-| `yano.block-producer.backfill-block-interval-slots` | 1 | Backfills place one block every N slots instead of every slot. Empty-block backfills (catch-up, time advance, epoch fast-forward) always add the first slot of each epoch and the target slot; the slot-leader catch-up forges the first eligible slot after each interval and after each epoch start, skipping leadership checks in between. Keep N below the stability window (3k/f) so a Haskell relay can validate the chain |
+| `yano.block-producer.slot-length-millis` | 0 | Legacy compatibility property; does not override Shelley genesis `slotLength`. Conflicting values are ignored with a warning. |
+| `yano.block-producer.backfill-block-interval-slots` | 1 | `0` selects automatic sparse backfill from genesis; `1` preserves dense backfill; larger values specify slot spacing below the `floor(3k/f)` forecast window. Empty-block backfill includes epoch starts and the target. Slot-leader backfill searches for eligibility after each interval and at epoch starts. Live scheduling is unchanged. |
+
+Slot duration always comes from Shelley genesis: set `slotLength` to `0.3` for
+300 ms slots. The internal millisecond value is derived from it for live production,
+leadership checks, catch-up, and time advance. Genesis must provide a positive
+slot duration representable as whole milliseconds. `block-time-millis` remains
+a separate live scheduling setting and does not redefine slot duration.
+
+For fast-forwarding a devkit devnet from three epochs in the past, set
+`yano.block-producer.backfill-block-interval-slots=0`. Backfill builds historical
+blocks without waiting for the configured block timer. Slot timestamps and the
+wall-clock target still use the configured slot length, including 300 ms slots.
+For example, three 1,200-slot epochs at 300 ms span 1,080,000 ms, not 3,600 seconds.
+
+Automatic empty-block spacing is `floor(3k/f) - 1` slots. Slot-leader backfill
+starts its eligibility search halfway through that window to leave search
+headroom. With `k=100` and `f=1`, these intervals are 299 and 150 slots respectively.
+Epoch boundaries can shorten either interval. Slot-leader backfill may finish
+with a tip behind the processed target because the target need not be eligible.
+Its VRF cost depends on relative stake; sparse catch-up fails if no eligible
+block is found before the forecast window expires, or stake/nonce prerequisites
+are unavailable. Reduce spacing or increase devnet producer stake in that case.
+
+The forecast window is measured in **slots**, while `k` is measured in blocks.
+Staying within the forecast horizon addresses header forecasting; it is not a
+guarantee of chain density, finality, or compatibility with every relay mode.
+Validate the chosen genesis and relay configuration together before relying on it.
 | `yano.dev-mode` | true | Enables devnet REST APIs |
 
 Genesis files are at `config/network/devnet/`.

--- a/app/docs/devnet-modes.md
+++ b/app/docs/devnet-modes.md
@@ -48,6 +48,7 @@ All config is in `application.yml` under the `%devnet` profile. Key properties:
 | `yano.block-producer.lazy` | false | If true, skip empty blocks |
 | `yano.block-producer.genesis-timestamp` | 0 (auto) | Genesis time; 0 = use current time |
 | `yano.block-producer.slot-length-millis` | 0 (auto) | Slot length; 0 = derive from genesis |
+| `yano.block-producer.backfill-block-interval-slots` | 1 | Empty-block backfills (catch-up, time advance, epoch fast-forward) place one block every N slots instead of every slot; the first slot of each epoch and the target slot always get a block. Keep N below the stability window (3k/f) so a Haskell relay can validate the chain |
 | `yano.dev-mode` | true | Enables devnet REST APIs |
 
 Genesis files are at `config/network/devnet/`.

--- a/app/docs/devnet-modes.md
+++ b/app/docs/devnet-modes.md
@@ -48,7 +48,7 @@ All config is in `application.yml` under the `%devnet` profile. Key properties:
 | `yano.block-producer.lazy` | false | If true, skip empty blocks |
 | `yano.block-producer.genesis-timestamp` | 0 (auto) | Genesis time; 0 = use current time |
 | `yano.block-producer.slot-length-millis` | 0 (auto) | Slot length; 0 = derive from genesis |
-| `yano.block-producer.backfill-block-interval-slots` | 1 | Empty-block backfills (catch-up, time advance, epoch fast-forward) place one block every N slots instead of every slot; the first slot of each epoch and the target slot always get a block. Keep N below the stability window (3k/f) so a Haskell relay can validate the chain |
+| `yano.block-producer.backfill-block-interval-slots` | 1 | Backfills place one block every N slots instead of every slot. Empty-block backfills (catch-up, time advance, epoch fast-forward) always add the first slot of each epoch and the target slot; the slot-leader catch-up forges the first eligible slot after each interval and after each epoch start, skipping leadership checks in between. Keep N below the stability window (3k/f) so a Haskell relay can validate the chain |
 | `yano.dev-mode` | true | Enables devnet REST APIs |
 
 Genesis files are at `config/network/devnet/`.

--- a/app/docs/sparse-backfill-validation.md
+++ b/app/docs/sparse-backfill-validation.md
@@ -1,0 +1,67 @@
+# Sparse backfill validation
+
+Tested on 2026-09-10 using the JVM application and cardano-node 11.0.1.
+
+The automatic mode is opt-in:
+
+```properties
+yano.block-producer.backfill-block-interval-slots=0
+```
+
+The default remains `1`. Historical production does not sleep for the live block
+timer; its target is calculated using the configured slot duration.
+
+## Empty-block integration result
+
+An isolated copy of the PV10 devnet genesis used `epochLength=1200`, `k=100`,
+`f=1`, and `slotLength=0.3`. Both slot and block timers were set to 300 ms.
+The epoch-shift API moved genesis back three epochs (1,080,000 ms).
+
+After nine initial blocks, catch-up produced 15 more blocks and reached slot
+3612, block 24, in 0.536 seconds including HTTP overhead. Automatic spacing was
+299 slots, with additional blocks at epoch starts and the target.
+
+The Haskell node started from an empty database and accepted slots 0, 1200,
+2400, 3600, and 3612. It continued following live blocks. At slot 3657 its hash
+matched Yano:
+
+```text
+f36388e97795410f43bf31c1eb4c715c1486eac52a620a76ec45475ae92fc783
+```
+
+Raw logs and isolated genesis/database files from this local run are retained
+under `/tmp/yano-sparse-it.iTe5YY/`. Only test-owned processes were stopped.
+
+## Slot-leader coverage and outstanding integration issue
+
+The unit regression forges real signed sparse blocks across three epochs,
+checks nonce epoch progression, and resumes scheduled production at the next
+slot. Another regression verifies that an unsuccessful eligibility search stops
+before the forecast window is exceeded.
+
+A fresh slot-leader integration run with `f=0.2` failed at epoch shift, before
+backfill: `Canonical block hash is required` while storing genesis UTXOs.
+`DevnetGenesisShiftService` calls `storeGenesisUtxosIfNeeded` before
+`startSlotLeaderTimeTravel`, and the latter does not synchronously create a
+genesis block. This pre-existing bootstrap issue must be addressed before
+claiming end-to-end support for a fresh slot-leader devnet with UTXOs enabled.
+Logs are under `/tmp/yano-sparse-it.iTe5YY/leader/`.
+
+Native-image validation and low-relative-stake relay validation remain open.
+
+## Forecast interpretation
+
+`k` is a block count; the forecast horizon is expressed in slots. See the
+[Ouroboros consensus discussion of forecasting and stability](https://ouroboros-consensus.cardano.intersectmbo.org/docs/references/miscellaneous/hard_won_wisdom/).
+Bounding individual block gaps does not establish every chain-density or
+finality property. The integration result above applies to the tested genesis
+and Haskell configuration.
+
+## Local testkit failure
+
+The reported `shelley-genesis.json` byte mismatch came from a local runtime
+rewrite of `systemStart` and removal of the trailing newline, not the PR.
+The modified file was preserved at
+`/tmp/yano-sparse-backfill-shelley-genesis-before-fix-20260910.json` before
+restoring the tracked fixture bytes. The complete testkit suite then passed.
+Run devnets against copied genesis files to avoid modifying this fixture again.

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
@@ -425,7 +425,8 @@ public class YanoProducer {
     @ConfigProperty(name = YanoPropertyKeys.BlockProducer.GENESIS_TIMESTAMP, defaultValue = "0")
     long genesisTimestamp;
 
-    @ConfigProperty(name = YanoPropertyKeys.BlockProducer.SLOT_LENGTH_MILLIS, defaultValue = "1000")
+    // Retained for compatibility; runtime always uses the Shelley genesis slotLength.
+    @ConfigProperty(name = YanoPropertyKeys.BlockProducer.SLOT_LENGTH_MILLIS, defaultValue = "0")
     int slotLengthMillis;
 
     @ConfigProperty(name = YanoPropertyKeys.BlockProducer.TX_EVALUATION, defaultValue = "true")

--- a/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
+++ b/app/src/main/java/com/bloxbean/cardano/yano/app/YanoProducer.java
@@ -467,6 +467,9 @@ public class YanoProducer {
     @ConfigProperty(name = YanoPropertyKeys.BlockProducer.PAST_TIME_TRAVEL_SLOT_LEADER_MODE, defaultValue = "false")
     boolean pastTimeTravelSlotLeaderMode;
 
+    @ConfigProperty(name = YanoPropertyKeys.BlockProducer.BACKFILL_BLOCK_INTERVAL_SLOTS, defaultValue = "1")
+    int backfillBlockIntervalSlots;
+
     // Bootstrap config
     @ConfigProperty(name = YanoPropertyKeys.Bootstrap.ENABLED, defaultValue = "false")
     boolean bootstrapEnabled;
@@ -579,6 +582,7 @@ public class YanoProducer {
                 .startEpoch(startEpoch)
                 .pastTimeTravelMode(pastTimeTravelMode)
                 .pastTimeTravelSlotLeaderMode(pastTimeTravelSlotLeaderMode)
+                .backfillBlockIntervalSlots(backfillBlockIntervalSlots)
                 .shelleyGenesisHash(shelleyGenesisHash.orElse(null))
                 .shelleyGenesisFile(resolvedShelleyGenesis)
                 .byronGenesisFile(resolvedByronGenesis)

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -356,7 +356,7 @@ yano:
     block-time-millis: 0
     lazy: false
     genesis-timestamp: 0
-    slot-length-millis: 0
+    slot-length-millis: 0 # Legacy compatibility only; Shelley genesis slotLength is authoritative.
     start-epoch: 0
     past-time-travel-mode: false
     past-time-travel-slot-leader-mode: false
@@ -411,7 +411,7 @@ yano:
       block-time-millis: 0
       lazy: false
       genesis-timestamp: 0
-      slot-length-millis: 0
+      slot-length-millis: 0 # Legacy compatibility only; Shelley genesis slotLength is authoritative.
       vrf-skey-file: config/network/devnet/vrf.skey
       kes-skey-file: config/network/devnet/kes.skey
       opcert-file: config/network/devnet/opcert.cert
@@ -452,7 +452,7 @@ yano:
       slot-leader-mode: true
       lazy: false
       genesis-timestamp: 0
-      slot-length-millis: 0
+      slot-length-millis: 0 # Legacy compatibility only; Shelley genesis slotLength is authoritative.
       start-epoch: 0
       vrf-skey-file: config/network/devnet/vrf.skey
       kes-skey-file: config/network/devnet/kes.skey

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoConfig.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoConfig.java
@@ -106,6 +106,13 @@ public class YanoConfig implements NodeConfig {
     @Builder.Default
     private boolean pastTimeTravelSlotLeaderMode = false;
 
+    // Empty-block backfills (catch-up, time advance, epoch fast-forward) place one block every
+    // this many slots instead of every slot. The first slot of every epoch and the target slot
+    // always get a block. Keep it below the stability window (3k/f) so a Haskell relay can
+    // still validate the chain. 1 = one block per slot (default).
+    @Builder.Default
+    private int backfillBlockIntervalSlots = 1;
+
     // Epoch/slot config — set from genesis at runtime via propagateGenesisToConfig().
     // No defaults: fail fast if not initialized from genesis.
     private Long epochLength;           // From shelley-genesis.json epochLength
@@ -571,6 +578,11 @@ public class YanoConfig implements NodeConfig {
             if (!enableBlockProducer) {
                 throw new IllegalArgumentException("Past time travel mode requires block producer to be enabled");
             }
+        }
+
+        if (backfillBlockIntervalSlots < 1) {
+            throw new IllegalArgumentException("Backfill block interval must be at least 1 slot, got: "
+                    + backfillBlockIntervalSlots);
         }
 
         if (pastTimeTravelSlotLeaderMode) {

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoConfig.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoConfig.java
@@ -60,6 +60,7 @@ public class YanoConfig implements NodeConfig {
     private int blockTimeMillis;
     private boolean lazyBlockProduction;
     private long genesisTimestamp;
+    // Resolved from Shelley genesis by runtime. Legacy builder/property values cannot override genesis.
     private int slotLengthMillis;
     private String shelleyGenesisHash;     // Hex-encoded blake2b-256 of shelley-genesis.json (optional, overrides file hashing)
     private String shelleyGenesisFile;     // Path to shelley-genesis.json
@@ -107,9 +108,9 @@ public class YanoConfig implements NodeConfig {
     private boolean pastTimeTravelSlotLeaderMode = false;
 
     // Empty-block backfills (catch-up, time advance, epoch fast-forward) place one block every
-    // this many slots instead of every slot. The first slot of every epoch and the target slot
-    // always get a block. Keep it below the stability window (3k/f) so a Haskell relay can
-    // still validate the chain. 1 = one block per slot (default).
+    // this many slots instead of every slot. 0 selects automatic genesis-derived spacing;
+    // 1 preserves dense production (default). Slot-leader searches require eligibility,
+    // so the last processed slot can be ahead of the last produced block.
     @Builder.Default
     private int backfillBlockIntervalSlots = 1;
 
@@ -547,7 +548,7 @@ public class YanoConfig implements NodeConfig {
                 throw new IllegalArgumentException("Block producer mode requires server to be enabled");
             }
             // blockTimeMillis == 0 is valid: means auto-derive from genesis in Yano.
-            // slotLengthMillis == 0 is valid: means auto-derive from genesis in Yano.
+            // slotLengthMillis is always resolved from Shelley genesis by runtime.
         }
 
         if (slotLeaderMode) {
@@ -580,8 +581,8 @@ public class YanoConfig implements NodeConfig {
             }
         }
 
-        if (backfillBlockIntervalSlots < 1) {
-            throw new IllegalArgumentException("Backfill block interval must be at least 1 slot, got: "
+        if (backfillBlockIntervalSlots < 0) {
+            throw new IllegalArgumentException("Backfill block interval must be non-negative (0 = automatic), got: "
                     + backfillBlockIntervalSlots);
         }
 

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
@@ -525,6 +525,8 @@ public final class YanoPropertyKeys {
                 "yano.block-producer.past-time-travel-slot-leader-mode";
         public static final String PROCESS_SKIPPED_EPOCHS =
                 "yano.block-producer.process-skipped-epochs";
+        public static final String BACKFILL_BLOCK_INTERVAL_SLOTS =
+                "yano.block-producer.backfill-block-interval-slots";
 
         private BlockProducer() {
         }

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/config/YanoPropertyKeys.java
@@ -499,6 +499,7 @@ public final class YanoPropertyKeys {
         public static final String LAZY = "yano.block-producer.lazy";
         public static final String GENESIS_TIMESTAMP =
                 "yano.block-producer.genesis-timestamp";
+        /** Legacy compatibility key. Producer slot duration is always derived from Shelley genesis. */
         public static final String SLOT_LENGTH_MILLIS =
                 "yano.block-producer.slot-length-millis";
         public static final String TX_EVALUATION =

--- a/core-api/src/test/java/com/bloxbean/cardano/yano/api/config/YanoConfigTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/yano/api/config/YanoConfigTest.java
@@ -351,6 +351,50 @@ class YanoConfigTest {
     }
 
     @Test
+    void validate_backfillBlockIntervalSlots_defaultsToOneBlockPerSlot() {
+        YanoConfig config = YanoConfig.builder()
+                .enableClient(false)
+                .enableServer(true)
+                .serverPort(13337)
+                .enableBlockProducer(true)
+                .devMode(true)
+                .pastTimeTravelMode(true)
+                .protocolMagic(42)
+                .build();
+
+        assertThat(config.getBackfillBlockIntervalSlots()).isEqualTo(1);
+        assertThatCode(config::validate).doesNotThrowAnyException();
+    }
+
+    @Test
+    void validate_backfillBlockIntervalSlots_acceptsSparseIntervalAndRejectsZero() {
+        YanoConfig sparse = YanoConfig.builder()
+                .enableClient(false)
+                .enableServer(true)
+                .serverPort(13337)
+                .enableBlockProducer(true)
+                .devMode(true)
+                .pastTimeTravelMode(true)
+                .backfillBlockIntervalSlots(900)
+                .protocolMagic(42)
+                .build();
+        assertThatCode(sparse::validate).doesNotThrowAnyException();
+
+        YanoConfig zero = YanoConfig.builder()
+                .enableClient(false)
+                .enableServer(true)
+                .serverPort(13337)
+                .enableBlockProducer(true)
+                .devMode(true)
+                .backfillBlockIntervalSlots(0)
+                .protocolMagic(42)
+                .build();
+        assertThatThrownBy(zero::validate)
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Backfill block interval");
+    }
+
+    @Test
     void validate_pastTimeTravelMode_shouldThrowWhenDevModeDisabled() {
         YanoConfig config = YanoConfig.builder()
                 .enableClient(false)

--- a/core-api/src/test/java/com/bloxbean/cardano/yano/api/config/YanoConfigTest.java
+++ b/core-api/src/test/java/com/bloxbean/cardano/yano/api/config/YanoConfigTest.java
@@ -367,7 +367,7 @@ class YanoConfigTest {
     }
 
     @Test
-    void validate_backfillBlockIntervalSlots_acceptsSparseIntervalAndRejectsZero() {
+    void validate_backfillBlockIntervalSlots_acceptsSparseIntervalAndRejectsNegative() {
         YanoConfig sparse = YanoConfig.builder()
                 .enableClient(false)
                 .enableServer(true)
@@ -379,6 +379,8 @@ class YanoConfigTest {
                 .protocolMagic(42)
                 .build();
         assertThatCode(sparse::validate).doesNotThrowAnyException();
+        sparse.setBackfillBlockIntervalSlots(0);
+        assertThatCode(sparse::validate).doesNotThrowAnyException();
 
         YanoConfig zero = YanoConfig.builder()
                 .enableClient(false)
@@ -386,7 +388,7 @@ class YanoConfigTest {
                 .serverPort(13337)
                 .enableBlockProducer(true)
                 .devMode(true)
-                .backfillBlockIntervalSlots(0)
+                .backfillBlockIntervalSlots(-1)
                 .protocolMagic(42)
                 .build();
         assertThatThrownBy(zero::validate)

--- a/runtime/docs/block-producer-testing.md
+++ b/runtime/docs/block-producer-testing.md
@@ -90,6 +90,9 @@ python3 genesis_server.py &
 
 ## Step 2: Build and Start Yano
 
+Slot duration comes from Shelley genesis `slotLength` (seconds). Configure the
+genesis file for the desired duration; `slot-length-millis` no longer overrides it.
+
 ```bash
 # Build uber-jar (add type: uber-jar under quarkus.package.jar in application.yml)
 ./gradlew :app:quarkusBuild -x test
@@ -104,7 +107,6 @@ java \
   -Dyano.block-producer.block-time-millis=2000 \
   -Dyano.block-producer.lazy=false \
   -Dyano.block-producer.genesis-timestamp=0 \
-  -Dyano.block-producer.slot-length-millis=1000 \
   -Dyano.storage.rocksdb=false \
   -jar app/build/yano.jar
 ```

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BackfillPolicy.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BackfillPolicy.java
@@ -1,0 +1,36 @@
+package com.bloxbean.cardano.yano.runtime.blockproducer;
+
+/** Slot-based spacing for opt-in sparse Shelley devnet history. */
+public final class BackfillPolicy {
+    private BackfillPolicy() {
+    }
+
+    public static long forecastWindowSlots(long securityParam, double activeSlotsCoeff) {
+        if (securityParam <= 0 || !Double.isFinite(activeSlotsCoeff)
+                || activeSlotsCoeff <= 0 || activeSlotsCoeff > 1) {
+            throw new IllegalArgumentException("Backfill requires positive k and 0 < f <= 1");
+        }
+        double window = Math.floor(3.0 * securityParam / activeSlotsCoeff);
+        if (window >= Long.MAX_VALUE) {
+            throw new IllegalArgumentException("Backfill forecast window exceeds supported slot range");
+        }
+        return (long) window;
+    }
+
+    /** Zero selects automatic spacing; one preserves dense production. */
+    public static int resolveInterval(int requested, long securityParam, double activeSlotsCoeff,
+                                      boolean slotLeader) {
+        if (requested < 0) {
+            throw new IllegalArgumentException("Backfill interval must be non-negative");
+        }
+        long window = forecastWindowSlots(securityParam, activeSlotsCoeff);
+        if (requested >= window) {
+            throw new IllegalArgumentException("Backfill interval must be below forecast window of " + window + " slots");
+        }
+        if (requested > 0) {
+            return requested;
+        }
+        // Eligibility searches need headroom. Empty-block production has no such search.
+        return (int) Math.min(Integer.MAX_VALUE, Math.max(1, slotLeader ? window / 2 : window - 1));
+    }
+}

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProducerHelper.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/BlockProducerHelper.java
@@ -253,4 +253,14 @@ public final class BlockProducerHelper {
         if (epochProvider == null) return -1;
         return epochProvider.getEpochSlotCalc().slotToEpoch(slot);
     }
+
+    /**
+     * First slot of the epoch after the one containing {@code slot}, or -1 when no epoch
+     * provider is installed. Used by sparse backfills so every epoch starts with a block.
+     */
+    public static long firstSlotOfNextEpoch(long slot) {
+        if (epochProvider == null || slot < 0) return -1;
+        var calc = epochProvider.getEpochSlotCalc();
+        return calc.epochToStartSlot(calc.slotToEpoch(slot) + 1);
+    }
 }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducer.java
@@ -44,6 +44,7 @@ public class DevnetBlockProducer implements BlockProducerService {
     private long lastUsedSlot = -1;
     private volatile boolean running;
     private volatile boolean forceSequentialSlots = false;
+    private volatile int backfillBlockIntervalSlots = 1;
 
     public DevnetBlockProducer(ChainState chainState, MemPool memPool, NodeServer nodeServer,
                          EventBus eventBus, ScheduledExecutorService scheduler,
@@ -351,8 +352,44 @@ public class DevnetBlockProducer implements BlockProducerService {
     }
 
     /**
+     * Set how many slots apart empty-block backfills place their blocks. 1 (default) places a block
+     * in every slot. Larger values thin the backfill; the first slot of every epoch and the target
+     * slot always get a block. Keep it below the stability window (3k/f) so a Haskell relay can
+     * still validate the chain.
+     */
+    public void setBackfillBlockIntervalSlots(int backfillBlockIntervalSlots) {
+        if (backfillBlockIntervalSlots < 1) {
+            throw new IllegalArgumentException("backfillBlockIntervalSlots must be at least 1, got "
+                    + backfillBlockIntervalSlots);
+        }
+        this.backfillBlockIntervalSlots = backfillBlockIntervalSlots;
+    }
+
+    public int getBackfillBlockIntervalSlots() {
+        return backfillBlockIntervalSlots;
+    }
+
+    /**
+     * Slot of the next backfill block after {@code fromSlot}: {@code fromSlot + interval}, pulled back
+     * to the first slot of the next epoch when the step would cross an epoch boundary, and never past
+     * {@code targetSlot}. With interval 1 this is always {@code fromSlot + 1}.
+     */
+    long nextBackfillSlot(long fromSlot, long targetSlot) {
+        long next = Math.min(fromSlot + backfillBlockIntervalSlots, targetSlot);
+        if (backfillBlockIntervalSlots > 1) {
+            long epochStart = BlockProducerHelper.firstSlotOfNextEpoch(fromSlot);
+            if (epochStart > fromSlot && epochStart < next) {
+                next = epochStart;
+            }
+        }
+        return next;
+    }
+
+    /**
      * Produce empty blocks rapidly from the current tip slot up to (and including) targetSlot.
-     * Each block advances by one slot step. Used for time/slot advance in devnet mode.
+     * By default each block advances by one slot; with a backfill block interval above 1, blocks are
+     * placed every interval slots plus the first slot of each epoch and the target slot.
+     * Used for time/slot advance and catch-up in devnet mode.
      *
      * @param targetSlot the slot to advance to
      * @return number of blocks produced
@@ -364,7 +401,11 @@ public class DevnetBlockProducer implements BlockProducerService {
         }
 
         int blocksProduced = 0;
-        long currentSlot = lastUsedSlot + 1;
+        long currentSlot = nextBackfillSlot(lastUsedSlot, targetSlot);
+        if (backfillBlockIntervalSlots > 1) {
+            log.info("Sparse backfill: one block every {} slots from slot {} to {}",
+                    backfillBlockIntervalSlots, lastUsedSlot + 1, targetSlot);
+        }
 
         while (currentSlot <= targetSlot) {
             BlockProducerHelper.prepareEpochTransitionBeforeBlock(
@@ -385,7 +426,10 @@ public class DevnetBlockProducer implements BlockProducerService {
                 log.info("Time advance progress: {} blocks produced, current slot={}", blocksProduced, currentSlot);
             }
 
-            currentSlot++;
+            if (currentSlot >= targetSlot) {
+                break;
+            }
+            currentSlot = nextBackfillSlot(currentSlot, targetSlot);
         }
 
         // Notify server once at the end

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/EpochNonceState.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/EpochNonceState.java
@@ -111,6 +111,10 @@ public class EpochNonceState {
         return buildEpochSlotCalc().epochToStartSlot(epoch);
     }
 
+    public long forecastWindowSlots() {
+        return preConwayStabilityWindow;
+    }
+
     private com.bloxbean.cardano.yano.api.util.EpochSlotCalc buildEpochSlotCalc() {
         return new com.bloxbean.cardano.yano.api.util.EpochSlotCalc(epochLength, byronSlotsPerEpoch, shelleyStartSlot);
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/GenesisConfig.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/GenesisConfig.java
@@ -11,6 +11,7 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -39,6 +40,22 @@ public class GenesisConfig {
     private final ByronGenesisData byronGenesisData;
 
     private transient JsonNode parsedProtocolParameters;
+
+    /** Authoritative producer slot duration, derived from Shelley genesis in whole milliseconds. */
+    public int getSlotLengthMillis() {
+        if (shelleyGenesisData == null) {
+            throw new IllegalArgumentException("Shelley genesis is required to determine producer slot duration");
+        }
+        double seconds = shelleyGenesisData.slotLength();
+        if (!Double.isFinite(seconds) || seconds <= 0) {
+            throw new IllegalArgumentException("Genesis slotLength must be positive and finite: " + seconds);
+        }
+        try {
+            return BigDecimal.valueOf(seconds).movePointRight(3).intValueExact();
+        } catch (ArithmeticException e) {
+            throw new IllegalArgumentException("Genesis slotLength must fit in positive whole milliseconds: " + seconds, e);
+        }
+    }
 
     private GenesisConfig(Map<String, BigInteger> initialFunds, String protocolParameters,
                           Map<String, BigInteger> byronBalances, ShelleyGenesisData shelleyGenesisData,

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -203,8 +203,8 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
      * Set how many slots apart the catch-up backfill places its blocks. 1 (default) forges every
      * eligible slot. Above 1, after each block the scan jumps to the earlier of {@code block + interval}
      * and the next epoch start, and forges the first eligible slot from there. Leadership checks are
-     * skipped for the slots jumped over, so a multi-day catch-up costs a few dozen VRF evaluations.
-     * Keep it below the stability window (3k/f) so a Haskell relay can still validate the chain.
+     * skipped for the slots jumped over. Search cost depends on pool stake and eligibility.
+     * Sparse catch-up fails if it cannot find a block before the forecast window expires.
      * Scheduled (wall-clock and sequential-scan) production is not affected.
      */
     public void setBackfillBlockIntervalSlots(int backfillBlockIntervalSlots) {
@@ -274,41 +274,74 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         }
 
         int blocksProduced = 0;
+        long leadershipChecks = 0;
+        long started = System.nanoTime();
         long slot = lastCheckedSlot + 1;
         while (slot <= targetSlot) {
             if (interval > 1) {
                 ChainTip tip = chainState.getTip();
                 long candidate = nextSparseCandidateSlot(slot, tip != null ? tip.getSlot() : -1, interval);
+                if (tip != null) {
+                    long epochStart = epochNonceState.firstSlotOfEpoch(epochNonceState.epochForSlot(tip.getSlot()) + 1);
+                    candidate = Math.max(slot, Math.min(candidate, epochStart));
+                }
                 if (candidate > targetSlot) {
                     // Nothing more to forge before the target: count the rest as checked.
                     lastCheckedSlot = targetSlot;
                     break;
                 }
                 slot = candidate;
+                if (tip != null && slot - tip.getSlot() >= epochNonceState.forecastWindowSlots()) {
+                    throw new IllegalStateException("Sparse backfill found no eligible block within the forecast window; "
+                            + "reduce the interval or increase the devnet producer stake (tip=" + tip.getSlot()
+                            + ", candidate=" + slot + ")");
+                }
             }
-            lastCheckedSlot = slot;
             int epoch = epochNonceState.epochForSlot(slot);
             refreshStakeData(epoch);
+
+            if (interval > 1 && sigma.signum() <= 0) {
+                throw new IllegalStateException("Sparse backfill requires available positive producer stake in epoch " + epoch);
+            }
 
             if (sigma.signum() > 0) {
                 byte[] epochNonce = epochNonceState.previewEpochNonceForSlot(slot);
                 if (epochNonce == null) {
+                    if (interval > 1) {
+                        throw new IllegalStateException("Sparse backfill requires an epoch nonce at slot " + slot);
+                    }
                     log.warn("Epoch nonce not available, skipping leader check for slot {}", slot);
                 } else {
+                    leadershipChecks++;
                     BlockSigner.VrfSignResult vrfResult = slotLeaderCheck.checkAndProve(slot, epochNonce, sigma);
                     if (vrfResult != null) {
-                        produceBlock(slot, vrfResult);
-                        blocksProduced++;
+                        if (produceBlock(slot, vrfResult, !sparse)) {
+                            blocksProduced++;
+                            if (sparse && blocksProduced % 100 == 0) {
+                                log.info("Slot-leader backfill progress: blocks={}, checks={}, slot={}, target={}",
+                                        blocksProduced, leadershipChecks, slot, targetSlot);
+                            }
+                        }
                         if (stopAfterFirstBlock) {
+                            lastCheckedSlot = slot;
                             break;
                         }
                     }
                 }
             }
 
+            lastCheckedSlot = slot;
             slot++;
         }
 
+        if (sparse && blocksProduced > 0) {
+            BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+        }
+        if (sparse) {
+            log.info("Slot-leader backfill complete: blocks={}, checks={}, processedSlot={}, elapsedMillis={}",
+                    blocksProduced, leadershipChecks, lastCheckedSlot,
+                    TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - started));
+        }
         return blocksProduced;
     }
 
@@ -332,7 +365,7 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
                 epoch, poolStake, totalStake, sigma);
     }
 
-    private void produceBlock(long slot, BlockSigner.VrfSignResult vrfResult) {
+    private boolean produceBlock(long slot, BlockSigner.VrfSignResult vrfResult, boolean notifyServer) {
         ChainTip tip = chainState.getTip();
         long blockNumber = tip != null ? tip.getBlockNumber() + 1 : 0;
         byte[] prevHash = tip != null ? tip.getBlockHash() : null;
@@ -345,12 +378,15 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
             var result = blockBuilder.buildBlock(blockNumber, slot, prevHash, txList, vrfResult);
             BlockProducerHelper.storeProducedBlock(chainState, blockBuilder, result);
 
-            log.info("Slot-leader time-travel block #{} produced: slot={}, txs={}, hash={}",
+            log.debug("Slot-leader time-travel block #{} produced: slot={}, txs={}, hash={}",
                     blockNumber, slot, txList.size(), HexUtil.encodeHexString(result.blockHash()));
 
             BlockProducerHelper.publishEvent(eventBus, result, txList.size(), "slot-leader-time-travel");
             transactions.blockCandidatePublished();
-            BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+            if (notifyServer) {
+                BlockProducerHelper.notifyServer(nodeServerSupplier.get());
+            }
+            return true;
         } catch (UnfitBlockTransactionException e) {
             int removed;
             try {
@@ -360,6 +396,7 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
             }
             log.warn("Discarded {} mempool transaction(s) after block resource rejection: {}",
                     removed, e.getMessage());
+            return false;
         } catch (RuntimeException | Error e) {
             transactions.blockSelectionFailed();
             throw e;

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -47,6 +47,7 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
     private ScheduledFuture<?> scheduledTask;
     private volatile boolean running;
     private volatile boolean forceSequentialSlots = true;
+    private volatile int backfillBlockIntervalSlots = 1;
     private long lastCheckedSlot = -1;
     private int lastStakeEpoch = -1;
     private BigDecimal sigma = BigDecimal.ZERO;
@@ -189,8 +190,50 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         this.forceSequentialSlots = forceSequentialSlots;
     }
 
+    /**
+     * Catch-up entry point: scan from the last checked slot to {@code targetSlot} and forge every
+     * eligible slot, or, with a backfill block interval above 1, only the first eligible slot at or
+     * after each interval and after each epoch start (see {@link #setBackfillBlockIntervalSlots(int)}).
+     */
     public synchronized int produceToSlot(long targetSlot) {
-        return produceToSlot(targetSlot, false);
+        return produceToSlot(targetSlot, false, true);
+    }
+
+    /**
+     * Set how many slots apart the catch-up backfill places its blocks. 1 (default) forges every
+     * eligible slot. Above 1, after each block the scan jumps to the earlier of {@code block + interval}
+     * and the next epoch start, and forges the first eligible slot from there. Leadership checks are
+     * skipped for the slots jumped over, so a multi-day catch-up costs a few dozen VRF evaluations.
+     * Keep it below the stability window (3k/f) so a Haskell relay can still validate the chain.
+     * Scheduled (wall-clock and sequential-scan) production is not affected.
+     */
+    public void setBackfillBlockIntervalSlots(int backfillBlockIntervalSlots) {
+        if (backfillBlockIntervalSlots < 1) {
+            throw new IllegalArgumentException("backfillBlockIntervalSlots must be at least 1, got "
+                    + backfillBlockIntervalSlots);
+        }
+        this.backfillBlockIntervalSlots = backfillBlockIntervalSlots;
+    }
+
+    public int getBackfillBlockIntervalSlots() {
+        return backfillBlockIntervalSlots;
+    }
+
+    /**
+     * First slot worth a leadership check after a block at {@code lastBlockSlot}, given the interval:
+     * {@code lastBlockSlot + interval}, pulled back to the next epoch start when that comes first, and
+     * never before {@code slot} itself. Package-private for tests.
+     */
+    static long nextSparseCandidateSlot(long slot, long lastBlockSlot, int interval) {
+        if (interval <= 1 || lastBlockSlot < 0) {
+            return slot;
+        }
+        long earliest = lastBlockSlot + interval;
+        long epochStart = BlockProducerHelper.firstSlotOfNextEpoch(lastBlockSlot);
+        if (epochStart > lastBlockSlot && epochStart < earliest) {
+            earliest = epochStart;
+        }
+        return Math.max(slot, earliest);
     }
 
     public long getLastCheckedSlot() {
@@ -208,7 +251,7 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
                 return;
             }
             long fromSlot = lastCheckedSlot + 1;
-            int produced = produceToSlot(targetSlot, true);
+            int produced = produceToSlot(targetSlot, true, false);
             if (produced == 0) {
                 log.debug("No eligible slot found while scanning slots {}..{}", fromSlot, targetSlot);
             }
@@ -216,17 +259,33 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         }
 
         long wallClockSlot = calculateWallClockSlot();
-        produceToSlot(wallClockSlot, false);
+        produceToSlot(wallClockSlot, false, false);
     }
 
-    private int produceToSlot(long targetSlot, boolean stopAfterFirstBlock) {
+    private int produceToSlot(long targetSlot, boolean stopAfterFirstBlock, boolean sparse) {
         if (targetSlot <= lastCheckedSlot) {
             return 0;
+        }
+
+        int interval = sparse ? backfillBlockIntervalSlots : 1;
+        if (interval > 1) {
+            log.info("Sparse slot-leader backfill: first eligible slot every {} slots from slot {} to {}",
+                    interval, lastCheckedSlot + 1, targetSlot);
         }
 
         int blocksProduced = 0;
         long slot = lastCheckedSlot + 1;
         while (slot <= targetSlot) {
+            if (interval > 1) {
+                ChainTip tip = chainState.getTip();
+                long candidate = nextSparseCandidateSlot(slot, tip != null ? tip.getSlot() : -1, interval);
+                if (candidate > targetSlot) {
+                    // Nothing more to forge before the target: count the rest as checked.
+                    lastCheckedSlot = targetSlot;
+                    break;
+                }
+                slot = candidate;
+            }
             lastCheckedSlot = slot;
             int epoch = epochNonceState.epochForSlot(slot);
             refreshStakeData(epoch);

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -2396,20 +2396,15 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
     }
 
     private void autoDeriveSlotLengthMillis() {
-        if (config.getSlotLengthMillis() <= 0) {
-            if (genesisConfig.getShelleyGenesisData() != null
-                    && genesisConfig.getShelleyGenesisData().slotLength() > 0) {
-                int derivedSlotLength = (int) (genesisConfig.getShelleyGenesisData().slotLength() * 1000);
-                config.setSlotLengthMillis(derivedSlotLength);
-                log.info("Auto-derived slotLengthMillis={} from genesis slotLength={}",
-                        derivedSlotLength, genesisConfig.getShelleyGenesisData().slotLength());
-            } else {
-                config.setSlotLengthMillis(1000);
-                log.info("No genesis data available, using default slotLengthMillis=1000");
-            }
-        } else {
-            log.info("Using explicit slotLengthMillis={}", config.getSlotLengthMillis());
+        int genesisSlotLength = genesisConfig.getSlotLengthMillis();
+        int legacySlotLength = config.getSlotLengthMillis();
+        if (legacySlotLength != 0 && legacySlotLength != genesisSlotLength) {
+            log.warn("Ignoring legacy yano.block-producer.slot-length-millis={}; genesis slotLength defines {}ms slots",
+                    legacySlotLength, genesisSlotLength);
         }
+        config.setSlotLengthMillis(genesisSlotLength);
+        log.info("Derived slotLengthMillis={} from genesis slotLength={}",
+                genesisSlotLength, genesisConfig.getShelleyGenesisData().slotLength());
     }
 
     /**
@@ -2592,7 +2587,8 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
                     config.getSlotLengthMillis(),
                     config.getBlockTimeMillis(),
                     sequentialScanLimitSlots,
-                    config.getBackfillBlockIntervalSlots());
+                    BackfillPolicy.resolveInterval(config.getBackfillBlockIntervalSlots(),
+                            shelleyData.securityParam(), activeSlotsCoeff, true));
         } catch (Exception e) {
             throw new RuntimeException("Failed to create past-time-travel slot-leader block producer", e);
         }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -2591,7 +2591,8 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
                     resolvedGenesisTimestamp,
                     config.getSlotLengthMillis(),
                     config.getBlockTimeMillis(),
-                    sequentialScanLimitSlots);
+                    sequentialScanLimitSlots,
+                    config.getBackfillBlockIntervalSlots());
         } catch (Exception e) {
             throw new RuntimeException("Failed to create past-time-travel slot-leader block producer", e);
         }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -2471,7 +2471,8 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
                 config.isLazyBlockProduction(),
                 resolvedGenesisTimestamp,
                 config.getSlotLengthMillis(),
-                genesisConfig);
+                genesisConfig,
+                config.getBackfillBlockIntervalSlots());
     }
 
     private DevnetBlockBuilderFactory devnetBlockBuilderFactory() {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactory.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactory.java
@@ -46,6 +46,7 @@ public final class DevnetProducerFactory {
                 settings.resolvedGenesisTimestamp(),
                 settings.slotLengthMillis(),
                 settings.genesisConfig());
+        producer.setBackfillBlockIntervalSlots(settings.backfillBlockIntervalSlots());
         dependencies.producerSubsystem().installDevnet(producer, timeTravel);
         return producer;
     }
@@ -58,7 +59,22 @@ public final class DevnetProducerFactory {
             boolean lazyBlockProduction,
             long resolvedGenesisTimestamp,
             int slotLengthMillis,
-            GenesisConfig genesisConfig) {
+            GenesisConfig genesisConfig,
+            int backfillBlockIntervalSlots) {
+        public Settings {
+            if (backfillBlockIntervalSlots < 1) {
+                throw new IllegalArgumentException(
+                        "backfillBlockIntervalSlots must be at least 1, got " + backfillBlockIntervalSlots);
+            }
+        }
+
+        public Settings(int blockTimeMillis,
+                        boolean lazyBlockProduction,
+                        long resolvedGenesisTimestamp,
+                        int slotLengthMillis,
+                        GenesisConfig genesisConfig) {
+            this(blockTimeMillis, lazyBlockProduction, resolvedGenesisTimestamp, slotLengthMillis, genesisConfig, 1);
+        }
     }
 
     /**

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactory.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactory.java
@@ -4,6 +4,7 @@ import com.bloxbean.cardano.yaci.core.network.server.NodeServer;
 import com.bloxbean.cardano.yaci.core.storage.ChainState;
 import com.bloxbean.cardano.yaci.events.api.EventBus;
 import com.bloxbean.cardano.yano.runtime.blockproducer.DevnetBlockBuilder;
+import com.bloxbean.cardano.yano.runtime.blockproducer.BackfillPolicy;
 import com.bloxbean.cardano.yano.runtime.blockproducer.DevnetBlockProducer;
 import com.bloxbean.cardano.yano.runtime.blockproducer.GenesisConfig;
 import com.bloxbean.cardano.yano.runtime.tx.BlockTransactionSelector;
@@ -46,7 +47,15 @@ public final class DevnetProducerFactory {
                 settings.resolvedGenesisTimestamp(),
                 settings.slotLengthMillis(),
                 settings.genesisConfig());
-        producer.setBackfillBlockIntervalSlots(settings.backfillBlockIntervalSlots());
+        int interval = settings.backfillBlockIntervalSlots();
+        if (settings.genesisConfig() != null && settings.genesisConfig().getShelleyGenesisData() != null) {
+            interval = BackfillPolicy.resolveInterval(interval,
+                    settings.genesisConfig().getShelleyGenesisData().securityParam(),
+                    settings.genesisConfig().getActiveSlotsCoeff(), false);
+        } else if (interval == 0) {
+            throw new IllegalArgumentException("Automatic backfill requires Shelley genesis");
+        }
+        producer.setBackfillBlockIntervalSlots(interval);
         dependencies.producerSubsystem().installDevnet(producer, timeTravel);
         return producer;
     }
@@ -62,9 +71,9 @@ public final class DevnetProducerFactory {
             GenesisConfig genesisConfig,
             int backfillBlockIntervalSlots) {
         public Settings {
-            if (backfillBlockIntervalSlots < 1) {
+            if (backfillBlockIntervalSlots < 0) {
                 throw new IllegalArgumentException(
-                        "backfillBlockIntervalSlots must be at least 1, got " + backfillBlockIntervalSlots);
+                        "backfillBlockIntervalSlots must be non-negative, got " + backfillBlockIntervalSlots);
             }
         }
 

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/ProducerStartupCoordinator.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/ProducerStartupCoordinator.java
@@ -10,6 +10,7 @@ import com.bloxbean.cardano.yano.api.EpochParamProvider;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.ledgerstate.EpochParamTracker;
 import com.bloxbean.cardano.yano.runtime.blockproducer.BlockProducerHelper;
+import com.bloxbean.cardano.yano.runtime.blockproducer.BackfillPolicy;
 import com.bloxbean.cardano.yano.runtime.blockproducer.DevnetBlockBuilder;
 import com.bloxbean.cardano.yano.runtime.blockproducer.DevnetBlockProducer;
 import com.bloxbean.cardano.yano.runtime.blockproducer.EpochNonceEvolver;
@@ -224,16 +225,31 @@ public final class ProducerStartupCoordinator {
                             initialTarget);
                     int produced = 0;
                     long slot = 1;
+                    int backfillInterval = BackfillPolicy.resolveInterval(config.getBackfillBlockIntervalSlots(),
+                            securityParam, activeSlotsCoeff, true);
+                    long forecastWindow = BackfillPolicy.forecastWindowSlots(securityParam, activeSlotsCoeff);
                     while (true) {
                         long currentWallClockSlot =
                                 (System.currentTimeMillis() - actions.resolvedGenesisTimestamp())
                                         / config.getSlotLengthMillis();
+                        ChainTip previousTip = chainState.getTip();
+                        if (backfillInterval > 1 && previousTip != null) {
+                            long nextEpoch = epochNonceState.firstSlotOfEpoch(
+                                    epochNonceState.epochForSlot(previousTip.getSlot()) + 1);
+                            slot = Math.max(slot, Math.min(previousTip.getSlot() + backfillInterval, nextEpoch));
+                        }
                         if (slot > currentWallClockSlot) break;
+                        if (backfillInterval > 1 && previousTip != null
+                                && slot - previousTip.getSlot() >= forecastWindow) {
+                            throw new IllegalStateException("Startup backfill found no eligible block within forecast window");
+                        }
 
                         byte[] epochNonce = epochNonceState.previewEpochNonceForSlot(slot);
                         var vrfResult = slotLeaderCheck.checkAndProve(slot, epochNonce, java.math.BigDecimal.ONE);
                         if (vrfResult != null) {
                             ChainTip tip = chainState.getTip();
+                            BlockProducerHelper.prepareEpochTransitionBeforeBlock(
+                                    actions.eventBus(), slot, tip.getBlockNumber() + 1, "slot-leader-catch-up");
                             var result = signedBlockBuilder.buildBlock(
                                     tip.getBlockNumber() + 1,
                                     slot,

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/SlotLeaderProducerFactory.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/SlotLeaderProducerFactory.java
@@ -62,6 +62,20 @@ public final class SlotLeaderProducerFactory {
                                                               int slotLengthMillis,
                                                               int blockTimeMillis,
                                                               long sequentialScanLimitSlots) {
+        return createTimeTravel(signedBlockBuilder, epochNonceState, slotLeaderCheck, stakeDataProvider, poolHash,
+                resolvedGenesisTimestamp, slotLengthMillis, blockTimeMillis, sequentialScanLimitSlots, 1);
+    }
+
+    public SlotLeaderTimeTravelBlockProducer createTimeTravel(SignedBlockBuilder signedBlockBuilder,
+                                                              EpochNonceState epochNonceState,
+                                                              SlotLeaderCheck slotLeaderCheck,
+                                                              StakeDataProvider stakeDataProvider,
+                                                              String poolHash,
+                                                              long resolvedGenesisTimestamp,
+                                                              int slotLengthMillis,
+                                                              int blockTimeMillis,
+                                                              long sequentialScanLimitSlots,
+                                                              int backfillBlockIntervalSlots) {
         var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
                 dependencies.chainState(),
                 dependencies.transactions(),
@@ -77,6 +91,7 @@ public final class SlotLeaderProducerFactory {
                 slotLengthMillis,
                 blockTimeMillis,
                 sequentialScanLimitSlots);
+        producer.setBackfillBlockIntervalSlots(backfillBlockIntervalSlots);
         dependencies.producerSubsystem().installSlotLeaderTimeTravel(producer);
         return producer;
     }

--- a/runtime/src/main/resources/genesis/devnet/shelley-genesis.json
+++ b/runtime/src/main/resources/genesis/devnet/shelley-genesis.json
@@ -34,7 +34,7 @@
     "60ba957a0fff6816021b2afa7900beea68fd10f2d78fb5b64de0d2379c" : 3000000000000000,
     "604fb41f142d1f7b8e51dd9232a110cf72aec955275439b72870b9c20d" : 10000000000000
   },
-  "maxKESEvolutions" : 10000,
+  "maxKESEvolutions" : 62,
   "maxLovelaceSupply" : 45000000000000000,
   "networkId" : "Testnet",
   "networkMagic" : 42,
@@ -64,7 +64,7 @@
   },
   "securityParam" : 100,
   "slotLength" : 0.2,
-  "slotsPerKESPeriod" : 129600,
+  "slotsPerKESPeriod" : 10000000,
   "staking" : {
     "pools" : {
       "7301761068762f5900bde9eb7c1c15b09840285130f5b0f53606cc57" : {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/BackfillPolicyTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/BackfillPolicyTest.java
@@ -1,0 +1,27 @@
+package com.bloxbean.cardano.yano.runtime.blockproducer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class BackfillPolicyTest {
+    @Test
+    void automaticSpacingReservesForecastHeadroom() {
+        assertThat(BackfillPolicy.resolveInterval(0, 100, 1, false)).isEqualTo(299);
+        assertThat(BackfillPolicy.resolveInterval(0, 100, 1, true)).isEqualTo(150);
+        assertThat(BackfillPolicy.resolveInterval(0, 100, 0.2, false)).isEqualTo(1499);
+        assertThat(BackfillPolicy.resolveInterval(1, 100, 1, true)).isEqualTo(1);
+        assertThat(BackfillPolicy.resolveInterval(42, 100, 1, false)).isEqualTo(42);
+    }
+
+    @Test
+    void rejectsIntervalsAtForecastLimitAndInvalidGenesis() {
+        assertThatThrownBy(() -> BackfillPolicy.resolveInterval(300, 100, 1, false))
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("forecast window");
+        assertThatThrownBy(() -> BackfillPolicy.resolveInterval(0, 0, 1, false))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> BackfillPolicy.resolveInterval(0, 100, Double.NaN, false))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/DevnetBlockProducerTest.java
@@ -450,6 +450,100 @@ class DevnetBlockProducerTest {
         assertThat(chainState.getTip().getBlockNumber()).isEqualTo(0);
     }
 
+    @Test
+    void produceEmptyBlocksToSlot_defaultIntervalPlacesABlockInEverySlot() {
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+
+        int produced = blockProducer.produceEmptyBlocksToSlot(20);
+
+        assertThat(produced).isEqualTo(20);
+        assertThat(chainState.getTip().getSlot()).isEqualTo(20);
+        assertThat(chainState.getTip().getBlockNumber()).isEqualTo(20);
+        assertThat(producedSlots(eventBus)).hasSize(20).startsWith(1L, 2L, 3L).endsWith(19L, 20L);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_sparseIntervalPlacesBlocksEveryNSlotsAndAtTheTarget() {
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+        blockProducer.setBackfillBlockIntervalSlots(100);
+
+        int produced = blockProducer.produceEmptyBlocksToSlot(1_050);
+
+        assertThat(produced).isEqualTo(11);
+        assertThat(producedSlots(eventBus)).containsExactly(
+                100L, 200L, 300L, 400L, 500L, 600L, 700L, 800L, 900L, 1_000L, 1_050L);
+        assertThat(chainState.getTip().getSlot()).isEqualTo(1_050);
+        assertThat(chainState.getTip().getBlockNumber()).isEqualTo(11);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_sparseIntervalStillStartsEveryEpochWithABlock() {
+        BlockProducerHelper.setEpochParamProvider(new TestEpochParamProvider(250));
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+        blockProducer.setBackfillBlockIntervalSlots(100);
+
+        int produced = blockProducer.produceEmptyBlocksToSlot(620);
+
+        assertThat(produced).isEqualTo(8);
+        assertThat(producedSlots(eventBus)).containsExactly(100L, 200L, 250L, 350L, 450L, 500L, 600L, 620L);
+        assertThat(eventBus.events().stream().filter(EpochTransitionEvent.class::isInstance).count()).isEqualTo(2);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_intervalLongerThanAnEpochStillVisitsEveryEpoch() {
+        BlockProducerHelper.setEpochParamProvider(new TestEpochParamProvider(50));
+        RecordingEventBus eventBus = new RecordingEventBus();
+        blockProducer = createDevnetBlockProducerAtTip(0, new DevnetBlockBuilder(), eventBus);
+        blockProducer.stop();
+        blockProducer.setBackfillBlockIntervalSlots(1_000);
+
+        blockProducer.produceEmptyBlocksToSlot(175);
+
+        assertThat(producedSlots(eventBus)).containsExactly(50L, 100L, 150L, 175L);
+    }
+
+    @Test
+    void produceEmptyBlocksToSlot_afterSparseBackfillLiveProductionContinuesFromTheTip() {
+        // Running producer with a one-minute schedule, so only the explicit produceBlock() call below forges.
+        var existing = new DevnetBlockBuilder().buildBlock(0, 0, null, List.of());
+        chainState.storeBlock(existing.blockHash(), 0L, 0L, existing.blockCbor());
+        chainState.storeBlockHeader(existing.blockHash(), 0L, 0L, existing.wrappedHeaderCbor());
+        blockProducer = new DevnetBlockProducer(
+                chainState, memPool, null, new NoopEventBus(), scheduler, new DevnetBlockBuilder(),
+                60_000, false, System.currentTimeMillis(), 1000, null,
+                new DummyTransactionValidationService(null, null), null);
+        blockProducer.setForceSequentialSlots(true);
+        blockProducer.start();
+        blockProducer.setBackfillBlockIntervalSlots(40);
+        blockProducer.produceEmptyBlocksToSlot(90);
+
+        blockProducer.produceBlock();
+
+        assertThat(chainState.getTip().getSlot()).isEqualTo(91);
+        assertThat(chainState.getTip().getBlockNumber()).isEqualTo(4);
+    }
+
+    @Test
+    void setBackfillBlockIntervalSlots_rejectsValuesBelowOne() {
+        blockProducer = createDevnetBlockProducer(1000, false);
+
+        assertThrows(IllegalArgumentException.class, () -> blockProducer.setBackfillBlockIntervalSlots(0));
+        assertThat(blockProducer.getBackfillBlockIntervalSlots()).isEqualTo(1);
+    }
+
+    private static List<Long> producedSlots(RecordingEventBus eventBus) {
+        return eventBus.events().stream()
+                .filter(BlockProducedEvent.class::isInstance)
+                .map(event -> ((BlockProducedEvent) event).slot())
+                .toList();
+    }
+
     private DevnetBlockProducer createDevnetBlockProducer(int blockTimeMillis, boolean lazy) {
         return new DevnetBlockProducer(
                 chainState, memPool, null, new NoopEventBus(), scheduler,

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
@@ -1,6 +1,8 @@
 package com.bloxbean.cardano.yano.runtime.blockproducer;
 
 import com.bloxbean.cardano.yaci.events.impl.NoopEventBus;
+import com.bloxbean.cardano.yano.api.EpochParamProvider;
+import com.bloxbean.cardano.client.crypto.BlockProducerKeys;
 import com.bloxbean.cardano.yano.runtime.chain.InMemoryChainState;
 import com.bloxbean.cardano.yano.runtime.tx.BlockTransactionSelector;
 import org.junit.jupiter.api.AfterEach;
@@ -8,8 +10,9 @@ import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.util.List;
+import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -114,7 +117,7 @@ class SlotLeaderTimeTravelBlockProducerTest {
     }
 
     @Test
-    void catchUpSkipsLeadershipChecksInsideTheIntervalButScheduledScanDoesNot() {
+    void catchUpSkipsSlotsThenScansUntilEligibleOrTarget() {
         InMemoryChainState chainState = new InMemoryChainState();
         var existing = new DevnetBlockBuilder().buildBlock(0, 0, null, List.of());
         chainState.storeBlock(existing.blockHash(), 0L, 0L, existing.blockCbor());
@@ -139,7 +142,7 @@ class SlotLeaderTimeTravelBlockProducerTest {
                 return BigInteger.ONE;
             }
         };
-        EpochNonceState nonceState = new EpochNonceState(10_000, 1, 1.0);
+        EpochNonceState nonceState = new EpochNonceState(10_000, 1_000, 1.0);
         nonceState.initFromGenesisHash(new byte[32]);
         var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
                 chainState, emptyTransactions(), () -> null, new NoopEventBus(), scheduler,
@@ -173,7 +176,76 @@ class SlotLeaderTimeTravelBlockProducerTest {
         assertThat(producer.getBackfillBlockIntervalSlots()).isEqualTo(1);
     }
 
-    private static final class EpochLengthProvider implements com.bloxbean.cardano.yano.api.EpochParamProvider {
+    @Test
+    void sparseCatchUpForgesSignedBlocksAcrossThreeEpochsThenResumesDenseScheduling() throws Exception {
+        Path base = Path.of("src/test/resources/devnet");
+        var keys = BlockProducerKeys.load(base.resolve("vrf.skey"), base.resolve("kes.skey"), base.resolve("opcert.cert"));
+        var nonce = new EpochNonceState(1_200, 100, 1);
+        nonce.initFromGenesisHash(new byte[32]);
+        var builder = new SignedBlockBuilder(keys, 129_600, 60, nonce, null);
+        var chain = new InMemoryChainState();
+        var genesis = builder.buildBlock(0, 0, null, List.of());
+        BlockProducerHelper.storeProducedBlock(chain, builder, genesis);
+        List<Long> checked = new ArrayList<>();
+        CountDownLatch liveCheck = new CountDownLatch(1);
+        var check = new SlotLeaderCheck(keys.getVrfSkey(), BigDecimal.ONE, builder.getBlockSigner()) {
+            @Override
+            public BlockSigner.VrfSignResult checkAndProve(long slot, byte[] epochNonce, BigDecimal sigma) {
+                checked.add(slot);
+                if (slot > 3_600) liveCheck.countDown();
+                return super.checkAndProve(slot, epochNonce, sigma);
+            }
+        };
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(chain, emptyTransactions(),
+                () -> null, new NoopEventBus(), scheduler, builder, nonce, check, fullStake(), "pool",
+                System.currentTimeMillis() - 3_610 * 300L, 300, 10, 1);
+        producer.setBackfillBlockIntervalSlots(BackfillPolicy.resolveInterval(0, 100, 1, true));
+        assertThat(producer.produceToSlot(3_600)).isEqualTo(24);
+        assertThat(checked).hasSize(24).contains(1_200L, 2_400L, 3_600L);
+        assertThat(chain.getTip().getSlot()).isEqualTo(3_600);
+        assertThat(nonce.getCurrentEpoch()).isEqualTo(3);
+        producer.start();
+        try {
+            assertThat(liveCheck.await(5, TimeUnit.SECONDS)).isTrue();
+        } finally {
+            producer.stop();
+        }
+        assertThat(checked.get(24)).isEqualTo(3_601L);
+    }
+
+    @Test
+    void sparseCatchUpStopsBeforeExceedingForecastWindow() {
+        var chain = new InMemoryChainState();
+        var genesis = new DevnetBlockBuilder().buildBlock(0, 0, null, List.of());
+        chain.storeBlock(genesis.blockHash(), 0L, 0L, genesis.blockCbor());
+        var nonce = new EpochNonceState(1_200, 100, 1);
+        nonce.initFromGenesisHash(new byte[32]);
+        List<Long> checked = new ArrayList<>();
+        var check = new SlotLeaderCheck(new byte[64], BigDecimal.ONE, null) {
+            @Override
+            public BlockSigner.VrfSignResult checkAndProve(long slot, byte[] epochNonce, BigDecimal sigma) {
+                checked.add(slot);
+                return null;
+            }
+        };
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(chain, emptyTransactions(),
+                () -> null, new NoopEventBus(), scheduler, null, nonce, check, fullStake(), "pool",
+                0, 300, 300, 1);
+        producer.setBackfillBlockIntervalSlots(150);
+        assertThatThrownBy(() -> producer.produceToSlot(3_600))
+                .isInstanceOf(IllegalStateException.class).hasMessageContaining("forecast window");
+        assertThat(checked).hasSize(150).startsWith(150L).endsWith(299L);
+        assertThat(producer.getLastCheckedSlot()).isEqualTo(299);
+    }
+
+    private static StakeDataProvider fullStake() {
+        return new StakeDataProvider() {
+            public BigInteger getPoolStake(String poolHash, int epoch) { return BigInteger.ONE; }
+            public BigInteger getTotalStake(int epoch) { return BigInteger.ONE; }
+        };
+    }
+
+    private static final class EpochLengthProvider implements EpochParamProvider {
         private final long epochLength;
 
         private EpochLengthProvider(long epochLength) {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -17,6 +18,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SlotLeaderTimeTravelBlockProducerTest {
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -90,6 +92,112 @@ class SlotLeaderTimeTravelBlockProducerTest {
         } finally {
             releaseStakeRead.countDown();
             producer.stop();
+        }
+    }
+
+    @Test
+    void nextSparseCandidateSlot_stepsByIntervalButNeverPastAnEpochStart() {
+        BlockProducerHelper.setEpochParamProvider(new EpochLengthProvider(250));
+        try {
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(1, 0, 100)).isEqualTo(100);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(201, 200, 100)).isEqualTo(250);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(251, 250, 100)).isEqualTo(350);
+            // an interval longer than an epoch still visits every epoch start
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(1, 0, 1_000)).isEqualTo(250);
+            // never earlier than the slot being scanned, and interval 1 or no tip means no skipping
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(400, 0, 100)).isEqualTo(400);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(7, 6, 1)).isEqualTo(7);
+            assertThat(SlotLeaderTimeTravelBlockProducer.nextSparseCandidateSlot(7, -1, 100)).isEqualTo(7);
+        } finally {
+            BlockProducerHelper.setEpochParamProvider(null);
+        }
+    }
+
+    @Test
+    void catchUpSkipsLeadershipChecksInsideTheIntervalButScheduledScanDoesNot() {
+        InMemoryChainState chainState = new InMemoryChainState();
+        var existing = new DevnetBlockBuilder().buildBlock(0, 0, null, List.of());
+        chainState.storeBlock(existing.blockHash(), 0L, 0L, existing.blockCbor());
+        chainState.storeBlockHeader(existing.blockHash(), 0L, 0L, existing.wrappedHeaderCbor());
+
+        List<Long> checkedSlots = new ArrayList<>();
+        SlotLeaderCheck countingNeverLeader = new SlotLeaderCheck(new byte[64], BigDecimal.ONE, null) {
+            @Override
+            public BlockSigner.VrfSignResult checkAndProve(long slot, byte[] epochNonce, BigDecimal sigma) {
+                checkedSlots.add(slot);
+                return null;
+            }
+        };
+        StakeDataProvider fullStake = new StakeDataProvider() {
+            @Override
+            public BigInteger getPoolStake(String poolHash, int epoch) {
+                return BigInteger.ONE;
+            }
+
+            @Override
+            public BigInteger getTotalStake(int epoch) {
+                return BigInteger.ONE;
+            }
+        };
+        EpochNonceState nonceState = new EpochNonceState(10_000, 1, 1.0);
+        nonceState.initFromGenesisHash(new byte[32]);
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
+                chainState, emptyTransactions(), () -> null, new NoopEventBus(), scheduler,
+                null, nonceState, countingNeverLeader, fullStake,
+                "pool", System.currentTimeMillis() - 60_000, 1000, 1, 1);
+        producer.setBackfillBlockIntervalSlots(100);
+
+        producer.produceToSlot(1_000);
+
+        assertThat(checkedSlots).isNotEmpty();
+        assertThat(checkedSlots.get(0)).isEqualTo(100L);
+        assertThat(checkedSlots).hasSize(901);
+        assertThat(producer.getLastCheckedSlot()).isEqualTo(1_000);
+
+        // a catch-up that ends inside the interval forges nothing and lands on the target
+        checkedSlots.clear();
+        producer.setBackfillBlockIntervalSlots(5_000);
+        producer.produceToSlot(1_500);
+        assertThat(checkedSlots).isEmpty();
+        assertThat(producer.getLastCheckedSlot()).isEqualTo(1_500);
+    }
+
+    @Test
+    void setBackfillBlockIntervalSlots_rejectsValuesBelowOne() {
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
+                new InMemoryChainState(), emptyTransactions(), () -> null, new NoopEventBus(), scheduler,
+                null, new EpochNonceState(10, 1, 1.0), null, null,
+                "pool", System.currentTimeMillis() - 60_000, 1000, 1, 1);
+        assertThatThrownBy(() -> producer.setBackfillBlockIntervalSlots(0))
+                .isInstanceOf(IllegalArgumentException.class);
+        assertThat(producer.getBackfillBlockIntervalSlots()).isEqualTo(1);
+    }
+
+    private static final class EpochLengthProvider implements com.bloxbean.cardano.yano.api.EpochParamProvider {
+        private final long epochLength;
+
+        private EpochLengthProvider(long epochLength) {
+            this.epochLength = epochLength;
+        }
+
+        @Override
+        public BigInteger getKeyDeposit(long epoch) {
+            return BigInteger.ZERO;
+        }
+
+        @Override
+        public BigInteger getPoolDeposit(long epoch) {
+            return BigInteger.ZERO;
+        }
+
+        @Override
+        public long getEpochLength() {
+            return epochLength;
+        }
+
+        @Override
+        public long getByronSlotsPerEpoch() {
+            return epochLength;
         }
     }
 

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/config/GenesisSlotDurationTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/config/GenesisSlotDurationTest.java
@@ -1,0 +1,75 @@
+package com.bloxbean.cardano.yano.runtime.config;
+
+import com.bloxbean.cardano.yano.api.config.YanoConfig;
+import com.bloxbean.cardano.yano.runtime.blockproducer.GenesisConfig;
+import com.bloxbean.cardano.yano.runtime.internal.RuntimeNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class GenesisSlotDurationTest {
+    @TempDir
+    Path directory;
+
+    private GenesisConfig genesis(double seconds) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode json = (ObjectNode) mapper.readTree(Path.of("src/test/resources/devnet/shelley-genesis.json").toFile());
+        json.put("slotLength", seconds);
+        Path path = directory.resolve("shelley-genesis.json");
+        mapper.writeValue(path.toFile(), json);
+        return GenesisConfig.load(path.toString(), null, null);
+    }
+
+    @Test
+    void convertsGenesisSecondsWithoutTruncation() throws Exception {
+        for (int milliseconds : new int[]{200, 300, 1000, 1, 29}) {
+            assertThat(genesis(milliseconds / 1000.0).getSlotLengthMillis()).isEqualTo(milliseconds);
+        }
+    }
+
+    @Test
+    void rejectsUnsupportedGenesisDurations() throws Exception {
+        for (double seconds : new double[]{0, -0.3, 0.0001, 2147484}) {
+            GenesisConfig genesis = genesis(seconds);
+            assertThatThrownBy(genesis::getSlotLengthMillis).isInstanceOf(IllegalArgumentException.class);
+        }
+    }
+
+    @Test
+    void missingGenesisDoesNotInventOneSecondSlots() {
+        assertThatThrownBy(() -> GenesisConfig.load(null, null, null).getSlotLengthMillis())
+                .isInstanceOf(IllegalArgumentException.class).hasMessageContaining("Shelley genesis");
+    }
+
+    @Test
+    void runtimeReplacesLegacyValuesAndPreservesSeparateBlockTimer() throws Exception {
+        for (int legacy : new int[]{0, 300, 1000, -1}) {
+            for (int expected : new int[]{200, 300, 1000}) {
+                assertRuntimeDuration(legacy, expected / 1000.0, expected);
+            }
+        }
+    }
+
+    private void assertRuntimeDuration(int legacy, double seconds, int expected) throws Exception {
+        YanoConfig config = YanoConfig.builder().slotLengthMillis(legacy).blockTimeMillis(750).build();
+        RuntimeNode node = new RuntimeNode(config);
+        try {
+            var field = RuntimeNode.class.getDeclaredField("genesisConfig");
+            field.setAccessible(true);
+            field.set(node, genesis(seconds));
+            var resolve = RuntimeNode.class.getDeclaredMethod("autoDeriveSlotLengthMillis");
+            resolve.setAccessible(true);
+            resolve.invoke(node);
+            assertThat(config.getSlotLengthMillis()).isEqualTo(expected);
+            assertThat(config.getBlockTimeMillis()).isEqualTo(750);
+        } finally {
+            node.close();
+        }
+    }
+}

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetCatchUpServiceTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetCatchUpServiceTest.java
@@ -15,6 +15,18 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 class DevnetCatchUpServiceTest {
     @Test
+    void threeEpochCatchUpUsesThreeHundredMillisecondSlots() {
+        InMemoryChainState chainState = new InMemoryChainState();
+        storeTip(chainState, 0, 0);
+        ProducerSubsystem subsystem = new ProducerSubsystem();
+        FakeProduction production = new FakeProduction(chainState, ProducerMode.DEVNET, 15, 0);
+        subsystem.install(production);
+        var result = service(chainState, subsystem, false, 1_000, 300, 1_081_000).catchUpToWallClock();
+        assertEquals(3_600, production.emptyTargetSlot);
+        assertEquals(3_600, result.newSlot());
+    }
+
+    @Test
     void devnetCatchUpStopsProducerProducesToWallClockSlotAndRestarts() {
         InMemoryChainState chainState = new InMemoryChainState();
         storeTip(chainState, 10, 3);

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactoryTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactoryTest.java
@@ -67,8 +67,8 @@ class DevnetProducerFactoryTest {
     }
 
     @Test
-    void settingsRejectABackfillBlockIntervalBelowOne() {
-        assertThatThrownBy(() -> new DevnetProducerFactory.Settings(60_000, true, System.currentTimeMillis(), 1000, null, 0))
+    void settingsRejectANegativeBackfillBlockInterval() {
+        assertThatThrownBy(() -> new DevnetProducerFactory.Settings(60_000, true, System.currentTimeMillis(), 1000, null, -1))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("backfillBlockIntervalSlots");
     }

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactoryTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/producer/DevnetProducerFactoryTest.java
@@ -13,6 +13,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class DevnetProducerFactoryTest {
     private final ScheduledExecutorService scheduler = Executors.newSingleThreadScheduledExecutor();
@@ -51,6 +52,25 @@ class DevnetProducerFactoryTest {
         assertThat(producerSubsystem.modeOrNull()).isEqualTo(ProducerMode.DEVNET_TIME_TRAVEL);
         assertThat(producerSubsystem.isRunning()).isFalse();
         assertThat(producerSubsystem.slotLengthMillis("test")).isEqualTo(1000);
+    }
+
+    @Test
+    void settingsCarryTheBackfillBlockIntervalToTheProducer() {
+        ProducerSubsystem producerSubsystem = new ProducerSubsystem();
+        var sparse = new DevnetProducerFactory.Settings(60_000, true, System.currentTimeMillis(), 1000, null, 7);
+
+        var producer = factory(producerSubsystem).createTimeTravel(new DevnetBlockBuilder(), sparse);
+
+        assertThat(producer.getBackfillBlockIntervalSlots()).isEqualTo(7);
+        assertThat(factory(new ProducerSubsystem()).createLive(new DevnetBlockBuilder(), settings())
+                .getBackfillBlockIntervalSlots()).isEqualTo(1);
+    }
+
+    @Test
+    void settingsRejectABackfillBlockIntervalBelowOne() {
+        assertThatThrownBy(() -> new DevnetProducerFactory.Settings(60_000, true, System.currentTimeMillis(), 1000, null, 0))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("backfillBlockIntervalSlots");
     }
 
     private DevnetProducerFactory factory(ProducerSubsystem producerSubsystem) {

--- a/scripts/sparse-backfill/README.md
+++ b/scripts/sparse-backfill/README.md
@@ -1,0 +1,31 @@
+# Sparse backfill regression scripts
+
+Runner and helpers for the `test-sparse-backfill` skill
+(`.claude/skills/test-sparse-backfill/SKILL.md` — read that first). They validate
+`yano.block-producer.backfill-block-interval-slots` on a devkit devnet and prove a
+downstream Haskell `cardano-node` syncs the resulting history from genesis and keeps
+following live blocks.
+
+```bash
+./scripts/sparse-backfill/run-sparse-backfill-test.sh            # default devkit matrix
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --help
+```
+
+| file | role |
+|---|---|
+| `run-sparse-backfill-test.sh` | driver: case matrix, orchestration, report, exit code |
+| `lib/common.sh` | logging, probed ports, tracked PIDs, HTTP/JSON helpers |
+| `lib/yano.sh` | isolated Yano devnet process (all paths inside the case directory) |
+| `lib/haskell.sh` | per-case `cardano-node` instance (own db, socket, ports, topology) |
+| `tools/backfill_expect.py` | mirror of `BackfillPolicy` + `DevnetBlockProducer.nextBackfillSlot`, with the Java test vectors as `--self-test` |
+| `tools/prepare_genesis.py` | copy `app/config/network/devnet/pv10/` out and patch Shelley params |
+| `tools/verify_chain.py` | Yano-side verification (derived slot sequence, epochs, hashes, speed) |
+| `tools/haskell_check.py` | Haskell-side verification (adopted tips, hash match, live follow) |
+| `tools/render_report.py` | combined `report.md` |
+
+Related: `scripts/haskell-compatibility/` supplies the shared `cardano-node` binary
+(downloaded once); this runner never reuses its database or configuration for a test.
+
+When `DevnetBlockProducer.nextBackfillSlot` or `BackfillPolicy` changes, update
+`tools/backfill_expect.py` and its self-test vectors in the same commit — the runner
+refuses to proceed when the self-test fails.

--- a/scripts/sparse-backfill/lib/common.sh
+++ b/scripts/sparse-backfill/lib/common.sh
@@ -1,0 +1,165 @@
+#!/bin/bash
+# Shared helpers for the sparse-backfill regression runner.
+#
+# Isolation rules enforced here:
+#   * only PIDs started by this run are ever signalled (PID_FILE);
+#   * ports are probed, never defaults a developer node might be using;
+#   * every path handed to Yano is absolute and inside the per-case directory.
+
+# shellcheck disable=SC2034
+SPARSE_COMMON_LOADED=1
+
+log()  { printf '[%s] %s\n' "$(date +%H:%M:%S)" "$*"; }
+warn() { printf '[%s] WARN: %s\n' "$(date +%H:%M:%S)" "$*" >&2; }
+die()  { printf '[%s] ERROR: %s\n' "$(date +%H:%M:%S)" "$*" >&2; exit 1; }
+
+# --- process tracking -------------------------------------------------------
+# PID_FILE holds "<pid> <label>" for processes THIS run started. Nothing else is
+# ever signalled: no pkill, no port-based killing, no touching developer nodes.
+track_pid() {
+  echo "$1 $2" >> "$PID_FILE"
+}
+
+stop_tracked_pid() { # <pid> <label> [grace-seconds]
+  local pid="$1" label="$2" grace="${3:-60}" waited=0
+  kill -0 "$pid" 2>/dev/null || return 0
+  log "stopping $label (pid $pid, SIGTERM, up to ${grace}s)"
+  kill -TERM "$pid" 2>/dev/null || true
+  while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt "$grace" ]; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    warn "$label (pid $pid) did not exit within ${grace}s; sending SIGKILL"
+    kill -KILL "$pid" 2>/dev/null || true
+    return 2
+  fi
+  log "$label stopped after ${waited}s"
+  return 0
+}
+
+wait_pid_exit() { # <pid> <timeout-seconds> -> exit code of the process, or 124 on timeout
+  local pid="$1" timeout="$2" waited=0
+  while kill -0 "$pid" 2>/dev/null && [ "$waited" -lt "$timeout" ]; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+  if kill -0 "$pid" 2>/dev/null; then
+    return 124
+  fi
+  wait "$pid" 2>/dev/null
+  return $?
+}
+
+cleanup_tracked() {
+  [ -f "$PID_FILE" ] || return 0
+  local pid label
+  while read -r pid label; do
+    [ -n "${pid:-}" ] || continue
+    stop_tracked_pid "$pid" "$label" 30 || true
+  done < <(tail -r "$PID_FILE" 2>/dev/null || tac "$PID_FILE")
+  : > "$PID_FILE"
+}
+
+# --- JVM crash detection ----------------------------------------------------
+# A node must fail and shut down cleanly. A SIGSEGV in native code (RocksDB JNI)
+# exits within the SIGTERM grace period and would otherwise be recorded as a
+# normal stop, so every shutdown is checked for a crash signature.
+jvm_crash_detail() { # <work-dir> <log-file>... -> prints detail, returns 0 when crashed
+  local dir="$1"; shift
+  local log hs
+  for log in "$@"; do
+    [ -f "$log" ] || continue
+    if grep -q "A fatal error has been detected by the Java Runtime Environment" "$log"; then
+      grep -m1 -A1 "Problematic frame" "$log" | tail -1 | head -c 180
+      return 0
+    fi
+  done
+  hs=$(ls "$dir"/hs_err_pid*.log 2>/dev/null | head -1)
+  if [ -n "$hs" ]; then
+    printf 'JVM crash report present: %s' "$hs"
+    return 0
+  fi
+  return 1
+}
+
+# --- ports ------------------------------------------------------------------
+# Scan upward from a base for a port nothing is listening on. Never returns the
+# well-known dev ports (7070 Yano HTTP, 13337 n2n, 3002 Haskell, 32000 preprod).
+RESERVED_PORTS=" 7070 13337 3002 32000 12788 12798 "
+pick_port() { # <start>
+  local candidate="$1"
+  while [ "$candidate" -lt 65000 ]; do
+    case "$RESERVED_PORTS" in *" $candidate "*) candidate=$((candidate + 1)); continue ;; esac
+    if ! port_in_use "$candidate"; then
+      echo "$candidate"
+      return 0
+    fi
+    candidate=$((candidate + 1))
+  done
+  die "no free port found from $1"
+}
+
+port_in_use() { # <port>
+  python3 - "$1" <<'PY'
+import socket, sys
+port = int(sys.argv[1])
+with socket.socket() as probe:
+    probe.settimeout(0.4)
+    sys.exit(0 if probe.connect_ex(("127.0.0.1", port)) == 0 else 1)
+PY
+}
+
+# --- http -------------------------------------------------------------------
+http_json() { # <url> [method] [body]
+  local url="$1" method="${2:-GET}" body="${3:-}"
+  if [ "$method" = "POST" ]; then
+    curl -sS -X POST -H 'Content-Type: application/json' ${body:+-d "$body"} "$url"
+  else
+    curl -sS "$url"
+  fi
+}
+
+http_status_and_body() { # <url> <method> <body> <out-file> -> echoes status
+  local url="$1" method="$2" body="$3" out="$4"
+  curl -sS -o "$out" -w '%{http_code}' -X "$method" \
+    -H 'Content-Type: application/json' ${body:+-d "$body"} "$url"
+}
+
+json_get() { # <file> <dotted.path>
+  python3 - "$1" "$2" <<'PY'
+import json, sys
+value = json.load(open(sys.argv[1]))
+for key in sys.argv[2].split("."):
+    value = value[key] if isinstance(value, dict) else value[int(key)]
+print(value)
+PY
+}
+
+now_ms() { python3 -c 'import time;print(int(time.time()*1000))'; }
+
+wait_for_http() { # <url> <timeout-seconds> <label>
+  local url="$1" timeout="$2" label="$3" waited=0
+  while [ "$waited" -lt "$timeout" ]; do
+    if curl -sf -o /dev/null "$url"; then
+      log "$label ready after ${waited}s"
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+wait_for_log() { # <file> <regex> <timeout-seconds> <label>
+  local file="$1" pattern="$2" timeout="$3" label="$4" waited=0
+  while [ "$waited" -lt "$timeout" ]; do
+    if [ -f "$file" ] && grep -Eq "$pattern" "$file"; then
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  warn "timeout waiting for '$pattern' in $label"
+  return 1
+}

--- a/scripts/sparse-backfill/lib/haskell.sh
+++ b/scripts/sparse-backfill/lib/haskell.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+# Per-case Haskell cardano-node instance.
+#
+# The shared download at test-data-dir/haskell-node/ supplies the BINARY only.
+# Every case gets its own instance directory (config, genesis, topology, db,
+# socket, ports), so a run never touches another node's database and two cases
+# can never share chain state. Existing user nodes and databases are untouched.
+
+HASKELL_SHARED_DIR="$PROJECT_ROOT/test-data-dir/haskell-node"
+
+ensure_haskell_binary() {
+  if [ ! -x "$HASKELL_SHARED_DIR/bin/cardano-node" ]; then
+    log "cardano-node binary missing; running setup-haskell-test-node.sh (downloads once)"
+    bash "$PROJECT_ROOT/scripts/haskell-compatibility/setup-haskell-test-node.sh"
+  fi
+  [ -x "$HASKELL_SHARED_DIR/bin/cardano-node" ] || die "cardano-node binary not available"
+  [ -x "$HASKELL_SHARED_DIR/bin/cardano-cli" ] || die "cardano-cli binary not available"
+  "$HASKELL_SHARED_DIR/bin/cardano-node" --version | head -1
+}
+
+create_haskell_instance() { # <instance-dir> <genesis-dir> <yano-n2n-port> <ekg> <prometheus>
+  local dir="$1" genesis="$2" n2n_port="$3" ekg="$4" prometheus="$5"
+  mkdir -p "$dir/files" "$dir/db"
+
+  # Same genesis BYTES as Yano: copied after the epoch shift rewrote systemStart.
+  cp "$genesis/shelley-genesis.json" "$dir/files/"
+  cp "$genesis/byron-genesis.json"   "$dir/files/"
+  cp "$genesis/alonzo-genesis.json"  "$dir/files/"
+  cp "$genesis/conway-genesis.json"  "$dir/files/"
+  if [ -f "$HASKELL_SHARED_DIR/files/dijkstra-genesis.json" ]; then
+    cp "$HASKELL_SHARED_DIR/files/dijkstra-genesis.json" "$dir/files/"
+  fi
+
+  python3 - "$HASKELL_SHARED_DIR/configuration.json" "$dir/configuration.json" "$ekg" "$prometheus" <<'PY'
+import json, sys
+source, dest, ekg, prometheus = sys.argv[1], sys.argv[2], int(sys.argv[3]), int(sys.argv[4])
+config = json.load(open(source))
+config["hasEKG"] = ekg
+config["hasPrometheus"] = ["127.0.0.1", prometheus]
+json.dump(config, open(dest, "w"), indent=2, sort_keys=True)
+PY
+
+  cat > "$dir/files/topology.json" <<TOPO
+{
+  "bootstrapPeers": [
+    {"address": "127.0.0.1", "port": $n2n_port}
+  ],
+  "localRoots": [
+    {
+      "accessPoints": [
+        {"address": "127.0.0.1", "port": $n2n_port}
+      ],
+      "valency": 1
+    }
+  ],
+  "publicRoots": [],
+  "useLedgerAfterSlot": -1
+}
+TOPO
+}
+
+start_haskell_instance() { # <instance-dir> <node-port> <log> <label>
+  local dir="$1" node_port="$2" log_file="$3" label="$4"
+  local bin="$HASKELL_SHARED_DIR/bin/cardano-node"
+  {
+    printf 'cd %q\n' "$dir"
+    printf '%q run --topology files/topology.json --database-path db --socket-path db/node.socket ' "$bin"
+    printf -- '--host-addr 127.0.0.1 --port %s --config configuration.json\n' "$node_port"
+  } > "$dir/command.txt"
+
+  ( cd "$dir" && exec "$bin" run \
+      --topology files/topology.json \
+      --database-path db \
+      --socket-path db/node.socket \
+      --host-addr 127.0.0.1 \
+      --port "$node_port" \
+      --config configuration.json ) > "$log_file" 2>&1 &
+  local pid=$!
+  track_pid "$pid" "haskell:$label"
+  echo "$pid"
+}
+
+wait_haskell_socket() { # <instance-dir> <timeout> <pid>
+  local dir="$1" timeout="$2" pid="$3" waited=0
+  while [ "$waited" -lt "$timeout" ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      warn "cardano-node exited during startup"
+      return 2
+    fi
+    [ -S "$dir/db/node.socket" ] && { log "haskell socket up after ${waited}s"; return 0; }
+    sleep 1
+    waited=$((waited + 1))
+  done
+  return 1
+}
+
+# cardano-cli must reach the socket through a RELATIVE path: AF_UNIX paths are
+# capped at 104 bytes, and an absolute run-directory path blows that limit
+# ("pokeSockAddr: path is too long in SockAddrUnix"). The node binds it relative
+# to its own cwd for the same reason.
+haskell_tip() { # <instance-dir> <magic>
+  ( cd "$1" && CARDANO_NODE_SOCKET_PATH=db/node.socket \
+      "$HASKELL_SHARED_DIR/bin/cardano-cli" query tip --testnet-magic "$2" 2>/dev/null )
+}
+
+wait_haskell_slot() { # <instance-dir> <magic> <min-slot> <max-seconds> [stall-seconds]
+  # Bulk sync of a long sparse history is slow (the ledger ticks every skipped slot),
+  # so the overall cap is generous and progress is what actually decides: if the tip
+  # has not moved for <stall-seconds>, the sync is stuck and we stop waiting.
+  local dir="$1" magic="$2" min_slot="$3" timeout="$4" stall="${5:-240}"
+  local waited=0 since_progress=0 slot last=-1
+  while [ "$waited" -lt "$timeout" ]; do
+    slot=$(haskell_tip "$dir" "$magic" | python3 -c \
+      'import json,sys
+try:
+    print(json.load(sys.stdin)["slot"])
+except Exception:
+    print(-1)' 2>/dev/null || echo -1)
+    if [ "${slot:--1}" -ge "$min_slot" ] 2>/dev/null; then
+      log "haskell reached slot $slot (>= $min_slot) after ${waited}s"
+      return 0
+    fi
+    if [ "${slot:--1}" -gt "$last" ] 2>/dev/null; then
+      last="$slot"
+      since_progress=0
+      [ $((waited % 60)) -lt 5 ] && [ "$waited" -gt 0 ] \
+        && log "haskell syncing: slot $slot / $min_slot after ${waited}s"
+    else
+      since_progress=$((since_progress + 5))
+      if [ "$since_progress" -ge "$stall" ]; then
+        warn "haskell tip stuck at ${last} for ${stall}s (target ${min_slot}); giving up"
+        return 1
+      fi
+    fi
+    sleep 5
+    waited=$((waited + 5))
+  done
+  warn "haskell did not reach slot $min_slot within ${timeout}s (last=${last})"
+  return 1
+}

--- a/scripts/sparse-backfill/lib/yano.sh
+++ b/scripts/sparse-backfill/lib/yano.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# Start/stop an isolated Yano devnet node for one sparse-backfill case.
+#
+# Everything the node writes is inside the case directory: chainstate, history
+# archive, app-chain store, and the genesis copy whose systemStart the runtime
+# rewrites. The tracked fixtures under app/config/network/devnet/pv10/ are only
+# ever read (prepare_genesis.py copies them out first).
+
+yano_java_args() { # <case-dir> <genesis-dir> <http-port> <n2n-port> <interval> <mode>
+  local case_dir="$1" genesis="$2" http_port="$3" n2n_port="$4" interval="$5" mode="$6"
+  local args=(
+    -Dquarkus.profile=devnet
+    -Dquarkus.http.port="$http_port"
+    -Dyano.server.port="$n2n_port"
+    -Dyano.storage.path="$case_dir/chainstate"
+    -Dyano.history.dir="$case_dir/history"
+    -Dyano.app-chain.storage.path="$case_dir/appchain-chainstate"
+    -Dyano.genesis.shelley-genesis-file="$genesis/shelley-genesis.json"
+    -Dyano.genesis.byron-genesis-file="$genesis/byron-genesis.json"
+    -Dyano.genesis.alonzo-genesis-file="$genesis/alonzo-genesis.json"
+    -Dyano.genesis.conway-genesis-file="$genesis/conway-genesis.json"
+    -Dyano.genesis.protocol-parameters-file="$genesis/protocol-param.json"
+    -Dyano.genesis.shelley-genesis-hash=
+    -Dyano.block-producer.vrf-skey-file="$genesis/vrf.skey"
+    -Dyano.block-producer.kes-skey-file="$genesis/kes.skey"
+    -Dyano.block-producer.opcert-file="$genesis/opcert.cert"
+    -Dyano.block-producer.backfill-block-interval-slots="$interval"
+  )
+  if [ -n "${LEGACY_SLOT_LENGTH_MILLIS:-}" ]; then
+    args+=(-Dyano.block-producer.slot-length-millis="$LEGACY_SLOT_LENGTH_MILLIS")
+  fi
+  case "$mode" in
+    past-time-travel)
+      args+=(-Dyano.block-producer.past-time-travel-mode=true) ;;
+    slot-leader-time-travel)
+      args+=(-Dyano.block-producer.past-time-travel-mode=true
+             -Dyano.block-producer.past-time-travel-slot-leader-mode=true) ;;
+    live)
+      : ;;  # regular devnet producer, wall-clock slots (used for the restart check)
+    *) die "unknown yano mode: $mode" ;;
+  esac
+  printf '%s\n' "${args[@]}"
+}
+
+start_yano() { # <case-dir> <genesis-dir> <http> <n2n> <interval> <mode> <log> <label>
+  local case_dir="$1" genesis="$2" http_port="$3" n2n_port="$4" interval="$5" mode="$6"
+  local log_file="$7" label="$8"
+  local args=()
+  while IFS= read -r line; do args+=("$line"); done < <(
+    yano_java_args "$case_dir" "$genesis" "$http_port" "$n2n_port" "$interval" "$mode")
+
+  {
+    printf 'cd %q\n' "$case_dir"
+    printf '%q ' java "${args[@]}" -jar "$YANO_JAR"
+    printf '\n'
+  } > "$case_dir/${label}-command.txt"
+
+  ( cd "$case_dir" && exec java "${args[@]}" -jar "$YANO_JAR" ) > "$log_file" 2>&1 &
+  local pid=$!
+  track_pid "$pid" "yano:$label"
+  echo "$pid"
+}
+
+wait_yano_ready() { # <http-port> <timeout> <log> <pid>
+  local http_port="$1" timeout="$2" log_file="$3" pid="$4" waited=0
+  while [ "$waited" -lt "$timeout" ]; do
+    if ! kill -0 "$pid" 2>/dev/null; then
+      warn "yano exited during startup; see $log_file"
+      return 2
+    fi
+    if curl -sf -o /dev/null "http://127.0.0.1:$http_port/q/health/ready"; then
+      log "yano ready on port $http_port after ${waited}s"
+      return 0
+    fi
+    sleep 1
+    waited=$((waited + 1))
+  done
+  warn "yano did not become ready within ${timeout}s"
+  return 1
+}

--- a/scripts/sparse-backfill/run-sparse-backfill-test.sh
+++ b/scripts/sparse-backfill/run-sparse-backfill-test.sh
@@ -1,0 +1,675 @@
+#!/bin/bash
+# Sparse-backfill regression runner (see .claude/skills/test-sparse-backfill/SKILL.md).
+#
+# Validates fast devnet backfill across values of
+# yano.block-producer.backfill-block-interval-slots, and proves a downstream Haskell
+# cardano-node can sync the resulting history from genesis and keep following live blocks.
+#
+#   ./scripts/sparse-backfill/run-sparse-backfill-test.sh                    # devkit matrix
+#   ./scripts/sparse-backfill/run-sparse-backfill-test.sh --cases auto
+#   ./scripts/sparse-backfill/run-sparse-backfill-test.sh --cases all --slot-leader
+#   ./scripts/sparse-backfill/run-sparse-backfill-test.sh --no-haskell       # Yano-only smoke
+#
+# Isolation: every case gets its own genesis copy, chainstate, history archive, Haskell
+# database, socket, logs and probed ports. Only processes started here are stopped.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TOOLS="$SCRIPT_DIR/tools"
+# shellcheck source=lib/common.sh
+source "$SCRIPT_DIR/lib/common.sh"
+# shellcheck source=lib/yano.sh
+source "$SCRIPT_DIR/lib/yano.sh"
+# shellcheck source=lib/haskell.sh
+source "$SCRIPT_DIR/lib/haskell.sh"
+
+# --- defaults ---------------------------------------------------------------
+CASES="dense,interval2,auto,auto-1s,reject"
+WITH_SLOT_LEADER=0
+WITH_HASKELL=1
+EPOCHS=3
+EPOCH_LENGTH=1200
+SECURITY_PARAM=100
+ACTIVE_SLOTS_COEFF=1.0
+SLOTS_PER_KES_PERIOD=0   # 0 = keep the genesis value; Sum6KES covers only 64 periods
+SOURCE_GENESIS="$PROJECT_ROOT/app/config/network/devnet/pv10"
+YANO_JAR="$PROJECT_ROOT/app/build/yano.jar"
+MAGIC=42
+PORT_BASE=21000
+SEQUENTIAL_SECONDS=3        # scheduled sequential blocks before catch-up
+LIVE_FOLLOW_SECONDS=12      # Haskell live-follow observation window
+SKIP_BUILD=0
+LEGACY_SLOT_LENGTH_MILLIS=""
+RUN_DIR=""
+# Slot-leader scenario genesis: 3k/f and 10k/f must both stay <= epochLength or
+# cardano-node refuses the Shelley genesis before any block is exchanged.
+SL_SECURITY_PARAM=50
+SL_ACTIVE_SLOTS_COEFF=0.5
+
+usage() {
+  sed -n '2,15p' "$0"
+  cat <<'USAGE'
+Options:
+  --cases <list>       dense,interval2,auto,auto-1s,reject | all (default: all but slot-leader)
+  --slot-leader        also run the optional slot-leader scenario
+  --no-haskell         skip the downstream Haskell node (Yano-side checks only)
+  --run-dir <dir>      output directory (default: test-data-dir/sparse-backfill/<timestamp>)
+  --epochs <n>         epochs to shift genesis back (default: 3)
+  --epoch-length <n>   slots per epoch (default: 1200; mainnet shape is 432000)
+  --security-param <k> Shelley securityParam; automatic spacing is floor(3k/f)-1 (default: 100)
+  --slots-per-kes-period <n>  override slotsPerKESPeriod (Sum6KES signs only 64 periods total)
+  --skip-build         do not rebuild the uber-jar even if sources are newer
+  --legacy-slot-length-millis <n>  pass the obsolete property; verify genesis still determines slot duration
+  -h, --help
+USAGE
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --cases) CASES="$2"; shift 2 ;;
+    --slot-leader) WITH_SLOT_LEADER=1; shift ;;
+    --no-haskell) WITH_HASKELL=0; shift ;;
+    --run-dir) RUN_DIR="$2"; shift 2 ;;
+    --epochs) EPOCHS="$2"; shift 2 ;;
+    --epoch-length) EPOCH_LENGTH="$2"; shift 2 ;;
+    --security-param) SECURITY_PARAM="$2"; shift 2 ;;
+    --slots-per-kes-period) SLOTS_PER_KES_PERIOD="$2"; shift 2 ;;
+    --skip-build) SKIP_BUILD=1; shift ;;
+    --legacy-slot-length-millis) LEGACY_SLOT_LENGTH_MILLIS="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown option: $1 (try --help)" ;;
+  esac
+done
+[ "$CASES" = "all" ] && CASES="dense,interval2,auto,auto-1s,reject"
+[ "$WITH_SLOT_LEADER" = "1" ] && CASES="$CASES,slot-leader"
+
+if [ -z "$RUN_DIR" ]; then
+  RUN_DIR="$PROJECT_ROOT/test-data-dir/sparse-backfill/$(date +%Y%m%d-%H%M%S)"
+fi
+mkdir -p "$RUN_DIR"
+# Absolute from here on: each node runs with cwd = its case directory, so a relative
+# run-dir would make -Dyano.storage.path resolve inside the case dir and RocksDB would
+# fail with "While mkdir if missing: ... No such file or directory".
+RUN_DIR="$(cd "$RUN_DIR" && pwd)"
+PID_FILE="$RUN_DIR/started-pids"
+: > "$PID_FILE"
+export PID_FILE YANO_JAR PROJECT_ROOT
+
+trap 'log "cleanup: stopping processes started by this run"; cleanup_tracked' EXIT INT TERM
+
+# --- pre-flight -------------------------------------------------------------
+command -v java >/dev/null || die "java not on PATH"
+command -v curl >/dev/null || die "curl not on PATH"
+command -v python3 >/dev/null || die "python3 not on PATH"
+[ -d "$SOURCE_GENESIS" ] || die "genesis source not found: $SOURCE_GENESIS"
+
+if [ ! -f "$YANO_JAR" ]; then
+  [ "$SKIP_BUILD" = "1" ] && die "jar missing: $YANO_JAR"
+  log "building uber-jar (:app:quarkusBuild)"
+  (cd "$PROJECT_ROOT" && ./gradlew :app:quarkusBuild) || die "build failed"
+elif [ "$SKIP_BUILD" != "1" ]; then
+  STALE=$(find "$PROJECT_ROOT/runtime" "$PROJECT_ROOT/core-api" "$PROJECT_ROOT/app" \
+    -name '*.java' -newer "$YANO_JAR" -print -quit 2>/dev/null)
+  if [ -n "$STALE" ]; then
+    log "jar is older than $STALE — rebuilding so the test exercises the working tree"
+    (cd "$PROJECT_ROOT" && ./gradlew :app:quarkusBuild) || die "build failed"
+  fi
+fi
+
+log "expected-slot helper self-test"
+python3 "$TOOLS/backfill_expect.py" --self-test || die "backfill_expect self-test failed — the runtime algorithm changed"
+
+GENESIS_BEFORE=$(cd "$PROJECT_ROOT" && git status --porcelain app/config)
+log "run directory: $RUN_DIR"
+
+# --- per-case helpers -------------------------------------------------------
+# The cursor lives in a file: next_port is called from command substitution, so a
+# shell variable would be incremented in a subshell and lost, handing two services
+# the same port.
+PORT_STATE="$RUN_DIR/.port-cursor"
+echo "$PORT_BASE" > "$PORT_STATE"
+next_port() {
+  local cursor port
+  cursor=$(cat "$PORT_STATE")
+  port=$(pick_port "$cursor")
+  echo $((port + 1)) > "$PORT_STATE"
+  echo "$port"
+}
+
+record_crash_check() { # <case-dir> <stage> <work-dir> <log-file>...
+  local case_dir="$1" stage="$2" work_dir="$3"; shift 3
+  local detail
+  if detail=$(jvm_crash_detail "$work_dir" "$@"); then
+    record_stage "$case_dir" "$stage" FAIL "JVM crashed: $detail"
+  else
+    record_stage "$case_dir" "$stage" PASS "no JVM crash"
+  fi
+}
+
+record_stage() { # <case-dir> <stage> <status> <detail>
+  printf '%s\t%s\t%s\n' "$2" "$3" "${4:-}" >> "$1/stages.tsv"
+  case "$3" in
+    PASS) log "  [PASS] $2" ;;
+    NOTE) log "  [NOTE] $2 ${4:-}" ;;
+    *)    warn "  [$3] $2 ${4:-}" ;;
+  esac
+}
+
+write_meta() { # <case-dir> <json-body>
+  printf '%s\n' "$2" > "$1/meta.json"
+}
+
+case_status() { # <case-dir>
+  local file="$1/stages.tsv"
+  [ -f "$file" ] || { echo "BLOCKED"; return; }
+  if grep -q $'\tFAIL\t' "$file"; then echo FAIL
+  elif grep -q $'\tBLOCKED\t' "$file"; then echo BLOCKED
+  else echo PASS; fi
+}
+
+# --- main backfill case -----------------------------------------------------
+run_backfill_case() { # <name> <requested-interval> <slot-length-seconds> <restart:0|1>
+  local name="$1" requested="$2" slot_len="$3" do_restart="$4"
+  local case_dir="$RUN_DIR/case-$name"
+  local genesis="$case_dir/genesis"
+  mkdir -p "$case_dir"
+  : > "$case_dir/stages.tsv"
+  log "=== case $name: backfill-block-interval-slots=$requested, slotLength=${slot_len}s ==="
+
+  python3 "$TOOLS/prepare_genesis.py" --source "$SOURCE_GENESIS" --dest "$genesis" \
+    --slot-length "$slot_len" --epoch-length "$EPOCH_LENGTH" \
+    --security-param "$SECURITY_PARAM" --active-slots-coeff "$ACTIVE_SLOTS_COEFF" \
+    --epochs "$EPOCHS" --slots-per-kes-period "$SLOTS_PER_KES_PERIOD" \
+    > "$case_dir/genesis-params.json" \
+    || { record_stage "$case_dir" genesis-prep FAIL "prepare_genesis.py failed"; return; }
+  record_stage "$case_dir" genesis-prep PASS
+
+  local slot_ms expected_shift expected_target bounds_ok
+  slot_ms=$(json_get "$case_dir/genesis-params.json" slot_length_millis)
+  expected_shift=$(json_get "$case_dir/genesis-params.json" expected_shift_millis)
+  expected_target=$(json_get "$case_dir/genesis-params.json" expected_target_slot)
+  bounds_ok=$(json_get "$case_dir/genesis-params.json" genesis_bounds_ok)
+  [ "$bounds_ok" = "True" ] || record_stage "$case_dir" genesis-bounds FAIL \
+    "epochLength=$EPOCH_LENGTH is too short for k=$SECURITY_PARAM/f=$ACTIVE_SLOTS_COEFF"
+
+  local http n2n hnode ekg prom
+  http=$(next_port); n2n=$(next_port); hnode=$(next_port); ekg=$(next_port); prom=$(next_port)
+  log "ports: http=$http n2n=$n2n haskell=$hnode ekg=$ekg prometheus=$prom"
+
+  local yano_log="$case_dir/yano.log" pid
+  pid=$(start_yano "$case_dir" "$genesis" "$http" "$n2n" "$requested" past-time-travel \
+    "$yano_log" "ptt")
+  if ! wait_yano_ready "$http" 180 "$yano_log" "$pid"; then
+    record_stage "$case_dir" yano-start FAIL "node did not become ready (see yano.log)"
+    stop_tracked_pid "$pid" "yano:$name" 60
+    return
+  fi
+  record_stage "$case_dir" yano-start PASS
+  if wait_for_log "$yano_log" "Past time travel mode" 30 "yano.log"; then
+    record_stage "$case_dir" past-time-travel-deferred PASS
+  else
+    record_stage "$case_dir" past-time-travel-deferred FAIL "deferral line not logged"
+  fi
+
+  curl -sS "http://127.0.0.1:$http/api/v1/node/config" > "$case_dir/node-config.json" 2>/dev/null
+
+  # --- epoch shift ---------------------------------------------------------
+  local shift_start shift_elapsed
+  shift_start=$(now_ms)
+  http_status_and_body "http://127.0.0.1:$http/api/v1/devnet/epochs/shift" POST \
+    "{\"epochs\": $EPOCHS}" "$case_dir/shift.json" > "$case_dir/shift.status"
+  shift_elapsed=$(( $(now_ms) - shift_start ))
+  local shift_status shift_millis genesis_slot
+  shift_status=$(cat "$case_dir/shift.status")
+  if [ "$shift_status" != "200" ]; then
+    record_stage "$case_dir" epoch-shift FAIL "HTTP $shift_status: $(head -c 300 "$case_dir/shift.json")"
+    stop_tracked_pid "$pid" "yano:$name" 60
+    return
+  fi
+  shift_millis=$(json_get "$case_dir/shift.json" shift_millis)
+  genesis_slot=$(json_get "$case_dir/shift.json" genesis_slot)
+  if [ "$shift_millis" = "$expected_shift" ] && [ "$genesis_slot" = "0" ]; then
+    record_stage "$case_dir" epoch-shift PASS "shift_millis=$shift_millis genesis_slot=0"
+  else
+    record_stage "$case_dir" epoch-shift FAIL \
+      "shift_millis=$shift_millis (expected $expected_shift), genesis_slot=$genesis_slot"
+  fi
+
+  # Let the scheduler forge a few sequential blocks so the catch-up starts from a
+  # non-zero tip — the derivation must handle it without hardcoded numbers.
+  sleep "$SEQUENTIAL_SECONDS"
+  curl -sS "http://127.0.0.1:$http/api/v1/node/tip" > "$case_dir/pre-catchup-tip.json" 2>/dev/null
+
+  # --- catch-up ------------------------------------------------------------
+  local t0 t1 elapsed
+  t0=$(now_ms)
+  http_status_and_body "http://127.0.0.1:$http/api/v1/devnet/epochs/catch-up" POST "" \
+    "$case_dir/catchup.json" > "$case_dir/catchup.status"
+  t1=$(now_ms)
+  elapsed=$((t1 - t0))
+  if [ "$(cat "$case_dir/catchup.status")" != "200" ]; then
+    record_stage "$case_dir" catch-up FAIL \
+      "HTTP $(cat "$case_dir/catchup.status"): $(head -c 300 "$case_dir/catchup.json")"
+    stop_tracked_pid "$pid" "yano:$name" 60
+    return
+  fi
+  record_stage "$case_dir" catch-up PASS "elapsed=${elapsed}ms"
+
+  if python3 "$TOOLS/verify_chain.py" \
+      --base-url "http://127.0.0.1:$http" \
+      --yano-log "$yano_log" \
+      --catchup-json "$case_dir/catchup.json" \
+      --requested-interval "$requested" \
+      --security-param "$SECURITY_PARAM" \
+      --active-slots-coeff "$ACTIVE_SLOTS_COEFF" \
+      --epoch-length "$EPOCH_LENGTH" \
+      --slot-length-ms "$slot_ms" \
+      --elapsed-ms "$elapsed" \
+      --out "$case_dir/verify.json" > "$case_dir/verify.log" 2>&1; then
+    record_stage "$case_dir" chain-verification PASS
+  else
+    record_stage "$case_dir" chain-verification FAIL "see verify.log"
+  fi
+  cat "$case_dir/verify.log"
+
+  local produced_blocks target_slot epoch_starts expect_slots
+  produced_blocks=$(json_get "$case_dir/catchup.json" blocks_produced 2>/dev/null || echo 0)
+  target_slot=$(python3 -c "import json;print(json.load(open('$case_dir/verify.json'))['target_slot'])" 2>/dev/null || echo "$expected_target")
+  epoch_starts=$(python3 -c "import json;print(','.join(str(s) for s in json.load(open('$case_dir/verify.json'))['epoch_start_slots']))" 2>/dev/null || echo "")
+  expect_slots="0${epoch_starts:+,$epoch_starts},$target_slot"
+
+  # --- downstream Haskell node ---------------------------------------------
+  local hpid=0 haskell_elapsed=0 hdir="$case_dir/haskell"
+  if [ "$WITH_HASKELL" = "1" ]; then
+    ensure_haskell_binary > "$case_dir/haskell-version.txt" 2>&1
+    create_haskell_instance "$hdir" "$genesis" "$n2n" "$ekg" "$prom"
+    # Same bytes on both sides, proven not assumed.
+    if [ "$(shasum -a 256 "$genesis/shelley-genesis.json" | cut -d' ' -f1)" = \
+         "$(shasum -a 256 "$hdir/files/shelley-genesis.json" | cut -d' ' -f1)" ]; then
+      record_stage "$case_dir" genesis-bytes-identical PASS
+    else
+      record_stage "$case_dir" genesis-bytes-identical FAIL "shelley-genesis.json differs"
+    fi
+    shasum -a 256 "$genesis"/*.json "$hdir/files"/*.json > "$case_dir/genesis-sha256.txt"
+
+    local hstart
+    hstart=$(now_ms)
+    hpid=$(start_haskell_instance "$hdir" "$hnode" "$case_dir/haskell.log" "$name")
+    if ! wait_haskell_socket "$hdir" 120 "$hpid"; then
+      record_stage "$case_dir" haskell-start FAIL "socket never appeared (see haskell.log)"
+    else
+      record_stage "$case_dir" haskell-start PASS
+      # ~50 blocks/s is a conservative floor for bulk sync of sparse history;
+      # the stall detector inside wait_haskell_slot ends a genuinely stuck sync early.
+      local hsync_cap
+      hsync_cap=$(python3 -c "print(max(300, int($produced_blocks / 20) + 120))")
+      log "haskell sync cap: ${hsync_cap}s for $produced_blocks blocks"
+      if wait_haskell_slot "$hdir" "$MAGIC" "$target_slot" "$hsync_cap"; then
+        haskell_elapsed=$(( $(now_ms) - hstart ))
+        record_stage "$case_dir" haskell-sync PASS "elapsed=${haskell_elapsed}ms"
+      else
+        haskell_elapsed=$(( $(now_ms) - hstart ))
+        record_stage "$case_dir" haskell-sync FAIL "did not reach slot $target_slot"
+      fi
+      if python3 "$TOOLS/haskell_check.py" --haskell-log "$case_dir/haskell.log" \
+          --cli "$HASKELL_SHARED_DIR/bin/cardano-cli" --node-dir "$hdir" \
+          --magic "$MAGIC" --yano-base-url "http://127.0.0.1:$http" \
+          --expect-slots "$expect_slots" --phase initial --reach-slot "$target_slot" \
+          --out "$case_dir/haskell-initial.json" > "$case_dir/haskell-initial.log" 2>&1; then
+        record_stage "$case_dir" haskell-history-match PASS
+      else
+        record_stage "$case_dir" haskell-history-match FAIL "see haskell-initial.log"
+      fi
+      cat "$case_dir/haskell-initial.log"
+
+      log "observing live follow for ${LIVE_FOLLOW_SECONDS}s"
+      sleep "$LIVE_FOLLOW_SECONDS"
+      if python3 "$TOOLS/haskell_check.py" --haskell-log "$case_dir/haskell.log" \
+          --cli "$HASKELL_SHARED_DIR/bin/cardano-cli" --node-dir "$hdir" \
+          --magic "$MAGIC" --yano-base-url "http://127.0.0.1:$http" \
+          --expect-slots "$expect_slots" --phase live --min-live-slot "$target_slot" \
+          --out "$case_dir/haskell-live.json" > "$case_dir/haskell-live.log" 2>&1; then
+        record_stage "$case_dir" haskell-live-follow PASS
+      else
+        record_stage "$case_dir" haskell-live-follow FAIL "see haskell-live.log"
+      fi
+      cat "$case_dir/haskell-live.log"
+    fi
+  fi
+
+  # --- graceful restart ----------------------------------------------------
+  if [ "$do_restart" = "1" ]; then
+    curl -sS "http://127.0.0.1:$http/api/v1/node/tip" > "$case_dir/pre-restart-tip.json" 2>/dev/null
+    if stop_tracked_pid "$pid" "yano:$name" 60; then
+      record_stage "$case_dir" graceful-shutdown PASS
+      record_crash_check "$case_dir" shutdown-clean "$case_dir" "$yano_log"
+      # past-time-travel is a first-boot mode: ProducerStartupPlan defers whenever the
+      # flag is set, so the restart runs the regular devnet producer against the same
+      # chainstate and the already-shifted systemStart in the case genesis copy.
+      local pid2
+      pid2=$(start_yano "$case_dir" "$genesis" "$http" "$n2n" "$requested" live \
+        "$case_dir/yano-restart.log" "restart")
+      if wait_yano_ready "$http" 180 "$case_dir/yano-restart.log" "$pid2"; then
+        if grep -q "Block producer resuming from existing tip" "$case_dir/yano-restart.log"; then
+          record_stage "$case_dir" restart-resume PASS
+        else
+          record_stage "$case_dir" restart-resume FAIL "no resume-from-tip line in the new log"
+        fi
+        sleep 6
+        curl -sS "http://127.0.0.1:$http/api/v1/node/tip" > "$case_dir/post-restart-tip.json" 2>/dev/null
+        if python3 - "$case_dir/pre-restart-tip.json" "$case_dir/post-restart-tip.json" <<'PY'
+import json, sys
+before = json.load(open(sys.argv[1]))
+after = json.load(open(sys.argv[2]))
+sys.exit(0 if after["blockNumber"] > before["blockNumber"] and after["slot"] > before["slot"] else 1)
+PY
+        then
+          record_stage "$case_dir" restart-live-production PASS
+        else
+          record_stage "$case_dir" restart-live-production FAIL "tip did not advance after restart"
+        fi
+        if [ "$WITH_HASKELL" = "1" ] && [ "$hpid" != "0" ] && kill -0 "$hpid" 2>/dev/null; then
+          sleep "$LIVE_FOLLOW_SECONDS"
+          local restart_min
+          restart_min=$(json_get "$case_dir/pre-restart-tip.json" slot)
+          if python3 "$TOOLS/haskell_check.py" --haskell-log "$case_dir/haskell.log" \
+              --cli "$HASKELL_SHARED_DIR/bin/cardano-cli" --node-dir "$hdir" \
+              --magic "$MAGIC" --yano-base-url "http://127.0.0.1:$http" \
+              --expect-slots "$expect_slots" --phase live --min-live-slot "$restart_min" \
+              --out "$case_dir/haskell-post-restart.json" \
+              > "$case_dir/haskell-post-restart.log" 2>&1; then
+            record_stage "$case_dir" haskell-follow-after-restart PASS
+          else
+            record_stage "$case_dir" haskell-follow-after-restart FAIL "see haskell-post-restart.log"
+          fi
+        fi
+      else
+        record_stage "$case_dir" restart-resume FAIL "node did not become ready after restart"
+      fi
+      pid="$pid2"
+    else
+      record_stage "$case_dir" graceful-shutdown BLOCKED \
+        "SIGTERM did not stop the node within 60s (DuckDB/ducklake flush?); SIGKILL used"
+    fi
+  fi
+
+  [ "$hpid" != "0" ] && stop_tracked_pid "$hpid" "haskell:$name" 60
+  stop_tracked_pid "$pid" "yano:$name" 60
+  record_crash_check "$case_dir" final-shutdown-clean "$case_dir" \
+    "$yano_log" "$case_dir/yano-restart.log"
+
+  write_meta "$case_dir" "$(python3 - <<PY
+import json
+print(json.dumps({
+  "case": "$name", "kind": "backfill",
+  "requested_interval": $requested, "slot_length_ms": $slot_ms,
+  "epoch_length": $EPOCH_LENGTH, "security_param": $SECURITY_PARAM,
+  "active_slots_coeff": $ACTIVE_SLOTS_COEFF, "epochs_shifted": $EPOCHS,
+  "shift_millis": $shift_millis, "shift_api_millis": $shift_elapsed,
+  "catch_up_elapsed_ms": $elapsed, "haskell_sync_elapsed_ms": $haskell_elapsed,
+  "haskell_enabled": $WITH_HASKELL, "restart_checked": $do_restart,
+  "ports": {"http": $http, "n2n": $n2n, "haskell": $hnode}
+}, indent=2))
+PY
+)"
+  log "case $name: $(case_status "$case_dir")"
+}
+
+# --- rejection case ---------------------------------------------------------
+run_reject_case() {
+  local case_dir="$RUN_DIR/case-reject"
+  mkdir -p "$case_dir"
+  : > "$case_dir/stages.tsv"
+  local window
+  window=$(python3 -c "print(int(3*$SECURITY_PARAM/$ACTIVE_SLOTS_COEFF))")
+  log "=== case reject: negative interval and interval == forecast window ($window) ==="
+
+  run_reject_startup() { # <sub> <interval> <mode> <expected-message>
+    local sub="$1" interval="$2" mode="$3" expect="$4"
+    local dir="$case_dir/$sub"
+    mkdir -p "$dir"
+    python3 "$TOOLS/prepare_genesis.py" --source "$SOURCE_GENESIS" --dest "$dir/genesis" \
+      --slot-length 0.3 --epoch-length "$EPOCH_LENGTH" --security-param "$SECURITY_PARAM" \
+      --active-slots-coeff "$ACTIVE_SLOTS_COEFF" --epochs "$EPOCHS" > "$dir/genesis-params.json"
+    local http n2n pid
+    http=$(next_port); n2n=$(next_port)
+    pid=$(start_yano "$dir" "$dir/genesis" "$http" "$n2n" "$interval" "$mode" "$dir/yano.log" "$sub")
+
+    # The node reports YANO_STARTUP_FAILURE and refuses to initialize, but it does NOT
+    # exit the JVM: a plugin-metrics-cache thread retries ensureYano() every second.
+    # The assertion is therefore on the message and on production never starting.
+    if wait_for_log "$dir/yano.log" "$expect" 120 "$sub/yano.log"; then
+      record_stage "$case_dir" "$sub-rejected-with-error" PASS \
+        "$(grep -m1 -o "$expect.\{0,70\}" "$dir/yano.log" | head -1)"
+    else
+      record_stage "$case_dir" "$sub-rejected-with-error" FAIL \
+        "'$expect' never logged; last lines: $(tail -3 "$dir/yano.log" | tr '\n' ' ' | head -c 300)"
+    fi
+    if grep -q "Block producer started" "$dir/yano.log"; then
+      record_stage "$case_dir" "$sub-production-blocked" FAIL "block production started despite the invalid interval"
+    else
+      record_stage "$case_dir" "$sub-production-blocked" PASS "no block producer started"
+    fi
+    if kill -0 "$pid" 2>/dev/null; then
+      record_stage "$case_dir" "$sub-process-exit" NOTE \
+        "JVM stays alive after the startup failure and retries ensureYano() every second (SKILL.md 'Code vs. expectations' #8)"
+    else
+      record_stage "$case_dir" "$sub-process-exit" NOTE "JVM exited on its own"
+    fi
+    stop_tracked_pid "$pid" "yano:$sub" 30
+
+    # A rejected configuration must fail cleanly. A JVM-level crash on this path is a
+    # defect in its own right, so it is reported, never folded into "the node stopped".
+    # Checked after shutdown so a crash during teardown is caught too (see #8: an
+    # intermittent SIGSEGV in librocksdbjni RocksDB_iterator was observed here).
+    record_crash_check "$case_dir" "$sub-clean-failure" "$dir" "$dir/yano.log"
+  }
+
+  # (a) negative interval — rejected by YanoConfig.validate() at startup
+  run_reject_startup negative -1 past-time-travel "Backfill block interval must be non-negative"
+  # (c) interval == forecast window without past-time-travel — rejected at producer creation
+  run_reject_startup limit-live "$window" live "forecast window"
+
+  # (b) interval == forecast window WITH past-time-travel — the producer is created
+  # during /epochs/shift, so the rejection only surfaces on that call.
+  local dir="$case_dir/limit-ptt" http n2n pid status
+  mkdir -p "$dir"
+  python3 "$TOOLS/prepare_genesis.py" --source "$SOURCE_GENESIS" --dest "$dir/genesis" \
+    --slot-length 0.3 --epoch-length "$EPOCH_LENGTH" --security-param "$SECURITY_PARAM" \
+    --active-slots-coeff "$ACTIVE_SLOTS_COEFF" --epochs "$EPOCHS" > "$dir/genesis-params.json"
+  http=$(next_port); n2n=$(next_port)
+  pid=$(start_yano "$dir" "$dir/genesis" "$http" "$n2n" "$window" past-time-travel "$dir/yano.log" "limit-ptt")
+  if wait_yano_ready "$http" 180 "$dir/yano.log" "$pid"; then
+    http_status_and_body "http://127.0.0.1:$http/api/v1/devnet/epochs/shift" POST \
+      "{\"epochs\": $EPOCHS}" "$dir/shift.json" > "$dir/shift.status"
+    status=$(cat "$dir/shift.status")
+    if [ "$status" -ge 400 ] 2>/dev/null && grep -qi "forecast window" "$dir/shift.json" \
+        && grep -q "$window" "$dir/shift.json"; then
+      record_stage "$case_dir" limit-ptt-shift-rejected PASS \
+        "HTTP $status: $(head -c 200 "$dir/shift.json")"
+    else
+      record_stage "$case_dir" limit-ptt-shift-rejected FAIL \
+        "HTTP $status: $(head -c 300 "$dir/shift.json")"
+    fi
+    record_stage "$case_dir" limit-ptt-late-rejection-note PASS \
+      "explicit out-of-range interval is only rejected at /epochs/shift in past-time-travel mode (HTTP $status)"
+  else
+    record_stage "$case_dir" limit-ptt-shift-rejected FAIL "node did not start"
+  fi
+  stop_tracked_pid "$pid" "yano:limit-ptt" 60
+
+  write_meta "$case_dir" "$(python3 - <<PY
+import json
+print(json.dumps({"case": "reject", "kind": "rejection", "forecast_window_slots": $window,
+                  "requested_interval": "-1 and $window", "slot_length_ms": 300}, indent=2))
+PY
+)"
+  log "case reject: $(case_status "$case_dir")"
+}
+
+slot_leader_meta() { # <slot-ms> <catch-up-elapsed-ms or empty>
+  python3 - "$1" "${2:-}" "$SL_SECURITY_PARAM" "$SL_ACTIVE_SLOTS_COEFF" <<'META'
+import json, sys
+slot_ms, elapsed, k, f = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
+meta = {"case": "slot-leader", "kind": "slot-leader", "requested_interval": 0,
+        "slot_length_ms": int(slot_ms), "security_param": int(k),
+        "active_slots_coeff": float(f)}
+if elapsed:
+    meta["catch_up_elapsed_ms"] = int(elapsed)
+print(json.dumps(meta, indent=2))
+META
+}
+
+# --- optional slot-leader scenario -----------------------------------------
+run_slot_leader_case() {
+  local case_dir="$RUN_DIR/case-slot-leader"
+  local genesis="$case_dir/genesis"
+  mkdir -p "$case_dir"
+  : > "$case_dir/stages.tsv"
+  log "=== case slot-leader: past-time-travel slot-leader backfill, k=$SL_SECURITY_PARAM f=$SL_ACTIVE_SLOTS_COEFF ==="
+
+  python3 "$TOOLS/prepare_genesis.py" --source "$SOURCE_GENESIS" --dest "$genesis" \
+    --slot-length 0.3 --epoch-length "$EPOCH_LENGTH" --security-param "$SL_SECURITY_PARAM" \
+    --active-slots-coeff "$SL_ACTIVE_SLOTS_COEFF" --epochs "$EPOCHS" \
+    > "$case_dir/genesis-params.json" \
+    || { record_stage "$case_dir" genesis-prep FAIL "prepare_genesis.py failed"; return; }
+  if [ "$(json_get "$case_dir/genesis-params.json" genesis_bounds_ok)" != "True" ]; then
+    record_stage "$case_dir" genesis-bounds BLOCKED \
+      "epochLength=$EPOCH_LENGTH too short for k=$SL_SECURITY_PARAM/f=$SL_ACTIVE_SLOTS_COEFF; cardano-node would refuse the genesis"
+    return
+  fi
+  record_stage "$case_dir" genesis-prep PASS
+
+  local http n2n hnode ekg prom slot_ms expected_target
+  http=$(next_port); n2n=$(next_port); hnode=$(next_port); ekg=$(next_port); prom=$(next_port)
+  slot_ms=$(json_get "$case_dir/genesis-params.json" slot_length_millis)
+  expected_target=$(json_get "$case_dir/genesis-params.json" expected_target_slot)
+
+  local pid
+  pid=$(start_yano "$case_dir" "$genesis" "$http" "$n2n" 0 slot-leader-time-travel \
+    "$case_dir/yano.log" "slot-leader")
+  if ! wait_yano_ready "$http" 180 "$case_dir/yano.log" "$pid"; then
+    record_stage "$case_dir" yano-start FAIL "node did not become ready"
+    stop_tracked_pid "$pid" "yano:slot-leader" 60
+    return
+  fi
+  record_stage "$case_dir" yano-start PASS
+
+  http_status_and_body "http://127.0.0.1:$http/api/v1/devnet/epochs/shift" POST \
+    "{\"epochs\": $EPOCHS}" "$case_dir/shift.json" > "$case_dir/shift.status"
+  local status
+  status=$(cat "$case_dir/shift.status")
+  if [ "$status" != "200" ]; then
+    if grep -qi "Canonical block hash is required" "$case_dir/shift.json" "$case_dir/yano.log"; then
+      # Known pre-existing bootstrap defect: DevnetGenesisShiftService stores genesis
+      # UTXOs before the slot-leader path creates a canonical genesis block.
+      record_stage "$case_dir" slot-leader-bootstrap BLOCKED \
+        "fresh slot-leader bootstrap fails before backfill: 'Canonical block hash is required' (genesis UTXOs stored before a canonical genesis block exists). NOT worked around by disabling UTXOs."
+    else
+      record_stage "$case_dir" slot-leader-shift FAIL "HTTP $status: $(head -c 300 "$case_dir/shift.json")"
+    fi
+    stop_tracked_pid "$pid" "yano:slot-leader" 60
+    write_meta "$case_dir" "$(slot_leader_meta "$slot_ms" "")"
+    log "case slot-leader: $(case_status "$case_dir")"
+    return
+  fi
+  record_stage "$case_dir" slot-leader-shift PASS
+
+  sleep "$SEQUENTIAL_SECONDS"
+  local t0 elapsed
+  t0=$(now_ms)
+  http_status_and_body "http://127.0.0.1:$http/api/v1/devnet/epochs/catch-up" POST "" \
+    "$case_dir/catchup.json" > "$case_dir/catchup.status"
+  elapsed=$(( $(now_ms) - t0 ))
+  if [ "$(cat "$case_dir/catchup.status")" != "200" ]; then
+    record_stage "$case_dir" slot-leader-catch-up FAIL \
+      "HTTP $(cat "$case_dir/catchup.status"): $(head -c 300 "$case_dir/catchup.json")"
+  else
+    record_stage "$case_dir" slot-leader-catch-up PASS "elapsed=${elapsed}ms"
+    # Slot-leader backfill forges only ELIGIBLE slots, so the tip may sit behind the
+    # processed target and the spacing is a lower bound, not an equality.
+    if python3 - "$case_dir" "$EPOCH_LENGTH" "$SL_SECURITY_PARAM" "$SL_ACTIVE_SLOTS_COEFF" \
+        "http://127.0.0.1:$http" <<'PY' > "$case_dir/slot-leader-verify.log" 2>&1
+import json, re, sys, urllib.request
+case_dir, epoch_length, k, f, base = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), float(sys.argv[4]), sys.argv[5]
+log = open(case_dir + "/yano.log", errors="replace").read()
+done = re.findall(r"Slot-leader backfill complete: blocks=(\d+), checks=(\d+), processedSlot=(\d+), elapsedMillis=(\d+)", log)
+if not done:
+    print("FAIL: no 'Slot-leader backfill complete' line"); sys.exit(1)
+blocks, checks, processed, millis = (int(x) for x in done[-1])
+window = int(3 * k / f)
+tip = json.load(urllib.request.urlopen(base + "/api/v1/node/tip"))
+slots = []
+for number in range(0, tip["blockNumber"] + 1):
+    block = json.load(urllib.request.urlopen("%s/api/v1/blocks/%d" % (base, number)))
+    slots.append(block["slot"])
+gaps = [b - a for a, b in zip(slots, slots[1:])]
+widest = max(gaps) if gaps else 0
+print(json.dumps({"blocks": blocks, "leadership_checks": checks, "processed_slot": processed,
+                  "backfill_millis": millis, "tip": tip, "widest_gap": widest,
+                  "forecast_window": window}, indent=2))
+ok = blocks > 0 and checks > 0 and widest < window
+print("PASS" if ok else "FAIL: widest gap %d vs forecast window %d, blocks=%d checks=%d"
+      % (widest, window, blocks, checks))
+sys.exit(0 if ok else 1)
+PY
+    then
+      record_stage "$case_dir" slot-leader-eligibility PASS
+    else
+      record_stage "$case_dir" slot-leader-eligibility FAIL "see slot-leader-verify.log"
+    fi
+    cat "$case_dir/slot-leader-verify.log"
+  fi
+
+  if [ "$WITH_HASKELL" = "1" ]; then
+    local hdir="$case_dir/haskell" hpid
+    ensure_haskell_binary > "$case_dir/haskell-version.txt" 2>&1
+    create_haskell_instance "$hdir" "$genesis" "$n2n" "$ekg" "$prom"
+    hpid=$(start_haskell_instance "$hdir" "$hnode" "$case_dir/haskell.log" "slot-leader")
+    if wait_haskell_socket "$hdir" 120 "$hpid" && \
+       wait_haskell_slot "$hdir" "$MAGIC" "$((expected_target / 2))" 900; then
+      record_stage "$case_dir" haskell-accepts-slot-leader-history PASS
+    else
+      record_stage "$case_dir" haskell-accepts-slot-leader-history FAIL "see haskell.log"
+    fi
+    stop_tracked_pid "$hpid" "haskell:slot-leader" 60
+  fi
+  stop_tracked_pid "$pid" "yano:slot-leader" 60
+
+  write_meta "$case_dir" "$(slot_leader_meta "$slot_ms" "$elapsed")"
+  log "case slot-leader: $(case_status "$case_dir")"
+}
+
+# --- dispatch ---------------------------------------------------------------
+IFS=',' read -r -a CASE_LIST <<< "$CASES"
+for case_name in "${CASE_LIST[@]}"; do
+  case "$case_name" in
+    dense)       run_backfill_case dense 1 0.3 0 ;;
+    interval2)   run_backfill_case interval2 2 0.3 0 ;;
+    auto)        run_backfill_case auto 0 0.3 1 ;;
+    auto-1s)     run_backfill_case auto-1s 0 1.0 0 ;;
+    reject)      run_reject_case ;;
+    slot-leader) run_slot_leader_case ;;
+    "") ;;
+    *) die "unknown case: $case_name" ;;
+  esac
+done
+
+# --- report -----------------------------------------------------------------
+GENESIS_AFTER=$(cd "$PROJECT_ROOT" && git status --porcelain app/config)
+if [ "$GENESIS_BEFORE" = "$GENESIS_AFTER" ]; then
+  log "tracked genesis fixtures under app/config are unchanged"
+else
+  warn "app/config changed during the run — the tracked fixtures must stay read-only!"
+  (cd "$PROJECT_ROOT" && git status --porcelain app/config) | tee "$RUN_DIR/app-config-dirty.txt"
+fi
+
+python3 "$TOOLS/render_report.py" --run-dir "$RUN_DIR" --out "$RUN_DIR/report.md"
+cat "$RUN_DIR/report.md"
+log "artifacts: $RUN_DIR"
+
+if grep -q '^\*\*Overall: PASS\*\*$' "$RUN_DIR/report.md"; then
+  exit 0
+fi
+exit 1

--- a/scripts/sparse-backfill/tools/backfill_expect.py
+++ b/scripts/sparse-backfill/tools/backfill_expect.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Expected sparse-backfill slots, mirroring the Yano runtime.
+
+Java sources this file mirrors (keep in sync):
+  runtime/.../blockproducer/BackfillPolicy.java          -> resolve_interval / forecast_window
+  runtime/.../blockproducer/DevnetBlockProducer.java     -> next_backfill_slot / expected_slots
+                                                            (nextBackfillSlot, produceEmptyBlocksToSlot)
+
+Empty-block backfill places a block every `interval` slots, pulled back to the first
+slot of the next epoch when the step would cross an epoch boundary, and never past the
+target. The target slot always gets a block.
+
+Usage:
+  backfill_expect.py --self-test
+  backfill_expect.py --from 0 --target 3600 --interval 299 --epoch-length 1200
+  backfill_expect.py --resolve 0 --security-param 100 --active-slots-coeff 1
+"""
+import argparse
+import json
+import math
+import sys
+
+
+def forecast_window_slots(security_param, active_slots_coeff):
+    """floor(3k/f) — BackfillPolicy.forecastWindowSlots."""
+    if security_param <= 0 or not math.isfinite(active_slots_coeff) \
+            or active_slots_coeff <= 0 or active_slots_coeff > 1:
+        raise ValueError("backfill requires positive k and 0 < f <= 1")
+    return int(math.floor(3.0 * security_param / active_slots_coeff))
+
+
+def resolve_interval(requested, security_param, active_slots_coeff, slot_leader=False):
+    """BackfillPolicy.resolveInterval. 0 = automatic, 1 = dense, >= window rejected."""
+    if requested < 0:
+        raise ValueError("backfill interval must be non-negative")
+    window = forecast_window_slots(security_param, active_slots_coeff)
+    if requested >= window:
+        raise ValueError("backfill interval must be below forecast window of %d slots" % window)
+    if requested > 0:
+        return requested
+    return max(1, window // 2 if slot_leader else window - 1)
+
+
+def next_backfill_slot(from_slot, target_slot, interval, epoch_length=None):
+    """DevnetBlockProducer.nextBackfillSlot. epoch_length None/0 = no epoch provider."""
+    nxt = min(from_slot + interval, target_slot)
+    if interval > 1 and epoch_length:
+        epoch_start = (from_slot // epoch_length + 1) * epoch_length
+        if from_slot < epoch_start < nxt:
+            nxt = epoch_start
+    return nxt
+
+
+def expected_slots(from_slot, target_slot, interval, epoch_length=None):
+    """Slots produceEmptyBlocksToSlot() forges, given lastUsedSlot=from_slot."""
+    if target_slot <= from_slot:
+        return []
+    slots = []
+    current = next_backfill_slot(from_slot, target_slot, interval, epoch_length)
+    while current <= target_slot:
+        slots.append(current)
+        if current >= target_slot:
+            break
+        current = next_backfill_slot(current, target_slot, interval, epoch_length)
+    return slots
+
+
+# (from, target, interval, epoch_length, expected) — the first three come from
+# DevnetBlockProducerTest, the fourth from BackfillPolicyTest's automatic spacing,
+# and the last is the k=100/f=1 three-epoch scenario this skill exercises.
+SELF_TESTS = [
+    ((0, 1050, 100, None), [100, 200, 300, 400, 500, 600, 700, 800, 900, 1000, 1050]),
+    ((0, 620, 100, 250), [100, 200, 250, 350, 450, 500, 600, 620]),
+    ((0, 175, 1000, 50), [50, 100, 150, 175]),
+    ((0, 20, 1, 1200), list(range(1, 21))),
+]
+
+
+def self_test():
+    failures = []
+    for args, expected in SELF_TESTS:
+        actual = expected_slots(*args)
+        if actual != expected:
+            failures.append("expected_slots%s -> %s, want %s" % (args, actual, expected))
+
+    three_epochs = expected_slots(0, 3600, resolve_interval(0, 100, 1), 1200)
+    if len(three_epochs) != 15 or three_epochs[-1] != 3600 or 1200 not in three_epochs \
+            or 2400 not in three_epochs or 3600 not in three_epochs:
+        failures.append("k=100,f=1,epoch=1200,0->3600 -> %s (want 15 slots incl. every epoch start)"
+                        % three_epochs)
+
+    for args, want in [((0, 100, 1), 299), ((0, 100, 1, True), 150), ((0, 100, 0.2), 1499),
+                       ((1, 100, 1, True), 1), ((42, 100, 1), 42)]:
+        got = resolve_interval(*args)
+        if got != want:
+            failures.append("resolve_interval%s -> %s, want %s" % (args, got, want))
+    for args in [(300, 100, 1), (0, 0, 1), (-1, 100, 1)]:
+        try:
+            resolve_interval(*args)
+            failures.append("resolve_interval%s should have been rejected" % (args,))
+        except ValueError:
+            pass
+
+    for line in failures:
+        print("SELF-TEST FAIL: " + line, file=sys.stderr)
+    if failures:
+        return 1
+    print("backfill_expect self-test OK (%d vectors)" % (len(SELF_TESTS) + 6))
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--self-test", action="store_true")
+    parser.add_argument("--from", dest="from_slot", type=int)
+    parser.add_argument("--target", type=int)
+    parser.add_argument("--interval", type=int)
+    parser.add_argument("--epoch-length", type=int, default=0)
+    parser.add_argument("--resolve", type=int, help="requested interval to resolve through the policy")
+    parser.add_argument("--security-param", type=int)
+    parser.add_argument("--active-slots-coeff", type=float)
+    parser.add_argument("--slot-leader", action="store_true")
+    args = parser.parse_args()
+
+    if args.self_test:
+        return self_test()
+
+    if args.resolve is not None:
+        resolved = resolve_interval(args.resolve, args.security_param, args.active_slots_coeff,
+                                    args.slot_leader)
+        print(json.dumps({
+            "requested": args.resolve,
+            "resolved": resolved,
+            "forecast_window_slots": forecast_window_slots(args.security_param,
+                                                           args.active_slots_coeff),
+        }))
+        return 0
+
+    if args.from_slot is None or args.target is None or args.interval is None:
+        parser.error("--from, --target and --interval are required")
+    slots = expected_slots(args.from_slot, args.target, args.interval, args.epoch_length)
+    print(json.dumps({"from": args.from_slot, "target": args.target, "interval": args.interval,
+                      "epoch_length": args.epoch_length, "count": len(slots), "slots": slots}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sparse-backfill/tools/haskell_check.py
+++ b/scripts/sparse-backfill/tools/haskell_check.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Verify a downstream Haskell cardano-node accepted a Yano sparse-backfilled chain.
+
+Two independent sources, both required:
+
+  * `cardano-cli query tip` -> {slot, block, hash}, compared against Yano's block at the
+    same block number (slot AND hash must match). syncProgress is recorded but never
+    used as evidence on its own.
+  * the node log's "Chain extended, new tip: <hash> at slot <n>" lines (or the
+    "<hash>@<n>" variant), proving genesis, every crossed epoch start and the backfilled
+    target were adopted. Each sampled hash is looked up in Yano by hash, so a match
+    proves both nodes hold the identical block.
+"""
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+RE_CHAIN_EXTENDED = [
+    re.compile(r"Chain extended, new tip:\s*([0-9a-fA-F]{64})\s+at slot\s+(\d+)"),
+    re.compile(r"Chain extended, new tip:\s*([0-9a-fA-F]{64})@(\d+)"),
+]
+ERROR_PATTERNS = [
+    re.compile(r"\b(Invalid|invalid)\b"),
+    re.compile(r"\breject", re.I),
+    re.compile(r"\bValidationError|ValidationFailed|ExtValidationError", re.I),
+    re.compile(r"\bForecastError|OutsideForecastRange\b"),
+    re.compile(r"\bChainSyncClient.*(exception|error)", re.I),
+    re.compile(r"\bException\b"),
+    re.compile(r"\bError\b"),
+]
+ERROR_IGNORE = [
+    re.compile(r"Node configuration:"),          # verbose startup dump
+    re.compile(r"EKGView|Address already in use"),
+    re.compile(r"TraceErrorPolicy|ErrorPolicySuspend"),   # tracer names, not failures
+    re.compile(r"errorPolicy|TraceLocalErrorPolicy"),
+    re.compile(r"InvalidBlockPunishment"),        # tracer/type name in normal forge lines
+]
+
+
+def get_json(url, timeout=30):
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode())
+
+
+def yano_block(base_url, key):
+    try:
+        return get_json("%s/api/v1/blocks/%s" % (base_url.rstrip("/"), key))
+    except urllib.error.HTTPError as e:
+        return {"error": "HTTP %s" % e.code}
+    except Exception as e:  # noqa: BLE001
+        return {"error": str(e)}
+
+
+def query_tip(cli, node_dir, magic):
+    """Run from the instance directory with a RELATIVE socket path: AF_UNIX caps
+    paths at 104 bytes and absolute run-directory paths exceed it."""
+    env = dict(os.environ, CARDANO_NODE_SOCKET_PATH="db/node.socket")
+    out = subprocess.run([cli, "query", "tip", "--testnet-magic", str(magic)],
+                         capture_output=True, text=True, env=env, cwd=node_dir, timeout=120)
+    if out.returncode != 0:
+        return {"error": (out.stderr or out.stdout).strip()[:400]}
+    return json.loads(out.stdout)
+
+
+def adopted_from_log(log_path):
+    adopted = {}
+    for line in Path(log_path).read_text(errors="replace").splitlines():
+        for pattern in RE_CHAIN_EXTENDED:
+            match = pattern.search(line)
+            if match:
+                adopted[int(match.group(2))] = match.group(1).lower()
+                break
+    return adopted
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--haskell-log", required=True)
+    parser.add_argument("--cli", required=True)
+    parser.add_argument("--node-dir", required=True,
+                        help="Haskell instance directory (socket is read as db/node.socket from here)")
+    parser.add_argument("--magic", type=int, default=42)
+    parser.add_argument("--yano-base-url", required=True)
+    parser.add_argument("--expect-slots", required=True,
+                        help="comma-separated slots that must be adopted (genesis, epoch starts, target)")
+    parser.add_argument("--phase", default="initial", choices=["initial", "live"])
+    parser.add_argument("--min-live-slot", type=int, default=-1,
+                        help="live phase: Haskell tip slot must exceed this")
+    parser.add_argument("--reach-slot", type=int, default=-1,
+                        help="Haskell tip slot must be at or past this (the backfilled target)")
+    parser.add_argument("--hash-samples", type=int, default=20,
+                        help="how many adopted tips to hash-compare against Yano")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    checks = []
+
+    def add(name, ok, detail=""):
+        checks.append({"check": "haskell:%s:%s" % (args.phase, name),
+                       "status": "PASS" if ok else "FAIL", "detail": str(detail)})
+        return ok
+
+    adopted = adopted_from_log(args.haskell_log)
+    add("chain-extended lines parsed", bool(adopted),
+        "parsed %d adopted tips; if 0, the tracer format changed -- fix the parser" % len(adopted))
+
+    expected = [int(s) for s in args.expect_slots.split(",") if s.strip() != ""]
+    max_adopted = max(adopted) if adopted else -1
+    # During bulk sync the ChainDB tracer does not log a tip line for every block, so a
+    # required slot can be adopted without appearing here. Direct adoption is the strong
+    # evidence; otherwise the slot is covered by prefix implication -- the node started
+    # from an EMPTY database and its tip hash matches Yano's block at the same number
+    # (checked below), and a Cardano chain is a hash chain back to genesis, so every
+    # earlier slot in the chain is byte-identical too.
+    direct = [s for s in expected if s in adopted]
+    by_prefix = [s for s in expected if s not in adopted and s <= max_adopted]
+    uncovered = [s for s in expected if s not in adopted and s > max_adopted]
+    add("genesis adopted from slot 0", 0 in adopted,
+        "slot 0 %s in the adopted tips" % ("is" if 0 in adopted else "is NOT"))
+    add("required slots covered", not uncovered,
+        "uncovered=%s (directly adopted=%s, covered by prefix=%s, max adopted slot=%s)"
+        % (uncovered[:10], direct, by_prefix, max_adopted))
+
+    # Hash comparison: every required slot that was logged, plus a spread of other
+    # adopted tips, must resolve in Yano at exactly that slot.
+    sample = sorted(adopted)
+    if len(sample) > args.hash_samples:
+        step = len(sample) / float(args.hash_samples)
+        sample = [sample[int(i * step)] for i in range(args.hash_samples)]
+    hash_mismatch, hash_checked = [], []
+    for slot in sorted(set(direct) | set(sample)):
+        block_hash = adopted.get(slot)
+        if not block_hash:
+            continue
+        block = yano_block(args.yano_base_url, block_hash)
+        if "error" in block or int(block.get("slot", -1)) != slot:
+            hash_mismatch.append({"slot": slot, "haskell_hash": block_hash, "yano": block})
+        else:
+            hash_checked.append({"slot": slot, "hash": block_hash, "block": block["number"]})
+    add("adopted hashes exist in Yano at the same slot", not hash_mismatch and bool(hash_checked),
+        "checked=%d mismatches=%s" % (len(hash_checked), json.dumps(hash_mismatch[:3])))
+
+    tip = query_tip(args.cli, args.node_dir, args.magic)
+    add("cardano-cli query tip succeeded", "error" not in tip, tip.get("error", ""))
+    tip_compare = None
+    if "error" not in tip:
+        yano_tip_block = yano_block(args.yano_base_url, str(tip["block"]))
+        ok = ("error" not in yano_tip_block
+              and int(yano_tip_block["slot"]) == int(tip["slot"])
+              and yano_tip_block["hash"].lower() == tip["hash"].lower())
+        tip_compare = {"haskell": {k: tip.get(k) for k in ("slot", "block", "hash", "epoch",
+                                                           "syncProgress")},
+                       "yano": {k: yano_tip_block.get(k) for k in ("slot", "number", "hash", "epoch")}}
+        add("Haskell tip block matches Yano by slot and hash", ok, json.dumps(tip_compare))
+        if args.reach_slot >= 0:
+            add("Haskell reached the backfilled tip", int(tip["slot"]) >= args.reach_slot,
+                "haskell slot=%s, backfilled target=%s" % (tip["slot"], args.reach_slot))
+        if args.min_live_slot >= 0:
+            add("Haskell followed live blocks past the backfilled tip",
+                int(tip["slot"]) > args.min_live_slot,
+                "haskell slot=%s must exceed %s" % (tip["slot"], args.min_live_slot))
+
+    suspicious = []
+    for line in Path(args.haskell_log).read_text(errors="replace").splitlines():
+        if any(p.search(line) for p in ERROR_PATTERNS) and not any(p.search(line) for p in ERROR_IGNORE):
+            suspicious.append(line.strip()[:220])
+    add("no validation/forecast/rejection errors in the Haskell log", not suspicious,
+        "lines=%s" % suspicious[:5])
+
+    status = "FAIL" if any(c["status"] == "FAIL" for c in checks) else "PASS"
+    result = {"status": status, "phase": args.phase, "adopted_tip_count": len(adopted),
+              "adopted_max_slot": max_adopted,
+              "expected_slots": expected, "directly_adopted": direct,
+              "covered_by_prefix": by_prefix, "hash_checked": hash_checked,
+              "tip_compare": tip_compare, "suspicious_lines": suspicious[:20], "checks": checks}
+    Path(args.out).write_text(json.dumps(result, indent=2))
+    for item in checks:
+        print("  [%s] %s%s" % (item["status"], item["check"],
+                               "" if item["status"] == "PASS" else " -- " + item["detail"]))
+    print("haskell_check(%s): %s" % (args.phase, status))
+    return 0 if status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sparse-backfill/tools/prepare_genesis.py
+++ b/scripts/sparse-backfill/tools/prepare_genesis.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Copy a Haskell-compatible devnet genesis set into an isolated case directory.
+
+The runtime rewrites `systemStart` inside whatever shelley-genesis.json it is pointed
+at (GenesisConfig.resolveAndPersistGenesisTimestamp and DevnetGenesisShiftService), so
+tests must never point Yano at the tracked fixtures under app/config/network/devnet/.
+This copies them first and patches the Shelley parameters the case needs.
+
+Prints JSON: resolved parameters, per-file sha256, derived shift/target values.
+"""
+import argparse
+import hashlib
+import json
+import shutil
+import sys
+from pathlib import Path
+
+GENESIS_FILES = ["shelley-genesis.json", "byron-genesis.json", "alonzo-genesis.json",
+                 "conway-genesis.json", "protocol-param.json"]
+KEY_FILES = ["vrf.skey", "kes.skey", "opcert.cert"]
+
+
+def sha256(path):
+    return hashlib.sha256(Path(path).read_bytes()).hexdigest()
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--source", required=True, help="tracked genesis dir (read-only input)")
+    parser.add_argument("--dest", required=True, help="isolated per-case genesis dir")
+    parser.add_argument("--slot-length", type=float, required=True, help="Shelley slotLength, seconds")
+    parser.add_argument("--epoch-length", type=int, default=1200)
+    parser.add_argument("--security-param", type=int, default=100)
+    parser.add_argument("--active-slots-coeff", type=float, default=1.0)
+    parser.add_argument("--epochs", type=int, default=3, help="epochs the shift moves genesis back")
+    parser.add_argument("--slots-per-kes-period", type=int, default=0,
+                        help="override slotsPerKESPeriod; 0 keeps the source value. Sum6KES has only "
+                             "64 periods, so one opcert covers 64 * slotsPerKESPeriod slots")
+    args = parser.parse_args()
+
+    source, dest = Path(args.source), Path(args.dest)
+    dest.mkdir(parents=True, exist_ok=True)
+    for name in GENESIS_FILES + KEY_FILES:
+        src = source / name
+        if not src.exists():
+            print("ERROR: missing %s" % src, file=sys.stderr)
+            return 1
+        shutil.copy2(src, dest / name)
+
+    shelley_path = dest / "shelley-genesis.json"
+    shelley = json.loads(shelley_path.read_text())
+    original = {k: shelley.get(k) for k in
+                ["epochLength", "slotLength", "securityParam", "activeSlotsCoeff"]}
+    shelley["epochLength"] = args.epoch_length
+    shelley["slotLength"] = args.slot_length
+    shelley["securityParam"] = args.security_param
+    shelley["activeSlotsCoeff"] = args.active_slots_coeff
+    if args.slots_per_kes_period > 0:
+        shelley["slotsPerKESPeriod"] = args.slots_per_kes_period
+    shelley_path.write_text(json.dumps(shelley, indent=2) + "\n")
+
+    window = 3.0 * args.security_param / args.active_slots_coeff
+    result = {
+        "source": str(source),
+        "dest": str(dest),
+        "original_shelley_params": original,
+        "epoch_length": args.epoch_length,
+        "slot_length_seconds": args.slot_length,
+        "slot_length_millis": int(round(args.slot_length * 1000)),
+        "security_param": args.security_param,
+        "active_slots_coeff": args.active_slots_coeff,
+        "network_magic": shelley.get("networkMagic"),
+        "system_start_before_shift": shelley.get("systemStart"),
+        # DevnetGenesisShiftService.computeEpochShiftMillis: epochs * epochLength * slotLength * 1000.
+        # It reads genesis slotLength, NOT yano.block-producer.slot-length-millis.
+        "expected_shift_millis": int(args.epochs * args.epoch_length * args.slot_length * 1000),
+        "expected_target_slot": args.epochs * args.epoch_length,
+        "forecast_window_slots": int(window),
+        "slots_per_kes_period": shelley.get("slotsPerKESPeriod"),
+        # Sum6KES = 2^6 periods. One operational certificate can never sign beyond this.
+        "kes_coverage_slots": 64 * int(shelley.get("slotsPerKESPeriod", 0)),
+        "kes_covers_run": 64 * int(shelley.get("slotsPerKESPeriod", 0))
+                          >= args.epochs * args.epoch_length,
+        # cardano-node validates the Shelley genesis: the epoch must cover the stability
+        # window (3k/f) and the "epoch not long enough" bound (10k/f). Both must hold or
+        # the Haskell peer refuses the genesis before any block is exchanged.
+        "genesis_bounds_ok": args.epoch_length >= window and args.epoch_length >= 10.0 * window / 3.0,
+        "sha256": {name: sha256(dest / name) for name in GENESIS_FILES + KEY_FILES},
+    }
+    print(json.dumps(result, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sparse-backfill/tools/render_report.py
+++ b/scripts/sparse-backfill/tools/render_report.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Render the combined sparse-backfill report from per-case artifacts."""
+import argparse
+import json
+from pathlib import Path
+
+STATUS_ORDER = {"FAIL": 0, "BLOCKED": 1, "NOTE": 2, "PASS": 3}
+
+
+def read_json(path):
+    try:
+        return json.loads(Path(path).read_text())
+    except Exception:  # noqa: BLE001 - absent artifacts are reported as gaps
+        return {}
+
+
+def read_stages(path):
+    rows = []
+    if Path(path).exists():
+        for line in Path(path).read_text().splitlines():
+            parts = line.split("\t")
+            if len(parts) >= 2:
+                rows.append((parts[0], parts[1], parts[2] if len(parts) > 2 else ""))
+    return rows
+
+
+def case_status(stages):
+    if not stages:
+        return "BLOCKED"
+    statuses = {s for _, s, _ in stages}   # NOTE is informational and never fails a case
+    if "FAIL" in statuses:
+        return "FAIL"
+    if "BLOCKED" in statuses:
+        return "BLOCKED"
+    return "PASS"
+
+
+def fmt(value, suffix=""):
+    return "-" if value in (None, "", 0) and value != 0 else "%s%s" % (value, suffix)
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-dir", required=True)
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    run_dir = Path(args.run_dir)
+    cases = sorted(d for d in run_dir.glob("case-*") if d.is_dir())
+    lines = ["# Sparse backfill regression report", "",
+             "Run directory: `%s`" % run_dir, ""]
+
+    header = ("| case | interval setting | resolved interval | slot ms | initial slot | target slot |"
+              " blocks produced | backfill elapsed | Haskell sync | status |")
+    lines += [header, "|---|---|---|---|---|---|---|---|---|---|"]
+
+    dense_elapsed = None
+    rows = []
+    for case_dir in cases:
+        meta = read_json(case_dir / "meta.json")
+        verify = read_json(case_dir / "verify.json")
+        stages = read_stages(case_dir / "stages.tsv")
+        status = case_status(stages)
+        name = meta.get("case", case_dir.name.replace("case-", ""))
+        elapsed = verify.get("catch_up_elapsed_ms", meta.get("catch_up_elapsed_ms"))
+        if name == "dense" and elapsed:
+            dense_elapsed = elapsed
+        rows.append({
+            "name": name, "meta": meta, "verify": verify, "stages": stages,
+            "status": status, "dir": case_dir, "elapsed": elapsed,
+        })
+        lines.append("| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |" % (
+            name,
+            meta.get("requested_interval", "-"),
+            verify.get("resolved_interval", "-"),
+            meta.get("slot_length_ms", "-"),
+            verify.get("initial_slot", "-"),
+            verify.get("target_slot", "-"),
+            verify.get("blocks_produced", "-"),
+            fmt(elapsed, " ms"),
+            fmt(meta.get("haskell_sync_elapsed_ms"), " ms"),
+            status,
+        ))
+
+    lines += ["", "## Speed vs the dense baseline", ""]
+    if dense_elapsed:
+        lines.append("Dense (interval=1) catch-up took **%d ms**. Ratios are reported, not asserted;"
+                     " the only timing assertion is that a backfill never waits for the live block"
+                     " timer." % dense_elapsed)
+        lines.append("")
+        for row in rows:
+            if row["elapsed"] and row["name"] != "dense":
+                lines.append("- `%s`: %d ms (%.2fx the dense baseline, %s blocks vs %s)" % (
+                    row["name"], row["elapsed"], row["elapsed"] / dense_elapsed,
+                    row["verify"].get("blocks_produced", "?"),
+                    next((r["verify"].get("blocks_produced", "?") for r in rows
+                          if r["name"] == "dense"), "?")))
+    else:
+        lines.append("Dense baseline not run in this invocation.")
+
+    for row in rows:
+        lines += ["", "## Case `%s` — %s" % (row["name"], row["status"]), ""]
+        verify = row["verify"]
+        if verify:
+            lines.append("Recorded: initial tip slot **%s** (block %s), target slot **%s**, "
+                         "resolved interval **%s** (policy %s, forecast window %s slots), "
+                         "blocks produced **%s**, epoch starts %s."
+                         % (verify.get("initial_slot"), verify.get("initial_block_number"),
+                            verify.get("target_slot"), verify.get("resolved_interval"),
+                            verify.get("policy_interval"), verify.get("forecast_window_slots"),
+                            verify.get("blocks_produced"), verify.get("epoch_start_slots")))
+            if verify.get("speedup_vs_wallclock"):
+                lines.append("")
+                lines.append("Backfill covered %s ms of wall-clock time in %s ms (%sx)."
+                             % (verify.get("wallclock_span_ms"), verify.get("catch_up_elapsed_ms"),
+                                verify.get("speedup_vs_wallclock")))
+            if verify.get("sampled_verification"):
+                lines.append("")
+                lines.append("Block-by-block verification was sampled (consecutive windows plus every"
+                             " epoch-start block); counts and the tip were checked in full.")
+            lines.append("")
+        lines += ["| stage | status | detail |", "|---|---|---|"]
+        for stage, status, detail in sorted(row["stages"], key=lambda r: STATUS_ORDER.get(r[1], 3)):
+            lines.append("| %s | %s | %s |" % (stage, status, detail.replace("|", "\\|")[:220]))
+        for artifact in ("haskell-initial.json", "haskell-live.json", "haskell-post-restart.json"):
+            data = read_json(row["dir"] / artifact)
+            if data.get("tip_compare"):
+                lines += ["", "`%s`: %s adopted tips, matched hashes at slots %s; tip compare: %s"
+                          % (artifact, data.get("adopted_tip_count"),
+                             [h["slot"] for h in data.get("hash_checked", [])],
+                             json.dumps(data["tip_compare"]))]
+        lines.append("")
+        lines.append("Artifacts: `%s`" % row["dir"])
+
+    overall = "PASS"
+    for row in rows:
+        if row["status"] == "FAIL":
+            overall = "FAIL"
+            break
+        if row["status"] == "BLOCKED":
+            overall = "BLOCKED"
+    lines = lines[:3] + ["**Overall: %s**" % overall, ""] + lines[3:]
+
+    Path(args.out).write_text("\n".join(lines) + "\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sparse-backfill/tools/verify_chain.py
+++ b/scripts/sparse-backfill/tools/verify_chain.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Verify a Yano devnet chain after a sparse/dense empty-block backfill.
+
+Race-free by construction: the initial tip and the catch-up target are never taken from
+a /node/tip poll around the API call. They are recovered from three independent
+after-the-fact sources that must agree:
+
+  1. runtime log  "Catching up to wall-clock: N slots (current=S0, target=T)"
+  2. runtime log  "Sparse backfill: one block every I slots from slot S0+1 to T"
+                  (absent when the resolved interval is 1)
+  3. arithmetic   S0 = new_block_number - blocks_produced, from the catch-up response,
+                  cross-checked against the slot of block S0 (the past-time-travel
+                  prefix is dense, so block i sits at slot i)
+
+The expected slot sequence is then derived from the recorded (S0, T) with
+backfill_expect.py — never hardcoded.
+"""
+import argparse
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from backfill_expect import expected_slots, resolve_interval  # noqa: E402
+
+RE_CATCHING_UP = re.compile(r"Catching up to wall-clock: (\d+) slots \(current=(-?\d+), target=(\d+)\)")
+RE_SPARSE = re.compile(r"Sparse backfill: one block every (\d+) slots from slot (\d+) to (\d+)")
+RE_ADVANCE_DONE = re.compile(r"Time advance complete: (\d+) empty blocks produced, new tip slot=(\d+), block=(\d+)")
+RE_PRODUCER_STARTED = re.compile(r"Block producer started: interval=(\d+)ms, lazy=(\w+), slotLength=(\d+)ms")
+RE_EPOCH_TRANSITION = re.compile(r"Epoch transition detected \(block producer\): (\d+) -> (\d+) at slot (\d+), block (\d+)")
+RE_SKIPPED_EPOCHS = re.compile(r"Processing (\d+) skipped epoch transitions")
+ERROR_PATTERNS = [
+    re.compile(r"\bERROR\b"),
+    re.compile(r"forecast window", re.I),
+    re.compile(r"no eligible block", re.I),
+    re.compile(r"Exception|Caused by:"),
+    re.compile(r"nonce.*(missing|unavailable|failed)", re.I),
+    re.compile(r"Epoch transition.*fail", re.I),
+]
+# Known-harmless lines. Extend from the runner with --ignore <regex> rather than
+# widening these, so a new noisy line is a deliberate, reviewable decision.
+ERROR_IGNORE = [
+    re.compile(r"ExceptionMapper|ExceptionHandler"),          # class names in startup banners
+    re.compile(r"backfill-block-interval"),                   # config echo of the property name
+]
+
+
+class Checks:
+    def __init__(self):
+        self.items = []
+
+    def add(self, name, ok, detail=""):
+        self.items.append({"check": name, "status": "PASS" if ok else "FAIL", "detail": str(detail)})
+        return ok
+
+    def failed(self):
+        return [i for i in self.items if i["status"] == "FAIL"]
+
+
+def get_json(url, timeout=30):
+    with urllib.request.urlopen(url, timeout=timeout) as response:
+        return json.loads(response.read().decode())
+
+
+def fetch_block(base_url, number_or_hash):
+    try:
+        return get_json("%s/api/v1/blocks/%s" % (base_url.rstrip("/"), number_or_hash))
+    except urllib.error.HTTPError as e:
+        return {"error": "HTTP %s" % e.code}
+    except Exception as e:  # noqa: BLE001 - reported as a failed check
+        return {"error": str(e)}
+
+
+def select_numbers(first, last, epoch_start_numbers, max_fetch):
+    """All block numbers when small; otherwise consecutive windows so hash continuity
+    stays checkable, always covering both ends and every epoch-start block."""
+    total = last - first + 1
+    if total <= 0:
+        return [], False
+    if total <= max_fetch:
+        return list(range(first, last + 1)), False
+    keep = set(range(first, min(first + 10, last + 1)))
+    keep.update(range(max(first, last - 9), last + 1))
+    for number in epoch_start_numbers:
+        keep.update(n for n in (number - 1, number, number + 1) if first <= n <= last)
+    step = max(3, total // 40)
+    for start in range(first, last + 1, step):
+        keep.update(n for n in (start, start + 1, start + 2) if first <= n <= last)
+    return sorted(keep), True
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--yano-log", required=True)
+    parser.add_argument("--catchup-json", required=True)
+    parser.add_argument("--requested-interval", type=int, required=True)
+    parser.add_argument("--security-param", type=int, required=True)
+    parser.add_argument("--active-slots-coeff", type=float, required=True)
+    parser.add_argument("--epoch-length", type=int, required=True)
+    parser.add_argument("--slot-length-ms", type=int, required=True)
+    parser.add_argument("--elapsed-ms", type=int, required=True)
+    parser.add_argument("--max-fetch", type=int, default=400)
+    parser.add_argument("--ignore", action="append", default=[],
+                        help="extra regex for known-harmless log lines (repeatable)")
+    parser.add_argument("--out", required=True)
+    args = parser.parse_args()
+
+    checks = Checks()
+    log_text = Path(args.yano_log).read_text(errors="replace")
+    catchup = json.loads(Path(args.catchup_json).read_text())
+    base = args.base_url.rstrip("/")
+
+    # --- resolved configuration ------------------------------------------------
+    producer_started = RE_PRODUCER_STARTED.findall(log_text)
+    block_time_ms = int(producer_started[-1][0]) if producer_started else 0
+    log_slot_length_ms = int(producer_started[-1][2]) if producer_started else 0
+    checks.add("producer start line present", bool(producer_started), producer_started[-1:] or "none")
+    checks.add("resolved slotLength matches genesis", log_slot_length_ms == args.slot_length_ms,
+               "log=%sms expected=%sms" % (log_slot_length_ms, args.slot_length_ms))
+    # RuntimeNode.autoDeriveBlockTimeMillis: slotLength * 1000 / activeSlotsCoeff.
+    expected_block_time_ms = int(args.slot_length_ms / args.active_slots_coeff)
+    checks.add("resolved block interval matches genesis derivation",
+               block_time_ms == expected_block_time_ms,
+               "blockTime=%sms expected=%sms (slotLength=%sms / f=%s)"
+               % (block_time_ms, expected_block_time_ms, args.slot_length_ms, args.active_slots_coeff))
+
+    policy_interval = resolve_interval(args.requested_interval, args.security_param,
+                                       args.active_slots_coeff, slot_leader=False)
+
+    # --- initial tip and target, from three sources ----------------------------
+    catching_up = RE_CATCHING_UP.findall(log_text)
+    sparse = RE_SPARSE.findall(log_text)
+    produced = int(catchup["blocks_produced"])
+    final_block = int(catchup["new_block_number"])
+    final_slot = int(catchup["new_slot"])
+
+    checks.add("catch-up log line present", bool(catching_up), catching_up[-1:] or "none")
+    if not catching_up:
+        Path(args.out).write_text(json.dumps({"status": "FAIL", "checks": checks.items}, indent=2))
+        print("FAIL: catch-up log line missing", file=sys.stderr)
+        return 1
+    initial_slot = int(catching_up[-1][1])
+    target_slot = int(catching_up[-1][2])
+
+    derived_initial_block = final_block - produced
+    checks.add("initial tip agrees with block arithmetic", derived_initial_block == initial_slot,
+               "log current=%d, new_block_number-blocks_produced=%d" % (initial_slot, derived_initial_block))
+    checks.add("catch-up response tip equals recorded target", final_slot == target_slot,
+               "response new_slot=%d target=%d" % (final_slot, target_slot))
+
+    resolved_interval = policy_interval
+    if sparse:
+        log_interval, log_from, log_to = (int(x) for x in sparse[-1])
+        resolved_interval = log_interval
+        checks.add("logged interval matches BackfillPolicy", log_interval == policy_interval,
+                   "log=%d policy(requested=%d, k=%d, f=%s)=%d"
+                   % (log_interval, args.requested_interval, args.security_param,
+                      args.active_slots_coeff, policy_interval))
+        checks.add("sparse log start slot equals initial tip + 1", log_from == initial_slot + 1,
+                   "log from=%d initial=%d" % (log_from, initial_slot))
+        checks.add("sparse log target equals recorded target", log_to == target_slot,
+                   "log to=%d target=%d" % (log_to, target_slot))
+    else:
+        checks.add("dense run logs no sparse line", policy_interval == 1,
+                   "resolved interval=%d but no 'Sparse backfill' line" % policy_interval)
+
+    # --- expected slot sequence, derived from the recorded values --------------
+    expected = expected_slots(initial_slot, target_slot, resolved_interval, args.epoch_length)
+    checks.add("blocks_produced equals derived expectation", len(expected) == produced,
+               "expected=%d produced=%d (from=%d target=%d interval=%d epochLength=%d)"
+               % (len(expected), produced, initial_slot, target_slot, resolved_interval,
+                  args.epoch_length))
+    checks.add("final expected slot is the target",
+               bool(expected) and expected[-1] == target_slot,
+               "last expected=%s target=%d" % (expected[-1] if expected else None, target_slot))
+
+    epoch_starts = [s for s in expected if s % args.epoch_length == 0]
+    numbers_by_slot = {slot: derived_initial_block + 1 + index for index, slot in enumerate(expected)}
+    epoch_start_numbers = [numbers_by_slot[s] for s in epoch_starts]
+
+    # --- chain contents --------------------------------------------------------
+    prefix_numbers, prefix_sampled = select_numbers(0, derived_initial_block, [], args.max_fetch)
+    backfill_numbers, backfill_sampled = select_numbers(derived_initial_block + 1, final_block,
+                                                        epoch_start_numbers, args.max_fetch)
+    blocks = {}
+    for number in prefix_numbers + backfill_numbers:
+        blocks[number] = fetch_block(base, number)
+    missing = [n for n, b in blocks.items() if "error" in b]
+    checks.add("all sampled blocks readable", not missing, "missing=%s" % missing[:10])
+    if missing:
+        Path(args.out).write_text(json.dumps({"status": "FAIL", "checks": checks.items}, indent=2))
+        print("FAIL: blocks unreadable: %s" % missing[:10], file=sys.stderr)
+        return 1
+
+    prefix_bad = [n for n in prefix_numbers if blocks[n]["slot"] != n]
+    checks.add("past-time-travel prefix is dense (slot == block number)", not prefix_bad,
+               "mismatched=%s%s" % (prefix_bad[:10], " (sampled)" if prefix_sampled else ""))
+
+    slot_mismatch = [(n, blocks[n]["slot"], expected[n - derived_initial_block - 1])
+                     for n in backfill_numbers
+                     if blocks[n]["slot"] != expected[n - derived_initial_block - 1]]
+    checks.add("backfilled slots match the derived sequence", not slot_mismatch,
+               "first mismatches (number, actual, expected)=%s%s"
+               % (slot_mismatch[:5], " (sampled)" if backfill_sampled else ""))
+
+    gaps = [(expected[i - 1], expected[i]) for i in range(1, len(expected))
+            if expected[i] - expected[i - 1] > resolved_interval]
+    checks.add("no gap exceeds the resolved interval", not gaps, "gaps=%s" % gaps[:5])
+    window = int(3.0 * args.security_param / args.active_slots_coeff)
+    widest = max([expected[0] - initial_slot] + [expected[i] - expected[i - 1]
+                                                 for i in range(1, len(expected))]) if expected else 0
+    checks.add("widest gap stays inside the forecast window", widest < window,
+               "widest=%d window(3k/f)=%d" % (widest, window))
+
+    continuity_bad = []
+    fetched = sorted(blocks)
+    for previous, current in zip(fetched, fetched[1:]):
+        if current == previous + 1:
+            if (blocks[current].get("previous_block") or "").lower() != blocks[previous]["hash"].lower():
+                continuity_bad.append((previous, current))
+    checks.add("hash continuity across consecutive fetched blocks", not continuity_bad,
+               "breaks=%s" % continuity_bad[:5])
+
+    epoch_bad = [(n, blocks[n]["slot"], blocks[n]["epoch"]) for n in backfill_numbers
+                 if blocks[n]["epoch"] != blocks[n]["slot"] // args.epoch_length]
+    checks.add("reported epoch matches slot // epochLength", not epoch_bad, "mismatches=%s" % epoch_bad[:5])
+
+    epoch_start_present = [s for s in epoch_starts
+                           if numbers_by_slot[s] in blocks and blocks[numbers_by_slot[s]]["slot"] == s]
+    checks.add("every epoch start in range has a block",
+               len(epoch_start_present) == len(epoch_starts),
+               "epoch starts=%s verified=%s" % (epoch_starts, epoch_start_present))
+
+    transitions = [(int(a), int(b), int(s)) for a, b, s, _ in RE_EPOCH_TRANSITION.findall(log_text)]
+    crossed = [t for t in transitions if initial_slot < t[2] <= target_slot]
+    checks.add("one epoch transition logged per crossed boundary",
+               len(crossed) == len(epoch_starts)
+               and sorted(t[2] for t in crossed) == sorted(epoch_starts),
+               "logged=%s expected slots=%s" % (crossed, epoch_starts))
+    checks.add("no skipped-epoch batch processing", not RE_SKIPPED_EPOCHS.search(log_text),
+               RE_SKIPPED_EPOCHS.findall(log_text)[:3])
+
+    tip = get_json("%s/api/v1/node/tip" % base)
+    checks.add("tip block number matches catch-up response", tip["blockNumber"] >= final_block,
+               "tip=%s response block=%d" % (tip, final_block))
+
+    # --- speed: backfill must not wait for the live block timer -----------------
+    timer_bound_ms = produced * max(block_time_ms, 1)
+    checks.add("backfill did not wait for live block timers", args.elapsed_ms < timer_bound_ms,
+               "elapsed=%dms vs %d blocks x %dms=%dms" % (args.elapsed_ms, produced, block_time_ms,
+                                                          timer_bound_ms))
+    wallclock_span_ms = (target_slot - initial_slot) * args.slot_length_ms
+
+    # --- log scan ---------------------------------------------------------------
+    ignore = ERROR_IGNORE + [re.compile(pattern) for pattern in args.ignore]
+    suspicious = []
+    for line in log_text.splitlines():
+        if any(p.search(line) for p in ERROR_PATTERNS) and not any(p.search(line) for p in ignore):
+            suspicious.append(line.strip()[:200])
+    checks.add("no validation/nonce/forecast/epoch errors in the Yano log", not suspicious,
+               "lines=%s" % suspicious[:5])
+
+    status = "FAIL" if checks.failed() else "PASS"
+    result = {
+        "status": status,
+        "initial_slot": initial_slot,
+        "initial_block_number": derived_initial_block,
+        "target_slot": target_slot,
+        "final_block_number": final_block,
+        "blocks_produced": produced,
+        "requested_interval": args.requested_interval,
+        "resolved_interval": resolved_interval,
+        "policy_interval": policy_interval,
+        "forecast_window_slots": window,
+        "slot_length_ms": args.slot_length_ms,
+        "block_time_ms": block_time_ms,
+        "epoch_length": args.epoch_length,
+        "catch_up_elapsed_ms": args.elapsed_ms,
+        "wallclock_span_ms": wallclock_span_ms,
+        "speedup_vs_wallclock": round(wallclock_span_ms / args.elapsed_ms, 1) if args.elapsed_ms else None,
+        "expected_slots": expected if len(expected) <= 200 else expected[:100] + ["..."] + expected[-100:],
+        "epoch_start_slots": epoch_starts,
+        "sampled_verification": prefix_sampled or backfill_sampled,
+        "checks": checks.items,
+    }
+    Path(args.out).write_text(json.dumps(result, indent=2))
+    for item in checks.items:
+        print("  [%s] %s%s" % (item["status"], item["check"],
+                               "" if item["status"] == "PASS" else " -- " + item["detail"]))
+    print("verify_chain: %s (%d blocks from slot %d to %d, interval %d)"
+          % (status, produced, initial_slot, target_slot, resolved_interval))
+    return 0 if status == "PASS" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Purpose

Tracking PR for integrating and validating sparse devnet backfill before it reaches `main`.

Includes the work from #124, which adds a configurable backfill block interval for dense and slot-leader past-time-travel catch-up. The default remains one block per slot.

## Validation before marking ready

- [ ] Confirm interval 1 preserves existing behavior
- [ ] Exercise sparse empty-block catch-up across multiple epochs
- [ ] Exercise slot-leader catch-up with full and low relative stake
- [ ] Verify Haskell node synchronization from slot 0 and across at least two epoch boundaries
- [ ] Verify restart after sparse catch-up and transition to wall-clock production
- [ ] Test intervals around the recommended `3k/f` limit
- [ ] Run JVM and GraalVM/native past-time-travel regressions
- [ ] Clarify the slot-leader VRF evaluation/performance documentation

## Merge policy

Keep this PR in draft until interoperability and regression validation are complete.