### PR TITLE
fix: initialize devnet genesis UTXOs before block production

### DIFF
--- a/.agents/skills/test-sparse-backfill/SKILL.md
+++ b/.agents/skills/test-sparse-backfill/SKILL.md
@@ -18,6 +18,7 @@ blocks.
 ./scripts/sparse-backfill/run-sparse-backfill-test.sh --cases auto    # one interval
 ./scripts/sparse-backfill/run-sparse-backfill-test.sh --no-haskell    # Yano-side only, fast
 ./scripts/sparse-backfill/run-sparse-backfill-test.sh --slot-leader   # + optional slot-leader scenario
+./scripts/sparse-backfill/run-sparse-backfill-test.sh --cases slot-leader-dense,slot-leader
 ```
 
 Default cases: `dense,interval2,auto,auto-1s,reject`. The runner prints a combined
@@ -55,14 +56,17 @@ self-test, never against a live API call (see below).
 A live `/epochs/catch-up` never starts at slot 0: the past-time-travel scheduler forges
 sequential blocks (slot *i* = block *i*) while the test issues its HTTP calls, and the
 target is `(now − genesisTimestamp) / slotLength` at the moment of the call. The runner
-therefore records the real values after the fact and derives the expectation, from three
-sources that must agree:
+therefore records the real values after the fact and derives the expectation from:
 
 1. runtime log — `Catching up to wall-clock: N slots (current=S0, target=T)`
 2. runtime log — `Sparse backfill: one block every I slots from slot S0+1 to T`
    (absent when the resolved interval is 1)
 3. arithmetic — `S0 = new_block_number − blocks_produced` from the catch-up response,
-   cross-checked against the slot of block `S0`
+   cross-checked against the dense prefix and the slot of block `S0`. This is the actual
+   starting slot. The service's `current` log is emitted before stopping the scheduler,
+   so it may be earlier if a scheduled block completes in between. Require logged
+   `current <= S0`, not equality; the sparse producer's own start log must still equal
+   `S0 + 1`.
 
 `tools/backfill_expect.py` then reproduces `DevnetBlockProducer.nextBackfillSlot` for
 `(S0, T, resolved interval, epochLength)` — including the epoch-boundary pull-back and the
@@ -212,11 +216,16 @@ Genesis for this case uses `k=50`, `f=0.5` so that both `3k/f` and `10k/f` stay 
 `epochLength=1200`; cardano-node validates the Shelley genesis against those bounds and
 refuses it otherwise. Verify the bound from the Haskell startup log if you change `k`/`f`.
 
-**Known blocker:** a fresh slot-leader devnet fails at `/epochs/shift`, before any backfill,
-with `Canonical block hash is required` — `DevnetGenesisShiftService` calls
-`storeGenesisUtxosIfNeeded` before `startSlotLeaderTimeTravel`, which does not synchronously
-create a genesis block. The runner detects this and records the case **BLOCKED**. Never
-disable UTXOs to make it pass, and never report it as PASS.
+Genesis UTXOs must initialize at origin before the producer starts, without a canonical
+block hash. The pointer checkpoint is established by the first successful block apply.
+The first eligible block may be after slot zero; do not force a slot-zero block or disable
+UTXOs to make bootstrap pass. A `Canonical block hash is required` failure at shift is a
+bootstrap regression, not justification for forging before initializing genesis funds.
+
+`slot-leader-dense` uses interval 1; `slot-leader` uses automatic interval 0. Both wait for
+the full observed backfilled tip (not half the target), compare downstream hashes against
+Yano, check identical genesis files, and verify continued live following. Nonzero first
+slots are accepted through the matching-prefix proof from a fresh Haskell database.
 
 ## Isolation and cleanup
 

--- a/app/docs/genesis-utxo-pr125-review.md
+++ b/app/docs/genesis-utxo-pr125-review.md
@@ -1,0 +1,56 @@
+# PR #125: genesis UTXO bootstrap review
+
+Reviewed against main after #126 on 2026-09-11. The maintainer branch preserves
+the contributor's commit and resolves the overlapping producer tests and the
+new three-argument `produceToSlot` API. No genesis-state redesign is included yet.
+
+## Assessment
+
+The PR addresses a real fresh slot-leader startup failure, but its proposed
+ordering is a workaround for a storage-coordinate requirement. Genesis funds
+are initial ledger state, not outputs created by the first eligible block.
+
+1. `forgeFirstBlockNow()` uses normal transaction selection and publishes
+   `BlockAppliedEvent` before `DevnetGenesisShiftService` installs genesis UTXOs.
+   Thus first-block validation and synchronous observers cannot rely on the
+   complete initial UTXO state. A first-block genesis spend and observer-state
+   regression are needed.
+2. `RuntimeNode.storeGenesisUtxosIfNeeded` stamps genesis records with the
+   current tip's slot/hash, while passing block number zero. For a first eligible
+   block after slot zero, this falsely attributes initial funds to that block.
+   `DefaultUtxoStore` writes genesis records without an ordinary block delta,
+   so they are not simply deleted with that block on rollback; however its
+   pointer-marker rollback logic only preserves a genesis marker at block zero,
+   slot zero. A later-slot marker is cleared on rollback to origin. The current
+   model therefore does not cleanly represent genesis independently of blocks.
+3. The producer scheduler starts before synchronous forging and UTXO bootstrap
+   finish. It can race to advance the tip before genesis storage reads it.
+   Genesis storage still supplies block number zero, so its slot/hash can refer
+   to a later block while its block number remains zero. Start scheduled
+   production only after bootstrap completes.
+
+The contributor's new producer test checks the no-eligible-slot scan, not a
+successful first block or genesis storage. It is useful but does not establish
+the genesis-state invariants above.
+
+## Recommended follow-up
+
+- Represent genesis as an explicit origin/bootstrap coordinate for UTXO data
+  and readiness proofs, rather than borrowing a produced block hash. Inspect
+  existing `ChainPoint.ORIGIN` and genesis index-contributor contracts first.
+- Materialize initial funds and indexes idempotently before transaction selection
+  or first-block application. Do not replace the missing hash with an arbitrary
+  fake block hash just to satisfy validation.
+- Keep first eligible block production separate from genesis initialization;
+  start the scheduler only after initialization succeeds.
+- Test initial-state queries, first-block spending, a first eligible slot above
+  zero, rollback to origin and replacement of the first block, restart, and
+  pointer/stake-balance index readiness.
+- Then run fresh slot-leader backfill and downstream Haskell synchronization.
+
+## Validation so far
+
+`SlotLeaderTimeTravelBlockProducerTest` and `DevnetGenesisShiftServiceTest` pass
+after conflict resolution. This establishes compatibility with current main;
+it does not establish that the proposed genesis model is correct. Keep the
+maintainer PR in draft until the semantic follow-up is complete.

--- a/app/docs/genesis-utxo-pr125-review.md
+++ b/app/docs/genesis-utxo-pr125-review.md
@@ -2,7 +2,8 @@
 
 Reviewed against main after #126 on 2026-09-11. The maintainer branch preserves
 the contributor's commit and resolves the overlapping producer tests and the
-new three-argument `produceToSlot` API. No genesis-state redesign is included yet.
+new three-argument `produceToSlot` API. The follow-up now removes the block-first
+workaround; see the implementation notes below.
 
 ## Assessment
 
@@ -48,9 +49,106 @@ the genesis-state invariants above.
   pointer/stake-balance index readiness.
 - Then run fresh slot-leader backfill and downstream Haskell synchronization.
 
-## Validation so far
+## Initial conflict-resolution validation (before the follow-up)
 
 `SlotLeaderTimeTravelBlockProducerTest` and `DevnetGenesisShiftServiceTest` pass
 after conflict resolution. This establishes compatibility with current main;
 it does not establish that the proposed genesis model is correct. Keep the
 maintainer PR in draft until the semantic follow-up is complete.
+
+## Maintainer implementation
+
+DevKit #189 enables VRF checks when Haskell consumes an f<1 chain. That exposes
+the genuine bootstrap failure fixed tactically by #125. DevKit submits its
+governance transactions *after* the genesis shift completes, so the first-block
+transaction hazard above is a general runtime issue, not a demonstrated failure
+of that specific DevKit workflow. DevKit #191 reports successful downstream sync
+and cost-model enactment with the contributor's workaround.
+
+The replacement initializes Shelley genesis funds at origin (slot/block zero,
+empty block hash), before starting either deferred producer. Ordinary devnet
+startup now follows the same ordering, including before start-epoch catch-up.
+No synchronous first-block forge is needed to initialize funds.
+
+Pointer index **contents** are populated with genesis funds. A separate durable
+genesis-initialized flag permits the first successful block application to write
+the canonical pointer checkpoint atomically with its UTXO delta and cursor.
+Origin itself has no canonical block checkpoint. Rolling back to origin restores
+the genesis outputs, removes the checkpoint, and allows a replacement first block
+to establish it again. Existing block-bound genesis initialization remains
+supported for historical-sync/legacy callers; canonical block hash validation
+is not relaxed for block application.
+
+This matches the separation in Haskell's
+[registerInitialFunds](https://github.com/IntersectMBO/cardano-ledger/blob/master/eras/shelley/impl/src/Cardano/Ledger/Shelley/Transition.hs):
+initial funds are injected into the ledger's UTXO state, with initial stake updated,
+not represented as outputs of a newly forged block.
+
+The pointer index remains maintained for pre-Conway/historical consumers. This
+change does not remove it or pretend that origin is a canonical block.
+
+## Regression commands
+
+Focused runtime suite (92 tests) and full testkit suite (80 tests) passed on the
+replacement implementation, followed by a successful `:app:quarkusBuild`.
+
+```sh
+bash scripts/sparse-backfill/run-regular-sync-test.sh
+bash scripts/sparse-backfill/run-sparse-backfill-test.sh \
+  --cases dense,auto,slot-leader-dense,slot-leader --skip-build
+```
+
+The regular runner applies the `test-haskell-sync` skill with isolated directories
+and ports, 200 ms slots, 600-slot epochs, and k=50 (so genesis bounds remain valid).
+It does not shift genesis or invoke catch-up, and checks matching downstream hashes
+and at most two slots of lag after both epoch boundaries. The backfill runner uses
+300 ms slots and 1200-slot epochs, with f=0.5 for its slot-leader cases.
+
+## Downstream verification — 2026-09-11
+
+All runs used the final rebuilt JVM JAR and cardano-node 11.0.1 with the compatible
+PV10 genesis fixtures, copied into isolated directories. Genesis UTXOs remained enabled.
+
+| Scenario | Result | Evidence |
+| --- | --- | --- |
+| Regular production, no shift/catch-up | PASS | Haskell reached slot 1233 in epoch 2; hashes matched and sampled lag was at most two slots at both epoch boundaries |
+| Dense backfill, interval 1 | PASS | 3603 catch-up blocks, 4234 ms; full Haskell history and live hash checks |
+| Automatic sparse backfill, interval 0 | PASS | 15 catch-up blocks, 499 ms; history, live following, and restart following |
+| VRF slot-leader dense, interval 1, f=0.5 | PASS | 1823 catch-up blocks; full history and live hash checks |
+| VRF slot-leader sparse, interval 0, f=0.5 | PASS | 24 catch-up blocks; full history and live hash checks |
+
+Artifacts (repository-relative, gitignored):
+
+- `test-data-dir/regular-genesis-sync.GaBGKX/`
+- `test-data-dir/sparse-backfill/20260911-221707/` — auto and both slot-leader cases
+- `test-data-dir/sparse-backfill/20260911-221836/` — successful dense rerun
+
+The first final-build dense run passed downstream validation but failed the verifier's
+assumption that the service's pre-stop tip log equals the producer's actual starting tip.
+A scheduled block completed between the log and stopping the producer. The verifier now
+uses response arithmetic, checks the actual dense prefix, requires the pre-stop log not
+to be ahead of the actual start, and still checks the sparse producer's own start log
+exactly. The dense rerun passed. The original report is retained as FAIL, not rewritten.
+
+Tracked genesis fixtures were unchanged. Only test-owned processes were stopped.
+
+The final full `:runtime:test` run completed successfully in 8m 58s:
+1660 tests discovered, 1655 passed, 5 skipped, zero failures/errors. The earlier
+interrupted run was invalidated by an overlapping rebuild and is not counted.
+Full `:testkit:test`: 80 passed, zero skipped/failures/errors.
+
+## Review follow-up: origin restart gate
+
+The pointer-checkpoint applicability check now recognizes initialized origin state
+using the existing genesis flag, absent applied-block metadata, and an empty delta
+store. It does not require a checkpoint until a block has been applied. This fixes
+startup after rollback to origin without inventing another marker or block hash.
+`preparePointerIndex` now checks for a marker before reading its coordinate and
+returns unavailable when there is none.
+
+A RocksDB-backed regression exercises first apply, rollback to origin, close/reopen,
+the actual ledger startup gate, replacement first apply, and missing-checkpoint
+rejection after that apply. No producer or network configuration changes are involved.
+
+Validation: `:runtime:test --tests '*LedgerStateSubsystemTest' --tests '*DefaultUtxoStoreTest'`
+passed. The downstream Haskell runs above predate this follow-up; they were not rerun.

--- a/core-api/src/main/java/com/bloxbean/cardano/yano/api/utxo/UtxoState.java
+++ b/core-api/src/main/java/com/bloxbean/cardano/yano/api/utxo/UtxoState.java
@@ -193,9 +193,9 @@ public interface UtxoState {
      * Whether this store configuration can use the pointer UTXO index for
      * epoch-boundary stake input. Disabled, filtered, and incomplete UTXO
      * stores return false and must not be subjected to the pointer-index
-     * chainstate version gate. A completely uninitialized store also returns
-     * false until genesis establishes its canonical coordinate and readiness
-     * marker.
+     * chainstate version gate. A completely uninitialized store, or explicitly
+     * initialized genesis state with no applied blocks, also returns false:
+     * there is no canonical block checkpoint to require yet.
      */
     default boolean isPointerIndexApplicable() {
         return false;
@@ -205,8 +205,8 @@ public interface UtxoState {
      * Whether the pointer index has a valid completeness marker at the UTXO
      * store's current coordinate. Startup uses this to reject chainstates that
      * predate the index; boundary reads still fail closed to the historical
-     * scan if a later rollback clears the marker. A restart after such a deep
-     * rollback rejects an applicable preview chainstate until it is rebuilt.
+     * scan if a later rollback clears the marker. A restart with applied blocks
+     * but no usable marker rejects an applicable chainstate until it is rebuilt.
      */
     default boolean isPointerIndexReadyAtCurrentCoordinate() {
         return false;

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -193,6 +193,22 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         return produceToSlot(targetSlot, false);
     }
 
+    /**
+     * Forge the chain's first block right now instead of waiting for the first scheduled tick:
+     * scan from the last checked slot for the first eligible slot (bounded by the sequential scan
+     * limit and wall clock) and forge it. A fresh past-time-travel chain has no block until an
+     * eligible slot is found, and genesis UTXOs must bind to a real block, so the shift path calls
+     * this before storing them. Returns the number of blocks forged (0 when a tip already exists
+     * or no eligible slot was found in range).
+     */
+    public synchronized int forgeFirstBlockNow() {
+        if (chainState.getTip() != null) {
+            return 0;
+        }
+        long targetSlot = Math.min(lastCheckedSlot + sequentialScanLimitSlots, calculateWallClockSlot());
+        return produceToSlot(targetSlot, true);
+    }
+
     public long getLastCheckedSlot() {
         return lastCheckedSlot;
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducer.java
@@ -236,22 +236,6 @@ public class SlotLeaderTimeTravelBlockProducer implements BlockProducerService {
         return Math.max(slot, earliest);
     }
 
-    /**
-     * Forge the chain's first block right now instead of waiting for the first scheduled tick:
-     * scan from the last checked slot for the first eligible slot (bounded by the sequential scan
-     * limit and wall clock) and forge it. A fresh past-time-travel chain has no block until an
-     * eligible slot is found, and genesis UTXOs must bind to a real block, so the shift path calls
-     * this before storing them. Returns the number of blocks forged (0 when a tip already exists
-     * or no eligible slot was found in range).
-     */
-    public synchronized int forgeFirstBlockNow() {
-        if (chainState.getTip() != null) {
-            return 0;
-        }
-        long targetSlot = Math.min(lastCheckedSlot + sequentialScanLimitSlots, calculateWallClockSlot());
-        return produceToSlot(targetSlot, true, false);
-    }
-
     public long getLastCheckedSlot() {
         return lastCheckedSlot;
     }

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftService.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftService.java
@@ -129,19 +129,13 @@ public final class DevnetGenesisShiftService {
 
             switch (plan.mode()) {
                 case SLOT_LEADER_TIME_TRAVEL -> {
-                    // On a fresh start the producer forges the first eligible block
-                    // synchronously, so the genesis UTXOs stored next bind their indexes to a
-                    // real block hash (the pointer index marker rejects an empty one). A restart
-                    // restores the existing tip and stores nothing.
-                    actions.startSlotLeaderTimeTravel(freshStart);
+                    // Initial ledger state must exist before any eligible block is applied.
                     actions.storeGenesisUtxosIfNeeded(freshStart);
+                    actions.startSlotLeaderTimeTravel(freshStart);
                 }
                 case DEVNET_TIME_TRAVEL -> {
-                    // DevnetBlockProducer.start() creates and stores block zero
-                    // synchronously. Genesis UTXOs must bind their indexes to that real
-                    // block hash, never to a placeholder coordinate.
-                    actions.startDevnetTimeTravel(freshStart);
                     actions.storeGenesisUtxosIfNeeded(freshStart);
+                    actions.startDevnetTimeTravel(freshStart);
                 }
                 default -> throw new IllegalStateException(
                         "Unsupported deferred producer startup mode: " + plan.mode());

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftService.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftService.java
@@ -129,11 +129,12 @@ public final class DevnetGenesisShiftService {
 
             switch (plan.mode()) {
                 case SLOT_LEADER_TIME_TRAVEL -> {
-                    // Slot-leader deployments normally restore an existing genesis tip.
-                    // Preserve that ordering until the deferred producer owns fresh-genesis
-                    // creation itself.
-                    actions.storeGenesisUtxosIfNeeded(freshStart);
+                    // On a fresh start the producer forges the first eligible block
+                    // synchronously, so the genesis UTXOs stored next bind their indexes to a
+                    // real block hash (the pointer index marker rejects an empty one). A restart
+                    // restores the existing tip and stores nothing.
                     actions.startSlotLeaderTimeTravel(freshStart);
+                    actions.storeGenesisUtxosIfNeeded(freshStart);
                 }
                 case DEVNET_TIME_TRAVEL -> {
                     // DevnetBlockProducer.start() creates and stores block zero

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -2409,15 +2409,12 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
 
     /**
      * Store genesis UTXOs in the UTXO store using blake2b(address) tx hash convention.
-     * Must be called AFTER genesis block is stored in chainState (so getTip() returns the correct hash/slot).
+     * Genesis funds belong to the initial ledger state, not to the first produced block.
      */
     private void storeGenesisUtxosIfNeeded(boolean freshStart) {
-        if (freshStart && genesisConfig.hasInitialFunds() && utxoStore != null) {
-            var tip = chainState.getTip();
-            String blockHash = tip != null ? HexUtil.encodeHexString(tip.getBlockHash()) : "";
-            long slot = tip != null ? tip.getSlot() : 0;
+        if (freshStart && utxoStore != null) {
             utxoStore.storeGenesisUtxos(genesisConfig.getInitialFunds(),
-                    config.getProtocolMagic(), slot, 0, blockHash);
+                    config.getProtocolMagic(), 0, 0, "");
         }
     }
 
@@ -3649,16 +3646,6 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
         SlotLeaderTimeTravelBlockProducer producer = createSlotLeaderTimeTravelProducer(freshStart);
         producerSubsystem.setForceSequentialSlots(true, "Past time travel");
         producer.start();
-        if (freshStart) {
-            // A fresh chain has no block zero until the first eligible slot is forged. Do it now so
-            // the genesis UTXOs stored right after this bind to a real block hash.
-            int forged = producer.forgeFirstBlockNow();
-            if (chainState.getTip() == null) {
-                throw new IllegalStateException(
-                        "Past-time-travel slot-leader producer found no eligible slot for the first block");
-            }
-            log.info("First slot-leader time-travel block forged during epoch shift (blocks={})", forged);
-        }
     }
 
     private void startShiftedDevnetTimeTravelProducer(boolean freshStart) {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/internal/RuntimeNode.java
@@ -3651,6 +3651,16 @@ public class RuntimeNode implements NodeLifecycle, ChainQuery, LedgerQuery, TxGa
         SlotLeaderTimeTravelBlockProducer producer = createSlotLeaderTimeTravelProducer(freshStart);
         producerSubsystem.setForceSequentialSlots(true, "Past time travel");
         producer.start();
+        if (freshStart) {
+            // A fresh chain has no block zero until the first eligible slot is forged. Do it now so
+            // the genesis UTXOs stored right after this bind to a real block hash.
+            int forged = producer.forgeFirstBlockNow();
+            if (chainState.getTip() == null) {
+                throw new IllegalStateException(
+                        "Past-time-travel slot-leader producer found no eligible slot for the first block");
+            }
+            log.info("First slot-leader time-travel block forged during epoch shift (blocks={})", forged);
+        }
     }
 
     private void startShiftedDevnetTimeTravelProducer(boolean freshStart) {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/ProducerStartupCoordinator.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/producer/ProducerStartupCoordinator.java
@@ -86,6 +86,7 @@ public final class ProducerStartupCoordinator {
         actions.setConwayEraStartIfFreshStart(freshStart);
 
         DevnetBlockProducer producer = actions.createLiveDevnetProducer(blockBuilder);
+        actions.storeGenesisUtxosIfNeeded(freshStart);
         producer.start();
 
         if (freshStart && config.getStartEpoch() > 0) {
@@ -98,7 +99,6 @@ public final class ProducerStartupCoordinator {
             }
         }
 
-        actions.storeGenesisUtxosIfNeeded(freshStart);
         log.info("Block producer started (devnet mode)");
     }
 
@@ -197,6 +197,7 @@ public final class ProducerStartupCoordinator {
             var stakeDataProvider = StakeDataProviderFactory.createLiveSlotLeaderProvider(config);
 
             if (config.isDevMode() && freshStart) {
+                actions.storeGenesisUtxosIfNeeded(freshStart);
                 var genesisResult = signedBlockBuilder.buildBlock(0, 0, null, java.util.List.of());
                 try {
                     BlockProducerHelper.publishGenesisBlockEvent(
@@ -209,7 +210,6 @@ public final class ProducerStartupCoordinator {
                 log.info("Genesis block produced (slot-leader devnet): hash={}",
                         HexUtil.encodeHexString(genesisResult.blockHash()));
 
-                actions.storeGenesisUtxosIfNeeded(freshStart);
                 actions.setConwayEraStartIfFreshStart(freshStart);
 
                 BlockProducerHelper.publishEvent(

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/DefaultUtxoStore.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/DefaultUtxoStore.java
@@ -811,10 +811,11 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
         }
 
         try (ReadOptions readOptions = new ReadOptions().setFillCache(false)) {
-            CanonicalBlockReference actual = readStakeBalanceCoordinate(readOptions);
-            requireSameCoordinate(expectedCoordinate, actual);
             PointerIndexMarker marker = PointerIndexMarker.decode(
                     db.get(cfMeta, readOptions, PointerIndexMarker.KEY));
+            if (marker == null) return PointerIndexPreparation.unavailable();
+            CanonicalBlockReference actual = readStakeBalanceCoordinate(readOptions);
+            requireSameCoordinate(expectedCoordinate, actual);
             if (marker != null && marker.isUsableAt(actual)) {
                 return PointerIndexPreparation.available();
             }
@@ -830,10 +831,10 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
         if (!enabled || cfPointer == null || !hasCompleteStakeBalanceSource()) {
             return false;
         }
-        return !isCompletelyUninitialized();
+        return !isBeforePointerCheckpoint();
     }
 
-    private boolean isCompletelyUninitialized() {
+    private boolean isBeforePointerCheckpoint() {
         if (db == null || cfMeta == null || cfUnspent == null || cfDelta == null) {
             return false;
         }
@@ -844,8 +845,11 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
                     || db.get(cfMeta, readOptions, PointerIndexMarker.KEY) != null) {
                 return false;
             }
-            return isColumnFamilyEmpty(cfUnspent, readOptions)
-                    && isColumnFamilyEmpty(cfDelta, readOptions);
+            // No checkpoint is required before the first applied block, including
+            // after rollback to an explicitly initialized genesis state.
+            return isColumnFamilyEmpty(cfDelta, readOptions)
+                    && (db.get(cfMeta, readOptions, META_POINTER_GENESIS_INITIALIZED) != null
+                        || isColumnFamilyEmpty(cfUnspent, readOptions));
         } catch (RocksDBException e) {
             throw new StakeBalanceConsistencyException(
                     "Failed to inspect pointer index initialization state", e);
@@ -865,10 +869,11 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
             return false;
         }
         try (ReadOptions readOptions = new ReadOptions().setFillCache(false)) {
-            CanonicalBlockReference actual = readStakeBalanceCoordinate(readOptions);
             PointerIndexMarker marker = PointerIndexMarker.decode(
                     db.get(cfMeta, readOptions, PointerIndexMarker.KEY));
-            return marker != null && marker.isUsableAt(actual);
+            if (marker == null) return false;
+            CanonicalBlockReference actual = readStakeBalanceCoordinate(readOptions);
+            return marker.isUsableAt(actual);
         } catch (RocksDBException e) {
             throw new StakeBalanceConsistencyException(
                     "Failed to inspect pointer index marker", e);
@@ -1030,6 +1035,20 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
                 blockNumber, slot, decodeCanonicalHash(blockHash));
         batch.put(cfMeta, PointerIndexMarker.KEY,
                 PointerIndexMarker.encode(PointerIndexMarker.at(coordinate)));
+    }
+
+    private void stageGenesisPointerIndex(WriteBatch batch, long blockNumber,
+                                          long slot, String blockHash) throws RocksDBException {
+        if (blockHash == null || blockHash.isBlank()) {
+            if (blockNumber != 0 || slot != 0 || db.get(cfMeta, META_LAST_APPLIED_BLOCK) != null) {
+                throw new IllegalArgumentException("Origin genesis initialization requires an unapplied chain");
+            }
+            // Contents are initialized, but origin is not a canonical block. The first
+            // successful apply publishes the checkpoint in the same batch as its delta.
+            batch.put(cfMeta, META_POINTER_GENESIS_INITIALIZED, new byte[]{1});
+        } else {
+            stagePointerIndexMarker(batch, blockNumber, slot, blockHash);
+        }
     }
 
     private void markPointerIndexReadyNow(long blockNumber, long slot, String blockHash) {
@@ -1756,6 +1775,10 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
                                      String blockHash,
                                      List<UtxoDeltaCodec.OutRef> created,
                                      List<UtxoDeltaCodec.OutRef> spent) throws RocksDBException {
+        if (db.get(cfMeta, META_LAST_APPLIED_BLOCK) == null
+                && db.get(cfMeta, META_POINTER_GENESIS_INITIALIZED) != null) {
+            stagePointerIndexMarker(batch, blockNumber, slot, blockHash);
+        }
         byte[] delta = UtxoDeltaCodec.encode(blockNumber, slot, blockHash, created, spent);
         byte[] key = ByteBuffer.allocate(8).order(ByteOrder.BIG_ENDIAN).putLong(blockNumber).array();
         batch.put(cfDelta, key, delta);
@@ -1886,30 +1909,22 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
             indexes.registry().validateGenesisMaterialization(GenesisUtxos.of(shelleyFunds, java.util.Map.of(),
                     networkMagic, 0, 0, ChainPoint.ORIGIN.blockHash()));
         }
-        if (shelleyFunds == null || shelleyFunds.isEmpty()) {
-            markStakeBalanceIndexReadyNow();
-            markPointerIndexReadyNow(blockNumber, slot, blockHash);
-            return;
-        }
-
-        boolean isMainnet = (networkMagic == Constants.MAINNET_PROTOCOL_MAGIC);
-        String addrPrefix = isMainnet ? "addr" : "addr_test";
         int stored = 0;
 
         try (WriteBatch batch = new WriteBatch(); WriteOptions wo = new WriteOptions()) {
-            if (indexes.registry().enabled()) {
-                if (db.get(cfMeta, META_SHELLEY_GENESIS_MATERIALIZED) != null) return;
-                batch.put(cfMeta, META_SHELLEY_GENESIS_MATERIALIZED, new byte[]{1});
-            }
+            // A restart before the first block still looks fresh to ChainState.
+            // Do not duplicate balances or resurrect funds already spent after bootstrap.
+            if (db.get(cfMeta, META_SHELLEY_GENESIS_MATERIALIZED) != null) return;
+            batch.put(cfMeta, META_SHELLEY_GENESIS_MATERIALIZED, new byte[]{1});
             java.util.Map<StakeCredentialId, BigInteger> stakeBalanceDeltas = newStakeBalanceDeltaMap();
-            for (var entry : shelleyFunds.entrySet()) {
+            for (var entry : (shelleyFunds == null ? java.util.Map.<String, BigInteger>of() : shelleyFunds).entrySet()) {
                 String hexAddr = entry.getKey();
                 BigInteger lovelace = entry.getValue();
 
                 // Normalised once, shared. The tx-hash convention, the bech32 form and the
                 // output index live in GenesisUtxos so the ADR-039 projection derives exactly
                 // the same outputs rather than reimplementing them.
-                var genesisUtxo = com.bloxbean.cardano.yano.api.genesis.GenesisUtxos.shelley(
+                var genesisUtxo = GenesisUtxos.shelley(
                         hexAddr, lovelace, networkMagic, blockNumber, slot, blockHash);
                 String txHash = genesisUtxo.txHash();
                 int outputIndex = genesisUtxo.outputIndex();
@@ -1943,7 +1958,7 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
             }
             applyStakeBalanceDeltas(batch, stakeBalanceDeltas);
             markStakeBalanceIndexReady(batch);
-            stagePointerIndexMarker(batch, blockNumber, slot, blockHash);
+            stageGenesisPointerIndex(batch, blockNumber, slot, blockHash);
             db.write(wo, batch);
             if (stakeBalanceIndexEnabled) stakeBalanceIndexReady = true;
             log.info("Stored {} Shelley genesis UTXOs (tx_hash = blake2b(address), outputIndex=0)", stored);
@@ -2765,6 +2780,7 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
 
     private static final byte[] META_LAST_APPLIED_SLOT = "meta.last_applied_slot".getBytes(StandardCharsets.UTF_8);
     private static final byte[] META_SHELLEY_GENESIS_MATERIALIZED = "meta.shelley_genesis_materialized".getBytes(StandardCharsets.UTF_8);
+    private static final byte[] META_POINTER_GENESIS_INITIALIZED = "meta.utxo_pointer.genesis_initialized".getBytes(StandardCharsets.UTF_8);
     private static final byte[] META_LAST_APPLIED_BLOCK = "meta.last_applied_block".getBytes(StandardCharsets.UTF_8);
     private static final byte[] META_LAST_APPLIED_HASH = "meta.last_applied_hash".getBytes(StandardCharsets.UTF_8);
     private static final byte[] META_PRUNE_DELTA_CURSOR = "prune.delta.cursor".getBytes(StandardCharsets.UTF_8);
@@ -2873,6 +2889,11 @@ public final class DefaultUtxoStore implements UtxoState, UtxoStoreWriter, Pruna
 
     private void restorePointerMarkerAfterRollback(
             WriteBatch batch, UtxoDeltaCodec.Decoded retained) throws RocksDBException {
+        if (retained == null && db.get(cfMeta, META_POINTER_GENESIS_INITIALIZED) != null) {
+            // Genesis contents survive rollback; there is no block checkpoint at origin.
+            batch.delete(cfMeta, PointerIndexMarker.KEY);
+            return;
+        }
         PointerIndexMarker marker;
         CanonicalBlockReference current;
         try (ReadOptions readOptions = new ReadOptions().setFillCache(false)) {

--- a/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoStoreWriter.java
+++ b/runtime/src/main/java/com/bloxbean/cardano/yano/runtime/utxo/UtxoStoreWriter.java
@@ -29,9 +29,9 @@ public interface UtxoStoreWriter {
      *
      * @param shelleyFunds  hex-encoded address → lovelace (from shelley initialFunds)
      * @param networkMagic  protocol magic for bech32 prefix selection
-     * @param slot          slot number for the genesis block
-     * @param blockNumber   block number (typically 0)
-     * @param blockHash     block hash hex
+     * @param slot          0 for origin initialization; retained for legacy block-bound callers
+     * @param blockNumber   0 for origin initialization
+     * @param blockHash     empty at origin (before any block); otherwise a canonical block hash
      */
     default void storeGenesisUtxos(Map<String, BigInteger> shelleyFunds, long networkMagic,
                                    long slot, long blockNumber, String blockHash) {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -91,6 +92,42 @@ class SlotLeaderTimeTravelBlockProducerTest {
             releaseStakeRead.countDown();
             producer.stop();
         }
+    }
+
+    @Test
+    void forgeFirstBlockNowScansForTheFirstEligibleSlotWithoutWaitingForATick() {
+        List<Long> checkedSlots = new ArrayList<>();
+        SlotLeaderCheck countingNeverLeader = new SlotLeaderCheck(new byte[64], BigDecimal.ONE, null) {
+            @Override
+            public BlockSigner.VrfSignResult checkAndProve(long slot, byte[] epochNonce, BigDecimal sigma) {
+                checkedSlots.add(slot);
+                return null;
+            }
+        };
+        StakeDataProvider fullStake = new StakeDataProvider() {
+            @Override
+            public BigInteger getPoolStake(String poolHash, int epoch) {
+                return BigInteger.ONE;
+            }
+
+            @Override
+            public BigInteger getTotalStake(int epoch) {
+                return BigInteger.ONE;
+            }
+        };
+        EpochNonceState nonceState = new EpochNonceState(10_000, 1, 1.0);
+        nonceState.initFromGenesisHash(new byte[32]);
+        var producer = SlotLeaderTimeTravelBlockProducer.withTransactionSelector(
+                new InMemoryChainState(), emptyTransactions(), () -> null, new NoopEventBus(), scheduler,
+                null, nonceState, countingNeverLeader, fullStake,
+                "pool", System.currentTimeMillis() - 3_600_000, 1000, 60_000, 50);
+
+        int forged = producer.forgeFirstBlockNow();
+
+        // no eligible slot in the 50-slot scan window: nothing forged, but the scan happened at once
+        assertThat(forged).isEqualTo(0);
+        assertThat(checkedSlots).containsExactly(java.util.stream.LongStream.rangeClosed(0, 49).boxed().toArray(Long[]::new));
+        assertThat(producer.getLastCheckedSlot()).isEqualTo(49);
     }
 
     private static BlockTransactionSelector emptyTransactions() {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/blockproducer/SlotLeaderTimeTravelBlockProducerTest.java
@@ -288,7 +288,7 @@ class SlotLeaderTimeTravelBlockProducerTest {
         };
     }
     @Test
-    void forgeFirstBlockNowScansForTheFirstEligibleSlotWithoutWaitingForATick() {
+    void denseCatchUpScansEligibleSlotsWithoutWaitingForATick() {
         List<Long> checkedSlots = new ArrayList<>();
         SlotLeaderCheck countingNeverLeader = new SlotLeaderCheck(new byte[64], BigDecimal.ONE, null) {
             @Override
@@ -315,7 +315,7 @@ class SlotLeaderTimeTravelBlockProducerTest {
                 null, nonceState, countingNeverLeader, fullStake,
                 "pool", System.currentTimeMillis() - 3_600_000, 1000, 60_000, 50);
 
-        int forged = producer.forgeFirstBlockNow();
+        int forged = producer.produceToSlot(49);
 
         // no eligible slot in the 50-slot scan window: nothing forged, but the scan happened at once
         assertThat(forged).isEqualTo(0);

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftServiceTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftServiceTest.java
@@ -63,6 +63,23 @@ class DevnetGenesisShiftServiceTest {
     }
 
     @Test
+    void freshSlotLeaderTimeTravelShiftForgesBeforeStoringGenesisUtxos() {
+        FakeActions actions = new FakeActions(genesisConfig(shelleyGenesis(5, 1.0)), true);
+
+        service(
+                true,
+                new ProducerStartupPlan(ProducerMode.SLOT_LEADER_TIME_TRAVEL, true),
+                false,
+                50_000,
+                actions)
+                .shiftGenesisAndStartProducer(3);
+
+        assertTrue(actions.slotLeaderTimeTravelStarted);
+        assertTrue(actions.genesisUtxosStoredForFreshStart);
+        assertEquals("start-slot-leader,store-utxos", actions.startupOrder.toString());
+    }
+
+    @Test
     void preservesValidationOrderAndMessages() {
         FakeActions actions = new FakeActions(genesisConfig(shelleyGenesis(10, 1.0)), true);
 

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftServiceTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/devnet/DevnetGenesisShiftServiceTest.java
@@ -37,7 +37,7 @@ class DevnetGenesisShiftServiceTest {
         assertTrue(actions.genesisUtxosStoredForFreshStart);
         assertTrue(actions.devnetTimeTravelStarted);
         assertFalse(actions.slotLeaderTimeTravelStarted);
-        assertEquals("start-devnet,store-utxos", actions.startupOrder.toString());
+        assertEquals("store-utxos,start-devnet", actions.startupOrder.toString());
     }
 
     @Test
@@ -63,7 +63,7 @@ class DevnetGenesisShiftServiceTest {
     }
 
     @Test
-    void freshSlotLeaderTimeTravelShiftForgesBeforeStoringGenesisUtxos() {
+    void freshSlotLeaderTimeTravelShiftStoresGenesisUtxosBeforeStartingProducer() {
         FakeActions actions = new FakeActions(genesisConfig(shelleyGenesis(5, 1.0)), true);
 
         service(
@@ -76,7 +76,7 @@ class DevnetGenesisShiftServiceTest {
 
         assertTrue(actions.slotLeaderTimeTravelStarted);
         assertTrue(actions.genesisUtxosStoredForFreshStart);
-        assertEquals("start-slot-leader,store-utxos", actions.startupOrder.toString());
+        assertEquals("store-utxos,start-slot-leader", actions.startupOrder.toString());
     }
 
     @Test

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/ledger/LedgerStateSubsystemTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/ledger/LedgerStateSubsystemTest.java
@@ -1,6 +1,12 @@
 package com.bloxbean.cardano.yano.runtime.ledger;
 
 import com.bloxbean.cardano.yaci.events.impl.NoopEventBus;
+import com.bloxbean.cardano.yaci.core.model.Block;
+import com.bloxbean.cardano.yaci.core.model.Era;
+import com.bloxbean.cardano.yaci.core.protocol.chainsync.messages.Point;
+import com.bloxbean.cardano.yaci.core.util.HexUtil;
+import com.bloxbean.cardano.yano.api.CanonicalBlockReference;
+import com.bloxbean.cardano.yano.api.events.BlockAppliedEvent;
 import com.bloxbean.cardano.yano.api.config.RuntimeOptions;
 import com.bloxbean.cardano.yano.api.config.YanoConfig;
 import com.bloxbean.cardano.yano.api.genesis.GenesisBootstrapData;
@@ -11,11 +17,17 @@ import com.bloxbean.cardano.yano.api.utxo.UtxoState;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
 import com.bloxbean.cardano.yano.api.utxo.model.Utxo;
 import com.bloxbean.cardano.yano.runtime.chain.InMemoryChainState;
+import com.bloxbean.cardano.yano.runtime.chain.DirectRocksDBChainState;
+import com.bloxbean.cardano.yano.runtime.utxo.DefaultUtxoStore;
+import com.bloxbean.cardano.yano.runtime.db.UtxoCfNames;
 import com.bloxbean.cardano.yano.runtime.kernel.SubsystemHealth;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.LoggerFactory;
 
 import java.math.BigInteger;
+import java.nio.file.Path;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -26,6 +38,42 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class LedgerStateSubsystemTest {
+
+    @Test
+    void originRollbackRestartPassesGateButMissingAppliedCheckpointDoesNot(@TempDir Path directory)
+            throws Exception {
+        var log = LoggerFactory.getLogger(LedgerStateSubsystemTest.class);
+        String hash = "ab".repeat(32);
+        Block block = Block.builder().era(Era.Conway)
+                .transactionBodies(List.of()).invalidTransactions(List.of()).build();
+        try (var chain = new DirectRocksDBChainState(directory.toString())) {
+            var store = new DefaultUtxoStore(chain, log, Map.of("yano.utxo.enabled", true));
+            store.storeGenesisUtxos(Map.of("60" + "01".repeat(28), BigInteger.TEN), 42, 0, 0, "");
+            store.applyBlock(new BlockAppliedEvent(Era.Conway, 7, 0, hash, block));
+            assertThat(store.isPointerIndexReadyAtCurrentCoordinate()).isTrue();
+            store.rollbackToPoint(Point.ORIGIN);
+        }
+        try (var chain = new DirectRocksDBChainState(directory.toString())) {
+            var store = new DefaultUtxoStore(chain, log, Map.of("yano.utxo.enabled", true));
+            AtomicReference<Boolean> readiness = new AtomicReference<>();
+            assertThat(store.isPointerIndexApplicable()).isFalse();
+            assertThat(store.isPointerIndexReadyAtCurrentCoordinate()).isFalse();
+            assertThat(store.preparePointerIndex(
+                    new CanonicalBlockReference(0, 9, HexUtil.decodeHexString(hash)), 9).ready()).isFalse();
+            LedgerStateSubsystem.requirePointerIndexReadyIfApplicable(store, readiness::set, log);
+            assertThat(readiness.get()).isNull();
+
+            store.applyBlock(new BlockAppliedEvent(Era.Conway, 9, 0, hash, block));
+            LedgerStateSubsystem.requirePointerIndexReadyIfApplicable(store, readiness::set, log);
+            assertThat(readiness.get()).isTrue();
+
+            // The origin exception must not hide a missing checkpoint once blocks exist.
+            chain.rocks().db().delete(chain.rocks().handle(UtxoCfNames.UTXO_META),
+                    "meta.utxo_pointer.ready.v1".getBytes(StandardCharsets.UTF_8));
+            LedgerStateSubsystem.requirePointerIndexReadyIfApplicable(store, readiness::set, log);
+            assertThat(readiness.get()).isFalse();
+        }
+    }
 
     @Test
     void disabledLedgerStateStartsWithoutStoresAndClosesCleanly() {

--- a/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/utxo/DefaultUtxoStoreTest.java
+++ b/runtime/src/test/java/com/bloxbean/cardano/yano/runtime/utxo/DefaultUtxoStoreTest.java
@@ -13,6 +13,7 @@ import com.bloxbean.cardano.yano.api.archive.CanonicalProjectionContributor;
 import com.bloxbean.cardano.yano.api.archive.ProjectionCfNames;
 import com.bloxbean.cardano.yano.api.archive.ProjectionStagingWriter;
 import com.bloxbean.cardano.yano.api.events.ByronBlockProjectionEvent;
+import com.bloxbean.cardano.yano.api.genesis.GenesisUtxos;
 import com.bloxbean.cardano.yano.api.utxo.PointerUtxo;
 import com.bloxbean.cardano.yano.api.utxo.StakeBalanceConsistencyException;
 import com.bloxbean.cardano.yano.api.utxo.model.Outpoint;
@@ -313,6 +314,71 @@ class DefaultUtxoStoreTest {
 
         store.rollbackToPoint(Point.ORIGIN);
         assertNull(chain.rocks().db().get(pointerCf, outpoint));
+    }
+
+    @Test
+    void originGenesisIsSpendableInFirstNonzeroSlotAndSurvivesRollbackAndRestart() throws Exception {
+        String address = HexUtil.encodeHexString(new Address(POINTER_ADDRESS).getBytes());
+        BigInteger amount = BigInteger.valueOf(11_000_000L);
+        String txHash = GenesisUtxos.shelley(address, amount, 1, 0, 0, "").txHash();
+        Outpoint outpoint = new Outpoint(txHash, 0);
+        store.storeGenesisUtxos(Map.of(address, amount), 1, 0, 0, "");
+        assertTrue(store.getUtxo(outpoint).isPresent());
+        assertFalse(store.isPointerIndexReadyAtCurrentCoordinate());
+        assertNull(chain.rocks().db().get(chain.rocks().handle(UtxoCfNames.UTXO_META), PointerIndexMarker.KEY));
+
+        // Restart before the first block: genesis contents, not a fabricated block,
+        // must be sufficient to recover the deferred checkpoint initialization.
+        chain.close();
+        chain = new DirectRocksDBChainState(tempDir.getAbsolutePath());
+        store = new DefaultUtxoStore(chain, LoggerFactory.getLogger(DefaultUtxoStoreTest.class),
+                Map.of("yano.utxo.enabled", true));
+        bus = new SimpleEventBus();
+        new UtxoEventHandler(bus, store);
+        TransactionBody spend = TransactionBody.builder().txHash("ed".repeat(32))
+                .inputs(Set.of(TransactionInput.builder().transactionId(txHash).index(0).build()))
+                .outputs(List.of()).build();
+        Block first = Block.builder().era(Era.Babbage).transactionBodies(List.of(spend))
+                .invalidTransactions(List.of()).build();
+        publishBlock(7, 0, "ef".repeat(32), first);
+        assertTrue(store.getUtxo(outpoint).isEmpty());
+        store.storeGenesisUtxos(Map.of(address, amount), 1, 0, 0, "");
+        assertTrue(store.getUtxo(outpoint).isEmpty(), "reinitialization must not resurrect spent genesis funds");
+        assertTrue(store.isPointerIndexReadyAtCurrentCoordinate());
+        PointerIndexMarker marker = PointerIndexMarker.decode(chain.rocks().db().get(
+                chain.rocks().handle(UtxoCfNames.UTXO_META), PointerIndexMarker.KEY));
+        assertEquals(7, marker.slot());
+
+        store.rollbackToPoint(Point.ORIGIN);
+        assertTrue(store.getUtxo(outpoint).isPresent());
+        assertFalse(store.isPointerIndexReadyAtCurrentCoordinate());
+        assertNull(chain.rocks().db().get(chain.rocks().handle(UtxoCfNames.UTXO_META), PointerIndexMarker.KEY));
+        assertNotNull(chain.rocks().db().get(chain.rocks().handle(UtxoCfNames.UTXO_POINTER),
+                UtxoKeyUtil.outpointKey(txHash, 0)));
+        publishBlock(9, 0, "ee".repeat(32), first);
+        assertTrue(store.getUtxo(outpoint).isEmpty());
+        assertTrue(store.isPointerIndexReadyAtCurrentCoordinate());
+    }
+
+    @Test
+    void emptyOriginGenesisDefersCheckpointUntilFirstApply() throws Exception {
+        store.storeGenesisUtxos(Map.of(), 1, 0, 0, "");
+        assertNull(chain.rocks().db().get(chain.rocks().handle(UtxoCfNames.UTXO_META), PointerIndexMarker.KEY));
+        publishBlock(17, 0, "ec".repeat(32), Block.builder().era(Era.Babbage)
+                .transactionBodies(List.of()).invalidTransactions(List.of()).build());
+        assertTrue(store.isPointerIndexReadyAtCurrentCoordinate());
+    }
+
+    @Test
+    void originInitializationDoesNotRelaxCanonicalBlockHashValidation() {
+        assertThrows(RuntimeException.class,
+                () -> store.storeGenesisUtxos(Map.of(), 1, 7, 0, ""));
+        assertThrows(RuntimeException.class,
+                () -> store.storeGenesisUtxos(Map.of(), 1, 0, 0, "ab"));
+        publishBlock(7, 0, "ef".repeat(32), Block.builder().era(Era.Babbage)
+                .transactionBodies(List.of()).invalidTransactions(List.of()).build());
+        assertThrows(RuntimeException.class,
+                () -> store.storeGenesisUtxos(Map.of(), 1, 0, 0, ""));
     }
 
     @Test

--- a/scripts/sparse-backfill/run-regular-sync-test.sh
+++ b/scripts/sparse-backfill/run-regular-sync-test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Isolated test-haskell-sync skill: regular production, no shift or catch-up.
+set -euo pipefail
+PROJECT_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+source "$PROJECT_ROOT/scripts/sparse-backfill/lib/common.sh"
+source "$PROJECT_ROOT/scripts/sparse-backfill/lib/yano.sh"
+source "$PROJECT_ROOT/scripts/sparse-backfill/lib/haskell.sh"
+YANO_JAR="$PROJECT_ROOT/app/build/yano.jar"
+RUN_DIR=$(mktemp -d "$PROJECT_ROOT/test-data-dir/regular-genesis-sync.XXXXXX")
+PID_FILE="$RUN_DIR/started-pids"
+touch "$PID_FILE"
+export PID_FILE PROJECT_ROOT YANO_JAR
+trap cleanup_tracked EXIT
+http=$(pick_port 23000)
+n2n=$(pick_port "$((http + 1))")
+hnode=$(pick_port "$((n2n + 1))")
+ekg=$(pick_port "$((hnode + 1))")
+prom=$(pick_port "$((ekg + 1))")
+genesis="$RUN_DIR/genesis"
+log "Run directory: $RUN_DIR"
+python3 "$PROJECT_ROOT/scripts/sparse-backfill/tools/prepare_genesis.py" \
+  --source "$PROJECT_ROOT/app/config/network/devnet/pv10" --dest "$genesis" \
+  --slot-length 0.2 --epoch-length 600 --security-param 50 --active-slots-coeff 1 \
+  > "$RUN_DIR/genesis-params.json"
+pid=$(start_yano "$RUN_DIR" "$genesis" "$http" "$n2n" 1 live "$RUN_DIR/yano.log" regular)
+wait_yano_ready "$http" 180 "$RUN_DIR/yano.log" "$pid"
+ensure_haskell_binary > "$RUN_DIR/haskell-version.txt"
+hdir="$RUN_DIR/haskell"
+create_haskell_instance "$hdir" "$genesis" "$n2n" "$ekg" "$prom"
+for name in shelley byron alonzo conway; do
+  cmp "$genesis/$name-genesis.json" "$hdir/files/$name-genesis.json"
+done
+hpid=$(start_haskell_instance "$hdir" "$hnode" "$RUN_DIR/haskell.log" regular)
+wait_haskell_socket "$hdir" 120 "$hpid"
+for target in 610 1210; do
+  wait_haskell_slot "$hdir" 42 "$target" 360
+  python3 "$PROJECT_ROOT/scripts/sparse-backfill/tools/haskell_check.py" \
+    --haskell-log "$RUN_DIR/haskell.log" --cli "$HASKELL_SHARED_DIR/bin/cardano-cli" \
+    --node-dir "$hdir" --magic 42 --yano-base-url "http://127.0.0.1:$http" \
+    --expect-slots "0,600" --phase live --reach-slot "$target" --max-tip-lag 2 \
+    --out "$RUN_DIR/haskell-$target.json"
+done
+stop_tracked_pid "$hpid" haskell:regular 60
+stop_tracked_pid "$pid" yano:regular 60
+if jvm_crash_detail "$RUN_DIR" "$RUN_DIR/yano.log"; then
+  die "JVM crash during shutdown"
+fi
+log "PASS: regular production followed through two epochs with matching hashes"

--- a/scripts/sparse-backfill/run-sparse-backfill-test.sh
+++ b/scripts/sparse-backfill/run-sparse-backfill-test.sh
@@ -51,7 +51,7 @@ usage() {
   sed -n '2,15p' "$0"
   cat <<'USAGE'
 Options:
-  --cases <list>       dense,interval2,auto,auto-1s,reject | all (default: all but slot-leader)
+  --cases <list>       dense,interval2,auto,auto-1s,reject,slot-leader,slot-leader-dense | all
   --slot-leader        also run the optional slot-leader scenario
   --no-haskell         skip the downstream Haskell node (Yano-side checks only)
   --run-dir <dir>      output directory (default: test-data-dir/sparse-backfill/<timestamp>)
@@ -508,11 +508,11 @@ PY
   log "case reject: $(case_status "$case_dir")"
 }
 
-slot_leader_meta() { # <slot-ms> <catch-up-elapsed-ms or empty>
-  python3 - "$1" "${2:-}" "$SL_SECURITY_PARAM" "$SL_ACTIVE_SLOTS_COEFF" <<'META'
+slot_leader_meta() { # <slot-ms> <catch-up-elapsed-ms or empty> [requested]
+  python3 - "$1" "${2:-}" "$SL_SECURITY_PARAM" "$SL_ACTIVE_SLOTS_COEFF" "${3:-0}" <<'META'
 import json, sys
 slot_ms, elapsed, k, f = sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4]
-meta = {"case": "slot-leader", "kind": "slot-leader", "requested_interval": 0,
+meta = {"case": "slot-leader-" + sys.argv[5], "kind": "slot-leader", "requested_interval": int(sys.argv[5]),
         "slot_length_ms": int(slot_ms), "security_param": int(k),
         "active_slots_coeff": float(f)}
 if elapsed:
@@ -523,7 +523,8 @@ META
 
 # --- optional slot-leader scenario -----------------------------------------
 run_slot_leader_case() {
-  local case_dir="$RUN_DIR/case-slot-leader"
+  local requested="${1:-0}"
+  local case_dir="$RUN_DIR/case-slot-leader-$requested"
   local genesis="$case_dir/genesis"
   mkdir -p "$case_dir"
   : > "$case_dir/stages.tsv"
@@ -547,7 +548,7 @@ run_slot_leader_case() {
   expected_target=$(json_get "$case_dir/genesis-params.json" expected_target_slot)
 
   local pid
-  pid=$(start_yano "$case_dir" "$genesis" "$http" "$n2n" 0 slot-leader-time-travel \
+  pid=$(start_yano "$case_dir" "$genesis" "$http" "$n2n" "$requested" slot-leader-time-travel \
     "$case_dir/yano.log" "slot-leader")
   if ! wait_yano_ready "$http" 180 "$case_dir/yano.log" "$pid"; then
     record_stage "$case_dir" yano-start FAIL "node did not become ready"
@@ -570,7 +571,7 @@ run_slot_leader_case() {
       record_stage "$case_dir" slot-leader-shift FAIL "HTTP $status: $(head -c 300 "$case_dir/shift.json")"
     fi
     stop_tracked_pid "$pid" "yano:slot-leader" 60
-    write_meta "$case_dir" "$(slot_leader_meta "$slot_ms" "")"
+    write_meta "$case_dir" "$(slot_leader_meta "$slot_ms" "" "$requested")"
     log "case slot-leader: $(case_status "$case_dir")"
     return
   fi
@@ -590,7 +591,7 @@ run_slot_leader_case() {
     # Slot-leader backfill forges only ELIGIBLE slots, so the tip may sit behind the
     # processed target and the spacing is a lower bound, not an equality.
     if python3 - "$case_dir" "$EPOCH_LENGTH" "$SL_SECURITY_PARAM" "$SL_ACTIVE_SLOTS_COEFF" \
-        "http://127.0.0.1:$http" <<'PY' > "$case_dir/slot-leader-verify.log" 2>&1
+        "http://127.0.0.1:$http" "$expected_target" <<'PY' > "$case_dir/slot-leader-verify.log" 2>&1
 import json, re, sys, urllib.request
 case_dir, epoch_length, k, f, base = sys.argv[1], int(sys.argv[2]), int(sys.argv[3]), float(sys.argv[4]), sys.argv[5]
 log = open(case_dir + "/yano.log", errors="replace").read()
@@ -609,7 +610,7 @@ widest = max(gaps) if gaps else 0
 print(json.dumps({"blocks": blocks, "leadership_checks": checks, "processed_slot": processed,
                   "backfill_millis": millis, "tip": tip, "widest_gap": widest,
                   "forecast_window": window}, indent=2))
-ok = blocks > 0 and checks > 0 and widest < window
+ok = blocks > 0 and checks > 0 and widest < window and processed >= int(sys.argv[6])
 print("PASS" if ok else "FAIL: widest gap %d vs forecast window %d, blocks=%d checks=%d"
       % (widest, window, blocks, checks))
 sys.exit(0 if ok else 1)
@@ -623,21 +624,48 @@ PY
   fi
 
   if [ "$WITH_HASKELL" = "1" ]; then
-    local hdir="$case_dir/haskell" hpid
+    local hdir="$case_dir/haskell" hpid first_slot target_slot
+    curl -fsS "http://127.0.0.1:$http/api/v1/node/tip" > "$case_dir/backfilled-tip.json"
+    curl -fsS "http://127.0.0.1:$http/api/v1/blocks/0" > "$case_dir/first-block.json"
+    target_slot=$(json_get "$case_dir/backfilled-tip.json" slot)
+    first_slot=$(json_get "$case_dir/first-block.json" slot)
     ensure_haskell_binary > "$case_dir/haskell-version.txt" 2>&1
     create_haskell_instance "$hdir" "$genesis" "$n2n" "$ekg" "$prom"
+    local genesis_name
+    for genesis_name in shelley byron alonzo conway; do
+      if cmp -s "$genesis/$genesis_name-genesis.json" "$hdir/files/$genesis_name-genesis.json"; then
+        record_stage "$case_dir" "$genesis_name-genesis-identical" PASS
+      else
+        record_stage "$case_dir" "$genesis_name-genesis-identical" FAIL
+      fi
+    done
     hpid=$(start_haskell_instance "$hdir" "$hnode" "$case_dir/haskell.log" "slot-leader")
     if wait_haskell_socket "$hdir" 120 "$hpid" && \
-       wait_haskell_slot "$hdir" "$MAGIC" "$((expected_target / 2))" 900; then
-      record_stage "$case_dir" haskell-accepts-slot-leader-history PASS
+       wait_haskell_slot "$hdir" "$MAGIC" "$target_slot" 900; then
+      record_stage "$case_dir" haskell-accepts-slot-leader-history PASS "reached full backfilled tip $target_slot"
     else
       record_stage "$case_dir" haskell-accepts-slot-leader-history FAIL "see haskell.log"
     fi
+    local phase
+    for phase in initial live; do
+      [ "$phase" = live ] && sleep "$LIVE_FOLLOW_SECONDS"
+      if python3 "$TOOLS/haskell_check.py" --haskell-log "$case_dir/haskell.log" \
+          --cli "$HASKELL_SHARED_DIR/bin/cardano-cli" --node-dir "$hdir" \
+          --magic "$MAGIC" --yano-base-url "http://127.0.0.1:$http" \
+          --first-slot "$first_slot" --expect-slots "$first_slot,$target_slot" \
+          --phase "$phase" --reach-slot "$target_slot" --min-live-slot "$target_slot" \
+          --out "$case_dir/haskell-$phase.json" > "$case_dir/haskell-$phase.log" 2>&1; then
+        record_stage "$case_dir" "haskell-$phase-hash-match" PASS
+      else
+        record_stage "$case_dir" "haskell-$phase-hash-match" FAIL "see haskell-$phase.log"
+      fi
+    done
     stop_tracked_pid "$hpid" "haskell:slot-leader" 60
   fi
   stop_tracked_pid "$pid" "yano:slot-leader" 60
 
-  write_meta "$case_dir" "$(slot_leader_meta "$slot_ms" "$elapsed")"
+  record_crash_check "$case_dir" final-shutdown-clean "$case_dir" "$case_dir/yano.log"
+  write_meta "$case_dir" "$(slot_leader_meta "$slot_ms" "$elapsed" "$requested")"
   log "case slot-leader: $(case_status "$case_dir")"
 }
 
@@ -650,7 +678,8 @@ for case_name in "${CASE_LIST[@]}"; do
     auto)        run_backfill_case auto 0 0.3 1 ;;
     auto-1s)     run_backfill_case auto-1s 0 1.0 0 ;;
     reject)      run_reject_case ;;
-    slot-leader) run_slot_leader_case ;;
+    slot-leader) run_slot_leader_case 0 ;;
+    slot-leader-dense) run_slot_leader_case 1 ;;
     "") ;;
     *) die "unknown case: $case_name" ;;
   esac

--- a/scripts/sparse-backfill/tools/haskell_check.py
+++ b/scripts/sparse-backfill/tools/haskell_check.py
@@ -90,6 +90,9 @@ def main():
     parser.add_argument("--yano-base-url", required=True)
     parser.add_argument("--expect-slots", required=True,
                         help="comma-separated slots that must be adopted (genesis, epoch starts, target)")
+    parser.add_argument("--first-slot", type=int, default=0)
+    parser.add_argument("--max-tip-lag", type=int, default=-1,
+                        help="maximum allowed lag behind Yano's tip sampled before the CLI query")
     parser.add_argument("--phase", default="initial", choices=["initial", "live"])
     parser.add_argument("--min-live-slot", type=int, default=-1,
                         help="live phase: Haskell tip slot must exceed this")
@@ -122,8 +125,8 @@ def main():
     direct = [s for s in expected if s in adopted]
     by_prefix = [s for s in expected if s not in adopted and s <= max_adopted]
     uncovered = [s for s in expected if s not in adopted and s > max_adopted]
-    add("genesis adopted from slot 0", 0 in adopted,
-        "slot 0 %s in the adopted tips" % ("is" if 0 in adopted else "is NOT"))
+    add("first block covered", (0 in adopted if args.first_slot == 0 else args.first_slot <= max_adopted),
+        "first slot=%s, max adopted=%s (identical prefix checked below)" % (args.first_slot, max_adopted))
     add("required slots covered", not uncovered,
         "uncovered=%s (directly adopted=%s, covered by prefix=%s, max adopted slot=%s)"
         % (uncovered[:10], direct, by_prefix, max_adopted))
@@ -147,10 +150,16 @@ def main():
     add("adopted hashes exist in Yano at the same slot", not hash_mismatch and bool(hash_checked),
         "checked=%d mismatches=%s" % (len(hash_checked), json.dumps(hash_mismatch[:3])))
 
+    live_tip_before = (get_json(args.yano_base_url.rstrip("/") + "/api/v1/node/tip")
+                       if args.max_tip_lag >= 0 else None)
     tip = query_tip(args.cli, args.node_dir, args.magic)
     add("cardano-cli query tip succeeded", "error" not in tip, tip.get("error", ""))
     tip_compare = None
     if "error" not in tip:
+        if live_tip_before is not None:
+            lag = int(live_tip_before["slot"]) - int(tip["slot"])
+            add("Haskell stays close to Yano live tip", lag <= args.max_tip_lag,
+                "sampled slot lag=%s, maximum=%s" % (lag, args.max_tip_lag))
         yano_tip_block = yano_block(args.yano_base_url, str(tip["block"]))
         ok = ("error" not in yano_tip_block
               and int(yano_tip_block["slot"]) == int(tip["slot"])

--- a/scripts/sparse-backfill/tools/verify_chain.py
+++ b/scripts/sparse-backfill/tools/verify_chain.py
@@ -144,12 +144,16 @@ def main():
         Path(args.out).write_text(json.dumps({"status": "FAIL", "checks": checks.items}, indent=2))
         print("FAIL: catch-up log line missing", file=sys.stderr)
         return 1
-    initial_slot = int(catching_up[-1][1])
+    logged_initial_slot = int(catching_up[-1][1])
     target_slot = int(catching_up[-1][2])
 
     derived_initial_block = final_block - produced
-    checks.add("initial tip agrees with block arithmetic", derived_initial_block == initial_slot,
-               "log current=%d, new_block_number-blocks_produced=%d" % (initial_slot, derived_initial_block))
+    # The service logs before stopping the scheduler. A scheduled block can finish
+    # between those operations. The prefix is dense (independently checked below),
+    # so response arithmetic gives the actual starting slot of the stopped producer.
+    initial_slot = derived_initial_block
+    checks.add("actual initial tip is not before the pre-stop log", initial_slot >= logged_initial_slot,
+               "pre-stop log=%d, actual initial=%d" % (logged_initial_slot, initial_slot))
     checks.add("catch-up response tip equals recorded target", final_slot == target_slot,
                "response new_slot=%d target=%d" % (final_slot, target_slot))
 


### PR DESCRIPTION
## Summary

Fix the fresh devnet slot-leader bootstrap failure addressed by #125 without making genesis funds depend on a produced block.

- Initialize genesis UTXOs before both ordinary and deferred devnet production, using an empty block hash at origin.
- Remove the synchronous first-block-forging workaround; retain VRF eligibility checks.
- Populate pointer-index contents at genesis and write its canonical checkpoint atomically with the first successful block application.
- Make genesis materialization idempotent and preserve correct rollback/replay behavior.
- Recognize initialized origin state at the startup readiness gate, including after rollback and restart, without introducing another flag or API.
- Return pointer-index preparation as unavailable when no marker exists; retain strict checks once blocks are applied.
- Add restart/startup-gate regression coverage and strengthen downstream sync verification to check the full history, matching hashes, and live following.

## Validation

Before the final origin-readiness follow-up:
- Full runtime suite: 1,655 passed, 5 skipped, zero failures.
- Full testkit suite: 80 passed.
- Application build passed.
- Haskell cardano-node 11.0.1 with compatible PV10 genesis: ordinary production through two epochs, dense and automatic sparse backfill, and VRF slot-leader dense/sparse backfill all passed.
- Sparse restart and continued downstream following passed.

After the origin-readiness follow-up:
- 62 focused tests passed across LedgerStateSubsystemTest and DefaultUtxoStoreTest.
- The owner confirmed independent verification by Claude.
- The earlier Haskell runs were not rerun by Codex for this final follow-up.

The initial final-build dense verifier hit a pre-stop logging race; the verifier was corrected and the dense rerun passed. Original failed evidence is retained, not overwritten.

See app/docs/genesis-utxo-pr125-review.md for implementation details, test scope, and artifact paths.

## Branching

Base: feat/genesis-utxo-it, not main. Preserves the original contributor commit from #125 and its conflict-resolution history without changing the contributor fork. This PR is the maintainer integration/fix path; it does not merge the integration branch into main.
