### PR TITLE
Fix Scalus epoch calculation for transaction validation

### DIFF
--- a/app/src/test/java/org/yanoproject/app/e2e/PoolLifecycleDevnetTestProfile.java
+++ b/app/src/test/java/org/yanoproject/app/e2e/PoolLifecycleDevnetTestProfile.java
@@ -44,6 +44,13 @@ public final class PoolLifecycleDevnetTestProfile extends DevnetTestProfile {
 
     @Override
     public Map<String, String> getConfigOverrides() {
+        // External-URL mode runs the `test` profile against a node this test does not own.
+        // Contributing devnet genesis here would leave shelley=42 paired with the profile's
+        // inherited preprod byron=1, which NetworkGenesisConfig.load rejects. The parent
+        // already returns no overrides in that mode; honour it instead of layering on top.
+        if (System.getProperty("yano.e2e.baseUrl") != null) {
+            return Map.of();
+        }
         Map<String, String> overrides = new HashMap<>(super.getConfigOverrides());
         overrides.put("yano.storage.path", STORAGE_DIR.toString());
         overrides.put("yano.history.dir", HISTORY_DIR.toString());

--- a/app/src/test/java/org/yanoproject/app/e2e/PoolLifecycleE2ETest.java
+++ b/app/src/test/java/org/yanoproject/app/e2e/PoolLifecycleE2ETest.java
@@ -105,6 +105,10 @@ class PoolLifecycleE2ETest extends BaseE2ETest {
             }
         }
         awaitTransactions(submitTogether(stakeRegistrations));
+        awaitState("all delegator stake registrations visible", () -> pools.values().stream()
+                .flatMap(pool -> pool.delegators().stream())
+                .allMatch(delegator -> getJson("accounts/" + delegator.stakeAddress())
+                        .path("registered").asBoolean()));
 
         List<Transaction> delegations = new ArrayList<>();
         for (PoolFixture fixture : pools.values()) {
@@ -122,7 +126,8 @@ class PoolLifecycleE2ETest extends BaseE2ETest {
         awaitState("scenario E DRep delegation visible",
                 () -> hasDRepDelegation(retainedDRepDelegator));
 
-        advanceToEpoch(currentEpoch() + 17);
+        // Even +1 retirements must exceed the old adapter's inclusive epoch-18 ceiling.
+        advanceToEpoch(currentEpoch() + 18);
     }
 
     @Test

--- a/app/src/test/java/org/yanoproject/app/e2e/PoolLifecycleE2ETest.java
+++ b/app/src/test/java/org/yanoproject/app/e2e/PoolLifecycleE2ETest.java
@@ -121,6 +121,8 @@ class PoolLifecycleE2ETest extends BaseE2ETest {
         submitAndAwait(buildDRepDelegationOnly(retainedDRepDelegator));
         awaitState("scenario E DRep delegation visible",
                 () -> hasDRepDelegation(retainedDRepDelegator));
+
+        advanceToEpoch(currentEpoch() + 17);
     }
 
     @Test

--- a/ledger-rules/src/main/java/org/yanoproject/ledgerrules/SlotConfigSupplier.java
+++ b/ledger-rules/src/main/java/org/yanoproject/ledgerrules/SlotConfigSupplier.java
@@ -14,13 +14,12 @@ public interface SlotConfigSupplier {
     /**
      * Supplies the epoch geometry associated with the slot timing configuration.
      *
-     * <p>The default keeps existing third-party suppliers source-compatible. Callers that validate
-     * epoch-sensitive ledger rules should provide it so adapters do not have to assume mainnet
-     * epoch geometry.</p>
+     * <p>The default keeps existing suppliers source-compatible while failing clearly if a caller
+     * tries to use a three-field CCL slot configuration for epoch-sensitive validation.</p>
      *
-     * @return epoch/slot calculator, or {@code null} when the supplier has no epoch information
+     * @return epoch/slot calculator
      */
     default EpochSlotCalc getEpochSlotCalc() {
-        return null;
+        throw new IllegalStateException("Epoch slot configuration not available");
     }
 }

--- a/ledger-rules/src/main/java/org/yanoproject/ledgerrules/SlotConfigSupplier.java
+++ b/ledger-rules/src/main/java/org/yanoproject/ledgerrules/SlotConfigSupplier.java
@@ -1,6 +1,7 @@
 package org.yanoproject.ledgerrules;
 
 import com.bloxbean.cardano.client.common.model.SlotConfig;
+import org.yanoproject.api.util.EpochSlotCalc;
 
 /**
  * Supplies the slot timing configuration used by transaction validation and evaluation.
@@ -9,4 +10,17 @@ import com.bloxbean.cardano.client.common.model.SlotConfig;
 public interface SlotConfigSupplier {
 
     SlotConfig getSlotConfig();
+
+    /**
+     * Supplies the epoch geometry associated with the slot timing configuration.
+     *
+     * <p>The default keeps existing third-party suppliers source-compatible. Callers that validate
+     * epoch-sensitive ledger rules should provide it so adapters do not have to assume mainnet
+     * epoch geometry.</p>
+     *
+     * @return epoch/slot calculator, or {@code null} when the supplier has no epoch information
+     */
+    default EpochSlotCalc getEpochSlotCalc() {
+        return null;
+    }
 }

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluator.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluator.java
@@ -5,7 +5,6 @@ import com.bloxbean.cardano.client.api.common.OrderEnum;
 import com.bloxbean.cardano.client.api.model.ProtocolParams;
 import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.api.model.Utxo;
-import com.bloxbean.cardano.client.common.model.SlotConfig;
 import org.yanoproject.ledgerrules.EpochProtocolParamsSupplier;
 import org.yanoproject.ledgerrules.SlotConfigSupplier;
 import org.yanoproject.ledgerrules.TransactionEvaluator;
@@ -28,13 +27,6 @@ public class ScalusBasedTransactionEvaluator implements TransactionEvaluator {
     private final SlotConfigSupplier slotConfigSupplier;
     private final int networkId;
     private final LongSupplier currentSlotSupplier;
-
-    ScalusBasedTransactionEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                    com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                    SlotConfig slotConfig, int networkId,
-                                    LongSupplier currentSlotSupplier) {
-        this(protocolParamsSupplier, scriptSupplier, () -> slotConfig, networkId, currentSlotSupplier);
-    }
 
     ScalusBasedTransactionEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                     com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluator.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluator.java
@@ -68,7 +68,7 @@ public class ScalusBasedTransactionEvaluator implements TransactionEvaluator {
         };
 
         ProtocolParams protocolParams = protocolParamsSupplier.getProtocolParams(resolveCurrentSlot());
-        var scalusSlotConfig = SlotConfigAdapters.toScalus(slotConfigSupplier.getSlotConfig());
+        var scalusSlotConfig = SlotConfigAdapters.toScalus(slotConfigSupplier);
         Result<List<com.bloxbean.cardano.client.api.model.EvaluationResult>> result;
         try {
             result = evaluateWithScalus(scalusSlotConfig, protocolParams, utxoSupplier, txCbor, inputUtxos);

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidator.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidator.java
@@ -58,6 +58,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
     private final boolean requireLedgerStateProvider;
     private final boolean supplementaryRulesEnabled;
 
+    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
@@ -67,6 +68,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 null, null, false, false);
     }
 
+    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
@@ -87,6 +89,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 null, null, false, supplementaryRulesEnabled);
     }
 
+    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
@@ -97,6 +100,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 currentSlotSupplier, null);
     }
 
+    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
@@ -108,6 +112,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 currentSlotSupplier, currentEpochResolver, true, false);
     }
 
+    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidator.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidator.java
@@ -58,25 +58,13 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
     private final boolean requireLedgerStateProvider;
     private final boolean supplementaryRulesEnabled;
 
-    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                           com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
+                                           SlotConfigSupplier slotConfig,
                                            int networkId,
                                            LedgerStateProvider ledgerStateProvider) {
         this(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider,
                 null, null, false, false);
-    }
-
-    @Deprecated(forRemoval = true)
-    public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                           com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                           com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
-                                           int networkId,
-                                           LedgerStateProvider ledgerStateProvider,
-                                           boolean supplementaryRulesEnabled) {
-        this(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider,
-                null, null, false, supplementaryRulesEnabled);
     }
 
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
@@ -89,10 +77,9 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 null, null, false, supplementaryRulesEnabled);
     }
 
-    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                           com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
+                                           SlotConfigSupplier slotConfig,
                                            int networkId,
                                            LedgerStateProvider ledgerStateProvider,
                                            LongSupplier currentSlotSupplier) {
@@ -100,10 +87,9 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 currentSlotSupplier, null);
     }
 
-    @Deprecated(forRemoval = true)
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                           com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
+                                           SlotConfigSupplier slotConfig,
                                            int networkId,
                                            LedgerStateProvider ledgerStateProvider,
                                            LongSupplier currentSlotSupplier,
@@ -112,19 +98,6 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                 currentSlotSupplier, currentEpochResolver, true, false);
     }
 
-    @Deprecated(forRemoval = true)
-    public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                           com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                           com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
-                                           int networkId,
-                                           LedgerStateProvider ledgerStateProvider,
-                                           LongSupplier currentSlotSupplier,
-                                           LongFunction<Integer> currentEpochResolver,
-                                           boolean supplementaryRulesEnabled) {
-        this(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider,
-                currentSlotSupplier, currentEpochResolver, true, supplementaryRulesEnabled);
-    }
-
     public ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
                                            SlotConfigSupplier slotConfigSupplier,
@@ -135,19 +108,6 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
                                            boolean supplementaryRulesEnabled) {
         this(protocolParamsSupplier, scriptSupplier, slotConfigSupplier, networkId, ledgerStateProvider,
                 currentSlotSupplier, currentEpochResolver, true, supplementaryRulesEnabled);
-    }
-
-    private ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                            com.bloxbean.cardano.client.api.ScriptSupplier scriptSupplier,
-                                            com.bloxbean.cardano.client.common.model.SlotConfig slotConfig,
-                                            int networkId,
-                                            LedgerStateProvider ledgerStateProvider,
-                                            LongSupplier currentSlotSupplier,
-                                            LongFunction<Integer> currentEpochResolver,
-                                            boolean requireLedgerStateProvider,
-                                            boolean supplementaryRulesEnabled) {
-        this(protocolParamsSupplier, scriptSupplier, () -> slotConfig, networkId, ledgerStateProvider,
-                currentSlotSupplier, currentEpochResolver, requireLedgerStateProvider, supplementaryRulesEnabled);
     }
 
     ScalusBasedTransactionValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
@@ -249,10 +209,6 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
         return LedgerBridge.validate(
                 txCbor, protocolParams, inputUtxos, currentSlot,
                 resolveScalusSlotConfig(), networkId, scriptSupplier, ledgerStateProvider);
-    }
-
-    protected com.bloxbean.cardano.client.common.model.SlotConfig resolveCclSlotConfig() {
-        return slotConfigSupplier.getSlotConfig();
     }
 
     protected SlotConfig resolveScalusSlotConfig() {

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidator.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidator.java
@@ -251,7 +251,7 @@ public class ScalusBasedTransactionValidator implements TransactionValidator {
     }
 
     protected SlotConfig resolveScalusSlotConfig() {
-        return SlotConfigAdapters.toScalus(resolveCclSlotConfig());
+        return SlotConfigAdapters.toScalus(slotConfigSupplier);
     }
 
     private long resolveCurrentSlot(Transaction tx) {

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusTransactionFactory.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusTransactionFactory.java
@@ -1,7 +1,6 @@
 package org.yanoproject.scalusbridge;
 
 import com.bloxbean.cardano.client.api.ScriptSupplier;
-import com.bloxbean.cardano.client.common.model.SlotConfig;
 import org.yanoproject.api.account.LedgerStateProvider;
 import org.yanoproject.ledgerrules.EpochProtocolParamsSupplier;
 import org.yanoproject.ledgerrules.SlotConfigSupplier;
@@ -13,7 +12,7 @@ import java.util.function.LongSupplier;
 
 /**
  * Pure Java factory that hides Scala-compiled types from consumers.
- * Accepts only Java types (CCL {@link SlotConfig}) and returns {@link TransactionValidator}.
+ * Accepts Java suppliers with explicit slot timing and epoch geometry and returns {@link TransactionValidator}.
  */
 public class ScalusTransactionFactory {
 
@@ -26,31 +25,6 @@ public class ScalusTransactionFactory {
     // underlying constructor for standalone/static-param consumers.
     // ---------------------------------------------------------------------
 
-    @Deprecated(forRemoval = true)
-    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId) {
-        return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, null, false);
-    }
-
-    @Deprecated(forRemoval = true)
-    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId,
-                                                       LedgerStateProvider ledgerStateProvider) {
-        return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider, false);
-    }
-
-    @Deprecated(forRemoval = true)
-    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId,
-                                                       LedgerStateProvider ledgerStateProvider,
-                                                       boolean supplementaryRulesEnabled) {
-        return new ScalusBasedTransactionValidator(protocolParamsSupplier, scriptSupplier, () -> slotConfig,
-                networkId, ledgerStateProvider, null, null, false, supplementaryRulesEnabled);
-    }
-
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfigSupplier slotConfigSupplier, int networkId,
@@ -58,39 +32,6 @@ public class ScalusTransactionFactory {
                                                        boolean supplementaryRulesEnabled) {
         return new ScalusBasedTransactionValidator(protocolParamsSupplier, scriptSupplier, slotConfigSupplier,
                 networkId, ledgerStateProvider, null, null, false, supplementaryRulesEnabled);
-    }
-
-    @Deprecated(forRemoval = true)
-    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId,
-                                                       LedgerStateProvider ledgerStateProvider,
-                                                       LongSupplier currentSlotSupplier) {
-        return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId,
-                ledgerStateProvider, currentSlotSupplier, null, false);
-    }
-
-    @Deprecated(forRemoval = true)
-    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId,
-                                                       LedgerStateProvider ledgerStateProvider,
-                                                       LongSupplier currentSlotSupplier,
-                                                       LongFunction<Integer> currentEpochResolver) {
-        return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId,
-                ledgerStateProvider, currentSlotSupplier, currentEpochResolver, false);
-    }
-
-    @Deprecated(forRemoval = true)
-    public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId,
-                                                       LedgerStateProvider ledgerStateProvider,
-                                                       LongSupplier currentSlotSupplier,
-                                                       LongFunction<Integer> currentEpochResolver,
-                                                       boolean supplementaryRulesEnabled) {
-        return new ScalusBasedTransactionValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId,
-                ledgerStateProvider, currentSlotSupplier, currentEpochResolver, supplementaryRulesEnabled);
     }
 
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
@@ -117,28 +58,11 @@ public class ScalusTransactionFactory {
                 requireLedgerStateProvider, supplementaryRulesEnabled);
     }
 
-    @Deprecated(forRemoval = true)
-    public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId) {
-        return new ScalusBasedTransactionEvaluator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId,
-                null);
-    }
-
     public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfigSupplier slotConfigSupplier, int networkId) {
         return new ScalusBasedTransactionEvaluator(protocolParamsSupplier, scriptSupplier, slotConfigSupplier,
                 networkId, null);
-    }
-
-    @Deprecated(forRemoval = true)
-    public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
-                                                       ScriptSupplier scriptSupplier,
-                                                       SlotConfig slotConfig, int networkId,
-                                                       LongSupplier currentSlotSupplier) {
-        return new ScalusBasedTransactionEvaluator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId,
-                currentSlotSupplier);
     }
 
     public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusTransactionFactory.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/ScalusTransactionFactory.java
@@ -26,12 +26,14 @@ public class ScalusTransactionFactory {
     // underlying constructor for standalone/static-param consumers.
     // ---------------------------------------------------------------------
 
+    @Deprecated(forRemoval = true)
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId) {
         return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, null, false);
     }
 
+    @Deprecated(forRemoval = true)
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,
@@ -39,6 +41,7 @@ public class ScalusTransactionFactory {
         return createValidator(protocolParamsSupplier, scriptSupplier, slotConfig, networkId, ledgerStateProvider, false);
     }
 
+    @Deprecated(forRemoval = true)
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,
@@ -57,6 +60,7 @@ public class ScalusTransactionFactory {
                 networkId, ledgerStateProvider, null, null, false, supplementaryRulesEnabled);
     }
 
+    @Deprecated(forRemoval = true)
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,
@@ -66,6 +70,7 @@ public class ScalusTransactionFactory {
                 ledgerStateProvider, currentSlotSupplier, null, false);
     }
 
+    @Deprecated(forRemoval = true)
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,
@@ -76,6 +81,7 @@ public class ScalusTransactionFactory {
                 ledgerStateProvider, currentSlotSupplier, currentEpochResolver, false);
     }
 
+    @Deprecated(forRemoval = true)
     public static TransactionValidator createValidator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,
@@ -111,6 +117,7 @@ public class ScalusTransactionFactory {
                 requireLedgerStateProvider, supplementaryRulesEnabled);
     }
 
+    @Deprecated(forRemoval = true)
     public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId) {
@@ -125,6 +132,7 @@ public class ScalusTransactionFactory {
                 networkId, null);
     }
 
+    @Deprecated(forRemoval = true)
     public static TransactionEvaluator createEvaluator(EpochProtocolParamsSupplier protocolParamsSupplier,
                                                        ScriptSupplier scriptSupplier,
                                                        SlotConfig slotConfig, int networkId,

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/SlotConfigAdapters.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/SlotConfigAdapters.java
@@ -9,16 +9,6 @@ final class SlotConfigAdapters {
     private SlotConfigAdapters() {
     }
 
-    static scalus.cardano.ledger.SlotConfig toScalus(SlotConfig slotConfig) {
-        if (slotConfig == null) {
-            throw new IllegalStateException("SlotConfig not available");
-        }
-        return new scalus.cardano.ledger.SlotConfig(
-                slotConfig.getZeroTime(),
-                slotConfig.getZeroSlot(),
-                slotConfig.getSlotLength());
-    }
-
     static scalus.cardano.ledger.SlotConfig toScalus(SlotConfigSupplier slotConfigSupplier) {
         SlotConfig slotConfig = slotConfigSupplier.getSlotConfig();
         if (slotConfig == null) {
@@ -27,7 +17,7 @@ final class SlotConfigAdapters {
 
         EpochSlotCalc epochSlotCalc = slotConfigSupplier.getEpochSlotCalc();
         if (epochSlotCalc == null) {
-            return toScalus(slotConfig);
+            throw new IllegalStateException("Epoch slot configuration not available");
         }
 
         return new scalus.cardano.ledger.SlotConfig(

--- a/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/SlotConfigAdapters.java
+++ b/scalus-bridge/src/main/java/org/yanoproject/scalusbridge/SlotConfigAdapters.java
@@ -1,6 +1,8 @@
 package org.yanoproject.scalusbridge;
 
 import com.bloxbean.cardano.client.common.model.SlotConfig;
+import org.yanoproject.api.util.EpochSlotCalc;
+import org.yanoproject.ledgerrules.SlotConfigSupplier;
 
 final class SlotConfigAdapters {
 
@@ -15,5 +17,24 @@ final class SlotConfigAdapters {
                 slotConfig.getZeroTime(),
                 slotConfig.getZeroSlot(),
                 slotConfig.getSlotLength());
+    }
+
+    static scalus.cardano.ledger.SlotConfig toScalus(SlotConfigSupplier slotConfigSupplier) {
+        SlotConfig slotConfig = slotConfigSupplier.getSlotConfig();
+        if (slotConfig == null) {
+            throw new IllegalStateException("SlotConfig not available");
+        }
+
+        EpochSlotCalc epochSlotCalc = slotConfigSupplier.getEpochSlotCalc();
+        if (epochSlotCalc == null) {
+            return toScalus(slotConfig);
+        }
+
+        return new scalus.cardano.ledger.SlotConfig(
+                slotConfig.getZeroTime(),
+                slotConfig.getZeroSlot(),
+                slotConfig.getSlotLength(),
+                epochSlotCalc.shelleyEpochLength(),
+                epochSlotCalc.firstNonByronEpoch());
     }
 }

--- a/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
+++ b/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
@@ -38,7 +38,7 @@ class ScalusBasedTransactionEvaluatorTest {
                 slot -> {
                     throw new AssertionError("protocol parameters should not be requested");
                 },
-                null, slotConfig, 0, () -> -1L);
+                null, slotConfigSupplier(slotConfig, new EpochSlotCalc(1_200, 1_200, 0)), 0, () -> -1L);
 
         var ex = assertThrows(IllegalStateException.class,
                 () -> evaluator.evaluate(new byte[0], Set.of()));
@@ -53,7 +53,7 @@ class ScalusBasedTransactionEvaluatorTest {
                 slot -> {
                     throw new AssertionError("protocol parameters should not be requested");
                 },
-                null, slotConfig, 0, () -> {
+                null, slotConfigSupplier(slotConfig, new EpochSlotCalc(1_200, 1_200, 0)), 0, () -> {
             throw new IllegalStateException("tip unavailable");
         });
 
@@ -70,7 +70,7 @@ class ScalusBasedTransactionEvaluatorTest {
                 slot -> {
                     throw new IllegalStateException("resolved slot " + slot);
                 },
-                null, slotConfig, 0, () -> 123L);
+                null, slotConfigSupplier(slotConfig, new EpochSlotCalc(1_200, 1_200, 0)), 0, () -> 123L);
 
         var ex = assertThrows(IllegalStateException.class,
                 () -> evaluator.evaluate(new byte[0], Set.of()));
@@ -84,7 +84,7 @@ class ScalusBasedTransactionEvaluatorTest {
                 slot -> {
                     throw new IllegalStateException("resolved slot " + slot);
                 },
-                null, slotConfig, 0, null);
+                null, slotConfigSupplier(slotConfig, new EpochSlotCalc(1_200, 1_200, 0)), 0, null);
 
         var ex = assertThrows(IllegalStateException.class,
                 () -> evaluator.evaluate(new byte[0], Set.of()));

--- a/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
+++ b/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
@@ -118,7 +118,8 @@ class ScalusBasedTransactionEvaluatorTest {
     void scalusSlotConfigAdapterPreservesUnitsAndOrder() {
         var ccl = new SlotConfig(2_000, 42, 1_780_000_000_000L);
 
-        var scalus = SlotConfigAdapters.toScalus(ccl);
+        var scalus = SlotConfigAdapters.toScalus(slotConfigSupplier(
+                ccl, new EpochSlotCalc(1_200, 1_200, 0)));
 
         assertEquals(1_780_000_000_000L, scalus.zeroTime());
         assertEquals(42L, scalus.zeroSlot());
@@ -167,9 +168,46 @@ class ScalusBasedTransactionEvaluatorTest {
         assertEquals(1_596_059_091_000L, scalus.slotToTime(4_492_800));
     }
 
+    @Test
+    void scalusSlotConfigAdapterPreservesPreprodEpochGeometry() {
+        var supplier = slotConfigSupplier(
+                new SlotConfig(1_000, 86_400, 1_655_769_600_000L),
+                new EpochSlotCalc(432_000, 21_600, 86_400));
+
+        var scalus = SlotConfigAdapters.toScalus(supplier);
+
+        assertEquals(432_000L, scalus.epochLength());
+        assertEquals(4L, scalus.zeroEpoch());
+        assertEquals(100L, scalus.epochOf(41_558_400));
+    }
+
+    @Test
+    void scalusSlotConfigAdapterRejectsSupplierWithoutEpochGeometry() {
+        SlotConfigSupplier supplier = () -> new SlotConfig(1_000, 0, 1_780_000_000_000L);
+
+        var error = assertThrows(IllegalStateException.class, () -> SlotConfigAdapters.toScalus(supplier));
+
+        assertEquals("Epoch slot configuration not available", error.getMessage());
+    }
+
+    private static SlotConfigSupplier slotConfigSupplier(SlotConfig slotConfig, EpochSlotCalc epochSlotCalc) {
+        return new SlotConfigSupplier() {
+            @Override
+            public SlotConfig getSlotConfig() {
+                return slotConfig;
+            }
+
+            @Override
+            public EpochSlotCalc getEpochSlotCalc() {
+                return epochSlotCalc;
+            }
+        };
+    }
+
     private class BlstFailingEvaluator extends ScalusBasedTransactionEvaluator {
         BlstFailingEvaluator() {
-            super(slot -> new ProtocolParams(), null, slotConfig, 0, () -> 123L);
+            super(slot -> new ProtocolParams(), null,
+                    slotConfigSupplier(slotConfig, new EpochSlotCalc(1_200, 1_200, 0)), 0, () -> 123L);
         }
 
         @Override

--- a/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
+++ b/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionEvaluatorTest.java
@@ -5,6 +5,8 @@ import com.bloxbean.cardano.client.api.model.Result;
 import com.bloxbean.cardano.client.api.model.Utxo;
 import com.bloxbean.cardano.client.api.model.ProtocolParams;
 import com.bloxbean.cardano.client.common.model.SlotConfig;
+import org.yanoproject.api.util.EpochSlotCalc;
+import org.yanoproject.ledgerrules.SlotConfigSupplier;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
@@ -121,6 +123,48 @@ class ScalusBasedTransactionEvaluatorTest {
         assertEquals(1_780_000_000_000L, scalus.zeroTime());
         assertEquals(42L, scalus.zeroSlot());
         assertEquals(2_000L, scalus.slotLength());
+    }
+
+    @Test
+    void scalusSlotConfigAdapterPreservesDevnetEpochGeometry() {
+        var supplier = new SlotConfigSupplier() {
+            @Override
+            public SlotConfig getSlotConfig() {
+                return new SlotConfig(1_000, 0, 1_780_000_000_000L);
+            }
+
+            @Override
+            public EpochSlotCalc getEpochSlotCalc() {
+                return new EpochSlotCalc(1_200, 1_200, 0);
+            }
+        };
+
+        var scalus = SlotConfigAdapters.toScalus(supplier);
+
+        assertEquals(1_200L, scalus.epochLength());
+        assertEquals(0L, scalus.zeroEpoch());
+        assertEquals(55L, scalus.epochOf(66_166));
+    }
+
+    @Test
+    void scalusSlotConfigAdapterPreservesMainnetEpochAndTimeOrigin() {
+        var supplier = new SlotConfigSupplier() {
+            @Override
+            public SlotConfig getSlotConfig() {
+                return new SlotConfig(1_000, 4_492_800, 1_596_059_091_000L);
+            }
+
+            @Override
+            public EpochSlotCalc getEpochSlotCalc() {
+                return new EpochSlotCalc(432_000, 21_600, 4_492_800);
+            }
+        };
+
+        var scalus = SlotConfigAdapters.toScalus(supplier);
+
+        assertEquals(208L, scalus.epochOf(4_492_800));
+        assertEquals(550L, scalus.epochOf(152_236_800));
+        assertEquals(1_596_059_091_000L, scalus.slotToTime(4_492_800));
     }
 
     private class BlstFailingEvaluator extends ScalusBasedTransactionEvaluator {

--- a/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidatorTest.java
+++ b/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidatorTest.java
@@ -17,6 +17,7 @@ import com.bloxbean.cardano.client.transaction.spec.governance.VotingProcedures;
 import com.bloxbean.cardano.client.transaction.spec.governance.actions.GovActionId;
 import com.bloxbean.cardano.client.transaction.spec.governance.actions.ParameterChangeAction;
 import org.yanoproject.api.account.LedgerStateProvider;
+import org.yanoproject.api.util.EpochSlotCalc;
 import org.yanoproject.ledgerrules.SlotConfigSupplier;
 import org.yanoproject.ledgerrules.ValidationError;
 import org.junit.jupiter.api.Test;
@@ -128,8 +129,17 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void validateUsesDynamicSlotConfigSupplierPerCall() {
         var zeroTime = new AtomicLong(1_780_000_000_000L);
-        var validator = new SlotCapturingValidator(
-                () -> new SlotConfig(1_000, 0, zeroTime.get()));
+        var validator = new SlotCapturingValidator(new SlotConfigSupplier() {
+            @Override
+            public SlotConfig getSlotConfig() {
+                return new SlotConfig(1_000, 0, zeroTime.get());
+            }
+
+            @Override
+            public EpochSlotCalc getEpochSlotCalc() {
+                return new EpochSlotCalc(1_200, 1_200, 0);
+            }
+        });
 
         assertTrue(validator.validate(new byte[]{1, 2, 3}, Set.of()).valid());
         zeroTime.set(1_780_000_001_000L);
@@ -440,7 +450,7 @@ class ScalusBasedTransactionValidatorTest {
         @Override
         protected TransitResult runScalusValidation(byte[] txCbor, ProtocolParams protocolParams,
                                                     Set<Utxo> inputUtxos, long currentSlot) {
-            zeroTimes.add(resolveCclSlotConfig().getZeroTime());
+            zeroTimes.add(resolveScalusSlotConfig().zeroTime());
             return new TransitResult(true, null, null);
         }
 

--- a/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidatorTest.java
+++ b/scalus-bridge/src/test/java/org/yanoproject/scalusbridge/ScalusBasedTransactionValidatorTest.java
@@ -41,7 +41,7 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRuleExceptionRejectsTransaction() {
         LedgerStateProvider provider = new MinimalLedgerStateProvider();
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 provider, null);
         var tx = Transaction.builder().body(null).build();
 
@@ -116,7 +116,7 @@ class ScalusBasedTransactionValidatorTest {
         pp.setEMax(5);
 
         var validator = new ScalusBasedTransactionValidator(
-                slot -> pp, null, new SlotConfig(1000, 0, 0), 0,
+                slot -> pp, null, testSlotConfig(), 0,
                 new RegisteredPoolLedgerStateProvider(), () -> 12_345L, slot -> 10);
 
         var result = validator.runSupplementaryRules(poolRetirementTx(10), 12_345L, pp);
@@ -163,7 +163,7 @@ class ScalusBasedTransactionValidatorTest {
         ProtocolParams pp = new ProtocolParams();
         pp.setEMax(5);
         var validator = new ScalusBasedTransactionValidator(
-                slot -> pp, null, new SlotConfig(1000, 0, 0), 0,
+                slot -> pp, null, testSlotConfig(), 0,
                 new RegisteredPoolLedgerStateProvider(), () -> 0L, slot -> 0);
 
         var result = validator.runSupplementaryRules(poolRetirementTx(0), 0, pp);
@@ -178,7 +178,7 @@ class ScalusBasedTransactionValidatorTest {
         ProtocolParams pp = new ProtocolParams();
         pp.setEMax(5);
         var validator = new ScalusBasedTransactionValidator(
-                slot -> pp, null, new SlotConfig(1000, 0, 0), 0,
+                slot -> pp, null, testSlotConfig(), 0,
                 new RegisteredPoolLedgerStateProvider(), () -> 12_345L, slot -> null);
 
         var result = validator.runSupplementaryRules(poolRetirementTx(11), 12_345L, pp);
@@ -192,7 +192,7 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesValidateGovernanceVoteTargetsAndDisallowedVoters() {
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 new GovernanceProposalLedgerStateProvider("PARAMETER_CHANGE_ACTION", true, true));
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.STAKING_POOL_KEY_HASH), 0, new ProtocolParams());
@@ -205,7 +205,7 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesRejectVotingForInactiveGovernanceAction() {
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 new GovernanceProposalLedgerStateProvider("INFO_ACTION", false, true));
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.STAKING_POOL_KEY_HASH), 0, new ProtocolParams());
@@ -218,7 +218,7 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesValidateCommitteeHotVoterAuthorizationWhenAvailable() {
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 new GovernanceProposalLedgerStateProvider("INFO_ACTION", true, false));
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.CONSTITUTIONAL_COMMITTEE_HOT_KEY_HASH),
@@ -233,7 +233,7 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRulesUseCurrentTransactionHashForLocalProposalVotes() {
         String txHash = filledHex(32, 9);
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 new RegisteredPoolLedgerStateProvider());
 
         var result = validator.runSupplementaryRules(localProposalVoteTx(txHash), 0, new ProtocolParams(), txHash);
@@ -247,7 +247,7 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRulesRejectPrevGovActionWithDifferentPurpose() {
         String prevHash = filledHex(32, 7);
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 new GovernanceProposalLedgerStateProvider("INFO_ACTION", false, true));
 
         var result = validator.runSupplementaryRules(proposalWithPreviousAction(prevHash), 0, new ProtocolParams());
@@ -261,7 +261,7 @@ class ScalusBasedTransactionValidatorTest {
     void supplementaryRulesDoNotUseLocalProposalsForPreviousActionReferences() {
         String txHash = filledHex(32, 9);
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 new RegisteredPoolLedgerStateProvider());
 
         var result = validator.runSupplementaryRules(proposalWithPreviousAction(txHash), 0, new ProtocolParams(),
@@ -275,13 +275,27 @@ class ScalusBasedTransactionValidatorTest {
     @Test
     void supplementaryRulesUseTypedCommitteeHotCredentialAuthorization() {
         var validator = new ScalusBasedTransactionValidator(
-                slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+                slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                 new ScriptCommitteeHotLedgerStateProvider());
 
         var result = validator.runSupplementaryRules(votingTx(VoterType.CONSTITUTIONAL_COMMITTEE_HOT_SCRIPT_HASH),
                 0, new ProtocolParams());
 
         assertTrue(result.valid());
+    }
+
+    private static SlotConfigSupplier testSlotConfig() {
+        return new SlotConfigSupplier() {
+            @Override
+            public SlotConfig getSlotConfig() {
+                return new SlotConfig(1_000, 0, 0);
+            }
+
+            @Override
+            public EpochSlotCalc getEpochSlotCalc() {
+                return new EpochSlotCalc(1_200, 1_200, 0);
+            }
+        };
     }
 
     private static Transaction poolRetirementTx(long retireEpoch) {
@@ -405,7 +419,7 @@ class ScalusBasedTransactionValidatorTest {
 
         ScalusSuccessValidator(LedgerStateProvider provider, LongSupplier currentSlotSupplier,
                                boolean supplementaryRulesEnabled) {
-            super(slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0,
+            super(slot -> new ProtocolParams(), null, testSlotConfig(), 0,
                     provider, currentSlotSupplier, null, supplementaryRulesEnabled);
         }
 
@@ -429,7 +443,7 @@ class ScalusBasedTransactionValidatorTest {
 
     private static class BlstFailingValidator extends ScalusBasedTransactionValidator {
         BlstFailingValidator() {
-            super(slot -> new ProtocolParams(), null, new SlotConfig(1000, 0, 0), 0, null);
+            super(slot -> new ProtocolParams(), null, testSlotConfig(), 0, null);
         }
 
         @Override

--- a/tx-services/src/main/java/org/yanoproject/tx/DefaultTransactionServicesFactory.java
+++ b/tx-services/src/main/java/org/yanoproject/tx/DefaultTransactionServicesFactory.java
@@ -96,7 +96,10 @@ public final class DefaultTransactionServicesFactory {
                         epochSlotCalc.shelleyEpochLength(),
                         epochSlotCalc.firstNonByronEpoch());
             } else {
-                log.info("Yano transaction slot config supplier prepared; zeroTime will resolve at runtime");
+                log.info("Yano transaction slot config supplier prepared; zeroTime will resolve at runtime, "
+                                + "epochLength={}, zeroEpoch={}",
+                        epochSlotCalc.shelleyEpochLength(),
+                        epochSlotCalc.firstNonByronEpoch());
             }
 
             networkId = magic == Constants.MAINNET_PROTOCOL_MAGIC ? 1 : 0;

--- a/tx-services/src/main/java/org/yanoproject/tx/DefaultTransactionServicesFactory.java
+++ b/tx-services/src/main/java/org/yanoproject/tx/DefaultTransactionServicesFactory.java
@@ -81,17 +81,20 @@ public final class DefaultTransactionServicesFactory {
                 return tip != null ? tip.getSlot() : -1L;
             };
             RuntimeSlotConfigSupplier runtimeSlotConfigSupplier = new RuntimeSlotConfigSupplier(
-                    yaciConfig, context::resolvedGenesisTimestamp, genesis);
+                    yaciConfig, context::resolvedGenesisTimestamp, genesis, epochSlotCalc);
             slotConfigSupplier = runtimeSlotConfigSupplier;
 
             long magic = yaciConfig.getProtocolMagic();
 
             if (runtimeSlotConfigSupplier.canResolveZeroTimeNow()) {
                 var initialSlotConfig = runtimeSlotConfigSupplier.getSlotConfig();
-                log.info("Yano transaction slot config: slotLengthMillis={}, zeroSlot={}, zeroTimeMillis={}",
+                log.info("Yano transaction slot config: slotLengthMillis={}, zeroSlot={}, zeroTimeMillis={}, "
+                                + "epochLength={}, zeroEpoch={}",
                         initialSlotConfig.getSlotLength(),
                         initialSlotConfig.getZeroSlot(),
-                        initialSlotConfig.getZeroTime());
+                        initialSlotConfig.getZeroTime(),
+                        epochSlotCalc.shelleyEpochLength(),
+                        epochSlotCalc.firstNonByronEpoch());
             } else {
                 log.info("Yano transaction slot config supplier prepared; zeroTime will resolve at runtime");
             }

--- a/tx-services/src/main/java/org/yanoproject/tx/RuntimeSlotConfigSupplier.java
+++ b/tx-services/src/main/java/org/yanoproject/tx/RuntimeSlotConfigSupplier.java
@@ -52,27 +52,34 @@ final class RuntimeSlotConfigSupplier implements SlotConfigSupplier {
     }
 
     boolean canResolveZeroTimeNow() {
-        if (epochSlotCalc.firstNonByronSlot() > 0) {
-            return genesisConfig != null && genesisConfig.getSystemStartEpochMillis() > 0;
-        }
         if (config.getGenesisTimestamp() > 0) {
             return true;
         }
         if (resolvedGenesisTimestampSupplier.getAsLong() > 0) {
             return true;
         }
-        return genesisConfig != null && genesisConfig.getSystemStartEpochMillis() > 0;
+        return genesisConfig != null && (epochSlotCalc.firstNonByronSlot() > 0
+                ? genesisConfig.getNetworkStartTimeSeconds() > 0
+                : genesisConfig.getSystemStartEpochMillis() > 0);
     }
 
     long resolveZeroTimeMillis() {
+        long networkStartMillis = resolveNetworkStartMillis();
+        // Shelley genesis systemStart is the network start, including the Byron period.
+        // zeroTime must instead identify zeroSlot, the first post-Byron slot.
         if (epochSlotCalc.firstNonByronSlot() > 0) {
             if (genesisConfig == null) {
                 throw new IllegalStateException(
-                        "Cannot resolve Shelley transition time without Shelley genesis configuration");
+                        "Cannot resolve Shelley transition time without genesis configuration");
             }
-            return requireEpochMillis(genesisConfig.getSystemStartEpochMillis(), "Shelley systemStart");
+            long byronSlotMillis = Math.multiplyExact(genesisConfig.getByronSlotDurationSeconds(), 1_000L);
+            return Math.addExact(networkStartMillis,
+                    Math.multiplyExact(epochSlotCalc.firstNonByronSlot(), byronSlotMillis));
         }
+        return networkStartMillis;
+    }
 
+    private long resolveNetworkStartMillis() {
         long configured = config.getGenesisTimestamp();
         if (configured > 0) {
             return requireEpochMillis(configured, YanoPropertyKeys.BlockProducer.GENESIS_TIMESTAMP);
@@ -84,9 +91,12 @@ final class RuntimeSlotConfigSupplier implements SlotConfigSupplier {
         }
 
         if (genesisConfig != null) {
-            long systemStart = genesisConfig.getSystemStartEpochMillis();
+            // Keep millisecond precision on devnets; public Byron networks use Byron startTime.
+            long systemStart = epochSlotCalc.firstNonByronSlot() > 0
+                    ? Math.multiplyExact(genesisConfig.getNetworkStartTimeSeconds(), 1_000L)
+                    : genesisConfig.getSystemStartEpochMillis();
             if (systemStart > 0) {
-                return requireEpochMillis(systemStart, "Shelley systemStart");
+                return requireEpochMillis(systemStart, "genesis network start");
             }
         }
 

--- a/tx-services/src/main/java/org/yanoproject/tx/RuntimeSlotConfigSupplier.java
+++ b/tx-services/src/main/java/org/yanoproject/tx/RuntimeSlotConfigSupplier.java
@@ -52,6 +52,9 @@ final class RuntimeSlotConfigSupplier implements SlotConfigSupplier {
     }
 
     boolean canResolveZeroTimeNow() {
+        if (epochSlotCalc.firstNonByronSlot() > 0) {
+            return genesisConfig != null && genesisConfig.getSystemStartEpochMillis() > 0;
+        }
         if (config.getGenesisTimestamp() > 0) {
             return true;
         }
@@ -62,6 +65,14 @@ final class RuntimeSlotConfigSupplier implements SlotConfigSupplier {
     }
 
     long resolveZeroTimeMillis() {
+        if (epochSlotCalc.firstNonByronSlot() > 0) {
+            if (genesisConfig == null) {
+                throw new IllegalStateException(
+                        "Cannot resolve Shelley transition time without Shelley genesis configuration");
+            }
+            return requireEpochMillis(genesisConfig.getSystemStartEpochMillis(), "Shelley systemStart");
+        }
+
         long configured = config.getGenesisTimestamp();
         if (configured > 0) {
             return requireEpochMillis(configured, YanoPropertyKeys.BlockProducer.GENESIS_TIMESTAMP);

--- a/tx-services/src/main/java/org/yanoproject/tx/RuntimeSlotConfigSupplier.java
+++ b/tx-services/src/main/java/org/yanoproject/tx/RuntimeSlotConfigSupplier.java
@@ -3,6 +3,7 @@ package org.yanoproject.tx;
 import com.bloxbean.cardano.client.common.model.SlotConfig;
 import org.yanoproject.api.config.YanoConfig;
 import org.yanoproject.api.config.YanoPropertyKeys;
+import org.yanoproject.api.util.EpochSlotCalc;
 import org.yanoproject.ledgerrules.SlotConfigSupplier;
 import org.yanoproject.runtime.blockproducer.GenesisConfig;
 import org.slf4j.Logger;
@@ -26,20 +27,28 @@ final class RuntimeSlotConfigSupplier implements SlotConfigSupplier {
     private final YanoConfig config;
     private final LongSupplier resolvedGenesisTimestampSupplier;
     private final GenesisConfig genesisConfig;
+    private final EpochSlotCalc epochSlotCalc;
     private final AtomicBoolean slotLengthFallbackLogged = new AtomicBoolean();
 
     RuntimeSlotConfigSupplier(YanoConfig config,
                               LongSupplier resolvedGenesisTimestampSupplier,
-                              GenesisConfig genesisConfig) {
+                              GenesisConfig genesisConfig,
+                              EpochSlotCalc epochSlotCalc) {
         this.config = Objects.requireNonNull(config, "config must not be null");
         this.resolvedGenesisTimestampSupplier = Objects.requireNonNull(
                 resolvedGenesisTimestampSupplier, "resolvedGenesisTimestampSupplier must not be null");
         this.genesisConfig = genesisConfig;
+        this.epochSlotCalc = Objects.requireNonNull(epochSlotCalc, "epochSlotCalc must not be null");
     }
 
     @Override
     public SlotConfig getSlotConfig() {
-        return new SlotConfig(resolveSlotLengthMillis(), 0, resolveZeroTimeMillis());
+        return new SlotConfig(resolveSlotLengthMillis(), epochSlotCalc.firstNonByronSlot(), resolveZeroTimeMillis());
+    }
+
+    @Override
+    public EpochSlotCalc getEpochSlotCalc() {
+        return epochSlotCalc;
     }
 
     boolean canResolveZeroTimeNow() {

--- a/tx-services/src/test/java/org/yanoproject/tx/DefaultTransactionServicesFactoryIntegrationTest.java
+++ b/tx-services/src/test/java/org/yanoproject/tx/DefaultTransactionServicesFactoryIntegrationTest.java
@@ -2,10 +2,12 @@ package org.yanoproject.tx;
 
 import org.yanoproject.api.config.RuntimeOptions;
 import org.yanoproject.api.config.YanoConfig;
+import org.yanoproject.ledgerrules.SlotConfigSupplier;
 import org.yanoproject.runtime.assembly.YanoAssembly;
 import org.yanoproject.runtime.assembly.Yano;
 import org.yanoproject.runtime.config.InMemoryDevnetGenesis;
 import org.yanoproject.runtime.genesis.ShelleyGenesisParser;
+import org.yanoproject.runtime.tx.TransactionServices;
 import org.yanoproject.runtime.tx.TransactionBootstrapOptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -13,7 +15,10 @@ import org.junit.jupiter.api.io.TempDir;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -63,6 +68,7 @@ class DefaultTransactionServicesFactoryIntegrationTest {
                 testPath("app/config/network/devnet/shelley-genesis.json").toFile());
         var protocolParameters = Files.readString(testPath("app/config/network/devnet/protocol-param.json"));
         var inMemoryGenesis = new InMemoryDevnetGenesis(shelley, null, null, protocolParameters);
+        var capturedServices = new AtomicReference<TransactionServices>();
 
         RuntimeOptions runtimeOptions = new RuntimeOptions(null, null, Map.of(
                 "yano.utxo.enabled", true,
@@ -75,11 +81,25 @@ class DefaultTransactionServicesFactoryIntegrationTest {
                 .runtimeOptions(runtimeOptions)
                 .transactionBootstrap(
                         TransactionBootstrapOptions.enabled(false, false, "aiken"),
-                        DefaultTransactionServicesFactory::create)
+                        (context, options) -> {
+                            var services = DefaultTransactionServicesFactory.create(context, options);
+                            services.ifPresent(capturedServices::set);
+                            return services;
+                        })
                 .build();
 
         try {
             assertTrue(node.txEvaluationGateway().isTransactionEvaluationAvailable());
+            assertNotNull(capturedServices.get());
+            assertNotNull(capturedServices.get().validator());
+
+            var field = capturedServices.get().validator().getClass().getDeclaredField("slotConfigSupplier");
+            field.setAccessible(true);
+            var slotConfigSupplier = (SlotConfigSupplier) field.get(capturedServices.get().validator());
+
+            assertEquals(shelley.epochLength(), slotConfigSupplier.getEpochSlotCalc().shelleyEpochLength());
+            assertEquals(0, slotConfigSupplier.getEpochSlotCalc().firstNonByronEpoch());
+            assertEquals(0, slotConfigSupplier.getSlotConfig().getZeroSlot());
         } finally {
             node.close();
         }

--- a/tx-services/src/test/java/org/yanoproject/tx/DefaultTransactionServicesFactoryIntegrationTest.java
+++ b/tx-services/src/test/java/org/yanoproject/tx/DefaultTransactionServicesFactoryIntegrationTest.java
@@ -11,9 +11,11 @@ import org.yanoproject.runtime.tx.TransactionServices;
 import org.yanoproject.runtime.tx.TransactionBootstrapOptions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import scalus.cardano.ledger.SlotConfig;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -100,6 +102,8 @@ class DefaultTransactionServicesFactoryIntegrationTest {
             assertEquals(shelley.epochLength(), slotConfigSupplier.getEpochSlotCalc().shelleyEpochLength());
             assertEquals(0, slotConfigSupplier.getEpochSlotCalc().firstNonByronEpoch());
             assertEquals(0, slotConfigSupplier.getSlotConfig().getZeroSlot());
+            assertEquals(Instant.parse(shelley.systemStart()).toEpochMilli(),
+                    slotConfigSupplier.getSlotConfig().getZeroTime());
         } finally {
             node.close();
         }
@@ -132,6 +136,62 @@ class DefaultTransactionServicesFactoryIntegrationTest {
             assertFalse(node.txEvaluationGateway().isTransactionEvaluationAvailable());
         } finally {
             node.close();
+        }
+    }
+
+    @Test
+    void publicNetworkFactoryWiresTransitionTimeIntoValidatorAndEveryEvaluator(@TempDir Path tempDir)
+            throws Exception {
+        for (String network : new String[]{"mainnet", "preprod"}) {
+            boolean mainnet = network.equals("mainnet");
+            long expectedTime = mainnet ? 1_596_059_091_000L : 1_655_769_600_000L;
+            long expectedSlot = mainnet ? 4_492_800 : 86_400;
+            long expectedEpoch = mainnet ? 208 : 4;
+            for (String evaluator : new String[]{"scalus", "aiken", "julc"}) {
+                var config = YanoConfig.serverOnly(0);
+                config.setUseRocksDB(true);
+                config.setRocksDBPath(tempDir.resolve(network + "-" + evaluator).toString());
+                config.setProtocolMagic(mainnet ? 764_824_073 : 1);
+                String genesisDirectory = "app/config/network/" + network + "/";
+                config.setShelleyGenesisFile(testPath(genesisDirectory + "shelley-genesis.json").toString());
+                config.setByronGenesisFile(testPath(genesisDirectory + "byron-genesis.json").toString());
+                // Static parameters isolate slot geometry from effective-ledger availability.
+                config.setProtocolParametersFile(testPath("app/config/network/devnet/protocol-param.json").toString());
+                var captured = new AtomicReference<TransactionServices>();
+                var node = YanoAssembly.relay(config)
+                        .runtimeOptions(new RuntimeOptions(null, null, Map.of(
+                                "yano.utxo.enabled", true,
+                                "yano.metrics.sample.rocksdb.seconds", 0,
+                                "yano.validation.default-validator-enabled", false)))
+                        .transactionBootstrap(TransactionBootstrapOptions.enabled(false, false, evaluator),
+                                (context, options) -> {
+                                    var services = DefaultTransactionServicesFactory.create(context, options);
+                                    services.ifPresent(captured::set);
+                                    return services;
+                                }).build();
+                try {
+                    var services = captured.get();
+                    assertNotNull(services, network + "/" + evaluator);
+                    assertNotNull(services.validator());
+                    assertNotNull(services.scriptEvaluator());
+                    // Inspect the actual configuration handed to LedgerBridge, after conversion.
+                    var resolve = services.validator().getClass().getDeclaredMethod("resolveScalusSlotConfig");
+                    resolve.setAccessible(true);
+                    var scalusConfig = (SlotConfig) resolve.invoke(services.validator());
+                    assertEquals(expectedEpoch, scalusConfig.epochOf(expectedSlot));
+                    assertEquals(expectedTime, scalusConfig.slotToTime(expectedSlot));
+                    assertEquals(expectedTime + 123_000, scalusConfig.slotToTime(expectedSlot + 123));
+
+                    var field = services.scriptEvaluator().getClass().getDeclaredField("slotConfigSupplier");
+                    field.setAccessible(true);
+                    var supplier = (SlotConfigSupplier) field.get(services.scriptEvaluator());
+                    assertEquals(expectedSlot, supplier.getSlotConfig().getZeroSlot());
+                    assertEquals(expectedTime, supplier.getSlotConfig().getZeroTime());
+                    assertEquals(1_000, supplier.getSlotConfig().getSlotLength());
+                } finally {
+                    node.close();
+                }
+            }
         }
     }
 

--- a/tx-services/src/test/java/org/yanoproject/tx/RuntimeSlotConfigSupplierTest.java
+++ b/tx-services/src/test/java/org/yanoproject/tx/RuntimeSlotConfigSupplierTest.java
@@ -12,6 +12,7 @@ import java.time.Instant;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RuntimeSlotConfigSupplierTest {
@@ -113,7 +114,25 @@ class RuntimeSlotConfigSupplierTest {
 
         assertEquals(4_492_800, slotConfig.getZeroSlot());
         assertEquals(shelleyStart, slotConfig.getZeroTime());
-        assertEquals(mainnetEpochs, supplier.getEpochSlotCalc());
+        assertSame(mainnetEpochs, supplier.getEpochSlotCalc());
+    }
+
+    @Test
+    void byronNetworkAlwaysUsesShelleySystemStartAsSlotConfigOrigin() {
+        var config = YanoConfig.devnetDefault(13337);
+        config.setGenesisTimestamp(Instant.parse("2017-09-23T21:44:51Z").toEpochMilli());
+        var mainnetEpochs = new EpochSlotCalc(432_000, 21_600, 4_492_800);
+        long shelleyStart = Instant.parse("2020-07-29T21:44:51Z").toEpochMilli();
+        var supplier = new RuntimeSlotConfigSupplier(
+                config,
+                () -> Instant.parse("2017-09-23T21:44:51Z").toEpochMilli(),
+                genesis("2020-07-29T21:44:51Z", 1.0),
+                mainnetEpochs);
+
+        var slotConfig = supplier.getSlotConfig();
+
+        assertEquals(4_492_800, slotConfig.getZeroSlot());
+        assertEquals(shelleyStart, slotConfig.getZeroTime());
     }
 
     private static GenesisConfig genesis(String systemStart, double slotLengthSeconds) {

--- a/tx-services/src/test/java/org/yanoproject/tx/RuntimeSlotConfigSupplierTest.java
+++ b/tx-services/src/test/java/org/yanoproject/tx/RuntimeSlotConfigSupplierTest.java
@@ -8,10 +8,13 @@ import org.yanoproject.api.genesis.ShelleyGenesisBootstrap;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Instant;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -103,12 +106,12 @@ class RuntimeSlotConfigSupplierTest {
     }
 
     @Test
-    void anchorsSlotTimingAndEpochGeometryAtShelleyBoundary() {
+    void shippedMainnetGenesisResolvesShelleyBoundaryWithoutHistoricalChainState() {
         var config = YanoConfig.devnetDefault(13337);
         var mainnetEpochs = new EpochSlotCalc(432_000, 21_600, 4_492_800);
         long shelleyStart = Instant.parse("2020-07-29T21:44:51Z").toEpochMilli();
         var supplier = new RuntimeSlotConfigSupplier(
-                config, () -> 0L, genesis("2020-07-29T21:44:51Z", 1.0), mainnetEpochs);
+                config, () -> 0L, networkGenesis("mainnet"), mainnetEpochs);
 
         var slotConfig = supplier.getSlotConfig();
 
@@ -118,7 +121,7 @@ class RuntimeSlotConfigSupplierTest {
     }
 
     @Test
-    void byronNetworkAlwaysUsesShelleySystemStartAsSlotConfigOrigin() {
+    void byronNetworkPreservesTimestampOverridesAndAddsByronDuration() {
         var config = YanoConfig.devnetDefault(13337);
         config.setGenesisTimestamp(Instant.parse("2017-09-23T21:44:51Z").toEpochMilli());
         var mainnetEpochs = new EpochSlotCalc(432_000, 21_600, 4_492_800);
@@ -126,13 +129,52 @@ class RuntimeSlotConfigSupplierTest {
         var supplier = new RuntimeSlotConfigSupplier(
                 config,
                 () -> Instant.parse("2017-09-23T21:44:51Z").toEpochMilli(),
-                genesis("2020-07-29T21:44:51Z", 1.0),
+                networkGenesis("mainnet"),
                 mainnetEpochs);
 
         var slotConfig = supplier.getSlotConfig();
 
         assertEquals(4_492_800, slotConfig.getZeroSlot());
         assertEquals(shelleyStart, slotConfig.getZeroTime());
+        config.setGenesisTimestamp(config.getGenesisTimestamp() + 1_234);
+        assertEquals(shelleyStart + 1_234, supplier.getSlotConfig().getZeroTime());
+        config.setGenesisTimestamp(0);
+        assertEquals(shelleyStart, supplier.getSlotConfig().getZeroTime());
+    }
+
+    @Test
+    void shippedPreprodGenesisResolvesShelleyBoundary() {
+        var supplier = new RuntimeSlotConfigSupplier(YanoConfig.devnetDefault(13337), () -> 0L,
+                networkGenesis("preprod"), new EpochSlotCalc(432_000, 21_600, 86_400));
+
+        var timing = supplier.getSlotConfig();
+
+        assertEquals(86_400, timing.getZeroSlot());
+        assertEquals(1_655_769_600_000L, timing.getZeroTime());
+        assertEquals(1_000, timing.getSlotLength());
+        assertEquals(4, supplier.getEpochSlotCalc().firstNonByronEpoch());
+    }
+
+    @Test
+    void shippedPreviewGenesisNeedsNoByronTimeOffset() {
+        var genesis = networkGenesis("preview");
+        var supplier = new RuntimeSlotConfigSupplier(YanoConfig.devnetDefault(13337), () -> 0L,
+                genesis, new EpochSlotCalc(86_400, 4_320, 0));
+
+        assertEquals(0, supplier.getSlotConfig().getZeroSlot());
+        assertEquals(1_666_656_000_000L, supplier.getSlotConfig().getZeroTime());
+    }
+
+    private static GenesisConfig networkGenesis(String network) {
+        Path directory = Path.of("app/config/network", network);
+        if (!Files.isDirectory(directory)) {
+            directory = Path.of("..").resolve(directory);
+        }
+        var genesis = GenesisConfig.load(directory.resolve("shelley-genesis.json").toString(),
+                directory.resolve("byron-genesis.json").toString(), null);
+        assertNotNull(genesis.getShelleyGenesisData());
+        assertNotNull(genesis.getByronGenesisData());
+        return genesis;
     }
 
     private static GenesisConfig genesis(String systemStart, double slotLengthSeconds) {

--- a/tx-services/src/test/java/org/yanoproject/tx/RuntimeSlotConfigSupplierTest.java
+++ b/tx-services/src/test/java/org/yanoproject/tx/RuntimeSlotConfigSupplierTest.java
@@ -1,6 +1,7 @@
 package org.yanoproject.tx;
 
 import org.yanoproject.api.config.YanoConfig;
+import org.yanoproject.api.util.EpochSlotCalc;
 import org.yanoproject.runtime.blockproducer.GenesisConfig;
 import org.yanoproject.runtime.genesis.ShelleyGenesisData;
 import org.yanoproject.api.genesis.ShelleyGenesisBootstrap;
@@ -14,12 +15,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class RuntimeSlotConfigSupplierTest {
+    private static final EpochSlotCalc DEVNET_EPOCHS = new EpochSlotCalc(100, 100, 0);
 
     @Test
     void resolvesZeroTimeFromShelleySystemStartAsEpochMillis() {
         var config = YanoConfig.devnetDefault(13337);
         var systemStart = "2026-06-01T00:00:00Z";
-        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis(systemStart, 2.0));
+        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis(systemStart, 2.0), DEVNET_EPOCHS);
 
         var slotConfig = supplier.getSlotConfig();
 
@@ -34,7 +36,7 @@ class RuntimeSlotConfigSupplierTest {
         var supplier = new RuntimeSlotConfigSupplier(
                 config,
                 () -> Instant.parse("2026-06-01T00:00:00Z").toEpochMilli(),
-                genesis("2026-06-01T00:00:00Z", 1.0));
+                genesis("2026-06-01T00:00:00Z", 1.0), DEVNET_EPOCHS);
         long shiftedMillis = Instant.parse("2026-05-31T00:00:00Z").toEpochMilli();
 
         config.setGenesisTimestamp(shiftedMillis);
@@ -49,7 +51,7 @@ class RuntimeSlotConfigSupplierTest {
         var supplier = new RuntimeSlotConfigSupplier(
                 config,
                 () -> resolvedMillis,
-                genesis("2026-06-01T00:00:00Z", 1.0));
+                genesis("2026-06-01T00:00:00Z", 1.0), DEVNET_EPOCHS);
 
         assertEquals(resolvedMillis, supplier.getSlotConfig().getZeroTime());
     }
@@ -58,9 +60,9 @@ class RuntimeSlotConfigSupplierTest {
     void reportsWhetherZeroTimeCanBeResolvedAtBootstrap() {
         var config = YanoConfig.devnetDefault(13337);
 
-        var deferred = new RuntimeSlotConfigSupplier(config, () -> 0L, null);
+        var deferred = new RuntimeSlotConfigSupplier(config, () -> 0L, null, DEVNET_EPOCHS);
         var fromGenesis = new RuntimeSlotConfigSupplier(
-                config, () -> 0L, genesis("2026-06-01T00:00:00Z", 1.0));
+                config, () -> 0L, genesis("2026-06-01T00:00:00Z", 1.0), DEVNET_EPOCHS);
 
         assertEquals(false, deferred.canResolveZeroTimeNow());
         assertEquals(true, fromGenesis.canResolveZeroTimeNow());
@@ -70,7 +72,8 @@ class RuntimeSlotConfigSupplierTest {
     void rejectsSecondsLookingConfiguredGenesisTimestamp() {
         var config = YanoConfig.devnetDefault(13337);
         config.setGenesisTimestamp(1_780_000_000L);
-        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis("2026-06-01T00:00:00Z", 1.0));
+        var supplier = new RuntimeSlotConfigSupplier(
+                config, () -> 0L, genesis("2026-06-01T00:00:00Z", 1.0), DEVNET_EPOCHS);
 
         var error = assertThrows(IllegalStateException.class, supplier::getSlotConfig);
 
@@ -82,7 +85,8 @@ class RuntimeSlotConfigSupplierTest {
     void derivesSlotLengthFromGenesisWhenConfigUsesAutoValue() {
         var config = YanoConfig.devnetDefault(13337);
         config.setSlotLengthMillis(0);
-        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis("2026-06-01T00:00:00Z", 0.25));
+        var supplier = new RuntimeSlotConfigSupplier(
+                config, () -> 0L, genesis("2026-06-01T00:00:00Z", 0.25), DEVNET_EPOCHS);
 
         assertEquals(250, supplier.getSlotConfig().getSlotLength());
     }
@@ -91,9 +95,25 @@ class RuntimeSlotConfigSupplierTest {
     void usesExistingRuntimeSlotLengthFallbackWhenGenesisSlotLengthUnavailable() {
         var config = YanoConfig.devnetDefault(13337);
         config.setSlotLengthMillis(0);
-        var supplier = new RuntimeSlotConfigSupplier(config, () -> 0L, genesis("2026-06-01T00:00:00Z", 0));
+        var supplier = new RuntimeSlotConfigSupplier(
+                config, () -> 0L, genesis("2026-06-01T00:00:00Z", 0), DEVNET_EPOCHS);
 
         assertEquals(1_000, supplier.getSlotConfig().getSlotLength());
+    }
+
+    @Test
+    void anchorsSlotTimingAndEpochGeometryAtShelleyBoundary() {
+        var config = YanoConfig.devnetDefault(13337);
+        var mainnetEpochs = new EpochSlotCalc(432_000, 21_600, 4_492_800);
+        long shelleyStart = Instant.parse("2020-07-29T21:44:51Z").toEpochMilli();
+        var supplier = new RuntimeSlotConfigSupplier(
+                config, () -> 0L, genesis("2020-07-29T21:44:51Z", 1.0), mainnetEpochs);
+
+        var slotConfig = supplier.getSlotConfig();
+
+        assertEquals(4_492_800, slotConfig.getZeroSlot());
+        assertEquals(shelleyStart, slotConfig.getZeroTime());
+        assertEquals(mainnetEpochs, supplier.getEpochSlotCalc());
     }
 
     private static GenesisConfig genesis(String systemStart, double slotLengthSeconds) {


### PR DESCRIPTION
Fixes #133.

Scalus defaulted to mainnet epoch geometry when converting CCL's three-field slot configuration. On a devnet at slot 66,166 with 1,200-slot epochs, this produced epoch 0 instead of 55 and rejected valid pool retirements.

The runtime now supplies explicit epoch geometry and anchors timing at the first post-Byron slot. Its timestamp is network start plus firstNonByronSlot multiplied by Byron slot duration, in milliseconds. Shelley genesis systemStart is the network start, not the Shelley transition. Configured and resolved timestamp overrides retain their precedence.

The shared timing feeds Scalus validation and Scalus, Aiken, and JULC evaluation. The calculation needs genesis configuration and epoch geometry, without historical chain metadata. Scalus entry points without epoch geometry fail explicitly.

API migration: the non-functional SlotConfig-only Scalus factory/constructor overloads are removed. Consumers must use SlotConfigSupplier with both getSlotConfig() and getEpochSlotCalc() implemented. This is a source/binary API change; downstream consumers must rebuild and migrate those calls.

Regression coverage includes devnet, mainnet and preprod epochs, dynamic timestamps, factory wiring, and pool-lifecycle retirement after an explicit 18-epoch advance (including +1 retirements beyond the old inclusive epoch-18 limit). Timestamp tests load shipped mainnet, preprod and preview genesis files. Removing the Byron offset makes three tests fail with the exact incorrect timestamps reported in review. Public-network factory tests verify the final Scalus validator slot-to-time conversion and shared timing for Scalus, Aiken and JULC evaluators on both mainnet and preprod.

Validation:

- Transaction-services, Scalus bridge and ledger-rules test tasks pass.
- PoolLifecycleE2ETest passes against the embedded devnet. One initial run failed in setup with a missing stake registration before reaching the epoch advance; an unchanged rerun passed. Setup now explicitly waits for stake-registration state before submitting delegations, in addition to waiting for transaction inclusion.
- Full repository build passed before this timestamp correction; this follow-up reruns the relevant module tests and pool lifecycle E2E.

No live public-network or full UTxO-bootstrap end-to-end run was performed for this correction.
